### PR TITLE
Add standalone Zod schema validator for model exports

### DIFF
--- a/tools/schema-validator/README.md
+++ b/tools/schema-validator/README.md
@@ -1,0 +1,83 @@
+# OutSystems Model JSON Schema Validator
+
+This utility provides a portable Zod schema for the OutSystems 11 model export and a small CLI that highlights contract gaps in emitted JSON. It mirrors the invariants enforced by the .NET domain layer (module/entity/attribute uniqueness, identifier requirements, flag normalization, etc.) so you can validate payloads without building the full solution.
+
+## Prerequisites
+
+* Node.js 18 or later (needed for the ESM-based tooling and `tsx` runner).
+* `npm` (bundled with Node.js).
+
+## Installation
+
+```bash
+cd tools/schema-validator
+npm install
+```
+
+This installs the lightweight dependencies (`zod` and `tsx`).
+
+## Validating a model export
+
+Run the CLI and provide the path to your OutSystems model JSON file:
+
+```bash
+npm run validate -- ../../tests/Fixtures/model.edge-case.json
+```
+
+The command will parse the JSON, enforce the schema, and print a summary. If the payload passes, you will see output similar to:
+
+```
+✅ Model JSON matches the OutSystems 11 contract.
+Export timestamp: <not provided>
+Modules: 1
+  1. AppCore (system: no, active: yes, entities: 5)
+     • Customer / OSUSR_ABC_CUSTOMER — attributes: 12, indexes: 3, relationships: 2
+     • ...
+```
+
+Add `--print-normalized` (or `-p`) to emit the normalized projection the validator produced. This is helpful when you need to inspect the sanitized booleans, trimmed identifiers, or defaulted delete rules:
+
+```bash
+npm run validate -- my-export.json --print-normalized
+```
+
+## Interpreting validation errors
+
+When the schema check fails, the CLI surfaces each issue with a JSON pointer-like path and a descriptive message. For example:
+
+```
+✖ Schema validation failed with 2 issues:
+  1. modules[0].entities[2].attributes[4].name: Duplicate attribute logical name "Email" in entity "Customer" (first at index 1).
+  2. modules[0].entities[2].attributes: Entity "Customer" must include at least one attribute marked as identifier.
+```
+
+* `modules[0].entities[2].attributes[4].name` pinpoints the failing field (module index 0, entity index 2, attribute index 4, `name` property).
+* The message reuses the same business rules as the C# domain layer, so you can update your JSON to match the expected contract.
+
+Fix the highlighted fields and re-run the command until the validator reports success.
+
+## What the schema enforces
+
+The Zod schema (`src/modelSchema.ts`) mirrors the key OutSystems DDL exporter rules:
+
+* Module names must be unique (case-insensitive) and each module must contain at least one entity.
+* Entity logical/physical names must be unique within a module, have at least one attribute, and include at least one primary key (`isIdentifier: true`).
+* Attribute logical/physical names must be unique within an entity, numeric metadata (`length`, `precision`, `scale`) must be non-negative integers, and references require target entity metadata.
+* Indexes must contain at least one column with unique ordinals; composite indexes preserve ordering.
+* Relationship delete rules default to `"Ignore"` when absent and `hasDbConstraint` is normalized to a boolean.
+* Flags encoded as `0`/`1` are normalized to booleans, optional strings are trimmed, and absent optional values become `null` for easier diffing.
+
+By running the CLI against your exported JSON, you can quickly spot mismatches before handing the payload to the .NET pipeline.
+
+## Project structure
+
+```
+src/
+  modelSchema.ts      # Zod schema + helpers (formatting, summary)
+  validate-model.ts   # CLI entry point
+package.json          # Scripts (npm run validate) and dependencies
+README.md             # This guide
+```
+
+Feel free to copy `modelSchema.ts` into other tooling or pipelines; it is framework-agnostic and only relies on `zod`.
+

