### PR TITLE
Unify naming override rules across configuration and CLI

### DIFF
--- a/config/default-tightening.json
+++ b/config/default-tightening.json
@@ -27,8 +27,7 @@
     "sanitizeModuleNames": true,
     "emitConcatenatedConstraints": false,
     "namingOverrides": {
-      "tables": [],
-      "entities": []
+      "rules": []
     }
   },
   "mocking": {

--- a/tests/Osm.Cli.Tests/Configuration/CliConfigurationLoaderTests.cs
+++ b/tests/Osm.Cli.Tests/Configuration/CliConfigurationLoaderTests.cs
@@ -123,7 +123,7 @@ public sealed class CliConfigurationLoaderTests
                 includePlatformAutoIndexes = false,
                 sanitizeModuleNames = true,
                 emitConcatenatedConstraints = false,
-                namingOverrides = new { tables = Array.Empty<object>() }
+                namingOverrides = new { rules = Array.Empty<object>() }
             },
             mocking = new { useProfileMockFolder = false, profileMockFolder = (string?)null }
         });

--- a/tests/Osm.Dmm.Tests/DmmComparatorTests.cs
+++ b/tests/Osm.Dmm.Tests/DmmComparatorTests.cs
@@ -164,9 +164,9 @@ public class DmmComparatorTests
     [Fact]
     public void Compare_honors_entity_name_overrides()
     {
-        var overrideResult = EntityNamingOverride.Create(null, "Customer", "CUSTOMER_EXTERNAL");
+        var overrideResult = NamingOverrideRule.Create(null, null, null, "Customer", "CUSTOMER_EXTERNAL");
         Assert.True(overrideResult.IsSuccess);
-        var namingOverrides = NamingOverrideOptions.Create(null, new[] { overrideResult.Value });
+        var namingOverrides = NamingOverrideOptions.Create(new[] { overrideResult.Value });
         Assert.True(namingOverrides.IsSuccess);
 
         var renamedScript = EdgeCaseScript.Replace("OSUSR_ABC_CUSTOMER", "CUSTOMER_EXTERNAL");
@@ -199,9 +199,9 @@ public class DmmComparatorTests
         var smoOptions = SmoBuildOptions.FromEmission(options.Emission);
         var smoModel = new SmoModelFactory().Create(mutatedModel, decisions, smoOptions);
 
-        var overrideResult = EntityNamingOverride.Create("App Core", "Customer", "CUSTOMER_EXTERNAL");
+        var overrideResult = NamingOverrideRule.Create(null, null, "App Core", "Customer", "CUSTOMER_EXTERNAL");
         Assert.True(overrideResult.IsSuccess);
-        var namingOverrides = NamingOverrideOptions.Create(null, new[] { overrideResult.Value });
+        var namingOverrides = NamingOverrideOptions.Create(new[] { overrideResult.Value });
         Assert.True(namingOverrides.IsSuccess);
 
         var renamedScript = EdgeCaseScript.Replace("OSUSR_ABC_CUSTOMER", "CUSTOMER_EXTERNAL");

--- a/tests/Osm.Etl.Integration.Tests/EmissionPipelineTests.cs
+++ b/tests/Osm.Etl.Integration.Tests/EmissionPipelineTests.cs
@@ -57,7 +57,7 @@ public class EmissionPipelineTests
         var model = await LoadModelAsync(modelPath);
         var profile = await LoadProfileAsync(profilePath);
 
-        var overrideResult = TableNamingOverride.Create("dbo", "OSUSR_ABC_CUSTOMER", "CUSTOMER_PORTAL");
+        var overrideResult = NamingOverrideRule.Create("dbo", "OSUSR_ABC_CUSTOMER", null, null, "CUSTOMER_PORTAL");
         Assert.True(overrideResult.IsSuccess, string.Join(Environment.NewLine, overrideResult.Errors.Select(e => e.Message)));
 
         var overrideOptions = NamingOverrideOptions.Create(new[] { overrideResult.Value });

--- a/tests/Osm.Json.Tests/TighteningOptionsDeserializerTests.cs
+++ b/tests/Osm.Json.Tests/TighteningOptionsDeserializerTests.cs
@@ -48,7 +48,7 @@ public class TighteningOptionsDeserializerTests
     [Fact]
     public void Deserialize_Should_Parse_Entity_Naming_Overrides()
     {
-        const string json = "{ \"policy\": { \"mode\": \"EvidenceGated\", \"nullBudget\": 0.0 }, \"foreignKeys\": { \"enableCreation\": true, \"allowCrossSchema\": false, \"allowCrossCatalog\": false }, \"uniqueness\": { \"enforceSingleColumnUnique\": true, \"enforceMultiColumnUnique\": true }, \"remediation\": { \"generatePreScripts\": true, \"sentinels\": { \"numeric\": \"0\", \"text\": \"\", \"date\": \"1900-01-01\" }, \"maxRowsDefaultBackfill\": 10 }, \"emission\": { \"perTableFiles\": true, \"includePlatformAutoIndexes\": false, \"sanitizeModuleNames\": true, \"emitConcatenatedConstraints\": false, \"namingOverrides\": { \"entities\": [ { \"module\": null, \"entity\": \"Customer\", \"override\": \"CUSTOMER_EXTERNAL\" } ] } }, \"mocking\": { \"useProfileMockFolder\": false, \"profileMockFolder\": null } }";
+        const string json = "{ \"policy\": { \"mode\": \"EvidenceGated\", \"nullBudget\": 0.0 }, \"foreignKeys\": { \"enableCreation\": true, \"allowCrossSchema\": false, \"allowCrossCatalog\": false }, \"uniqueness\": { \"enforceSingleColumnUnique\": true, \"enforceMultiColumnUnique\": true }, \"remediation\": { \"generatePreScripts\": true, \"sentinels\": { \"numeric\": \"0\", \"text\": \"\", \"date\": \"1900-01-01\" }, \"maxRowsDefaultBackfill\": 10 }, \"emission\": { \"perTableFiles\": true, \"includePlatformAutoIndexes\": false, \"sanitizeModuleNames\": true, \"emitConcatenatedConstraints\": false, \"namingOverrides\": { \"rules\": [ { \"module\": null, \"entity\": \"Customer\", \"override\": \"CUSTOMER_EXTERNAL\" } ] } }, \"mocking\": { \"useProfileMockFolder\": false, \"profileMockFolder\": null } }";
         using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
 
         var result = _deserializer.Deserialize(stream);
@@ -59,4 +59,19 @@ public class TighteningOptionsDeserializerTests
         Assert.Equal("CUSTOMER_EXTERNAL", tableName.Value);
     }
 
+    [Fact]
+    public void Deserialize_Should_Honor_Legacy_Table_And_Entity_Collections()
+    {
+        const string json = "{ \"policy\": { \"mode\": \"EvidenceGated\", \"nullBudget\": 0.0 }, \"foreignKeys\": { \"enableCreation\": true, \"allowCrossSchema\": false, \"allowCrossCatalog\": false }, \"uniqueness\": { \"enforceSingleColumnUnique\": true, \"enforceMultiColumnUnique\": true }, \"remediation\": { \"generatePreScripts\": true, \"sentinels\": { \"numeric\": \"0\", \"text\": \"\", \"date\": \"1900-01-01\" }, \"maxRowsDefaultBackfill\": 10 }, \"emission\": { \"perTableFiles\": true, \"includePlatformAutoIndexes\": false, \"sanitizeModuleNames\": true, \"emitConcatenatedConstraints\": false, \"namingOverrides\": { \"tables\": [ { \"schema\": \"dbo\", \"table\": \"OSUSR_ABC_CUSTOMER\", \"override\": \"CUSTOMER_PORTAL\" } ], \"entities\": [ { \"module\": \"Sales\", \"entity\": \"Customer\", \"override\": \"CUSTOMER_EXTERNAL\" } ] } }, \"mocking\": { \"useProfileMockFolder\": false, \"profileMockFolder\": null } }";
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+
+        var result = _deserializer.Deserialize(stream);
+
+        Assert.True(result.IsSuccess);
+        var namingOverrides = result.Value.Emission.NamingOverrides;
+        Assert.True(namingOverrides.TryGetTableOverride("dbo", "OSUSR_ABC_CUSTOMER", out var physical));
+        Assert.Equal("CUSTOMER_PORTAL", physical);
+        Assert.True(namingOverrides.TryGetEntityOverride("Sales", "Customer", out var logical));
+        Assert.Equal("CUSTOMER_EXTERNAL", logical.Value);
+    }
 }


### PR DESCRIPTION
## Summary
- replace the table/entity naming override collections with unified rules that track both physical and logical coordinates
- extend CLI/configuration parsing and documentation to emit the new rule entries, including support for the combined `schema.table|Module::Entity` syntax
- refresh domain, emission, CLI, and JSON tests to cover the rule workflow while keeping legacy table/entity arrays backwards compatible

## Testing
- dotnet test OutSystemsModelToSql.sln -c Release --logger "console;verbosity=minimal"

------
https://chatgpt.com/codex/tasks/task_e_68de9fe7beec832b889f066cd2f6eb03