### PR TITLE
Handle duplicate entity logical names

### DIFF
--- a/src/Osm.Domain/Configuration/NamingOverrideOptions.cs
+++ b/src/Osm.Domain/Configuration/NamingOverrideOptions.cs
@@ -168,6 +168,29 @@ public sealed record NamingOverrideOptions
         return false;
     }
 
+    public bool TryGetModuleScopedEntityOverride(string module, string logicalName, out TableName overrideName)
+    {
+        if (module is null)
+        {
+            throw new ArgumentNullException(nameof(module));
+        }
+
+        if (logicalName is null)
+        {
+            throw new ArgumentNullException(nameof(logicalName));
+        }
+
+        var key = EntityKey(module, logicalName);
+        if (_entityOverrides.TryGetValue(key, out var value))
+        {
+            overrideName = value;
+            return true;
+        }
+
+        overrideName = default;
+        return false;
+    }
+
     public string GetEffectiveTableName(string schema, string table, string? logicalName = null, string? module = null)
     {
         if (TryGetTableOverride(schema, table, out var overrideName))

--- a/src/Osm.Validation/Tightening/PolicyDecisionReporter.cs
+++ b/src/Osm.Validation/Tightening/PolicyDecisionReporter.cs
@@ -39,7 +39,20 @@ public static class PolicyDecisionReporter
         var uniqueRationales = AggregateRationales(uniqueIndexReports.SelectMany(r => r.Rationales));
         var foreignKeyRationales = AggregateRationales(foreignKeyReports.SelectMany(r => r.Rationales));
 
-        return new PolicyDecisionReport(columnReports, uniqueIndexReports, foreignKeyReports, columnRationales, uniqueRationales, foreignKeyRationales);
+        var diagnostics = decisions.Diagnostics
+            .OrderBy(d => d.Severity)
+            .ThenBy(d => d.LogicalName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(d => d.CanonicalModule, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
+
+        return new PolicyDecisionReport(
+            columnReports,
+            uniqueIndexReports,
+            foreignKeyReports,
+            columnRationales,
+            uniqueRationales,
+            foreignKeyRationales,
+            diagnostics);
     }
 
     private static ImmutableDictionary<string, int> AggregateRationales(IEnumerable<string> rationales)
@@ -68,7 +81,8 @@ public sealed record PolicyDecisionReport(
     ImmutableArray<ForeignKeyDecisionReport> ForeignKeys,
     ImmutableDictionary<string, int> ColumnRationaleCounts,
     ImmutableDictionary<string, int> UniqueIndexRationaleCounts,
-    ImmutableDictionary<string, int> ForeignKeyRationaleCounts)
+    ImmutableDictionary<string, int> ForeignKeyRationaleCounts,
+    ImmutableArray<TighteningDiagnostic> Diagnostics)
 {
     public int ColumnCount => Columns.Length;
 

--- a/src/Osm.Validation/Tightening/PolicyDecisionSet.cs
+++ b/src/Osm.Validation/Tightening/PolicyDecisionSet.cs
@@ -5,11 +5,13 @@ namespace Osm.Validation.Tightening;
 public sealed record PolicyDecisionSet(
     ImmutableDictionary<ColumnCoordinate, NullabilityDecision> Nullability,
     ImmutableDictionary<ColumnCoordinate, ForeignKeyDecision> ForeignKeys,
-    ImmutableDictionary<IndexCoordinate, UniqueIndexDecision> UniqueIndexes)
+    ImmutableDictionary<IndexCoordinate, UniqueIndexDecision> UniqueIndexes,
+    ImmutableArray<TighteningDiagnostic> Diagnostics)
 {
     public static PolicyDecisionSet Create(
         ImmutableDictionary<ColumnCoordinate, NullabilityDecision> nullability,
         ImmutableDictionary<ColumnCoordinate, ForeignKeyDecision> foreignKeys,
-        ImmutableDictionary<IndexCoordinate, UniqueIndexDecision> uniqueIndexes)
-        => new(nullability, foreignKeys, uniqueIndexes);
+        ImmutableDictionary<IndexCoordinate, UniqueIndexDecision> uniqueIndexes,
+        ImmutableArray<TighteningDiagnostic> diagnostics)
+        => new(nullability, foreignKeys, uniqueIndexes, diagnostics);
 }

