### PR TITLE
Add entity naming overrides for emissions and comparisons

### DIFF
--- a/config/default-tightening.json
+++ b/config/default-tightening.json
@@ -27,7 +27,8 @@
     "sanitizeModuleNames": true,
     "emitConcatenatedConstraints": false,
     "namingOverrides": {
-      "tables": []
+      "tables": [],
+      "entities": []
     }
   },
   "mocking": {

--- a/src/Osm.Cli/Program.cs
+++ b/src/Osm.Cli/Program.cs
@@ -409,7 +409,7 @@ static async Task<int> RunDmmCompareAsync(string[] args)
     }
 
     var comparator = new DmmComparator();
-    var comparison = comparator.Compare(smoModel, parseResult.Value);
+    var comparison = comparator.Compare(smoModel, parseResult.Value, tighteningOptions.Emission.NamingOverrides);
 
     string diffArtifactPath;
     try

--- a/src/Osm.Emission/SsdtEmitter.cs
+++ b/src/Osm.Emission/SsdtEmitter.cs
@@ -59,7 +59,11 @@ public sealed class SsdtEmitter
             var indexesRoot = modulePaths.IndexesRoot;
             var foreignKeysRoot = modulePaths.ForeignKeysRoot;
 
-            var effectiveTableName = options.NamingOverrides.GetEffectiveTableName(table.Schema, table.Name, table.LogicalName);
+            var effectiveTableName = options.NamingOverrides.GetEffectiveTableName(
+                table.Schema,
+                table.Name,
+                table.LogicalName,
+                table.OriginalModule);
             var tableStatement = BuildCreateTableStatement(table, effectiveTableName);
             var tableScript = Script(tableStatement);
             var tableFilePath = Path.Combine(tablesRoot, $"{table.Schema}.{effectiveTableName}.sql");
@@ -104,7 +108,8 @@ public sealed class SsdtEmitter
                 var referencedTableName = options.NamingOverrides.GetEffectiveTableName(
                     foreignKey.ReferencedSchema,
                     foreignKey.ReferencedTable,
-                    foreignKey.ReferencedLogicalTable);
+                    foreignKey.ReferencedLogicalTable,
+                    foreignKey.ReferencedModule);
                 var foreignKeyName = ResolveConstraintName(foreignKey.Name, table.Name, table.LogicalName, effectiveTableName);
                 var fkStatement = BuildForeignKeyStatement(
                     table,

--- a/src/Osm.Smo/SmoModel.cs
+++ b/src/Osm.Smo/SmoModel.cs
@@ -20,6 +20,7 @@ public sealed record SmoModel(ImmutableArray<SmoTableDefinition> Tables)
 
 public sealed record SmoTableDefinition(
     string Module,
+    string OriginalModule,
     string Name,
     string Schema,
     string Catalog,
@@ -49,6 +50,7 @@ public sealed record SmoIndexColumnDefinition(string Name, int Ordinal);
 public sealed record SmoForeignKeyDefinition(
     string Name,
     string Column,
+    string ReferencedModule,
     string ReferencedTable,
     string ReferencedSchema,
     string ReferencedColumn,

--- a/src/Osm.Smo/SmoModelFactory.cs
+++ b/src/Osm.Smo/SmoModelFactory.cs
@@ -75,6 +75,7 @@ public sealed class SmoModelFactory
 
         return new SmoTableDefinition(
             moduleName,
+            context.ModuleName,
             context.Entity.PhysicalName.Value,
             context.Entity.Schema.Value,
             catalog,
@@ -278,6 +279,7 @@ public sealed class SmoModelFactory
             builder.Add(new SmoForeignKeyDefinition(
                 name,
                 attribute.LogicalName.Value,
+                targetEntity.ModuleName,
                 targetEntity.Entity.PhysicalName.Value,
                 targetEntity.Entity.Schema.Value,
                 referencedColumn.LogicalName.Value,


### PR DESCRIPTION
## Summary
- add entity-level naming overrides to `NamingOverrideOptions` and expose JSON configuration support
- ensure SMO emission, CLI DMM comparison, and related domain services honor entity overrides alongside table overrides
- expand domain, emission, JSON, and comparator tests to cover entity renaming and update default configs

## Testing
- dotnet test OutSystemsModelToSql.sln -c Release

------
https://chatgpt.com/codex/tasks/task_e_68dcaf761f60832b8656056d52650f71