--- a/tools/schema-validator/package-lock.json
+++ b/tools/schema-validator/package-lock.json
@@ -1,0 +1,584 @@
+{
+  "name": "outsystems-model-schema-validator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "outsystems-model-schema-validator",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.1",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tools/schema-validator/package.json
+++ b/tools/schema-validator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "outsystems-model-schema-validator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "tsx src/validate-model.ts"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/tools/schema-validator/src/modelSchema.ts
+++ b/tools/schema-validator/src/modelSchema.ts
@@ -1,0 +1,662 @@
+import { z, ZodError } from "zod";
+
+export interface AttributeReality {
+  readonly isNullableInDatabase: boolean | null;
+  readonly hasNulls: boolean | null;
+  readonly hasDuplicates: boolean | null;
+  readonly hasOrphans: boolean | null;
+  readonly isPresentButInactive: boolean;
+}
+
+export interface AttributeReference {
+  readonly isReference: boolean;
+  readonly targetEntityId: number | null;
+  readonly targetEntityName: string | null;
+  readonly targetEntityPhysicalName: string | null;
+  readonly deleteRuleCode: string | null;
+  readonly hasDbConstraint: boolean;
+}
+
+export interface NormalizedAttribute {
+  readonly name: string;
+  readonly physicalName: string;
+  readonly originalName: string | null;
+  readonly dataType: string;
+  readonly length: number | null;
+  readonly precision: number | null;
+  readonly scale: number | null;
+  readonly defaultValue: string | null;
+  readonly isMandatory: boolean;
+  readonly isIdentifier: boolean;
+  readonly isAutoNumber: boolean;
+  readonly isActive: boolean;
+  readonly externalDbType: string | null;
+  readonly reference: AttributeReference;
+  readonly reality: AttributeReality;
+}
+
+export interface NormalizedIndexColumn {
+  readonly attribute: string;
+  readonly physicalColumn: string;
+  readonly ordinal: number;
+}
+
+export interface NormalizedIndex {
+  readonly name: string;
+  readonly isUnique: boolean;
+  readonly isPrimary: boolean;
+  readonly isPlatformAuto: boolean;
+  readonly columns: NormalizedIndexColumn[];
+}
+
+export interface NormalizedRelationship {
+  readonly viaAttributeName: string;
+  readonly toEntityName: string;
+  readonly toEntityPhysicalName: string;
+  readonly deleteRuleCode: string;
+  readonly hasDbConstraint: boolean;
+}
+
+export interface NormalizedEntity {
+  readonly name: string;
+  readonly physicalName: string;
+  readonly schema: string;
+  readonly catalog: string | null;
+  readonly isStatic: boolean;
+  readonly isExternal: boolean;
+  readonly isActive: boolean;
+  readonly attributes: NormalizedAttribute[];
+  readonly indexes: NormalizedIndex[];
+  readonly relationships: NormalizedRelationship[];
+}
+
+export interface NormalizedModule {
+  readonly name: string;
+  readonly isSystem: boolean;
+  readonly isActive: boolean;
+  readonly entities: NormalizedEntity[];
+}
+
+export interface NormalizedModel {
+  readonly exportedAtUtc: Date | null;
+  readonly modules: NormalizedModule[];
+}
+
+const BOOL_ZERO_ONE = [0, 1] as const;
+
+type BoolZeroOne = (typeof BOOL_ZERO_ONE)[number];
+
+const boolish = z
+  .union([z.boolean(), z.number().int().refine((value) => BOOL_ZERO_ONE.includes(value as BoolZeroOne), {
+    message: "Expected 0 or 1 for boolean flag."
+  })])
+  .transform((value) => (typeof value === "number" ? value === 1 : value));
+
+const optionalBoolean = z
+  .union([boolish, z.null(), z.undefined()])
+  .transform((value) => (value === null || value === undefined ? null : value));
+
+function optionalTrimmedString(label: string, options?: { maxLength?: number }) {
+  const maxLength = options?.maxLength ?? 512;
+  return z
+    .union([z.string(), z.number(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (value === null || value === undefined) {
+        return null;
+      }
+
+      const stringValue = typeof value === "number" ? value.toString() : value;
+      const trimmed = stringValue.trim();
+      if (trimmed.length === 0) {
+        return null;
+      }
+
+      if (trimmed.length > maxLength) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          maximum: maxLength,
+          type: "string",
+          inclusive: true,
+          message: `${label} must be ${maxLength} characters or fewer.`
+        });
+        return z.NEVER;
+      }
+
+      return trimmed;
+    });
+}
+
+function requiredIdentifier(label: string, options?: { maxLength?: number }) {
+  const maxLength = options?.maxLength ?? 256;
+  return z
+    .string({ required_error: `${label} is required.` })
+    .trim()
+    .min(1, { message: `${label} is required.` })
+    .max(maxLength, { message: `${label} must be ${maxLength} characters or fewer.` });
+}
+
+function optionalNonNegativeInt(label: string) {
+  return z
+    .union([z.number(), z.string(), z.null(), z.undefined()])
+    .transform((value, ctx) => {
+      if (value === null || value === undefined || value === "") {
+        return null;
+      }
+
+      const numeric = typeof value === "string" ? Number(value) : value;
+      if (!Number.isInteger(numeric)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${label} must be an integer.`
+        });
+        return z.NEVER;
+      }
+
+      if (numeric < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          minimum: 0,
+          type: "number",
+          inclusive: true,
+          message: `${label} must be zero or positive.`
+        });
+        return z.NEVER;
+      }
+
+      return numeric;
+    });
+}
+
+function positiveInt(label: string) {
+  return z
+    .union([z.number(), z.string()])
+    .transform((value, ctx) => {
+      const numeric = typeof value === "string" ? Number(value) : value;
+      if (!Number.isInteger(numeric)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${label} must be an integer.`
+        });
+        return z.NEVER;
+      }
+
+      if (numeric <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          minimum: 1,
+          type: "number",
+          inclusive: true,
+          message: `${label} must be greater than zero.`
+        });
+        return z.NEVER;
+      }
+
+      return numeric;
+    });
+}
+
+function optionalArray<T extends z.ZodTypeAny>(schema: T) {
+  return z.union([z.array(schema), z.null(), z.undefined()]).transform((value) => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    return [] as z.infer<T>[];
+  });
+}
+
+const attributeRealitySchema = z
+  .object({
+    isNullableInDatabase: optionalBoolean,
+    hasNulls: optionalBoolean,
+    hasDuplicates: optionalBoolean,
+    hasOrphans: optionalBoolean
+  })
+  .strict()
+  .transform(
+    (value): AttributeReality => ({
+      isNullableInDatabase: value.isNullableInDatabase,
+      hasNulls: value.hasNulls,
+      hasDuplicates: value.hasDuplicates,
+      hasOrphans: value.hasOrphans,
+      isPresentButInactive: false
+    })
+  );
+
+const attributeSchema = z
+  .object({
+    name: requiredIdentifier("Attribute logical name"),
+    physicalName: requiredIdentifier("Attribute physical name"),
+    originalName: optionalTrimmedString("Attribute original name"),
+    dataType: z
+      .string({ required_error: "Attribute dataType is required." })
+      .trim()
+      .min(1, { message: "Attribute dataType is required." })
+      .max(256, { message: "Attribute dataType must be 256 characters or fewer." }),
+    length: optionalNonNegativeInt("Attribute length"),
+    precision: optionalNonNegativeInt("Attribute precision"),
+    scale: optionalNonNegativeInt("Attribute scale"),
+    default: optionalTrimmedString("Attribute default value", { maxLength: 4000 }),
+    isMandatory: boolish,
+    isIdentifier: boolish,
+    isAutoNumber: z.union([boolish, z.undefined()]).transform((value) =>
+      value === undefined ? false : value
+    ),
+    isActive: boolish,
+    isReference: boolish,
+    refEntityId: z.union([z.number().int(), z.string(), z.null(), z.undefined()]).transform((value, ctx) => {
+      if (value === null || value === undefined || value === "") {
+        return null;
+      }
+
+      const numeric = typeof value === "string" ? Number(value) : value;
+      if (!Number.isInteger(numeric)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Referenced entity id must be an integer."
+        });
+        return z.NEVER;
+      }
+
+      return numeric;
+    }),
+    "refEntity.name": optionalTrimmedString("Referenced entity logical name"),
+    "refEntity.physicalName": optionalTrimmedString("Referenced entity physical name"),
+    "reference.deleteRuleCode": optionalTrimmedString("Reference delete rule code"),
+    "reference.hasDbConstraint": z
+      .union([boolish, z.null(), z.undefined()])
+      .transform((value) => (value === null || value === undefined ? null : value)),
+    "external.dbType": optionalTrimmedString("External database type"),
+    "physical.isPresentButInactive": boolish,
+    reality: z.union([attributeRealitySchema, z.null(), z.undefined()])
+  })
+  .strict()
+  .superRefine((attribute, ctx) => {
+    if (attribute.isReference) {
+      if (!attribute["refEntity.name"]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Referenced entity logical name is required when isReference is true.",
+          path: ["refEntity.name"]
+        });
+      }
+
+      if (!attribute["refEntity.physicalName"]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Referenced entity physical name is required when isReference is true.",
+          path: ["refEntity.physicalName"]
+        });
+      }
+    }
+  })
+  .transform((attribute) => {
+    const isReference = attribute.isReference;
+
+    const reality: AttributeReality = {
+      ...(attribute.reality ?? {
+        isNullableInDatabase: null,
+        hasNulls: null,
+        hasDuplicates: null,
+        hasOrphans: null
+      }),
+      isPresentButInactive: attribute["physical.isPresentButInactive"]
+    };
+
+    const reference: AttributeReference = isReference
+      ? {
+          isReference: true,
+          targetEntityId: attribute.refEntityId,
+          targetEntityName: attribute["refEntity.name"]!,
+          targetEntityPhysicalName: attribute["refEntity.physicalName"]!,
+          deleteRuleCode: attribute["reference.deleteRuleCode"] ?? null,
+          hasDbConstraint: attribute["reference.hasDbConstraint"] === null ? false : attribute["reference.hasDbConstraint"]!
+        }
+      : {
+          isReference: false,
+          targetEntityId: null,
+          targetEntityName: null,
+          targetEntityPhysicalName: null,
+          deleteRuleCode: null,
+          hasDbConstraint: false
+        };
+
+    const normalized: NormalizedAttribute = {
+      name: attribute.name,
+      physicalName: attribute.physicalName,
+      originalName: attribute.originalName,
+      dataType: attribute.dataType,
+      length: attribute.length,
+      precision: attribute.precision,
+      scale: attribute.scale,
+      defaultValue: attribute.default,
+      isMandatory: attribute.isMandatory,
+      isIdentifier: attribute.isIdentifier,
+      isAutoNumber: attribute.isAutoNumber,
+      isActive: attribute.isActive,
+      externalDbType: attribute["external.dbType"],
+      reference,
+      reality
+    };
+
+    return normalized;
+  });
+
+const indexColumnSchema = z
+  .object({
+    attribute: requiredIdentifier("Index column attribute name"),
+    physicalColumn: requiredIdentifier("Index column physical name"),
+    ordinal: positiveInt("Index column ordinal")
+  })
+  .strict()
+  .transform((column) => ({
+    attribute: column.attribute,
+    physicalColumn: column.physicalColumn,
+    ordinal: column.ordinal
+  } satisfies NormalizedIndexColumn));
+
+const indexSchema = z
+  .object({
+    name: requiredIdentifier("Index name"),
+    isUnique: boolish,
+    isPrimary: z.union([boolish, z.undefined()]).transform((value) =>
+      value === undefined ? false : value
+    ),
+    isPlatformAuto: boolish,
+    columns: z.array(indexColumnSchema)
+  })
+  .strict()
+  .superRefine((index, ctx) => {
+    const seenOrdinals = new Map<number, number>();
+    index.columns.forEach((column, columnIndex) => {
+      const existing = seenOrdinals.get(column.ordinal);
+      if (existing !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate index column ordinal ${column.ordinal}; first seen at index ${existing}.`,
+          path: ["columns", columnIndex, "ordinal"]
+        });
+      } else {
+        seenOrdinals.set(column.ordinal, columnIndex);
+      }
+    });
+
+    if (index.columns.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Index must include at least one column.",
+        path: ["columns"]
+      });
+    }
+  })
+  .transform((index) => ({
+    name: index.name,
+    isUnique: index.isUnique,
+    isPrimary: index.isPrimary,
+    isPlatformAuto: index.isPlatformAuto,
+    columns: index.columns
+  } satisfies NormalizedIndex));
+
+const relationshipSchema = z
+  .object({
+    viaAttributeId: z.union([z.number(), z.string(), z.null(), z.undefined()]).optional(),
+    viaAttributeName: requiredIdentifier("Relationship attribute name"),
+    "toEntity.name": requiredIdentifier("Relationship target entity name"),
+    "toEntity.physicalName": requiredIdentifier("Relationship target entity physical name"),
+    deleteRuleCode: optionalTrimmedString("Relationship delete rule code"),
+    hasDbConstraint: z.union([boolish, z.null(), z.undefined()]).transform((value) =>
+      value === null || value === undefined ? false : value
+    )
+  })
+  .strict()
+  .transform((relationship) => ({
+    viaAttributeName: relationship.viaAttributeName,
+    toEntityName: relationship["toEntity.name"],
+    toEntityPhysicalName: relationship["toEntity.physicalName"],
+    deleteRuleCode:
+      relationship.deleteRuleCode && relationship.deleteRuleCode.length > 0
+        ? relationship.deleteRuleCode
+        : "Ignore",
+    hasDbConstraint: relationship.hasDbConstraint
+  } satisfies NormalizedRelationship));
+
+function findDuplicates(values: string[], options?: { caseInsensitive?: boolean }) {
+  const seen = new Map<string, number>();
+  const duplicates: Array<{ value: string; firstIndex: number; duplicateIndex: number }> = [];
+  values.forEach((value, index) => {
+    const key = options?.caseInsensitive ? value.toLowerCase() : value;
+    const existing = seen.get(key);
+    if (existing !== undefined) {
+      duplicates.push({ value, firstIndex: existing, duplicateIndex: index });
+    } else {
+      seen.set(key, index);
+    }
+  });
+  return duplicates;
+}
+
+const entitySchema = z
+  .object({
+    name: requiredIdentifier("Entity logical name"),
+    physicalName: requiredIdentifier("Entity physical name"),
+    isStatic: boolish,
+    isExternal: boolish,
+    isActive: boolish,
+    "db.catalog": optionalTrimmedString("Entity catalog"),
+    "db.schema": requiredIdentifier("Entity schema"),
+    attributes: z.array(attributeSchema),
+    indexes: optionalArray(indexSchema),
+    relationships: optionalArray(relationshipSchema)
+  })
+  .strict()
+  .superRefine((entity, ctx) => {
+    if (entity.attributes.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Entity "${entity.name}" must contain at least one attribute.`,
+        path: ["attributes"]
+      });
+    }
+
+    if (!entity.attributes.some((attribute) => attribute.isIdentifier)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Entity "${entity.name}" must include at least one attribute marked as identifier.`,
+        path: ["attributes"]
+      });
+    }
+
+    const logicalDuplicates = findDuplicates(entity.attributes.map((attr) => attr.name));
+    logicalDuplicates.forEach((duplicate) => {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate attribute logical name "${duplicate.value}" in entity "${entity.name}" (first at index ${duplicate.firstIndex}).`,
+        path: ["attributes", duplicate.duplicateIndex, "name"]
+      });
+    });
+
+    const physicalDuplicates = findDuplicates(entity.attributes.map((attr) => attr.physicalName), {
+      caseInsensitive: true
+    });
+    physicalDuplicates.forEach((duplicate) => {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate attribute physical name "${duplicate.value}" in entity "${entity.name}" (first at index ${duplicate.firstIndex}).`,
+        path: ["attributes", duplicate.duplicateIndex, "physicalName"]
+      });
+    });
+  })
+  .transform((entity) => ({
+    name: entity.name,
+    physicalName: entity.physicalName,
+    schema: entity["db.schema"],
+    catalog: entity["db.catalog"],
+    isStatic: entity.isStatic,
+    isExternal: entity.isExternal,
+    isActive: entity.isActive,
+    attributes: entity.attributes,
+    indexes: entity.indexes,
+    relationships: entity.relationships
+  } satisfies NormalizedEntity));
+
+const moduleSchema = z
+  .object({
+    name: requiredIdentifier("Module name"),
+    isSystem: boolish,
+    isActive: boolish,
+    entities: z.array(entitySchema)
+  })
+  .strict()
+  .superRefine((module, ctx) => {
+    if (module.entities.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Module "${module.name}" must include at least one entity.`,
+        path: ["entities"]
+      });
+    }
+
+    const logicalDuplicates = findDuplicates(module.entities.map((entity) => entity.name));
+    logicalDuplicates.forEach((duplicate) => {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate entity logical name "${duplicate.value}" within module "${module.name}" (first at index ${duplicate.firstIndex}).`,
+        path: ["entities", duplicate.duplicateIndex, "name"]
+      });
+    });
+
+    const physicalDuplicates = findDuplicates(
+      module.entities.map((entity) => entity.physicalName),
+      { caseInsensitive: true }
+    );
+    physicalDuplicates.forEach((duplicate) => {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate entity physical name "${duplicate.value}" within module "${module.name}" (first at index ${duplicate.firstIndex}).`,
+        path: ["entities", duplicate.duplicateIndex, "physicalName"]
+      });
+    });
+  })
+  .transform((module) => ({
+    name: module.name,
+    isSystem: module.isSystem,
+    isActive: module.isActive,
+    entities: module.entities
+  } satisfies NormalizedModule));
+
+const exportedAtUtcSchema = z
+  .union([z.string(), z.date(), z.null(), z.undefined()])
+  .transform((value, ctx) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (value instanceof Date) {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "exportedAtUtc must be a valid ISO-8601 timestamp when provided."
+      });
+      return z.NEVER;
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "exportedAtUtc must be a valid ISO-8601 timestamp when provided."
+      });
+      return z.NEVER;
+    }
+
+    return parsed;
+  });
+
+export const modelSchema = z
+  .object({
+    exportedAtUtc: exportedAtUtcSchema.optional(),
+    modules: z.array(moduleSchema)
+  })
+  .strict()
+  .superRefine((model, ctx) => {
+    if (model.modules.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Model must contain at least one module.",
+        path: ["modules"]
+      });
+    }
+
+    const duplicates = findDuplicates(model.modules.map((module) => module.name), { caseInsensitive: true });
+    duplicates.forEach((duplicate) => {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate module name "${duplicate.value}" (first at index ${duplicate.firstIndex}).`,
+        path: ["modules", duplicate.duplicateIndex, "name"]
+      });
+    });
+  })
+  .transform((model) => ({
+    exportedAtUtc: model.exportedAtUtc ?? null,
+    modules: model.modules
+  } satisfies NormalizedModel));
+
+export function parseModelJson(input: unknown): NormalizedModel {
+  return modelSchema.parse(input);
+}
+
+export function safeParseModelJson(input: unknown) {
+  return modelSchema.safeParse(input);
+}
+
+function formatIssuePath(path: (string | number)[]): string {
+  if (path.length === 0) {
+    return "";
+  }
+
+  return path
+    .map((segment, index) => {
+      if (typeof segment === "number") {
+        return `[${segment}]`;
+      }
+
+      return index === 0 ? segment : `.${segment}`;
+    })
+    .join("");
+}
+
+export function formatZodErrors(error: ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = formatIssuePath(issue.path);
+    return path ? `${path}: ${issue.message}` : issue.message;
+  });
+}
+
+export function summarizeModel(model: NormalizedModel): string[] {
+  const lines: string[] = [];
+  lines.push(
+    model.exportedAtUtc
+      ? `Export timestamp: ${model.exportedAtUtc.toISOString()}`
+      : "Export timestamp: <not provided>"
+  );
+  lines.push(`Modules: ${model.modules.length}`);
+  model.modules.forEach((module, moduleIndex) => {
+    lines.push(
+      `  ${moduleIndex + 1}. ${module.name} (system: ${module.isSystem ? "yes" : "no"}, active: ${
+        module.isActive ? "yes" : "no"
+      }, entities: ${module.entities.length})`
+    );
+    module.entities.forEach((entity) => {
+      lines.push(
+        `     • ${entity.name} / ${entity.physicalName} — attributes: ${entity.attributes.length}, indexes: ${entity.indexes.length}, relationships: ${entity.relationships.length}`
+      );
+    });
+  });
+
+  return lines;
+}
+

--- a/tools/schema-validator/src/validate-model.ts
+++ b/tools/schema-validator/src/validate-model.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import { ZodError } from "zod";
+
+import {
+  formatZodErrors,
+  parseModelJson,
+  summarizeModel,
+  type NormalizedModel
+} from "./modelSchema.js";
+
+interface CliOptions {
+  readonly filePath: string;
+  readonly printNormalized: boolean;
+}
+
+function parseArguments(argv: string[]): CliOptions | null {
+  let filePath: string | undefined;
+  let printNormalized = false;
+
+  for (const argument of argv) {
+    if (argument === "--help" || argument === "-h") {
+      return null;
+    }
+
+    if (argument === "--print-normalized" || argument === "-p") {
+      printNormalized = true;
+      continue;
+    }
+
+    if (argument.startsWith("-")) {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+
+    if (filePath) {
+      throw new Error("Only one JSON file path can be supplied.");
+    }
+
+    filePath = argument;
+  }
+
+  if (!filePath) {
+    throw new Error("Path to the emitted OutSystems model JSON is required.");
+  }
+
+  return { filePath, printNormalized };
+}
+
+function printUsage(): void {
+  console.log(`Usage: npm run validate -- <model.json> [options]\n\n` +
+    `Options:\n` +
+    `  -h, --help              Show this message.\n` +
+    `  -p, --print-normalized  Print the normalized JSON after validation.\n` +
+    `\nExamples:\n` +
+    `  npm run validate -- tests/Fixtures/model.edge-case.json\n` +
+    `  npm run validate -- my-export.json --print-normalized\n`);
+}
+
+async function loadJson(filePath: string): Promise<unknown> {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  const payload = await fs.readFile(absolutePath, "utf8");
+  try {
+    return JSON.parse(payload);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Failed to parse JSON from ${absolutePath}: ${error.message}`);
+    }
+
+    throw error;
+  }
+}
+
+function printSummary(model: NormalizedModel): void {
+  const lines = summarizeModel(model);
+  for (const line of lines) {
+    console.log(line);
+  }
+}
+
+async function main(): Promise<void> {
+  let options: CliOptions | null;
+  try {
+    options = parseArguments(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`✖ ${error.message}`);
+    } else {
+      console.error("✖ Unable to read CLI arguments.");
+    }
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options === null) {
+    printUsage();
+    return;
+  }
+
+  let rawModel: unknown;
+  try {
+    rawModel = await loadJson(options.filePath);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`✖ ${error.message}`);
+    } else {
+      console.error("✖ Unable to load the JSON file.");
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  let model: NormalizedModel;
+  try {
+    model = parseModelJson(rawModel);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const issues = formatZodErrors(error);
+      console.error(`✖ Schema validation failed with ${issues.length} issue${issues.length === 1 ? "" : "s"}:`);
+      issues.forEach((issue, index) => {
+        console.error(`  ${index + 1}. ${issue}`);
+      });
+    } else if (error instanceof Error) {
+      console.error(`✖ ${error.message}`);
+    } else {
+      console.error("✖ Unexpected error during validation.", error);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("✅ Model JSON matches the OutSystems 11 contract.");
+  printSummary(model);
+
+  if (options.printNormalized) {
+    console.log("\nNormalized projection:\n");
+    const replacer = (_key: string, value: unknown) =>
+      value instanceof Date ? value.toISOString() : value;
+    console.log(JSON.stringify(model, replacer, 2));
+  }
+}
+
+main().catch((error) => {
+  console.error("✖ Unhandled error:", error);
+  process.exit(1);
+});
+

--- a/tools/schema-validator/tsconfig.json
+++ b/tools/schema-validator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a `tools/schema-validator` workspace with a comprehensive Zod schema mirroring the OutSystems model contract
- expose a TypeScript CLI that validates model JSON files, reports schema issues, and optionally prints the normalized projection
- document setup and usage instructions for the validator package

## Testing
- dotnet restore OutSystemsModelToSql.sln
- dotnet build OutSystemsModelToSql.sln -c Release --no-restore
- dotnet test OutSystemsModelToSql.sln -c Release --no-build
- npm --prefix tools/schema-validator run validate -- ../../tests/Fixtures/model.edge-case.json


------
https://chatgpt.com/codex/tasks/task_e_68dc7bf6de68832bab243213be9a0c84