--- a/src/Osm.Validation/Tightening/TighteningDiagnostic.cs
+++ b/src/Osm.Validation/Tightening/TighteningDiagnostic.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+
+namespace Osm.Validation.Tightening;
+
+public enum TighteningDiagnosticSeverity
+{
+    Info = 0,
+    Warning = 1
+}
+
+public sealed record TighteningDuplicateCandidate(string Module, string Schema, string PhysicalName);
+
+public sealed record TighteningDiagnostic(
+    string Code,
+    string Message,
+    TighteningDiagnosticSeverity Severity,
+    string LogicalName,
+    string CanonicalModule,
+    string CanonicalSchema,
+    string CanonicalPhysicalName,
+    ImmutableArray<TighteningDuplicateCandidate> Candidates,
+    bool ResolvedByOverride);

--- a/tests/Fixtures/emission/edge-case-rename/policy-decisions.json
+++ b/tests/Fixtures/emission/edge-case-rename/policy-decisions.json
@@ -242,5 +242,6 @@
         "DELETE_RULE_IGNORE"
       ]
     }
-  ]
+  ],
+  "Diagnostics": []
 }

--- a/tests/Fixtures/emission/edge-case/policy-decisions.json
+++ b/tests/Fixtures/emission/edge-case/policy-decisions.json
@@ -242,5 +242,6 @@
         "DELETE_RULE_IGNORE"
       ]
     }
-  ]
+  ],
+  "Diagnostics": []
 }

--- a/tests/Osm.Smo.Tests/SmoModelFactoryTests.cs
+++ b/tests/Osm.Smo.Tests/SmoModelFactoryTests.cs
@@ -190,7 +190,8 @@ public class SmoModelFactoryTests
         var decisions = PolicyDecisionSet.Create(
             ImmutableDictionary<ColumnCoordinate, NullabilityDecision>.Empty,
             ImmutableDictionary<ColumnCoordinate, ForeignKeyDecision>.Empty.Add(fkCoordinate, foreignKeyDecision),
-            ImmutableDictionary<IndexCoordinate, UniqueIndexDecision>.Empty);
+            ImmutableDictionary<IndexCoordinate, UniqueIndexDecision>.Empty,
+            ImmutableArray<TighteningDiagnostic>.Empty);
 
         var factory = new SmoModelFactory();
         var smoOptions = SmoBuildOptions.FromEmission(TighteningOptions.Default.Emission);

--- a/tests/Osm.Validation.Tests/Policy/DecisionReportTests.cs
+++ b/tests/Osm.Validation.Tests/Policy/DecisionReportTests.cs
@@ -36,5 +36,7 @@ public sealed class DecisionReportTests
 
         var suppressedForeignKey = Assert.Single(report.ForeignKeys.Where(f => !f.CreateConstraint));
         Assert.Contains(TighteningRationales.DeleteRuleIgnore, suppressedForeignKey.Rationales);
+
+        Assert.Empty(report.Diagnostics);
     }
 }


### PR DESCRIPTION
## Summary
- group entities by logical name during tightening, honoring module-scoped naming overrides and emitting diagnostics for duplicates
- surface tightening diagnostics through the policy decision set, decision report, CLI warnings, and decision logs
- add regression coverage for duplicate logical name handling and update fixtures to include diagnostic metadata

## Testing
- dotnet build OutSystemsModelToSql.sln -c Release --no-restore
- dotnet test OutSystemsModelToSql.sln -c Release --no-build

------
https://chatgpt.com/codex/tasks/task_e_68dec4723610832b8df9356c61f1f606