### PR TITLE
Fix profiler row count query syntax and filter targeted tables

### DIFF
--- a/src/Osm.Pipeline/Properties/AssemblyInfo.cs
+++ b/src/Osm.Pipeline/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Osm.Pipeline.Tests")]

--- a/tests/Osm.Pipeline.Tests/SqlDataProfilerCommandBuilderTests.cs
+++ b/tests/Osm.Pipeline.Tests/SqlDataProfilerCommandBuilderTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using Microsoft.Data.SqlClient;
+using Osm.Pipeline.Profiling;
+using Xunit;
+
+namespace Osm.Pipeline.Tests;
+
+public sealed class SqlDataProfilerCommandBuilderTests
+{
+    [Fact]
+    public void BuildTableFilterClause_AddsParametersForEachTable()
+    {
+        using var command = new SqlCommand();
+        var tables = new (string Schema, string Table)[]
+        {
+            ("dbo", "OSUSR_A_ENTITY"),
+            ("sales", "ORDERS")
+        };
+
+        var clause = SqlDataProfiler.BuildTableFilterClause(command, tables, "s.name", "t.name");
+
+        Assert.Equal(
+            "EXISTS (SELECT 1 FROM (VALUES (@schema0, @table0), (@schema1, @table1)) AS targets(SchemaName, TableName) WHERE targets.SchemaName = s.name AND targets.TableName = t.name)",
+            clause);
+        Assert.Equal(4, command.Parameters.Count);
+        Assert.Collection(command.Parameters.Cast<SqlParameter>(),
+            parameter =>
+            {
+                Assert.Equal("@schema0", parameter.ParameterName);
+                Assert.Equal("dbo", parameter.Value);
+            },
+            parameter =>
+            {
+                Assert.Equal("@table0", parameter.ParameterName);
+                Assert.Equal("OSUSR_A_ENTITY", parameter.Value);
+            },
+            parameter =>
+            {
+                Assert.Equal("@schema1", parameter.ParameterName);
+                Assert.Equal("sales", parameter.Value);
+            },
+            parameter =>
+            {
+                Assert.Equal("@table1", parameter.ParameterName);
+                Assert.Equal("ORDERS", parameter.Value);
+            });
+    }
+
+    [Fact]
+    public void BuildTableFilterClause_ReturnsFalseClause_WhenTableListEmpty()
+    {
+        using var command = new SqlCommand();
+
+        var clause = SqlDataProfiler.BuildTableFilterClause(command, Array.Empty<(string Schema, string Table)>(), "s.name", "t.name");
+
+        Assert.Equal("1 = 0", clause);
+        Assert.Empty(command.Parameters);
+    }
+}


### PR DESCRIPTION
## Summary
- quote the row count alias and filter metadata/row count queries to the requested tables to avoid syntax errors and unnecessary scanning
- factor the shared table filter builder so commands add parameters safely and expose it internally for reuse
- cover the new filter helper with unit tests and allow the pipeline test assembly to access internals

## Testing
- dotnet build OutSystemsModelToSql.sln -c Release --no-restore
- dotnet test OutSystemsModelToSql.sln -c Release --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dca2ce3158832b9c9d1074eae28d69