### PR TITLE
C.2: Implement special-circumstances axis with operator allowlists

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -18915,3 +18915,95 @@ The two failure modes share a root cause family: **defaulting to structured/dest
 - `sidecar/projection/HANDOFF.md` — restored to carry slice-C.1 mid-chapter letter PLUS the preserved chapter-B.4 close letter (which the prior commit had clobbered); the slice-C.1 letter rewritten as prose addressed to the next agent.
 - `DECISIONS 2026-05-20 (test-failure capture protocol)` — sibling codification from the same session; same shape (recurring agent failure mode → structural protocol in CLAUDE.md operating disciplines).
 
+
+## 2026-05-20 (slice C.2 — special-circumstances axis full lift) — operator allowlists for missing-PK targets + circular-dependency cycles bind from config, structural scan emits typed DiagnosticEntries through the LogSink envelope stream, matching findings carry Metadata.acceptedVia annotation per the annotate-don't-suppress discipline
+
+### Context
+
+Per the chapter-C slice queue + `DECISIONS 2026-05-19 (chapter B.4 hygiene strike + axis-survey supplement)`: C.2 is the special-circumstances axis — operator config publishes "I've already acknowledged these source defects." Two findings: missing primary keys on referenced kinds; unresolved circular FK dependencies. Both signals exist internally in V2 today (`SymmetricClosure` skips inverse-creation with `ClosureSkipped TargetHasNoPrimaryKey`; `TopologicalOrderPass.runWith` returns `TopologicalOrder.Cycles : CycleDiagnostic list`) but neither flows to the operator-visible `DiagnosticEntry` stream or to LogSink. The dormant `Overrides.CircularDependencies.AllowedCycles` config section parses but has no consumer; `Model.ValidationOverrides.AllowMissingPrimaryKey` lives in the wrong location (Model vs Overrides) and parses as bare strings rather than typed entries.
+
+### Two principal-PO scope decisions at slice open
+
+(a) **AllowMissingPrimaryKey ref shape.** Three options — copy `TighteningBinding`'s logical-or-physical `SsKey` ref form (uniform Chapter C surface; ~20 LOC more); typed `(Module × Entity)` tuples at parse time (lighter, no physical fallback, divergent from C.1); bare-string `"Module.Entity"` form (simplest). **Decision: typed `(Module × Entity)` tuples** (`Config.LogicalName list`) — V2 already names this shape (`LogicalName`); operator-readable; no physical-fallback complexity. Resolution to typed `SsKey` happens at bind time via a new `SpecialCircumstancesBinding` mirror of TighteningBinding.
+
+(b) **CircularDependencies + AllowMissingPrimaryKey consumer disposition.** Three options — annotate as accepted + keep diagnostic visible (per slice-6 reshape lesson "actionability = enrichment + presentation, NOT occlusion"); suppress outright when allowlisted; bifurcate. **Decision: annotate-don't-suppress** for both axes — the diagnostic stream still carries the source-defect finding; matching entries receive `Metadata.acceptedVia = "config:overrides.<axis>"` so downstream consumers see the acceptance state without occluding the underlying defect.
+
+### Scope adjustment at slice open
+
+The principal-PO's annotate-don't-suppress decision presumed a DiagnosticEntry stream that **doesn't exist today** for these signals (missing-PK lives in `LineageEvent.Annotated`; cycles in `TopologicalOrder.Cycles`; neither routes to LogSink). Three scope options — binder + pure-F# reconciliation function only (lightest); binder + structured-payload Acceptance field extension (medium); full lift including new DiagnosticEntry emission sites + LogSink routing (largest). **Decision: full lift**, accepting the slice budget overrun risk (5-7h vs the architect's 3-5h target). The full lift is what makes the operator-visible "accepted" surface actually operator-visible.
+
+### What shipped
+
+**Approach decision (load-bearing).** Rather than reshape every pass's return type (would cascade through ~70 consumer sites for `TopologicalOrderPass` alone, plus ~19 for `SymmetricClosure`), C.2 adds a **new pure-additive scan step** that observes the post-chain `Catalog` + `ComposeState` and emits `DiagnosticEntry`s with acceptance annotation in one pass. Zero pass-internal changes; mirrors the "consumer pass" framing the slice-C.1 architect's HANDOFF letter named.
+
+**`src/Projection.Pipeline/Config.fs` (~50 LOC delta)** — schema reshape:
+- `Model.ValidationOverrides.AllowMissingPrimaryKey` (parse-only `string list`) **removed**; replaced by `Overrides.AllowMissingPrimaryKey : LogicalName list`. The old location was structurally wrong (Model owns catalog source; Overrides owns operator-driven catalog rewrites/annotations); the new location matches the architect's mental model in the slice-C.1 HANDOFF letter + matches `Overrides.CircularDependencies`'s neighborhood. Reshaping the type from bare strings to typed `LogicalName` per the operator decision.
+- New `parseAllowMissingPrimaryKey` parser — reads array of `{ module, entity }` objects via the existing `parseLogicalName` helper; structured `pipeline.config.typeMismatch` errors for non-object entries / non-array roots.
+
+**`src/Projection.Pipeline/SpecialCircumstancesBinding.fs` (~150 LOC NEW)** — the binder + the typed runtime value:
+- `type AcceptanceState = NotAccepted | AcceptedByConfig of source: string`.
+- `type SpecialCircumstances = { AllowedMissingPrimaryKeys : Set<SsKey>; AllowedCycles : Set<Set<SsKey>> }` + `SpecialCircumstances.empty`.
+- `resolveKindByLogical : Catalog -> LogicalName -> Result<SsKey>` — module-then-entity lookup; `pipeline.specialCircumstances.allowMissingPk.unresolved` on miss.
+- `resolveKindByPhysicalTable : Catalog -> string -> Result<SsKey>` — for cycle entries (V1's `CircularDependencyEntry.TableName` is physical); `pipeline.specialCircumstances.allowedCycle.unresolved` on miss. Schema disambiguation deferred — current cycles config doesn't carry schema (IR-grows-under-evidence).
+- `bindCycle` — resolves each `TableOrdering` entry's `TableName` and folds into a `Set<SsKey>` (set semantics so cycle-matching is order-independent).
+- `bindAllowMissingPrimaryKey` + `bindAllowedCycles` — typed-set producers from config sections.
+- `fromConfig : Catalog -> Config.Config -> Result<SpecialCircumstances>` — aggregates per-axis errors so the operator sees every malformed entry in one pass.
+
+**`src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs` (~140 LOC NEW)** — the scan + annotation step:
+- `kindHasNoPrimaryKey` predicate (mirrors the SymmetricClosure `buildInverse` skip-with-`TargetHasNoPrimaryKey` predicate; reuses `Kind.primaryKey`).
+- `emitMissingPrimaryKeyDiagnostics` — for every catalog reference whose target kind has no PK, emits ONE `DiagnosticEntry` per **unique target** (deduplicated across the N references pointing at it). Source = `specialCircumstancesScan`; Code = `structural.targetMissingPrimaryKey`; Severity = Warning; SsKey = Some target.SsKey; Metadata carries `targetKind` (rendered SsKey) + `acceptedVia` when the target is in `AllowedMissingPrimaryKeys`.
+- `emitCycleDiagnostics` — for every unresolved `CycleDiagnostic` in `state.TopologicalOrder`, emits one `DiagnosticEntry`. Source / Code / Severity as above; SsKey = None (catalog-level diagnostic — cycles have multiple members with no canonical single identity); Metadata carries `members` (semicolon-separated rendered SsKeys) + `reason` (V1-style human prose) + `acceptedVia` when `Set.ofList cycle.Members` matches an entry in `AllowedCycles`. Cycle-matching is set-equality (order-independent per the test fixture).
+- `emit : SpecialCircumstances -> ComposeState -> DiagnosticEntry list` — composes both emissions. `state.TopologicalOrder = None` (catalog without topo evidence yet) yields zero cycle entries cleanly.
+
+**`src/Projection.Pipeline/Pipeline.fs` (~70 LOC delta)** — threading:
+- New `Compose.RunReport = { Paths : string list; Diagnostics : DiagnosticEntry list }`. CLI consumers (full-export's LogSink emission; legacy `emit --config`'s stderr narration) consume the diagnostics field; tests inspect both.
+- New `projectFromChainWithState` factored out of `projectFromChain` — returns `(Outputs * ComposeState)` rather than discarding the writer at the post-chain seam. `projectFromChain` is now a thin wrapper that drops the state for callers (`Compose.project` / `Compose.projectWith`) that don't need it.
+- New `Compose.projectWithState : Policy -> Profile -> EmissionPolicy -> Catalog -> Outputs * ComposeState` — `projectWith` sibling.
+- `runWithConfig` widened — its return type changes from `Task<Result<string list>>` to `Task<Result<RunReport>>`. The body now binds `SpecialCircumstances` via `SpecialCircumstancesBinding.fromConfig`, calls `projectWithState`, runs `SpecialCircumstancesDiagnostics.emit` against the final state, and returns the diagnostics alongside the written paths. Aggregates Policy + SpecialCircumstances binder errors so the operator sees both axes' malformed entries together.
+
+**`src/Projection.Cli/Program.fs`** — emission:
+- New `emitSpecialCircumstancesDiagnostics` helper — maps each `DiagnosticEntry.Severity` to the corresponding `LogSink.Level` and emits a `transform.diagnostic` envelope per entry (Category = `LogSink.Transform`; Phase = `LogSink.End`). The entry's typed `Metadata` flattens into the envelope payload, so `acceptedVia` (when present) lands as a top-level payload key visible to LogSink rollup consumers.
+- `runFullExport` updated — pattern-match changes from `| Ok paths` to `| Ok report`; calls `emitSpecialCircumstancesDiagnostics` before recording artifacts so the diagnostic envelopes precede the artifact-path narration in the NDJSON stream.
+- `runEmitFromConfig` (legacy `emit --config`) updated — emits diagnostics to stderr in a one-line-per-finding `diagnostic [Severity] code: message [accepted]` form (the legacy surface pre-dates LogSink and uses Console).
+
+**`tests/Projection.Tests/FullExportCliTests.fs`** — mirror the production `runFullExport` LogSink emission path so the in-process test harness sees the same envelope stream the CLI does.
+
+### Tests
+
+**`tests/Projection.Tests/SpecialCircumstancesBindingTests.fs` (7 facts)** — mirrors the `TighteningBindingTests` structure. Covers: empty overrides yield `SpecialCircumstances.empty`; valid `LogicalName` resolves to the kind's SsKey; unresolved `LogicalName` surfaces `pipeline.specialCircumstances.allowMissingPk.unresolved`; multiple unresolved entries aggregate (no short-circuit); valid `TableName` cycle entries resolve to a `Set<SsKey>`; unresolved `TableName` surfaces `pipeline.specialCircumstances.allowedCycle.unresolved`; errors aggregate across both axes in one binder call.
+
+**`tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs` (10 facts)** — covers: missing-PK scan yields no entries when every referenced kind has a PK (the `sampleCatalog` Customer-with-PK case); scan emits one entry per missing-PK *target* kind (Audit-no-PK referenced by Logger); deduplication holds (Audit referenced by N kinds → one entry); allowlisted target carries `Metadata.acceptedVia = "config:overrides.allowMissingPrimaryKey"`; unreferenced missing-PK kinds are ignored (the scan only fires on referenced targets — V1 / SymmetricClosure parity); no cycle entries when `state.TopologicalOrder = None`; one cycle entry per unresolved `CycleDiagnostic` in the topo; allowlisted cycle carries `Metadata.acceptedVia = "config:overrides.circularDependencies"`; cycle-allowlist matching is set-equality (order-independent: members `[A;B]` allowlisted as `Set [B;A]` still match); cycle entry carries `members` + `reason` in `Metadata`.
+
+Total new test count: **17 facts**. Test baseline post-C.2: **1871 passing / 0 failed / 172 skipped** (was 1854 post-housekeeping pre-C.2; +17 from the new test files). Build clean under `TreatWarningsAsErrors=true`; 0 warnings.
+
+### Disciplines reinforced
+
+**Pure-additive scan over IR-traversal cascade.** The architect's HANDOFF letter implicitly assumed `SymmetricClosure` + `TopologicalOrderPass` would grow `DiagnosticEntry` emission via return-type widening (`Lineage<Catalog>` → `Lineage<Diagnostics<Catalog>>`). That route cascades through ~90 consumer sites across emitters, tests, and pass orchestration. The pure-additive scan-step alternative: observe the same structural conditions from outside the passes (`Kind.primaryKey k = []` for missing-PK; `state.TopologicalOrder.Cycles` for cycles); zero pass-internal changes. Trade-off: missing-PK detection logic exists in two places (`SymmetricClosure.buildInverse` skip predicate + `SpecialCircumstancesDiagnostics.kindHasNoPrimaryKey`); both consult `Kind.primaryKey` so the underlying invariant has one source of truth. The duplicate predicate is acceptable; the alternative — threading writer through every pass for one new emission — is not. **When a new operator-visible signal needs lifting from internal pass state, prefer a post-chain scan step over pass-internal writer extension** unless the new signal requires per-pass attribution.
+
+**`Metadata.acceptedVia` as the annotation surface.** Per `Diagnostics.fs:55-60`: `DiagnosticEntry.Metadata : Map<string, string>` is the structural-payload field; the slice-6 actionable-diagnostics work added `SuggestedConfig`. C.2 adds `acceptedVia` as a new convention key naming the config-source path that allowlists the finding. Per the slice-6 reshape lesson ("actionability = enrichment + presentation, NOT occlusion"): the entry remains in the stream + downstream consumers see the annotation. The key namespace (`config:overrides.<axis>` strings) is conventional, not typed; promote to a typed `Acceptance : AcceptanceState option` field on `DiagnosticEntry` when a second annotation source (e.g., per-tenant override; per-PR exception) demands the lift (IR-grows-under-evidence).
+
+**Aggregated binder errors across axes.** `SpecialCircumstancesBinding.fromConfig` returns `Result<SpecialCircumstances>` aggregating `bindAllowMissingPrimaryKey` + `bindAllowedCycles` errors so the operator sees both axes' malformed entries in one pass. `runWithConfig` further aggregates Policy + SpecialCircumstances binder errors (the four-arm match). Mirrors the C.1 `TighteningBinding.fromConfig` per-entry aggregation discipline; consistency across Chapter C boundary surfaces.
+
+**Catalog-level diagnostic for inherently-multi-key findings.** `DiagnosticEntry.SsKey = None` is the convention per `Diagnostics.fs:50-53` for diagnostics that don't point at a specific IR node. Cycles have multiple members; picking one as canonical (e.g., the alphabetically-first SsKey) would be misleading — the cycle is the unit, not its members. Convention applied: `SsKey = None`; `Metadata.members` carries the semicolon-separated member list. The convention pairs naturally with the operator's allowlist shape (cycles are allowlisted as member-sets, not as single-key references).
+
+### Phase A1 status (operator-config wiring)
+
+Chapter C is six slices total. **C.1 + C.2 shipped.** Remaining: C.3 (emission-folders — `Overrides.EmissionFolders` + `RelativePath` rewrite pass), C.4 (tag-groups — `TransformGroup` closed-DU + `RegisteredTransform.Tags` filter), C.5 (insertion semantics — `Policy.InsertionPolicy` config binding), C.6 (verbosity flags — `--verbose` / `--debug` per §4 + per-category filters).
+
+The C.2 scan-step pattern generalizes for future slices that need to surface internal pass state without reshaping return types: define a typed runtime overlay (e.g., `EmissionFolders` for C.3), bind from config, run a post-chain consumer step that observes the relevant `ComposeState` slots and emits `DiagnosticEntry`s with operator-allowlist annotations.
+
+### Cross-references
+
+- `src/Projection.Pipeline/Config.fs` — `Overrides.AllowMissingPrimaryKey : LogicalName list` (relocated from `Model.ValidationOverrides`); `parseAllowMissingPrimaryKey` typed-tuple parser.
+- `src/Projection.Pipeline/SpecialCircumstancesBinding.fs` — NEW typed runtime value + binder + `pipeline.specialCircumstances.*` error code namespace.
+- `src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs` — NEW post-chain scan + acceptance-annotation step.
+- `src/Projection.Pipeline/Pipeline.fs` — `Compose.RunReport`; `projectFromChainWithState`; `projectWithState`; widened `runWithConfig`.
+- `src/Projection.Cli/Program.fs` — `emitSpecialCircumstancesDiagnostics`; updated `runFullExport` + `runEmitFromConfig`.
+- `tests/Projection.Tests/FullExportCliTests.fs` — mirror LogSink emission for in-process tests.
+- `tests/Projection.Tests/SpecialCircumstancesBindingTests.fs` — NEW 7-fact binder coverage.
+- `tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs` — NEW 10-fact scan + annotation coverage.
+- `DECISIONS 2026-05-20 (slice C.1 — tightening axis config wiring)` — the template C.2 mirrors at the binder layer; the disciplines (operator-supplied-ref resolution; per-attribute aggregation) carry forward.
+- `DECISIONS 2026-05-19 (chapter B.4 hygiene strike + axis-survey supplement)` — Chapter C 6-slice plan; named `Overrides.AllowMissingPrimaryKey` + `Overrides.CircularDependencies` as C.2 scope.
+- `src/Projection.Core/Passes/SymmetricClosure.fs:162` — `Skip (ClosureSkipped TargetHasNoPrimaryKey)` — the structural source of the missing-PK predicate the scan mirrors.
+- `src/Projection.Core/TopologicalOrder.fs:59` — `CycleDiagnostic` — the structural source the cycle scan reads.
+

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,61 @@
+# Handoff letter — 2026-05-20 (Chapter C slice 2 of 6 done; mid-chapter)
+
+To the next agent.
+
+You're picking up V2 with **Chapter C two slices in** and the substrate doing more work for you than the slice queue length suggests. C.1 (tightening axis) shipped earlier today and set the binder + chain-factory template; C.2 (special-circumstances axis — `AllowMissingPrimaryKey` + `CircularDependencies` consumer) shipped this session as the **first non-binder-only Chapter C slice** — operator allowlists now bind from config + a post-chain scan emits the missing-PK / cycle findings as typed `DiagnosticEntry`s through the LogSink envelope stream, with `Metadata.acceptedVia` annotation on allowlist matches per the annotate-don't-suppress discipline. Four Chapter C slices remain. **Your next slice is C.3 (emission-folders)** unless the principal-PO redirects.
+
+## What C.2 changed that C.3 inherits
+
+The big load-bearing shape C.2 introduced is the **pure-additive post-chain scan pattern**, generalizable across the remaining slices. Rather than reshape pass return types (the architect's slice-C.1 HANDOFF letter implicitly assumed this; would cascade through ~90 consumer sites for `TopologicalOrderPass` + `SymmetricClosure` alone), C.2 added `src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs` — a 140-LOC scan step that observes the post-chain `Catalog` + `ComposeState` (read via the new `Compose.projectFromChainWithState` factored out of `projectFromChain`) and emits `DiagnosticEntry`s with operator-allowlist annotations applied in one pass. **Future slices needing to surface internal pass state without return-type cascade should mirror this shape.**
+
+The other big surface change is **`runWithConfig` widened** — return type went from `Task<Result<string list>>` to `Task<Result<Compose.RunReport>>` where `RunReport = { Paths : string list; Diagnostics : DiagnosticEntry list }`. The three consumers (`Program.fs runFullExport` + `Program.fs runEmitFromConfig` + `FullExportCliTests.runFullExportInProcess`) all updated; the diagnostic stream flows to LogSink envelopes in full-export, to stderr text in legacy `emit --config`, to the test harness's captured envelope stream in tests.
+
+## Two principal-PO scope decisions C.2 surfaced (read these — they generalize for C.3-C.6)
+
+(a) **Operator config ref shape: typed tuples over full SsKey-ref form.** The architect's slice-C.1 letter recommended copying `TighteningBinding`'s logical-or-physical `SsKey` ref shape verbatim for C.2. The operator chose typed `(Module × Entity)` tuples (`Config.LogicalName list`) instead — lighter parser, smaller test surface, no physical-name fallback. The trade-off: divergent surface from C.1's tightening axis (which DOES carry the logical-or-physical shape). The principle: **slice-by-slice scope decisions belong to the principal-PO at slice open, not pre-decided by HANDOFF recommendations.** Bring C.3's `EmissionFolders` ref shape decision (likely `Map<SsKey, string>` with the SsKey resolved at bind time from a `LogicalName`) to the principal-PO; don't presume.
+
+(b) **Annotate vs suppress, and what depth the annotation lives at.** Operator decision: annotate, not suppress, per the slice-6 reshape lesson ("actionability = enrichment + presentation, NOT occlusion"). What surprised me: the architect's HANDOFF letter assumed the annotation surface was `DiagnosticEntry.Metadata.acceptedVia` — but missing-PK and cycle signals **don't reach the DiagnosticEntry stream at all today** (missing-PK lives in `LineageEvent.Annotated`; cycles live in `TopologicalOrder.Cycles : CycleDiagnostic list`). So C.2's "annotate" actually required FIRST lifting these signals into operator-visible `DiagnosticEntry` emissions (new emission sites) BEFORE annotation could land. That's the "full lift" scope option I brought to the principal-PO; operator accepted the budget overrun (~5-7h instead of 3-5h). **C.3 may have a similar discovery — emission folders likely don't have an existing operator-visible diagnostic surface either; budget accordingly.**
+
+## Where you are in the spine
+
+C.3 wires the **emission-folders axis** per `DECISIONS 2026-05-19 (chapter B.4 hygiene strike + axis-survey supplement)`. The scope: a new `Overrides.EmissionFolders : Map<SsKey, string>` config section + an `SsdtFile.RelativePath` rewrite pass + emit-time validation. Touchpoints per the architect's slice-C.1 letter: `src/Projection.Targets.SSDT/SsdtFile.fs` for the `RelativePath` shape; `src/Projection.Pipeline/Pipeline.fs` around line 120 for the `SsdtBundle.compose` site; `src/Projection.Pipeline/Config.fs` for the new section. The rewrite fires **after** SSDT emit produces the bundle but before write. Architect's recommendation: add `Compose.applyEmissionFolderOverrides : Map<SsKey, string> -> SsdtBundle -> Result<SsdtBundle>` as a post-emit step in `runWithConfig`; validate target folder paths at the binder layer (no `..`; no absolute paths; no path-separator chars in segment names) before the rewrite fires.
+
+## Read order (~30 min) — same shape as the C.1 letter below
+
+1. **This letter + the slice-C.1 architect letter below** (the "What to know about the V2 shape" + "Per-slice guide" sections specifically — they're still the operator's-manual for the next 2-3 weeks).
+2. **`DECISIONS 2026-05-20 (slice C.2 — special-circumstances axis full lift)`** — names the binder shape, the pure-additive scan pattern, the `acceptedVia` annotation convention, the scope-adjustment rationale, the disciplines reinforced.
+3. **`src/Projection.Pipeline/SpecialCircumstancesBinding.fs` (~150 LOC)** — read alongside `TighteningBinding.fs`; the binder shape generalizes for C.3 (typed `EmissionFolders` resolution).
+4. **`src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs` (~140 LOC)** — read for the post-chain scan pattern. C.3's `Compose.applyEmissionFolderOverrides` is a sibling but operates on `SsdtBundle` (not `DiagnosticEntry list`).
+5. **The five operating disciplines below** before writing code (same four as C.1's letter + one new from C.2).
+
+## Disciplines internalized this session (C.2 contribution + carry-forward from C.1)
+
+**Pure-additive scan over IR-traversal cascade (C.2 contribution)** — when a new operator-visible signal needs lifting from internal pass state, prefer a post-chain scan step over pass-internal writer-extension unless the new signal requires per-pass attribution. Trade-off: small predicate duplication is acceptable (both consult the same primitive — e.g., `Kind.primaryKey k = []`); the alternative — threading the `Diagnostics` writer through every pass for one new emission — is not. Mirrors the C.1 "factory shape" pattern (`allChainStepsFor` policy-parameterized chain) one layer up: structural observability without invasive rewiring.
+
+**The four C.1-era disciplines carry forward unchanged.** Operator-supplied-ref resolution (resolve at bind time, not at use time; structured ValidationError on miss); single-entry-shape pattern across DU variants (apply if C.5 goes per-target Insertion); Global-MutableState xUnit collection (any test touching Bench/LogSink state); TRX-first test-failure capture protocol (mandatory when dotnet test reports `Failed:` > 0).
+
+**HANDOFF append-only-within-chapter + handoff-as-prose-letter disciplines** — read the CLAUDE.md operating-disciplines table rows. C.2 honored both (this letter prepends above the C.1 + B.4 close letters via Edit, not Write overwrite; addresses you in second person).
+
+## Test baseline + branch state
+
+**1871/1871 non-Docker passing; 0 warnings under TreatWarningsAsErrors=true.** Was 1854 pre-C.2 (post-housekeeping baseline above the architect's 1793 starting point); +17 from the two new C.2 test files (7 binder facts + 10 scan facts). Operator-reality canary unchanged from C.1 (no chain-factory touch this slice; the new scan runs once at `runWithConfig` boundary, costs ~1 catalog walk for missing-PK + one `Set.contains` per cycle). Branch stays `claude/v2-chapter-c-continue-XGxAL`; PR #552 has merged the prior C.1 + B.4 work into `main` — this session's commit lives on the continuation branch.
+
+## Pitfalls C.2 hit that you can avoid
+
+- **Don't presume the HANDOFF letter's recommended consumer shape exists.** The slice-C.1 architect letter recommended `DiagnosticEntry.Metadata.acceptedVia` as the annotation surface. The signals being annotated turned out to NOT flow through `DiagnosticEntry` at all. Verify the consumer substrate exists BEFORE committing to the architect's recipe; bring scope-adjustment options to the principal-PO if the substrate is missing.
+- **Don't widen pass return types speculatively.** I almost reshaped `SymmetricClosure` + `TopologicalOrderPass` from `Lineage<_>` to `Lineage<Diagnostics<_>>` to absorb the new emissions. The cascade is ~90 consumer sites. The pure-additive scan-step alternative is structurally equivalent + zero cascade. Run the blast-radius `grep` before any return-type widening.
+- **`Model.ValidationOverrides` vs `Overrides`.** The dormant `AllowMissingPrimaryKey` field lived in the wrong section pre-C.2 (`Model.ValidationOverrides` rather than `Overrides`). Moving was correct — `Overrides` is the operator-driven-catalog-rewrites/annotations neighborhood; `Model` owns the catalog source. C.3 may face a similar location question if `EmissionFolders` parses anywhere else today; verify.
+
+## Open questions for chapter close (C.6+)
+
+Same as the C.1 letter's chapter-close section. The C.2 contribution to the list: when C.6 ships, the chapter-close ritual's "Promote any new L3 axioms" step should consider an **L3-CC-AcceptanceAnnotation** axiom (every operator-visible structural finding with an addressable acceptance path carries the annotation in `Metadata.acceptedVia`; the diagnostic remains visible). The annotate-don't-suppress discipline is operative for all of C.3-C.5 as the special-circumstances pattern generalizes.
+
+Hold the spine. The Chapter C arc is mechanical wiring against a substrate that already exists, plus the occasional discovery that a recommended consumer surface doesn't exist (C.2's case) — bring those scope-adjustments to the principal-PO at slice open. Each slice earned, one at a time.
+
+— The slice-C.2 architect.
+
+---
+
 # Handoff letter — 2026-05-20 (Chapter C slice 1 of 6 done; mid-chapter)
 
 To the next agent.

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -178,6 +178,38 @@ let private emitTransformErrors (errors: ValidationError list) : unit =
             { LogSink.envelope LogSink.Error LogSink.Transform "transform.diagnostic" payload with
                 Phase = LogSink.ErrorPhase }
 
+/// Chapter C slice C.2 — emit each `SpecialCircumstancesDiagnostics`
+/// entry as a `transform.diagnostic` LogSink envelope. Per §7.4 the
+/// envelope level mirrors the entry's `Severity`; the entry's typed
+/// `Metadata` (including `acceptedVia` on operator-allowlisted
+/// findings) flattens into the envelope payload so downstream LogSink
+/// consumers (the `summary.runComplete` rollup; future operator
+/// dashboards) see the acceptance state without re-walking the
+/// catalog.
+let private emitSpecialCircumstancesDiagnostics (entries: DiagnosticEntry list) : unit =
+    for entry in entries do
+        let level =
+            match entry.Severity with
+            | DiagnosticSeverity.Info    -> LogSink.Info
+            | DiagnosticSeverity.Warning -> LogSink.Warn
+            | DiagnosticSeverity.Error   -> LogSink.Error
+        let basePayload : Map<string, objnull> =
+            Map.ofList [
+                "source",  box entry.Source
+                "code",    box entry.Code
+                "message", box entry.Message
+            ]
+        let withSsKey =
+            match entry.SsKey with
+            | Some k -> basePayload |> Map.add "ssKey" (box (SsKey.rootOriginal k))
+            | None   -> basePayload
+        let payload =
+            entry.Metadata
+            |> Map.fold (fun acc k v -> Map.add k (box v) acc) withSsKey
+        LogSink.emit
+            { LogSink.envelope level LogSink.Transform "transform.diagnostic" payload with
+                Phase = LogSink.End }
+
 /// Resolve the effective output directory: CLI `--output` override
 /// wins over the config's `Output.Dir`. Defaults to the config value.
 let private resolveOutputDir
@@ -254,10 +286,11 @@ let private runFullExport
                     let result = task.GetAwaiter().GetResult()
                     sw.Stop()
                     match result with
-                    | Ok paths ->
+                    | Ok report ->
                         recordStage "pipeline" LogSink.Succeeded sw.ElapsedMilliseconds
-                        printfn "projection: wrote %d artifact(s) to %s" paths.Length effectiveOutput
-                        paths
+                        emitSpecialCircumstancesDiagnostics report.Diagnostics
+                        printfn "projection: wrote %d artifact(s) to %s" report.Paths.Length effectiveOutput
+                        report.Paths
                         |> List.iter (fun p ->
                             let info = FileInfo p
                             LogSink.recordArtifact {
@@ -370,12 +403,22 @@ let private runEmitFromConfig (configPath: string) : int =
         let result = task.GetAwaiter().GetResult()
         let exitCode =
             match result with
-            | Ok paths ->
-                printfn "projection: wrote %d artifact(s) to %s" paths.Length config.Output.Dir
-                paths
+            | Ok report ->
+                printfn "projection: wrote %d artifact(s) to %s" report.Paths.Length config.Output.Dir
+                report.Paths
                 |> List.iter (fun p ->
                     let info = FileInfo p
                     printfn "  %s (%d bytes)" p info.Length)
+                // Chapter C slice C.2 — surface special-circumstances
+                // findings to stderr (the legacy `emit --config` surface
+                // pre-dates LogSink and uses Console for narration).
+                for entry in report.Diagnostics do
+                    let accepted =
+                        if Map.containsKey "acceptedVia" entry.Metadata then " [accepted]"
+                        else ""
+                    Console.Error.WriteLine (
+                        sprintf "  diagnostic [%s] %s: %s%s"
+                            (string entry.Severity) entry.Code entry.Message accepted)
                 0
             | Error errors ->
                 Console.Error.WriteLine "projection: emit failed:"

--- a/sidecar/projection/src/Projection.Pipeline/Config.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Config.fs
@@ -43,7 +43,6 @@ module Config =
         | WithEntities of name: string * entities: string list
 
     type ValidationOverrides = {
-        AllowMissingPrimaryKey : string list
         AllowMissingSchema     : string list
     }
 
@@ -123,6 +122,15 @@ module Config =
         MigrationDependencies  : FilePathOverride option
         StaticData             : FilePathOverride option
         CircularDependencies   : CircularDependenciesSection option
+        /// Chapter C slice C.2 — operator allowlist of kinds whose
+        /// missing primary key is acknowledged. Entries are typed
+        /// `(Module, Entity)` logical pairs (operator-readable);
+        /// the binder resolves each to a `SsKey` against the loaded
+        /// catalog at bind time. Downstream diagnostics still fire
+        /// for matching kinds but carry `Metadata.acceptedVia =
+        /// "config:overrides.allowMissingPrimaryKey"` per the
+        /// annotate-don't-suppress discipline.
+        AllowMissingPrimaryKey : LogicalName list
     }
 
     type EmissionSection = {
@@ -230,7 +238,6 @@ module Config =
     // -----------------------------------------------------------------------
 
     let private defaultValidationOverrides : ValidationOverrides = {
-        AllowMissingPrimaryKey = []
         AllowMissingSchema     = []
     }
 
@@ -256,10 +263,11 @@ module Config =
     }
 
     let private defaultOverrides : OverridesSection = {
-        TableRenames          = []
-        MigrationDependencies = None
-        StaticData            = None
-        CircularDependencies  = None
+        TableRenames           = []
+        MigrationDependencies  = None
+        StaticData             = None
+        CircularDependencies   = None
+        AllowMissingPrimaryKey = []
     }
 
     let private defaultEmission : EmissionSection = {
@@ -537,13 +545,10 @@ module Config =
             | JsonValueKind.Null | JsonValueKind.Undefined ->
                 Result.success defaultValidationOverrides
             | JsonValueKind.Object ->
-                match getStringListOrEmpty v "allowMissingPrimaryKey" with
+                match getStringListOrEmpty v "allowMissingSchema" with
                 | Error es -> Error es
-                | Ok pks ->
-                    match getStringListOrEmpty v "allowMissingSchema" with
-                    | Error es -> Error es
-                    | Ok schemas ->
-                        Result.success { AllowMissingPrimaryKey = pks; AllowMissingSchema = schemas }
+                | Ok schemas ->
+                    Result.success { AllowMissingSchema = schemas }
             | _ ->
                 Result.failureOf (
                     configError "typeMismatch" "model.validationOverrides must be an object.")
@@ -767,6 +772,33 @@ module Config =
                 | Ok strict ->
                     Result.success (Some { AllowedCycles = cycles; StrictMode = strict })
 
+    /// Parse `overrides.allowMissingPrimaryKey` as a list of typed
+    /// `{ module, entity }` objects (Chapter C slice C.2). Operator
+    /// chose typed tuples over bare strings (DECISIONS 2026-05-20 —
+    /// special-circumstances axis scope). Each entry resolves to a
+    /// Kind `SsKey` at bind time via `SpecialCircumstancesBinding`.
+    let private parseAllowMissingPrimaryKey (element: JsonElement) : Result<LogicalName list> =
+        match element.TryGetProperty("allowMissingPrimaryKey") with
+        | false, _ -> Result.success []
+        | true, v ->
+            match v.ValueKind with
+            | JsonValueKind.Null | JsonValueKind.Undefined -> Result.success []
+            | JsonValueKind.Array ->
+                v.EnumerateArray()
+                |> Seq.toList
+                |> List.map (fun e ->
+                    if e.ValueKind = JsonValueKind.Object then
+                        parseLogicalName e
+                    else
+                        Result.failureOf (
+                            configError
+                                "typeMismatch"
+                                "overrides.allowMissingPrimaryKey entries must be { module, entity } objects."))
+                |> Result.aggregate
+            | _ ->
+                Result.failureOf (
+                    configError "typeMismatch" "overrides.allowMissingPrimaryKey must be an array.")
+
     let private parseOverrides (root: JsonElement) : Result<OverridesSection> =
         match tryGetProperty root "overrides" with
         | None -> Result.success defaultOverrides
@@ -783,12 +815,16 @@ module Config =
                         match parseCircularDependencies element with
                         | Error es -> Error es
                         | Ok cycles ->
-                            Result.success {
-                                TableRenames          = renames
-                                MigrationDependencies = migDeps
-                                StaticData            = staticData
-                                CircularDependencies  = cycles
-                            }
+                            match parseAllowMissingPrimaryKey element with
+                            | Error es -> Error es
+                            | Ok allowedPks ->
+                                Result.success {
+                                    TableRenames           = renames
+                                    MigrationDependencies  = migDeps
+                                    StaticData             = staticData
+                                    CircularDependencies   = cycles
+                                    AllowMissingPrimaryKey = allowedPks
+                                }
 
     let private parseEmission (root: JsonElement) : Result<EmissionSection> =
         match tryGetProperty root "emission" with

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -62,6 +62,19 @@ module Compose =
             Distributions : JsonNode
         }
 
+    /// Chapter C slice C.2 — run-shape value returned by
+    /// `runWithConfig`. Carries the written artifact paths AND the
+    /// post-run diagnostic stream (today: the special-circumstances
+    /// scan emissions for missing-PK targets + unresolved cycles,
+    /// with operator-allowlist `Metadata.acceptedVia` annotations
+    /// applied). CLI consumers (`runFullExport`) emit each
+    /// diagnostic as a LogSink envelope; other consumers (older
+    /// `emit --config` surface) may ignore.
+    type RunReport = {
+        Paths       : string list
+        Diagnostics : DiagnosticEntry list
+    }
+
     /// Per-artifact relative path. Centralized so tests and the CLI
     /// agree on naming.
     [<RequireQualifiedAccess>]
@@ -100,23 +113,27 @@ module Compose =
     /// unconditionally; decision-set passes write back evidence the
     /// emitters do not yet consume (decision-set consumption is a
     /// future-chapter concern).
-    let private projectFromChain
+    /// Chapter C slice C.2 — state-capturing project. Returns both
+    /// the `Outputs` and the post-chain `ComposeState` so downstream
+    /// consumers (today: `SpecialCircumstancesDiagnostics.emit`) can
+    /// observe per-pass evidence without re-running the chain.
+    /// `projectFromChain` is now a thin wrapper that drops the state.
+    let private projectFromChainWithState
         (chain: PassChainAdapter list)
         (policy: EmissionPolicy)
         (catalog: Catalog)
-        : Outputs =
+        : Outputs * ComposeState =
         use _ = Bench.scope "compose.project"
-        let composedCatalog =
+        let composedState =
             (use _ = Bench.scope "compose.runChain"
              PassChainAdapter.compose chain (ComposeState.initial catalog)
-             |> LineageDiagnostics.payload
-             |> fun state -> state.Catalog)
+             |> LineageDiagnostics.payload)
         // Chapter 4.9 slice δ — apply EmissionPolicy.filterPlatformAutoIndexes
         // at the post-chain seam. The filter is `OperatorIntent of Emission`
         // per pillar 9; lives outside the registered pass chain because
         // its evidence is policy, not catalog-derived. Identity when
         // `IncludePlatformAutoIndexes = true` (V1 parity default).
-        let emittedCatalog = EmissionPolicy.filterPlatformAutoIndexes policy composedCatalog
+        let emittedCatalog = EmissionPolicy.filterPlatformAutoIndexes policy composedState.Catalog
         let bundle =
             (use _ = Bench.scope "emit.ssdtBundle.compose"
              match SsdtDdlEmitter.emitSlices emittedCatalog with
@@ -143,11 +160,19 @@ module Compose =
              match JsonNode.Parse(DistributionsEmitter.emit emittedCatalog Profile.empty) with
              | null -> invalidOp "Compose.project: DistributionsEmitter.emit produced unparseable text (unreachable)"
              | n    -> n)
-        {
+        let outputs = {
             SsdtBundle    = bundle
             Json          = json
             Distributions = distributions
         }
+        outputs, composedState
+
+    let private projectFromChain
+        (chain: PassChainAdapter list)
+        (policy: EmissionPolicy)
+        (catalog: Catalog)
+        : Outputs =
+        projectFromChainWithState chain policy catalog |> fst
 
     /// Production-shape project: routes through
     /// `RegisteredTransforms.allChainSteps`. The hand-coded "emit raw
@@ -171,6 +196,19 @@ module Compose =
         : Outputs =
         let chain = RegisteredTransforms.allChainStepsFor fullPolicy profile
         projectFromChain chain emissionPolicy catalog
+
+    /// Chapter C slice C.2 — `projectWith` sibling that returns the
+    /// post-chain `ComposeState` alongside the outputs. Used by
+    /// `runWithConfig` to feed `SpecialCircumstancesDiagnostics`
+    /// without re-running the registered chain.
+    let projectWithState
+        (fullPolicy: Policy)
+        (profile: Profile)
+        (emissionPolicy: EmissionPolicy)
+        (catalog: Catalog)
+        : Outputs * ComposeState =
+        let chain = RegisteredTransforms.allChainStepsFor fullPolicy profile
+        projectFromChainWithState chain emissionPolicy catalog
 
     /// Skeleton-shape project: routes through
     /// `RegisteredTransforms.skeletonChainSteps` (per chapter A.4.7'
@@ -407,25 +445,36 @@ module Compose =
 
     /// Full end-to-end driven by a parsed `Config`. Reads `Model.Path`,
     /// applies config-driven catalog rewrites (rename), binds operator
-    /// `Policy` (tightening — Chapter C slice C.1), projects through
-    /// the policy-aware chain, writes to `Output.Dir`. Threading the
-    /// remaining dormant sections (Selection / Insertion / Emission
-    /// folders / TagGroups) is the work of subsequent Chapter C
-    /// slices.
-    let runWithConfig (cfg: Config.Config) : Task<Result<string list>> =
+    /// `Policy` (tightening — Chapter C slice C.1) + operator
+    /// `SpecialCircumstances` (missing-PK / circular-deps
+    /// acknowledgements — Chapter C slice C.2), projects through the
+    /// policy-aware chain capturing the post-chain `ComposeState`,
+    /// emits special-circumstances diagnostics with operator-allowlist
+    /// `Metadata.acceptedVia` annotation, writes to `Output.Dir`,
+    /// returns the paths + the diagnostic stream as a `RunReport`.
+    let runWithConfig (cfg: Config.Config) : Task<Result<RunReport>> =
         task {
             let! parsed = read cfg.Model.Path
             match parsed with
             | Ok catalog ->
                 match applyRenames cfg catalog with
                 | Ok renamedCatalog ->
-                    match buildPolicyFromConfig cfg renamedCatalog with
-                    | Ok policy ->
-                        let outputs =
-                            projectWith policy Profile.empty EmissionPolicy.empty renamedCatalog
-                        return write cfg.Output.Dir outputs
-                    | Error errors ->
-                        return Result.failure errors
+                    let policyR     = buildPolicyFromConfig cfg renamedCatalog
+                    let overridesR  = SpecialCircumstancesBinding.fromConfig renamedCatalog cfg
+                    match policyR, overridesR with
+                    | Ok policy, Ok overrides ->
+                        let outputs, finalState =
+                            projectWithState policy Profile.empty EmissionPolicy.empty renamedCatalog
+                        let diagnostics =
+                            SpecialCircumstancesDiagnostics.emit overrides finalState
+                        match write cfg.Output.Dir outputs with
+                        | Ok paths ->
+                            return Result.success { Paths = paths; Diagnostics = diagnostics }
+                        | Error errors ->
+                            return Result.failure errors
+                    | Error es1, Error es2 -> return Result.failure (es1 @ es2)
+                    | Error errors, _      -> return Result.failure errors
+                    | _, Error errors      -> return Result.failure errors
                 | Error errors ->
                     return Result.failure errors
             | Error errors ->

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -13,6 +13,8 @@
     <Compile Include="Config.fs" />
     <Compile Include="RenameBinding.fs" />
     <Compile Include="TighteningBinding.fs" />
+    <Compile Include="SpecialCircumstancesBinding.fs" />
+    <Compile Include="SpecialCircumstancesDiagnostics.fs" />
     <Compile Include="Pipeline.fs" />
     <Compile Include="RegisteredAllTransforms.fs" />
     <Compile Include="Bulk.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesBinding.fs
@@ -1,0 +1,161 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// Chapter C slice C.2 — operator-supplied acknowledgements that
+/// source-side defects (missing primary keys; unresolved circular
+/// FK dependencies) are known + accepted. The binder resolves the
+/// textual config refs against the loaded `Catalog` into typed
+/// `SsKey` sets consumed by the downstream diagnostics annotator
+/// (`SpecialCircumstancesDiagnostics`).
+///
+/// **Annotate-don't-suppress discipline** (slice-6 reshape lesson;
+/// codified DECISIONS 2026-05-20 — special-circumstances axis).
+/// Allowlisted findings still surface in the diagnostic stream; the
+/// annotator stamps `Metadata.acceptedVia` on matches so downstream
+/// operator surfaces (LogSink envelopes) can render the acceptance
+/// without occluding the underlying source defect.
+///
+/// **Pillar 9 classification** — `SpecialCircumstances` is an
+/// operator-supplied annotation overlay (operator publishes "I've
+/// already acknowledged this"). Distinct from `Policy` axes
+/// (which change pipeline behavior); these change presentation
+/// only. Lives parallel to `Policy`, not as a Policy axis, until a
+/// future slice formalizes a `Policy.Annotation` axis if needed.
+[<RequireQualifiedAccess>]
+type AcceptanceState =
+    | NotAccepted
+    | AcceptedByConfig of source: string
+
+/// Typed runtime form of `Overrides.AllowMissingPrimaryKey` +
+/// `Overrides.CircularDependencies.AllowedCycles`. Each field is a
+/// set keyed by `SsKey` (or set-of-`SsKey`-sets, for cycles —
+/// SCC membership is set-shaped). `empty` is the no-acknowledgements
+/// default; consuming sites must produce identical diagnostic
+/// streams (modulo annotation) for `empty` vs unpopulated.
+type SpecialCircumstances = {
+    AllowedMissingPrimaryKeys : Set<SsKey>
+    AllowedCycles             : Set<Set<SsKey>>
+}
+
+[<RequireQualifiedAccess>]
+module SpecialCircumstances =
+
+    let empty : SpecialCircumstances = {
+        AllowedMissingPrimaryKeys = Set.empty
+        AllowedCycles             = Set.empty
+    }
+
+
+[<RequireQualifiedAccess>]
+module SpecialCircumstancesBinding =
+
+    let private bindError (code: string) (message: string) : ValidationError =
+        ValidationError.create (sprintf "pipeline.specialCircumstances.%s" code) message
+
+    /// Resolve an operator-supplied `LogicalName` (Module.Entity) to
+    /// the matching kind's `SsKey`. Errors structurally if no kind
+    /// in `catalog` matches the (module, entity) logical pair.
+    let private resolveKindByLogical
+        (catalog: Catalog)
+        (ref: Config.LogicalName)
+        : Result<SsKey> =
+        let hit =
+            catalog.Modules
+            |> List.tryPick (fun m ->
+                if Name.value m.Name = ref.Module then
+                    m.Kinds
+                    |> List.tryFind (fun k -> Name.value k.Name = ref.Entity)
+                else None)
+        match hit with
+        | Some k -> Result.success k.SsKey
+        | None ->
+            Result.failureOf (
+                bindError
+                    "allowMissingPk.unresolved"
+                    (sprintf
+                        "overrides.allowMissingPrimaryKey entry %s.%s did not match any catalog kind."
+                        ref.Module ref.Entity))
+
+    /// Resolve a single cycle entry's physical `TableName` to the
+    /// matching kind's `SsKey`. Cycle entries reference kinds by
+    /// physical name (`Schema.Table`-style; the existing
+    /// `CircularDependencyEntry` shape carries `TableName : string`).
+    /// Currently matches against `k.Physical.Table` ignoring schema —
+    /// V1's circular-dependency cycle entries don't disambiguate
+    /// schemas. Promote to schema-qualified matching when a real
+    /// multi-schema cycle surfaces (IR-grows-under-evidence).
+    let private resolveKindByPhysicalTable
+        (catalog: Catalog)
+        (tableName: string)
+        : Result<SsKey> =
+        let hit =
+            catalog.Modules
+            |> List.tryPick (fun m ->
+                m.Kinds
+                |> List.tryFind (fun k -> k.Physical.Table = tableName))
+        match hit with
+        | Some k -> Result.success k.SsKey
+        | None ->
+            Result.failureOf (
+                bindError
+                    "allowedCycle.unresolved"
+                    (sprintf
+                        "overrides.circularDependencies.allowedCycles entry tableName='%s' did not match any catalog kind."
+                        tableName))
+
+    let private bindCycle
+        (catalog: Catalog)
+        (cycle: Config.CircularDependencyCycle)
+        : Result<Set<SsKey>> =
+        cycle.TableOrdering
+        |> List.map (fun e -> resolveKindByPhysicalTable catalog e.TableName)
+        |> Result.aggregate
+        |> Result.map Set.ofList
+
+    /// Bind the `Overrides.AllowMissingPrimaryKey` allowlist to a
+    /// typed `Set<SsKey>` against the loaded catalog. Empty list →
+    /// empty set.
+    let bindAllowMissingPrimaryKey
+        (catalog: Catalog)
+        (entries: Config.LogicalName list)
+        : Result<Set<SsKey>> =
+        entries
+        |> List.map (resolveKindByLogical catalog)
+        |> Result.aggregate
+        |> Result.map Set.ofList
+
+    /// Bind the `Overrides.CircularDependencies.AllowedCycles` list
+    /// to a typed `Set<Set<SsKey>>` (each inner set is one cycle's
+    /// member-kind set). `None` (no circularDependencies config
+    /// section) → empty set.
+    let bindAllowedCycles
+        (catalog: Catalog)
+        (section: Config.CircularDependenciesSection option)
+        : Result<Set<Set<SsKey>>> =
+        match section with
+        | None -> Result.success Set.empty
+        | Some s ->
+            s.AllowedCycles
+            |> List.map (bindCycle catalog)
+            |> Result.aggregate
+            |> Result.map Set.ofList
+
+    /// Build the typed `SpecialCircumstances` runtime value from a
+    /// parsed `Config`. Aggregates all binder errors so the operator
+    /// sees every malformed entry in one pass.
+    let fromConfig
+        (catalog: Catalog)
+        (cfg: Config.Config)
+        : Result<SpecialCircumstances> =
+        let pksR     = bindAllowMissingPrimaryKey catalog cfg.Overrides.AllowMissingPrimaryKey
+        let cyclesR  = bindAllowedCycles catalog cfg.Overrides.CircularDependencies
+        match pksR, cyclesR with
+        | Ok pks, Ok cycles ->
+            Result.success {
+                AllowedMissingPrimaryKeys = pks
+                AllowedCycles             = cycles
+            }
+        | Error es1, Error es2 -> Error (es1 @ es2)
+        | Error es, _          -> Error es
+        | _, Error es          -> Error es

--- a/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesDiagnostics.fs
@@ -1,0 +1,161 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// Chapter C slice C.2 — operator-visible diagnostic surface for
+/// source-side defects that the existing structural passes detect
+/// internally but don't route to the operator. Two findings:
+///
+/// 1. **`structural.targetMissingPrimaryKey`** — for every catalog
+///    reference whose target kind has no primary-key attribute, emit
+///    one `DiagnosticEntry` keyed by the target kind's `SsKey`. The
+///    underlying observation matches the `SymmetricClosure` pass's
+///    `Skip (ClosureSkipped TargetHasNoPrimaryKey)` event but lifts
+///    it from lineage-only annotation to operator-visible diagnostic.
+///    Emission is per *unique target kind* (deduplicated across the
+///    references that point at it), not per reference; one
+///    actionable surface per kind matches the operator allowlist's
+///    one-entry-per-kind shape.
+///
+/// 2. **`structural.cycleUnresolved`** — for every unresolved SCC
+///    in the post-chain `ComposeState.TopologicalOrder.Cycles`, emit
+///    one `DiagnosticEntry` carrying the cycle's member list in
+///    `Metadata.members` (semicolon-separated rendered SsKeys; same
+///    format used elsewhere in the diagnostic surface).
+///
+/// **Acceptance annotation** — each emitted entry is cross-checked
+/// against the operator's `SpecialCircumstances` allowlist; matches
+/// receive `Metadata.acceptedVia` naming the config source. Per the
+/// annotate-don't-suppress discipline (slice-6 reshape lesson): the
+/// diagnostic still appears in the stream; the annotation lets
+/// downstream operator surfaces render the acceptance without
+/// occluding the underlying source defect.
+///
+/// **Pillar 9 classification** — this module is a `DataIntent` scan
+/// (the structural findings derive from `Catalog × ComposeState`,
+/// reachable from `Project(catalog, Policy.empty, profile)` without
+/// operator opinion). The acceptance annotation overlay is
+/// `OperatorIntent` on the annotation axis (operator publishes
+/// "this is acknowledged"). The two compose: the scan is pure
+/// observation; the annotation is operator overlay. Architecture
+/// mirrors the C.1 binder + chain-factory separation — the
+/// observation produces the typed value; the overlay adds operator
+/// intent on top.
+[<RequireQualifiedAccess>]
+module SpecialCircumstancesDiagnostics =
+
+    let private source = "specialCircumstancesScan"
+
+    let private missingPrimaryKeyCode = "structural.targetMissingPrimaryKey"
+    let private cycleUnresolvedCode   = "structural.cycleUnresolved"
+
+    let private acceptedViaMissingPk = "config:overrides.allowMissingPrimaryKey"
+    let private acceptedViaCycle     = "config:overrides.circularDependencies"
+
+    /// Render a list of `SsKey`s as a single semicolon-separated
+    /// string for `DiagnosticEntry.Metadata`. Per Metadata's current
+    /// `Map<string, string>` shape; promote to a typed payload when
+    /// a consumer demands structured access (IR-grows-under-evidence).
+    let private renderKeys (keys: SsKey seq) : string =
+        keys
+        |> Seq.map SsKey.rootOriginal
+        |> String.concat ";"
+
+    /// True iff `k` has no primary-key attribute (`Kind.primaryKey k`
+    /// returns the empty list). Mirrors the predicate that
+    /// `SymmetricClosure.buildInverse` uses to skip with reason
+    /// `TargetHasNoPrimaryKey`.
+    let private kindHasNoPrimaryKey (k: Kind) : bool =
+        List.isEmpty (Kind.primaryKey k)
+
+    let private emitMissingPrimaryKeyDiagnostics
+        (allowed: Set<SsKey>)
+        (catalog: Catalog)
+        : DiagnosticEntry list =
+        let allKinds = Catalog.allKinds catalog
+        let kindByKey =
+            allKinds
+            |> List.map (fun k -> k.SsKey, k)
+            |> Map.ofList
+        // Target-kind SsKeys referenced by ANY kind, whose target has
+        // no PK. Deduplicate at the target-kind level: one entry per
+        // missing-PK target regardless of how many references point at
+        // it (operator allowlist is keyed by target kind).
+        let targetsNeedingPk =
+            allKinds
+            |> List.collect (fun src -> src.References |> List.map (fun r -> r.TargetKind))
+            |> List.distinct
+            |> List.choose (fun targetKey ->
+                Map.tryFind targetKey kindByKey
+                |> Option.bind (fun target ->
+                    if kindHasNoPrimaryKey target then Some target else None))
+        targetsNeedingPk
+        |> List.map (fun target ->
+            let isAccepted = Set.contains target.SsKey allowed
+            let baseMeta : Map<string, string> =
+                Map.empty
+                |> Map.add "targetKind" (SsKey.rootOriginal target.SsKey)
+            let meta =
+                if isAccepted then
+                    baseMeta |> Map.add "acceptedVia" acceptedViaMissingPk
+                else baseMeta
+            {
+                Source          = source
+                Severity        = DiagnosticSeverity.Warning
+                Code            = missingPrimaryKeyCode
+                Message         =
+                    sprintf
+                        "Kind %s has no primary key; references pointing at it cannot get symmetric-closure inverses (downstream FK creation may be skipped)."
+                        (SsKey.rootOriginal target.SsKey)
+                SsKey           = Some target.SsKey
+                Metadata        = meta
+                SuggestedConfig = None
+            })
+
+    let private emitCycleDiagnostics
+        (allowed: Set<Set<SsKey>>)
+        (topo: TopologicalOrder)
+        : DiagnosticEntry list =
+        topo.Cycles
+        |> List.map (fun cycle ->
+            let memberSet = Set.ofList cycle.Members
+            let isAccepted = Set.contains memberSet allowed
+            let baseMeta : Map<string, string> =
+                Map.empty
+                |> Map.add "members" (renderKeys cycle.Members)
+                |> Map.add "reason"  cycle.Reason
+            let meta =
+                if isAccepted then
+                    baseMeta |> Map.add "acceptedVia" acceptedViaCycle
+                else baseMeta
+            // Catalog-level diagnostic — cycles have multiple members
+            // with no canonical single identity. SsKey left None per
+            // the convention named in `Diagnostics.fs:50-53`.
+            {
+                Source          = source
+                Severity        = DiagnosticSeverity.Warning
+                Code            = cycleUnresolvedCode
+                Message         =
+                    sprintf
+                        "Topological sort surfaced unresolved cycle [%s]: %s"
+                        (renderKeys cycle.Members)
+                        cycle.Reason
+                SsKey           = None
+                Metadata        = meta
+                SuggestedConfig = None
+            })
+
+    /// Scan `state.Catalog` for missing-PK targets + read
+    /// `state.TopologicalOrder.Cycles` for unresolved cycles; emit
+    /// one `DiagnosticEntry` per finding, with `Metadata.acceptedVia`
+    /// stamped on entries the operator has allowlisted.
+    let emit
+        (overrides: SpecialCircumstances)
+        (state: ComposeState)
+        : DiagnosticEntry list =
+        let pks = emitMissingPrimaryKeyDiagnostics overrides.AllowedMissingPrimaryKeys state.Catalog
+        let cycles =
+            match state.TopologicalOrder with
+            | None    -> []
+            | Some t  -> emitCycleDiagnostics overrides.AllowedCycles t
+        pks @ cycles

--- a/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
@@ -143,7 +143,6 @@ let private fullConfigJson = """{
         "includeInactiveModules": false,
         "onlyActiveAttributes": true,
         "validationOverrides": {
-            "allowMissingPrimaryKey": [ "Mod::Ent" ],
             "allowMissingSchema": [ "Mod::*" ]
         }
     },
@@ -170,7 +169,10 @@ let private fullConfigJson = """{
                 ] }
             ],
             "strictMode": false
-        }
+        },
+        "allowMissingPrimaryKey": [
+            { "module": "AppCore", "entity": "LegacyAuditLog" }
+        ]
     },
     "dynamicData": {
         "insertMode": "PerEntity",

--- a/sidecar/projection/tests/Projection.Tests/FullExportCliTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportCliTests.fs
@@ -162,7 +162,7 @@ let private runFullExportInProcess
                 let result = task.GetAwaiter().GetResult()
                 sw.Stop()
                 match result with
-                | Ok paths ->
+                | Ok report ->
                     LogSink.recordStage "pipeline" sw.ElapsedMilliseconds LogSink.Succeeded
                     let stagePayload : Map<string, objnull> =
                         Map.ofList [
@@ -174,7 +174,33 @@ let private runFullExportInProcess
                         { LogSink.envelope LogSink.Info LogSink.Summary "summary.stageCompleted" stagePayload with
                             Phase = LogSink.End
                             StepId = Some "pipeline" }
-                    paths
+                    // Chapter C slice C.2 — mirror the production
+                    // `runFullExport` path: emit each special-circumstances
+                    // diagnostic as a `transform.diagnostic` envelope so
+                    // the test harness sees the same stream the CLI does.
+                    for entry in report.Diagnostics do
+                        let level =
+                            match entry.Severity with
+                            | DiagnosticSeverity.Info    -> LogSink.Info
+                            | DiagnosticSeverity.Warning -> LogSink.Warn
+                            | DiagnosticSeverity.Error   -> LogSink.Error
+                        let basePayload : Map<string, objnull> =
+                            Map.ofList [
+                                "source",  box entry.Source
+                                "code",    box entry.Code
+                                "message", box entry.Message
+                            ]
+                        let withSsKey =
+                            match entry.SsKey with
+                            | Some k -> basePayload |> Map.add "ssKey" (box (SsKey.rootOriginal k))
+                            | None   -> basePayload
+                        let payload =
+                            entry.Metadata
+                            |> Map.fold (fun acc k v -> Map.add k (box v) acc) withSsKey
+                        LogSink.emit
+                            { LogSink.envelope level LogSink.Transform "transform.diagnostic" payload with
+                                Phase = LogSink.End }
+                    report.Paths
                     |> List.iter (fun p ->
                         let info = FileInfo p
                         LogSink.recordArtifact {

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -40,6 +40,8 @@
     <Compile Include="ActionableDiagnosticsTests.fs" />
     <Compile Include="TableRenameTests.fs" />
     <Compile Include="TighteningBindingTests.fs" />
+    <Compile Include="SpecialCircumstancesBindingTests.fs" />
+    <Compile Include="SpecialCircumstancesDiagnosticsTests.fs" />
     <Compile Include="ComposeAtomicWriteTests.fs" />
     <Compile Include="SqlTypeCorrespondenceTests.fs" />
     <Compile Include="SqlLiteralTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
@@ -1,0 +1,245 @@
+module Projection.Tests.SpecialCircumstancesBindingTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+/// Chapter C slice C.2 — `SpecialCircumstancesBinding.fromConfig`
+/// coverage. Mirrors `TighteningBindingTests`'s structure: a small
+/// V1 JSON fixture loads a real catalog through `Compose.readJson`;
+/// the binder is exercised across empty / valid / unresolvable / aggregated
+/// paths; structured errors carry the `pipeline.specialCircumstances.*`
+/// code namespace.
+
+let private v1Json : string =
+    """{
+  "exportedAtUtc": "2026-05-20T00:00:00.0000000+00:00",
+  "modules": [
+    {
+      "name": "AppCore",
+      "isSystem": false,
+      "isActive": true,
+      "entities": [
+        {
+          "name": "User",
+          "physicalName": "OSUSR_APPCORE_USER",
+          "isStatic": false,
+          "isExternal": false,
+          "isActive": true,
+          "db_catalog": null,
+          "db_schema": "dbo",
+          "attributes": [
+            {
+              "name": "Id", "physicalName": "ID", "originalName": null,
+              "dataType": "Identifier", "length": null, "precision": null, "scale": null,
+              "default": null, "isMandatory": true, "isIdentifier": true, "isAutoNumber": true,
+              "isActive": true, "isReference": 0, "refEntityId": null,
+              "refEntity_name": null, "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0,
+              "external_dbType": null, "physical_isPresentButInactive": 0
+            }
+          ],
+          "relationships": [], "indexes": [], "triggers": []
+        },
+        {
+          "name": "Organization",
+          "physicalName": "OSUSR_APPCORE_ORG",
+          "isStatic": false,
+          "isExternal": false,
+          "isActive": true,
+          "db_catalog": null,
+          "db_schema": "dbo",
+          "attributes": [
+            {
+              "name": "Id", "physicalName": "ID", "originalName": null,
+              "dataType": "Identifier", "length": null, "precision": null, "scale": null,
+              "default": null, "isMandatory": true, "isIdentifier": true, "isAutoNumber": true,
+              "isActive": true, "isReference": 0, "refEntityId": null,
+              "refEntity_name": null, "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0,
+              "external_dbType": null, "physical_isPresentButInactive": 0
+            }
+          ],
+          "relationships": [], "indexes": [], "triggers": []
+        }
+      ]
+    }
+  ]
+}"""
+
+let private loadCatalog () : Catalog =
+    let task = Compose.readJson v1Json
+    match task.GetAwaiter().GetResult() with
+    | Ok c -> c
+    | Error errs -> failwithf "test fixture invalid: %A" errs
+
+let private emptyOverrides : Config.OverridesSection = {
+    TableRenames           = []
+    MigrationDependencies  = None
+    StaticData             = None
+    CircularDependencies   = None
+    AllowMissingPrimaryKey = []
+}
+
+let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
+    {
+        Model       = {
+            Path                   = "ignored.json"
+            Modules                = []
+            IncludeSystemModules   = false
+            IncludeInactiveModules = false
+            OnlyActiveAttributes   = true
+            ValidationOverrides    = { AllowMissingSchema = [] }
+        }
+        Profile     = { Path = None }
+        Cache       = { Root = ""; Refresh = false; TtlSeconds = 0 }
+        Profiler    = { Provider = "fixture"; MockFolder = None }
+        TypeMapping = { Path = None; Default = None; Overrides = Map.empty }
+        Overrides   = overrides
+        Emission    = {
+            Ssdt = true; Dacpac = true; Json = true; Distributions = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true
+        }
+        Policy      = {
+            Selection    = "IncludeAll"
+            Insertion    = "SchemaOnly"
+            UserMatching = { Strategy = "ByEmail"; Fallback = "NoFallback" }
+            Tightening   = None
+        }
+        Output      = { Dir = "out/" }
+    }
+
+let private hasErrorCode (code: string) (errs: ValidationError list) : bool =
+    errs |> List.exists (fun e -> e.Code = code)
+
+// ----------------------------------------------------------------------
+// Empty paths
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``C.2: empty Overrides yields SpecialCircumstances.empty`` () =
+    let catalog = loadCatalog ()
+    let cfg = mkConfig emptyOverrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok sc ->
+        Assert.True(Set.isEmpty sc.AllowedMissingPrimaryKeys)
+        Assert.True(Set.isEmpty sc.AllowedCycles)
+    | Error errs -> Assert.Fail(sprintf "expected Ok, got errors: %A" errs)
+
+// ----------------------------------------------------------------------
+// AllowMissingPrimaryKey binder
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``C.2: AllowMissingPrimaryKey resolves valid LogicalName to kind SsKey`` () =
+    let catalog = loadCatalog ()
+    let overrides =
+        { emptyOverrides with
+            AllowMissingPrimaryKey = [ { Module = "AppCore"; Entity = "User" } ] }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok sc ->
+        Assert.Equal(1, Set.count sc.AllowedMissingPrimaryKeys)
+        // The resolved SsKey should match the User kind's SsKey.
+        let user =
+            Catalog.allKinds catalog
+            |> List.find (fun k -> Name.value k.Name = "User")
+        Assert.Contains(user.SsKey, sc.AllowedMissingPrimaryKeys)
+    | Error errs -> Assert.Fail(sprintf "expected Ok, got %A" errs)
+
+[<Fact>]
+let ``C.2: AllowMissingPrimaryKey unresolved LogicalName surfaces structured error`` () =
+    let catalog = loadCatalog ()
+    let overrides =
+        { emptyOverrides with
+            AllowMissingPrimaryKey = [ { Module = "AppCore"; Entity = "NoSuchKind" } ] }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok _ -> Assert.Fail("expected Error for unresolved LogicalName")
+    | Error errs ->
+        Assert.True(
+            hasErrorCode "pipeline.specialCircumstances.allowMissingPk.unresolved" errs,
+            sprintf "expected pipeline.specialCircumstances.allowMissingPk.unresolved; got %A" errs)
+
+[<Fact>]
+let ``C.2: AllowMissingPrimaryKey aggregates errors across multiple unresolved entries`` () =
+    let catalog = loadCatalog ()
+    let overrides =
+        { emptyOverrides with
+            AllowMissingPrimaryKey =
+                [ { Module = "Ghost"; Entity = "One" }
+                  { Module = "Ghost"; Entity = "Two" } ] }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok _ -> Assert.Fail("expected Error")
+    | Error errs ->
+        let unresolved =
+            errs
+            |> List.filter (fun e -> e.Code = "pipeline.specialCircumstances.allowMissingPk.unresolved")
+        Assert.Equal(2, unresolved.Length)
+
+// ----------------------------------------------------------------------
+// AllowedCycles binder
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``C.2: AllowedCycles resolves physical TableName entries to SsKey set`` () =
+    let catalog = loadCatalog ()
+    let cycle : Config.CircularDependencyCycle = {
+        TableOrdering = [
+            { TableName = "OSUSR_APPCORE_USER"; Position = 1 }
+            { TableName = "OSUSR_APPCORE_ORG";  Position = 2 }
+        ]
+    }
+    let overrides =
+        { emptyOverrides with
+            CircularDependencies = Some { AllowedCycles = [ cycle ]; StrictMode = false } }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok sc ->
+        Assert.Equal(1, Set.count sc.AllowedCycles)
+        // The resolved cycle should carry both kinds' SsKeys.
+        let resolvedCycle = sc.AllowedCycles |> Set.toList |> List.head
+        Assert.Equal(2, Set.count resolvedCycle)
+    | Error errs -> Assert.Fail(sprintf "expected Ok, got %A" errs)
+
+[<Fact>]
+let ``C.2: AllowedCycles unresolved TableName surfaces structured error`` () =
+    let catalog = loadCatalog ()
+    let cycle : Config.CircularDependencyCycle = {
+        TableOrdering = [
+            { TableName = "OSUSR_DOES_NOT_EXIST"; Position = 1 }
+        ]
+    }
+    let overrides =
+        { emptyOverrides with
+            CircularDependencies = Some { AllowedCycles = [ cycle ]; StrictMode = false } }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok _ -> Assert.Fail("expected Error")
+    | Error errs ->
+        Assert.True(
+            hasErrorCode "pipeline.specialCircumstances.allowedCycle.unresolved" errs,
+            sprintf "expected pipeline.specialCircumstances.allowedCycle.unresolved; got %A" errs)
+
+// ----------------------------------------------------------------------
+// Aggregated errors across axes
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``C.2: errors aggregate across both allowMissingPk and allowedCycles axes`` () =
+    let catalog = loadCatalog ()
+    let cycle : Config.CircularDependencyCycle = {
+        TableOrdering = [ { TableName = "OSUSR_NOPE"; Position = 1 } ]
+    }
+    let overrides =
+        { emptyOverrides with
+            AllowMissingPrimaryKey = [ { Module = "Ghost"; Entity = "Kind" } ]
+            CircularDependencies   = Some { AllowedCycles = [ cycle ]; StrictMode = false } }
+    let cfg = mkConfig overrides
+    match SpecialCircumstancesBinding.fromConfig catalog cfg with
+    | Ok _ -> Assert.Fail("expected Error")
+    | Error errs ->
+        Assert.True(hasErrorCode "pipeline.specialCircumstances.allowMissingPk.unresolved" errs)
+        Assert.True(hasErrorCode "pipeline.specialCircumstances.allowedCycle.unresolved" errs)

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs
@@ -1,0 +1,208 @@
+module Projection.Tests.SpecialCircumstancesDiagnosticsTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+open Projection.Tests.IRBuilders
+
+/// Chapter C slice C.2 — `SpecialCircumstancesDiagnostics.emit`
+/// coverage. Two structural findings under scan: missing-PK target
+/// kinds (referenced by some other kind) + unresolved cycles from
+/// the post-chain `TopologicalOrder`. Acceptance annotation via
+/// `Metadata.acceptedVia` cross-references the operator allowlist.
+
+let private mkName (s: string) : Name = Name.create s |> Result.value
+
+let private mkKindNoPk (kindName: string) (table: string) : Kind =
+    let kKey = kindKey [ kindName ]
+    let aKey = attrKey [ kindName; "Label" ]
+    { Kind.create
+        kKey
+        (mkName kindName)
+        { Schema = "dbo"; Table = table; Catalog = None }
+        [ { Attribute.create aKey (mkName "Label") PrimitiveType.Text with
+              Column       = { ColumnName = "LABEL"; IsNullable = false }
+              IsPrimaryKey = false } ]
+        with References = [] }
+
+let private mkKindWithRefTo (kindName: string) (table: string) (target: Kind) : Kind =
+    let kKey  = kindKey [ kindName ]
+    let idKey = attrKey [ kindName; "Id" ]
+    let fkKey = attrKey [ kindName; sprintf "%sId" (Name.value target.Name) ]
+    let rKey  = refKey  [ kindName; Name.value target.Name ]
+    { Kind.create
+        kKey
+        (mkName kindName)
+        { Schema = "dbo"; Table = table; Catalog = None }
+        [ { Attribute.create idKey (mkName "Id") PrimitiveType.Integer with
+              Column       = { ColumnName = "ID"; IsNullable = false }
+              IsPrimaryKey = true }
+          { Attribute.create fkKey (mkName (sprintf "%sId" (Name.value target.Name))) PrimitiveType.Integer with
+              Column       = { ColumnName = (sprintf "%s_ID" ((Name.value target.Name).ToUpperInvariant()))
+                               IsNullable = false }
+              IsPrimaryKey = false } ]
+        with
+        References =
+            [ Reference.create rKey target.Name fkKey target.SsKey ] }
+
+let private stateOf (catalog: Catalog) : ComposeState =
+    ComposeState.initial catalog
+
+// ----------------------------------------------------------------------
+// Missing primary key
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``C.2: emit yields no missing-PK entries when every referenced kind has a PK`` () =
+    // sampleCatalog: Order → Customer (Customer has PK), plus Country (static).
+    let state = stateOf sampleCatalog
+    let entries =
+        SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty state
+    let pkEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.targetMissingPrimaryKey")
+    Assert.Empty(pkEntries)
+
+[<Fact>]
+let ``C.2: emit surfaces one missing-PK entry per missing-PK referenced kind`` () =
+    let auditNoPk = mkKindNoPk "Audit" "OSUSR_TEST_AUDIT"
+    let logger    = mkKindWithRefTo "Logger" "OSUSR_TEST_LOGGER" auditNoPk
+    let modKey'   = modKey "Test"
+    let catalog   =
+        mkCatalog [ mkModule modKey' (mkName "Test") [ auditNoPk; logger ] ]
+    let entries =
+        SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty (stateOf catalog)
+    let pkEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.targetMissingPrimaryKey")
+    Assert.Equal(1, pkEntries.Length)
+    let entry = pkEntries |> List.head
+    Assert.Equal(Some auditNoPk.SsKey, entry.SsKey)
+    Assert.Equal(DiagnosticSeverity.Warning, entry.Severity)
+    Assert.False(Map.containsKey "acceptedVia" entry.Metadata)
+
+[<Fact>]
+let ``C.2: emit deduplicates missing-PK to one entry per target kind even with N referencing kinds`` () =
+    let auditNoPk = mkKindNoPk "Audit" "OSUSR_TEST_AUDIT"
+    let l1        = mkKindWithRefTo "LoggerA" "OSUSR_TEST_LOGA" auditNoPk
+    let l2        = mkKindWithRefTo "LoggerB" "OSUSR_TEST_LOGB" auditNoPk
+    let modKey'   = modKey "Test"
+    let catalog   =
+        mkCatalog [ mkModule modKey' (mkName "Test") [ auditNoPk; l1; l2 ] ]
+    let entries =
+        SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty (stateOf catalog)
+    let pkEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.targetMissingPrimaryKey")
+    Assert.Equal(1, pkEntries.Length)
+
+[<Fact>]
+let ``C.2: missing-PK entry whose target is in allowlist carries acceptedVia metadata`` () =
+    let auditNoPk = mkKindNoPk "Audit" "OSUSR_TEST_AUDIT"
+    let logger    = mkKindWithRefTo "Logger" "OSUSR_TEST_LOGGER" auditNoPk
+    let modKey'   = modKey "Test"
+    let catalog   =
+        mkCatalog [ mkModule modKey' (mkName "Test") [ auditNoPk; logger ] ]
+    let overrides = { SpecialCircumstances.empty with
+                        AllowedMissingPrimaryKeys = Set.singleton auditNoPk.SsKey }
+    let entries =
+        SpecialCircumstancesDiagnostics.emit overrides (stateOf catalog)
+    let entry =
+        entries
+        |> List.find (fun e -> e.Code = "structural.targetMissingPrimaryKey")
+    Assert.Equal(
+        Some "config:overrides.allowMissingPrimaryKey",
+        Map.tryFind "acceptedVia" entry.Metadata)
+
+[<Fact>]
+let ``C.2: ignored unreferenced missing-PK kinds — scan only fires on referenced targets`` () =
+    let lonelyNoPk = mkKindNoPk "Lonely" "OSUSR_TEST_LONELY"
+    let modKey'    = modKey "Test"
+    let catalog    =
+        mkCatalog [ mkModule modKey' (mkName "Test") [ lonelyNoPk ] ]
+    let entries =
+        SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty (stateOf catalog)
+    let pkEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.targetMissingPrimaryKey")
+    Assert.Empty(pkEntries)
+
+// ----------------------------------------------------------------------
+// Unresolved cycles
+// ----------------------------------------------------------------------
+
+let private mkCycleDiag (members: SsKey list) (reason: string) : CycleDiagnostic = {
+    Members        = members
+    BreakableEdges = []
+    Reason         = reason
+}
+
+let private mkTopo (cycles: CycleDiagnostic list) : TopologicalOrder = {
+    Mode         = Alphabetical
+    Order        = []
+    Edges        = []
+    MissingEdges = []
+    Cycles       = cycles
+    Diagnostics  = []
+}
+
+let private stateWithTopo (catalog: Catalog) (topo: TopologicalOrder) : ComposeState =
+    { ComposeState.initial catalog with TopologicalOrder = Some topo }
+
+[<Fact>]
+let ``C.2: emit yields no cycle entries when TopologicalOrder absent`` () =
+    let entries =
+        SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty (stateOf sampleCatalog)
+    let cycleEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.cycleUnresolved")
+    Assert.Empty(cycleEntries)
+
+[<Fact>]
+let ``C.2: emit yields one cycle entry per unresolved cycle in TopologicalOrder`` () =
+    let topo = mkTopo [ mkCycleDiag [ customerKey; orderKey ] "unresolved 2-cycle" ]
+    let state = stateWithTopo sampleCatalog topo
+    let entries = SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty state
+    let cycleEntries =
+        entries |> List.filter (fun e -> e.Code = "structural.cycleUnresolved")
+    Assert.Equal(1, cycleEntries.Length)
+    let entry = cycleEntries |> List.head
+    Assert.Equal(DiagnosticSeverity.Warning, entry.Severity)
+    Assert.Equal(None, entry.SsKey)
+    Assert.False(Map.containsKey "acceptedVia" entry.Metadata)
+
+[<Fact>]
+let ``C.2: cycle entry whose member-set matches allowlist carries acceptedVia metadata`` () =
+    let cycleMembers = Set.ofList [ customerKey; orderKey ]
+    let topo = mkTopo [ mkCycleDiag [ customerKey; orderKey ] "unresolved 2-cycle" ]
+    let state = stateWithTopo sampleCatalog topo
+    let overrides = { SpecialCircumstances.empty with
+                        AllowedCycles = Set.singleton cycleMembers }
+    let entries = SpecialCircumstancesDiagnostics.emit overrides state
+    let entry =
+        entries |> List.find (fun e -> e.Code = "structural.cycleUnresolved")
+    Assert.Equal(
+        Some "config:overrides.circularDependencies",
+        Map.tryFind "acceptedVia" entry.Metadata)
+
+[<Fact>]
+let ``C.2: cycle allowlist matches on set-equality (order-independent)`` () =
+    // Allowlist registered with members in reverse order — set semantics
+    // mean the cycle is still recognized.
+    let cycleMembersReversed = Set.ofList [ orderKey; customerKey ]
+    let topo = mkTopo [ mkCycleDiag [ customerKey; orderKey ] "unresolved 2-cycle" ]
+    let state = stateWithTopo sampleCatalog topo
+    let overrides = { SpecialCircumstances.empty with
+                        AllowedCycles = Set.singleton cycleMembersReversed }
+    let entries = SpecialCircumstancesDiagnostics.emit overrides state
+    let entry =
+        entries |> List.find (fun e -> e.Code = "structural.cycleUnresolved")
+    Assert.True(Map.containsKey "acceptedVia" entry.Metadata)
+
+[<Fact>]
+let ``C.2: cycle entry carries member list in Metadata`` () =
+    let topo = mkTopo [ mkCycleDiag [ customerKey; orderKey ] "test cycle" ]
+    let state = stateWithTopo sampleCatalog topo
+    let entries = SpecialCircumstancesDiagnostics.emit SpecialCircumstances.empty state
+    let entry =
+        entries |> List.find (fun e -> e.Code = "structural.cycleUnresolved")
+    let members = Map.find "members" entry.Metadata
+    Assert.Contains(SsKey.rootOriginal customerKey, members)
+    Assert.Contains(SsKey.rootOriginal orderKey, members)
+    Assert.Equal("test cycle", Map.find "reason" entry.Metadata)


### PR DESCRIPTION
## Summary

Implements Chapter C slice C.2 — the special-circumstances axis for operator acknowledgement of source-side defects. Adds config-driven allowlists for missing primary keys on referenced kinds and unresolved circular FK dependencies, with structured diagnostic emission and acceptance annotation per the annotate-don't-suppress discipline.

## Key Changes

- **New `SpecialCircumstancesBinding` module** — binds operator config allowlists (`AllowMissingPrimaryKey` and `CircularDependencies.AllowedCycles`) to typed `SsKey` sets by resolving logical/physical references against the loaded catalog. Aggregates all binder errors for single-pass operator feedback.

- **New `SpecialCircumstancesDiagnostics` module** — post-chain scan that emits two structural findings as `DiagnosticEntry`s:
  - `structural.targetMissingPrimaryKey` — one entry per unique missing-PK target kind referenced by any source kind
  - `structural.cycleUnresolved` — one entry per unresolved SCC in `TopologicalOrder.Cycles`
  - Applies `Metadata.acceptedVia` annotation on allowlist matches without suppressing the underlying diagnostic

- **Config shape changes**:
  - Moved `AllowMissingPrimaryKey` from `Model.ValidationOverrides` to `Overrides` section
  - Changed from bare strings to typed `LogicalName` tuples `{ Module: string; Entity: string }`
  - Removed unused `AllowMissingPrimaryKey` from `ValidationOverrides`

- **Pipeline integration**:
  - Factored `projectFromChain` into `projectFromChainWithState` to expose post-chain `ComposeState` for diagnostic scanning without re-running passes
  - Widened `runWithConfig` return type from `Task<Result<string list>>` to `Task<Result<Compose.RunReport>>` carrying both artifact paths and diagnostic entries
  - Updated all three consumers (`Program.runFullExport`, `Program.runEmitFromConfig`, test harness) to handle new return shape

- **CLI emission** — new `emitSpecialCircumstancesDiagnostics` function routes each diagnostic entry as a `transform.diagnostic` LogSink envelope with severity-mapped levels and flattened metadata (including `acceptedVia` on accepted findings)

- **Test coverage** — two new test modules mirror `TighteningBindingTests` structure:
  - `SpecialCircumstancesBindingTests` — validates binder resolution, error aggregation, and empty-path handling
  - `SpecialCircumstancesDiagnosticsTests` — validates missing-PK and cycle emission, deduplication, and acceptance annotation

## Implementation Notes

- Follows the pure-additive post-chain scan pattern established in C.2, generalizable for remaining Chapter C slices without cascading return-type changes through ~90 consumer sites
- Annotate-don't-suppress discipline: allowlisted findings still appear in diagnostic stream with `acceptedVia` metadata, enabling downstream consumers to render acceptance state without occluding source defects
- Cycle allowlist matching uses set-equality (order-independent) on member SsKey sets
- Missing-PK diagnostics deduplicate at target-kind level (one entry per missing-PK kind regardless of reference count)

https://claude.ai/code/session_01Vcw5Uz2Cwx4ZBAJCo2FTSM