### PR TITLE
Normalize model JSON field names to avoid dot notation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ E AS (
   "isStatic": false,
   "isExternal": false,
   "isActive": true,
-  "db.catalog": null,
-  "db.schema": "dbo",
+  "db_catalog": null,
+  "db_schema": "dbo",
   "attributes": [ /* attributes[] below */ ],
   "relationships": [ /* derived references */ ],
   "indexes": [ /* modeled indexes */ ]
@@ -223,12 +223,12 @@ E AS (
   "isIdentifier": false,
   "isReference": 0,
   "refEntityId": null,
-  "refEntity.name": null,
-  "refEntity.physicalName": null,
-  "reference.deleteRuleCode": null,
-  "reference.hasDbConstraint": 0,
-  "external.dbType": null,
-  "physical.isPresentButInactive": 0
+  "refEntity_name": null,
+  "refEntity_physicalName": null,
+  "reference_deleteRuleCode": null,
+  "reference_hasDbConstraint": 0,
+  "external_dbType": null,
+  "physical_isPresentButInactive": 0
 }
 ```
 
@@ -238,8 +238,8 @@ E AS (
 {
   "viaAttributeId": 12345,
   "viaAttributeName": "CityId",
-  "toEntity.name": "City",
-  "toEntity.physicalName": "OSUSR_DEF_CITY",
+  "toEntity_name": "City",
+  "toEntity_physicalName": "OSUSR_DEF_CITY",
   "deleteRuleCode": "Protect",
   "hasDbConstraint": 1
 }

--- a/src/AdvancedSql/outsystems_model_export.sql
+++ b/src/AdvancedSql/outsystems_model_export.sql
@@ -87,8 +87,8 @@ SELECT
       en.IsStaticEntity AS [isStatic],
       en.IsExternalEntity AS [isExternal],
       en.EntityIsActive AS [isActive],
-      en.DbCatalog AS [db.catalog],
-      en.DbSchema AS [db.schema],
+      en.DbCatalog AS [db_catalog],
+      en.DbSchema AS [db_schema],
       (
         SELECT
           a.AttrName AS [name],
@@ -102,12 +102,12 @@ SELECT
           a.IsIdentifier AS [isIdentifier],
           CASE WHEN a.RefEntityId IS NOT NULL THEN 1 ELSE 0 END AS [isReference],
           a.RefEntityId AS [refEntityId],
-          refEn.EntityName AS [refEntity.name],
-          refEn.PhysicalTableName AS [refEntity.physicalName],
-          a.DeleteRuleCode AS [reference.deleteRuleCode],
-          CASE WHEN a.RefEntityId IS NOT NULL AND (a.DeleteRuleCode IN ('Protect','Delete',1,2)) THEN 1 ELSE 0 END AS [reference.hasDbConstraint],
-          a.ExternalColumnType AS [external.dbType],
-          CASE WHEN a.AttrIsActive = 0 AND EXISTS (SELECT 1 FROM PhysCols pc WHERE pc.AttrId = a.AttrId) THEN 1 ELSE 0 END AS [physical.isPresentButInactive]
+          refEn.EntityName AS [refEntity_name],
+          refEn.PhysicalTableName AS [refEntity_physicalName],
+          a.DeleteRuleCode AS [reference_deleteRuleCode],
+          CASE WHEN a.RefEntityId IS NOT NULL AND (a.DeleteRuleCode IN ('Protect','Delete',1,2)) THEN 1 ELSE 0 END AS [reference_hasDbConstraint],
+          a.ExternalColumnType AS [external_dbType],
+          CASE WHEN a.AttrIsActive = 0 AND EXISTS (SELECT 1 FROM PhysCols pc WHERE pc.AttrId = a.AttrId) THEN 1 ELSE 0 END AS [physical_isPresentButInactive]
         FROM AttrAll a
         LEFT JOIN Ent refEn ON refEn.EntityId = a.RefEntityId
         WHERE a.EntityId = en.EntityId
@@ -118,8 +118,8 @@ SELECT
         SELECT DISTINCT
           f.AttrId AS [viaAttributeId],
           a.AttrName AS [viaAttributeName],
-          toEn.EntityName AS [toEntity.name],
-          toEn.PhysicalTableName AS [toEntity.physicalName],
+          toEn.EntityName AS [toEntity_name],
+          toEn.PhysicalTableName AS [toEntity_physicalName],
           a.DeleteRuleCode AS [deleteRuleCode],
           CASE WHEN a.DeleteRuleCode IN ('Protect','Delete',1,2) THEN 1 ELSE 0 END AS [hasDbConstraint]
         FROM RefMap f

--- a/src/Osm.Json/ModelJsonDeserializer.cs
+++ b/src/Osm.Json/ModelJsonDeserializer.cs
@@ -415,10 +415,10 @@ public sealed class ModelJsonDeserializer : IModelJsonDeserializer
         [JsonPropertyName("isActive")]
         public bool IsActive { get; init; } = true;
 
-        [JsonPropertyName("db.catalog")]
+        [JsonPropertyName("db_catalog")]
         public string? Catalog { get; init; }
 
-        [JsonPropertyName("db.schema")]
+        [JsonPropertyName("db_schema")]
         public string? Schema { get; init; }
 
         [JsonPropertyName("attributes")]
@@ -475,22 +475,22 @@ public sealed class ModelJsonDeserializer : IModelJsonDeserializer
         [JsonPropertyName("refEntityId")]
         public int? ReferenceEntityId { get; init; }
 
-        [JsonPropertyName("refEntity.name")]
+        [JsonPropertyName("refEntity_name")]
         public string? ReferenceEntityName { get; init; }
 
-        [JsonPropertyName("refEntity.physicalName")]
+        [JsonPropertyName("refEntity_physicalName")]
         public string? ReferenceEntityPhysicalName { get; init; }
 
-        [JsonPropertyName("reference.deleteRuleCode")]
+        [JsonPropertyName("reference_deleteRuleCode")]
         public string? ReferenceDeleteRuleCode { get; init; }
 
-        [JsonPropertyName("reference.hasDbConstraint")]
+        [JsonPropertyName("reference_hasDbConstraint")]
         public int? ReferenceHasDbConstraint { get; init; }
 
-        [JsonPropertyName("external.dbType")]
+        [JsonPropertyName("external_dbType")]
         public string? ExternalDbType { get; init; }
 
-        [JsonPropertyName("physical.isPresentButInactive")]
+        [JsonPropertyName("physical_isPresentButInactive")]
         public int PhysicalIsPresentButInactive { get; init; }
 
         [JsonPropertyName("reality")]
@@ -549,10 +549,10 @@ public sealed class ModelJsonDeserializer : IModelJsonDeserializer
         [JsonPropertyName("viaAttributeName")]
         public string? ViaAttributeName { get; init; }
 
-        [JsonPropertyName("toEntity.name")]
+        [JsonPropertyName("toEntity_name")]
         public string? TargetEntityName { get; init; }
 
-        [JsonPropertyName("toEntity.physicalName")]
+        [JsonPropertyName("toEntity_physicalName")]
         public string? TargetEntityPhysicalName { get; init; }
 
         [JsonPropertyName("deleteRuleCode")]

--- a/tests/Fixtures/model.edge-case.json
+++ b/tests/Fixtures/model.edge-case.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -28,12 +28,12 @@
               "isIdentifier": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "Email",
@@ -49,12 +49,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "FirstName",
@@ -70,12 +70,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "LastName",
@@ -91,12 +91,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "CityId",
@@ -112,12 +112,12 @@
               "isIdentifier": false,
               "isReference": 1,
               "refEntityId": 2001,
-              "refEntity.name": "City",
-              "refEntity.physicalName": "OSUSR_DEF_CITY",
-              "reference.deleteRuleCode": "Protect",
-              "reference.hasDbConstraint": 1,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": "City",
+              "refEntity_physicalName": "OSUSR_DEF_CITY",
+              "reference_deleteRuleCode": "Protect",
+              "reference_hasDbConstraint": 1,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "LegacyCode",
@@ -133,20 +133,20 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 1
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 1
             }
           ],
           "relationships": [
             {
               "viaAttributeId": 31001,
               "viaAttributeName": "CityId",
-              "toEntity.name": "City",
-              "toEntity.physicalName": "OSUSR_DEF_CITY",
+              "toEntity_name": "City",
+              "toEntity_physicalName": "OSUSR_DEF_CITY",
               "deleteRuleCode": "Protect",
               "hasDbConstraint": 1
             }
@@ -177,8 +177,8 @@
           "isStatic": true,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -194,12 +194,12 @@
               "isIdentifier": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "Name",
@@ -215,12 +215,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "IsActive",
@@ -236,12 +236,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "relationships": [],
@@ -269,8 +269,8 @@
           "isStatic": false,
           "isExternal": true,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "billing",
+          "db_catalog": null,
+          "db_schema": "billing",
           "attributes": [
             {
               "name": "Id",
@@ -286,12 +286,12 @@
               "isIdentifier": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": "int",
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": "int",
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "AccountNumber",
@@ -307,12 +307,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": "varchar(50)",
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": "varchar(50)",
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "ExtRef",
@@ -328,12 +328,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": "varchar(50)",
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": "varchar(50)",
+              "physical_isPresentButInactive": 0
             }
           ],
           "relationships": [],
@@ -361,8 +361,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -378,12 +378,12 @@
               "isIdentifier": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "TriggeredByUserId",
@@ -399,12 +399,12 @@
               "isIdentifier": false,
               "isReference": 1,
               "refEntityId": 1001,
-              "refEntity.name": "Customer",
-              "refEntity.physicalName": "OSUSR_ABC_CUSTOMER",
-              "reference.deleteRuleCode": "Ignore",
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": "Customer",
+              "refEntity_physicalName": "OSUSR_ABC_CUSTOMER",
+              "reference_deleteRuleCode": "Ignore",
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "CreatedOn",
@@ -420,20 +420,20 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "relationships": [
             {
               "viaAttributeId": 41003,
               "viaAttributeName": "TriggeredByUserId",
-              "toEntity.name": "Customer",
-              "toEntity.physicalName": "OSUSR_ABC_CUSTOMER",
+              "toEntity_name": "Customer",
+              "toEntity_physicalName": "OSUSR_ABC_CUSTOMER",
               "deleteRuleCode": "Ignore",
               "hasDbConstraint": 0
             }

--- a/tests/Fixtures/model.micro-fk-ignore.json
+++ b/tests/Fixtures/model.micro-fk-ignore.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -29,12 +29,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [],
@@ -46,8 +46,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -64,12 +64,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "AId",
@@ -86,12 +86,12 @@
               "isActive": true,
               "isReference": 1,
               "refEntityId": 1,
-              "refEntity.name": "A",
-              "refEntity.physicalName": "OSUSR_A",
-              "reference.deleteRuleCode": "Ignore",
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": "A",
+              "refEntity_physicalName": "OSUSR_A",
+              "reference_deleteRuleCode": "Ignore",
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [],
@@ -99,8 +99,8 @@
             {
               "viaAttributeId": 2,
               "viaAttributeName": "AId",
-              "toEntity.name": "A",
-              "toEntity.physicalName": "OSUSR_A",
+              "toEntity_name": "A",
+              "toEntity_physicalName": "OSUSR_A",
               "deleteRuleCode": "Ignore",
               "hasDbConstraint": 0
             }

--- a/tests/Fixtures/model.micro-fk-protect.json
+++ b/tests/Fixtures/model.micro-fk-protect.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -29,12 +29,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [],
@@ -46,8 +46,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -64,12 +64,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "ParentId",
@@ -86,12 +86,12 @@
               "isActive": true,
               "isReference": 1,
               "refEntityId": 1,
-              "refEntity.name": "Parent",
-              "refEntity.physicalName": "OSUSR_P_PARENT",
-              "reference.deleteRuleCode": "Protect",
-              "reference.hasDbConstraint": 1,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": "Parent",
+              "refEntity_physicalName": "OSUSR_P_PARENT",
+              "reference_deleteRuleCode": "Protect",
+              "reference_hasDbConstraint": 1,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [],
@@ -99,8 +99,8 @@
             {
               "viaAttributeId": 2,
               "viaAttributeName": "ParentId",
-              "toEntity.name": "Parent",
-              "toEntity.physicalName": "OSUSR_P_PARENT",
+              "toEntity_name": "Parent",
+              "toEntity_physicalName": "OSUSR_P_PARENT",
               "deleteRuleCode": "Protect",
               "hasDbConstraint": 1
             }

--- a/tests/Fixtures/model.micro-physical.json
+++ b/tests/Fixtures/model.micro-physical.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -28,12 +28,12 @@
               "isIdentifier": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "ExternalCode",
@@ -49,12 +49,12 @@
               "isIdentifier": false,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "relationships": [],

--- a/tests/Fixtures/model.micro-unique-composite.json
+++ b/tests/Fixtures/model.micro-unique-composite.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -29,12 +29,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "CountryId",
@@ -51,12 +51,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "DocumentId",
@@ -73,12 +73,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "Quantity",
@@ -95,12 +95,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [

--- a/tests/Fixtures/model.micro-unique.json
+++ b/tests/Fixtures/model.micro-unique.json
@@ -11,8 +11,8 @@
           "isStatic": false,
           "isExternal": false,
           "isActive": true,
-          "db.catalog": null,
-          "db.schema": "dbo",
+          "db_catalog": null,
+          "db_schema": "dbo",
           "attributes": [
             {
               "name": "Id",
@@ -29,12 +29,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             },
             {
               "name": "Email",
@@ -51,12 +51,12 @@
               "isActive": true,
               "isReference": 0,
               "refEntityId": null,
-              "refEntity.name": null,
-              "refEntity.physicalName": null,
-              "reference.deleteRuleCode": null,
-              "reference.hasDbConstraint": 0,
-              "external.dbType": null,
-              "physical.isPresentButInactive": 0
+              "refEntity_name": null,
+              "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null,
+              "reference_hasDbConstraint": 0,
+              "external_dbType": null,
+              "physical_isPresentButInactive": 0
             }
           ],
           "indexes": [

--- a/tests/Osm.Json.Tests/ModelJsonDeserializerTests.cs
+++ b/tests/Osm.Json.Tests/ModelJsonDeserializerTests.cs
@@ -27,7 +27,7 @@ public class ModelJsonDeserializerTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",
@@ -47,10 +47,10 @@ public class ModelJsonDeserializerTests
                       "isAutoNumber": false,
                       "isReference": 1,
                       "refEntityId": 100,
-                      "refEntity.name": "Customer",
-                      "refEntity.physicalName": "OSUSR_FIN_CUSTOMER",
-                      "reference.deleteRuleCode": "Protect",
-                      "reference.hasDbConstraint": 1,
+                      "refEntity_name": "Customer",
+                      "refEntity_physicalName": "OSUSR_FIN_CUSTOMER",
+                      "reference_deleteRuleCode": "Protect",
+                      "reference_hasDbConstraint": 1,
                       "isActive": true
                     },
                     {
@@ -63,14 +63,14 @@ public class ModelJsonDeserializerTests
                       "isIdentifier": false,
                       "isAutoNumber": false,
                       "isActive": false,
-                      "physical.isPresentButInactive": 1
+                      "physical_isPresentButInactive": 1
                     }
                   ],
                   "relationships": [
                     {
                       "viaAttributeName": "CustomerId",
-                      "toEntity.name": "Customer",
-                      "toEntity.physicalName": "OSUSR_FIN_CUSTOMER",
+                      "toEntity_name": "Customer",
+                      "toEntity_physicalName": "OSUSR_FIN_CUSTOMER",
                       "deleteRuleCode": "Protect",
                       "hasDbConstraint": 1
                     }
@@ -170,7 +170,7 @@ public class ModelJsonDeserializerTests
                 {
                   "name": "Invoice",
                   "physicalName": "OSUSR_FIN_INVOICE",
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",
@@ -239,7 +239,7 @@ public class ModelJsonDeserializerTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo"
+                  "db_schema": "dbo"
                 }
               ]
             }
@@ -268,7 +268,7 @@ public class ModelJsonDeserializerTests
                 {
                   "name": "Invoice",
                   "physicalName": "OSUSR_FIN_INVOICE",
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "CustomerId",
@@ -278,7 +278,7 @@ public class ModelJsonDeserializerTests
                       "isIdentifier": false,
                       "isAutoNumber": false,
                       "isReference": 1,
-                      "refEntity.physicalName": "OSUSR_FIN_CUSTOMER"
+                      "refEntity_physicalName": "OSUSR_FIN_CUSTOMER"
                     },
                     {
                       "name": "Id",
@@ -317,7 +317,7 @@ public class ModelJsonDeserializerTests
                 {
                   "name": "Invoice",
                   "physicalName": "OSUSR_FIN_INVOICE",
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "CustomerId",
@@ -327,7 +327,7 @@ public class ModelJsonDeserializerTests
                       "isIdentifier": false,
                       "isAutoNumber": false,
                       "isReference": 1,
-                      "refEntity.name": "Customer"
+                      "refEntity_name": "Customer"
                     },
                     {
                       "name": "Id",
@@ -371,7 +371,7 @@ public class ModelJsonDeserializerTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",
@@ -425,7 +425,7 @@ public class ModelJsonDeserializerTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",
@@ -444,7 +444,7 @@ public class ModelJsonDeserializerTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",

--- a/tests/Osm.Pipeline.Tests/ModelIngestionServiceTests.cs
+++ b/tests/Osm.Pipeline.Tests/ModelIngestionServiceTests.cs
@@ -33,7 +33,7 @@ public class ModelIngestionServiceTests
                   "isStatic": false,
                   "isExternal": false,
                   "isActive": true,
-                  "db.schema": "dbo",
+                  "db_schema": "dbo",
                   "attributes": [
                     {
                       "name": "Id",

--- a/tools/schema-validator/src/modelSchema.ts
+++ b/tools/schema-validator/src/modelSchema.ts
@@ -260,32 +260,32 @@ const attributeSchema = z
 
       return numeric;
     }),
-    "refEntity.name": optionalTrimmedString("Referenced entity logical name"),
-    "refEntity.physicalName": optionalTrimmedString("Referenced entity physical name"),
-    "reference.deleteRuleCode": optionalTrimmedString("Reference delete rule code"),
-    "reference.hasDbConstraint": z
+    refEntity_name: optionalTrimmedString("Referenced entity logical name"),
+    refEntity_physicalName: optionalTrimmedString("Referenced entity physical name"),
+    reference_deleteRuleCode: optionalTrimmedString("Reference delete rule code"),
+    reference_hasDbConstraint: z
       .union([boolish, z.null(), z.undefined()])
       .transform((value) => (value === null || value === undefined ? null : value)),
-    "external.dbType": optionalTrimmedString("External database type"),
-    "physical.isPresentButInactive": boolish,
+    external_dbType: optionalTrimmedString("External database type"),
+    physical_isPresentButInactive: boolish,
     reality: z.union([attributeRealitySchema, z.null(), z.undefined()])
   })
   .strict()
   .superRefine((attribute, ctx) => {
     if (attribute.isReference) {
-      if (!attribute["refEntity.name"]) {
+      if (!attribute.refEntity_name) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Referenced entity logical name is required when isReference is true.",
-          path: ["refEntity.name"]
+          path: ["refEntity_name"]
         });
       }
 
-      if (!attribute["refEntity.physicalName"]) {
+      if (!attribute.refEntity_physicalName) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Referenced entity physical name is required when isReference is true.",
-          path: ["refEntity.physicalName"]
+          path: ["refEntity_physicalName"]
         });
       }
     }
@@ -300,17 +300,20 @@ const attributeSchema = z
         hasDuplicates: null,
         hasOrphans: null
       }),
-      isPresentButInactive: attribute["physical.isPresentButInactive"]
+      isPresentButInactive: attribute.physical_isPresentButInactive
     };
 
     const reference: AttributeReference = isReference
       ? {
           isReference: true,
           targetEntityId: attribute.refEntityId,
-          targetEntityName: attribute["refEntity.name"]!,
-          targetEntityPhysicalName: attribute["refEntity.physicalName"]!,
-          deleteRuleCode: attribute["reference.deleteRuleCode"] ?? null,
-          hasDbConstraint: attribute["reference.hasDbConstraint"] === null ? false : attribute["reference.hasDbConstraint"]!
+          targetEntityName: attribute.refEntity_name!,
+          targetEntityPhysicalName: attribute.refEntity_physicalName!,
+          deleteRuleCode: attribute.reference_deleteRuleCode ?? null,
+          hasDbConstraint:
+            attribute.reference_hasDbConstraint === null
+              ? false
+              : attribute.reference_hasDbConstraint!
         }
       : {
           isReference: false,
@@ -334,7 +337,7 @@ const attributeSchema = z
       isIdentifier: attribute.isIdentifier,
       isAutoNumber: attribute.isAutoNumber,
       isActive: attribute.isActive,
-      externalDbType: attribute["external.dbType"],
+      externalDbType: attribute.external_dbType,
       reference,
       reality
     };
@@ -401,8 +404,8 @@ const relationshipSchema = z
   .object({
     viaAttributeId: z.union([z.number(), z.string(), z.null(), z.undefined()]).optional(),
     viaAttributeName: requiredIdentifier("Relationship attribute name"),
-    "toEntity.name": requiredIdentifier("Relationship target entity name"),
-    "toEntity.physicalName": requiredIdentifier("Relationship target entity physical name"),
+    toEntity_name: requiredIdentifier("Relationship target entity name"),
+    toEntity_physicalName: requiredIdentifier("Relationship target entity physical name"),
     deleteRuleCode: optionalTrimmedString("Relationship delete rule code"),
     hasDbConstraint: z.union([boolish, z.null(), z.undefined()]).transform((value) =>
       value === null || value === undefined ? false : value
@@ -411,8 +414,8 @@ const relationshipSchema = z
   .strict()
   .transform((relationship) => ({
     viaAttributeName: relationship.viaAttributeName,
-    toEntityName: relationship["toEntity.name"],
-    toEntityPhysicalName: relationship["toEntity.physicalName"],
+    toEntityName: relationship.toEntity_name,
+    toEntityPhysicalName: relationship.toEntity_physicalName,
     deleteRuleCode:
       relationship.deleteRuleCode && relationship.deleteRuleCode.length > 0
         ? relationship.deleteRuleCode
@@ -442,8 +445,8 @@ const entitySchema = z
     isStatic: boolish,
     isExternal: boolish,
     isActive: boolish,
-    "db.catalog": optionalTrimmedString("Entity catalog"),
-    "db.schema": requiredIdentifier("Entity schema"),
+    db_catalog: optionalTrimmedString("Entity catalog"),
+    db_schema: requiredIdentifier("Entity schema"),
     attributes: z.array(attributeSchema),
     indexes: optionalArray(indexSchema),
     relationships: optionalArray(relationshipSchema)
@@ -489,8 +492,8 @@ const entitySchema = z
   .transform((entity) => ({
     name: entity.name,
     physicalName: entity.physicalName,
-    schema: entity["db.schema"],
-    catalog: entity["db.catalog"],
+    schema: entity.db_schema,
+    catalog: entity.db_catalog,
     isStatic: entity.isStatic,
     isExternal: entity.isExternal,
     isActive: entity.isActive,


### PR DESCRIPTION
## Summary
- replace dotted JSON aliases in the Advanced SQL exporter with underscore names so JSON_QUERY emits stable properties
- update the schema validator, JSON deserializer, fixtures, and documentation to use the new field names consistently

## Testing
- dotnet build OutSystemsModelToSql.sln -c Release --no-restore
- dotnet test OutSystemsModelToSql.sln -c Release --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dc94914164832ba7a5c8be481e5fd3