### PR TITLE
Separate semantic PrimitiveType from concrete SqlStorageType

### DIFF
--- a/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
@@ -698,33 +698,139 @@ module CatalogReader =
     // Subsequent fixtures extend the table.
     // -----------------------------------------------------------------------
 
-    let private parsePrimitiveType (dataType: string) : Result<PrimitiveType> =
-        // V1's `OutsystemsAttribute.DataType` carries the OutSystems
-        // domain-type name (not the SQL type). Chapter 5.0 slice γ
-        // extends the mapping to cover the data types V1's
-        // `model.edge-case.seed.sql` fixture uses (Identifier / Text /
-        // Boolean / DateTime / Integer / Decimal). The mapping is
-        // V1-derived per the OSSYS adapter translation rule index
-        // (`DECISIONS 2026-05-15 — OSSYS adapter translation rules`).
-        match dataType with
-        | "Identifier"        -> Result.success Integer
-        | "Integer"           -> Result.success Integer
-        | "LongInteger"       -> Result.success Integer
-        | "Text"              -> Result.success Text
-        | "Email"             -> Result.success Text
-        | "PhoneNumber"       -> Result.success Text
-        | "Boolean"           -> Result.success Boolean
-        | "DateTime"          -> Result.success DateTime
-        | "Date"              -> Result.success Date
-        | "Time"              -> Result.success Time
-        | "Decimal"           -> Result.success Decimal
-        | "Currency"          -> Result.success Decimal
-        | "BinaryData"        -> Result.success Binary
+    /// Normalize an `ossys_EntityAttr.Type` value to its mapping key.
+    /// V1's `Osm.Smo/TypeMappingKeyNormalizer` is the donor: strip the
+    /// `rt` runtime-type prefix (`rtText` → `Text`), drop separators
+    /// (`_`, `-`, space), lowercase. Both the runtime form (`rtText`,
+    /// `rtLongInteger`, `rtPhoneNumber`) and the bare domain form
+    /// (`Text`, `LongInteger`) collapse to one key.
+    let private normalizeAttributeType (rawType: string) : string =
+        let trimmed = rawType.Trim()
+        let withoutRt =
+            if trimmed.Length > 2
+               && System.String.Equals(
+                    trimmed.Substring(0, 2), "rt",
+                    System.StringComparison.OrdinalIgnoreCase)
+            then trimmed.Substring(2)
+            else trimmed
+        withoutRt
+            .Replace("_", System.String.Empty)
+            .Replace("-", System.String.Empty)
+            .Replace(" ", System.String.Empty)
+            .ToLowerInvariant()
+
+    /// `Text` / `VarChar` width: OutSystems treats a declared length at
+    /// or above the unicode-text threshold (V1's `maxLengthThreshold =
+    /// 2000`) as open-ended `(MAX)`; a positive sub-threshold length is
+    /// `Bounded`; absence is `(MAX)`.
+    let private textLength (length: int option) : SqlLength =
+        match length with
+        | Some n when n >= 2000 -> Max
+        | Some n when n > 0     -> Bounded n
+        | _                     -> Max
+
+    let private boundedOr (fallback: SqlLength) (length: int option) : SqlLength =
+        match length with
+        | Some n when n > 0 -> Bounded n
+        | _                 -> fallback
+
+    /// Resolve an OSSYS attribute's semantic category AND its concrete
+    /// SQL Server storage type from `ossys_EntityAttr.Type` plus the
+    /// declared length / precision / scale. The mapping is V1-derived
+    /// from `config/type-mapping.default.json` (the donor table; see
+    /// `DECISIONS 2026-05-15 — OSSYS adapter translation rules`):
+    ///   - `longinteger` → `BIGINT` (not `INT` — the semantic category
+    ///     `Integer` collapses both; the concrete storage keeps them
+    ///     apart);
+    ///   - `datetime` → `DATETIME` (not `DATETIME2` — V1's `datetime`
+    ///     maps to the legacy type; `rtDateTime2` is the path to
+    ///     `DATETIME2`).
+    /// Returns the semantic `PrimitiveType` paired with the concrete
+    /// `SqlStorageType` so the attribute carries both consistently.
+    let private parseSemanticType
+        (normalizedType: string)
+        (length: int option)
+        (precision: int option)
+        (scale: int option)
+        : Result<PrimitiveType * SqlStorageType> =
+        match normalizedType with
+        | "identifier"     -> Result.success (Integer, SqlStorageType.BigInt)
+        | "autonumber"     -> Result.success (Integer, SqlStorageType.BigInt)
+        | "integer"        -> Result.success (Integer, SqlStorageType.Int)
+        | "longinteger"    -> Result.success (Integer, SqlStorageType.BigInt)
+        | "boolean"        -> Result.success (Boolean, SqlStorageType.Bit)
+        | "datetime"       -> Result.success (DateTime, SqlStorageType.DateTime)
+        | "datetime2"      -> Result.success (DateTime, SqlStorageType.DateTime2 (Some 7))
+        | "datetimeoffset" -> Result.success (DateTime, SqlStorageType.DateTimeOffset (Some 7))
+        | "date"           -> Result.success (Date, SqlStorageType.Date)
+        | "time"           -> Result.success (Time, SqlStorageType.Time (Some 7))
+        | "decimal"        ->
+            Result.success
+                (Decimal,
+                 SqlStorageType.Decimal
+                    (Option.defaultValue 18 precision, Option.defaultValue 0 scale))
+        | "currency"       -> Result.success (Decimal, SqlStorageType.Decimal (37, 8))
+        | "double" | "float" -> Result.success (Decimal, SqlStorageType.Float)
+        | "real"           -> Result.success (Decimal, SqlStorageType.Real)
+        | "binarydata" | "longbinarydata" ->
+            Result.success (Binary, SqlStorageType.VarBinary Max)
+        | "binary"         -> Result.success (Binary, SqlStorageType.VarBinary (boundedOr Max length))
+        | "varbinary"      -> Result.success (Binary, SqlStorageType.VarBinary (boundedOr Max length))
+        | "image"          -> Result.success (Binary, SqlStorageType.Image)
+        | "longtext"       -> Result.success (Text, SqlStorageType.NVarChar Max)
+        | "text"           -> Result.success (Text, SqlStorageType.NVarChar (textLength length))
+        | "email"          -> Result.success (Text, SqlStorageType.VarChar (boundedOr (Bounded 250) length))
+        | "phonenumber" | "phone" ->
+            Result.success (Text, SqlStorageType.VarChar (boundedOr (Bounded 20) length))
+        | "url" | "password" | "username" | "identifiertext" ->
+            Result.success (Text, SqlStorageType.NVarChar (textLength length))
+        | "guid" | "uniqueidentifier" -> Result.success (Guid, SqlStorageType.UniqueIdentifier)
+        | "xml"            -> Result.success (Text, SqlStorageType.Xml)
+        // Entity-reference attribute (FK). `ossys_EntityAttr.Type`
+        // encodes references either as the logical `rtEntityReference`
+        // code or as the structural `bt<EspaceSsKey>*<EntitySsKey>`
+        // form (the binding-type encoding; the GUID hyphens are
+        // stripped by `normalizeAttributeType` but the `bt` prefix and
+        // `*` separator survive). The attribute's own storage is the
+        // *target entity's identifier* — Long Integer (`BIGINT`) by
+        // OutSystems convention. The reference itself (target kind, FK
+        // constraint) is wired separately via `isReference` /
+        // `refEntityId`.
+        | "entityreference" -> Result.success (Integer, SqlStorageType.BigInt)
+        | other when other.StartsWith("bt", System.StringComparison.Ordinal)
+                     && other.Contains("*") ->
+            Result.success (Integer, SqlStorageType.BigInt)
         | other ->
             Result.failureOf (
                 adapterError
                     "unmappedDataType"
                     (sprintf "DataType '%s' has no V2 PrimitiveType mapping yet." other))
+
+    /// Full attribute-type resolution: semantic category + concrete
+    /// storage, with the optional `external_dbType` override applied.
+    /// V1's `TypeMappingPolicy.Resolve` priority is preserved — an
+    /// `external_dbType` SQL-type string overrides the OSSYS-derived
+    /// storage EXCEPT for `identifier` / `autonumber` / `longinteger`,
+    /// which force the runtime mapping (so a `longinteger` stays
+    /// `BIGINT` regardless of any external override).
+    let private resolveAttributeType
+        (rawType: string)
+        (length: int option)
+        (precision: int option)
+        (scale: int option)
+        (externalDbType: string option)
+        : Result<PrimitiveType * SqlStorageType> =
+        let normalized = normalizeAttributeType rawType
+        parseSemanticType normalized length precision scale
+        |> Result.map (fun (pt, ossysStorage) ->
+            let storage =
+                match normalized with
+                | "identifier" | "autonumber" | "longinteger" -> ossysStorage
+                | _ ->
+                    match externalDbType |> Option.bind (fun raw -> SqlStorageType.ofSqlType raw None None None) with
+                    | Some overridden -> overridden
+                    | None -> ossysStorage
+            pt, storage)
 
     /// V1 reference_deleteRuleCode → V2 ReferenceAction. Mirrors the
     /// V1 mapping in `Osm.Smo/SmoEntityEmitter.cs`:
@@ -814,7 +920,6 @@ module CatalogReader =
           Ok mandatory, Ok identifier ->
             let nameDU       = Name.create rawName
             let key          = attributeSsKey moduleName entityName rawName
-            let primitive    = parsePrimitiveType rawDataType
             let description  =
                 match descriptionResult with
                 | Ok d -> d
@@ -836,6 +941,16 @@ module CatalogReader =
             let lengthOpt    = getOptionalInt attrJson "length"
             let precisionOpt = getOptionalInt attrJson "precision"
             let scaleOpt     = getOptionalInt attrJson "scale"
+            // Resolve the semantic category + concrete SQL Server
+            // storage type from the OutSystems type name (rt-prefix
+            // aware) plus the declared length / precision / scale, with
+            // the optional `external_dbType` override applied. The
+            // semantic `PrimitiveType` stays canonical for the IR's
+            // `Type` field; the concrete `SqlStorageType` carries the
+            // emission evidence (`rtLongInteger` → BIGINT, etc.).
+            let typeEvidence =
+                resolveAttributeType
+                    rawDataType lengthOpt precisionOpt scaleOpt externalDatabaseType
             // Identity = isAutoNumber per V1 convention (only
             // primary-key columns marked isAutoNumber=true map to
             // SQL Server IDENTITY).
@@ -851,9 +966,9 @@ module CatalogReader =
             // upstream (the parent record error path handles the
             // primitive's Error case).
             let defaultValue : SqlLiteral option =
-                match primitive with
+                match typeEvidence with
                 | Error _ -> None
-                | Ok p ->
+                | Ok (p, _) ->
                     match attrJson.TryGetProperty("default") with
                     | true, value when value.ValueKind <> JsonValueKind.Null ->
                         let rawOpt =
@@ -868,8 +983,8 @@ module CatalogReader =
                             | _ -> None
                         rawOpt |> Option.map (SqlLiteral.ofRaw p)
                     | _ -> None
-            match nameDU, key, primitive with
-            | Ok n, Ok k, Ok p ->
+            match nameDU, key, typeEvidence with
+            | Ok n, Ok k, Ok (p, storage) ->
                 Result.success
                     { SsKey        = k
                       Name         = n
@@ -895,16 +1010,17 @@ module CatalogReader =
                       // properties at the boundary today.
                       ExtendedProperties = []
                       OriginalName       = originalName
-                      ExternalDatabaseType = externalDatabaseType }
+                      ExternalDatabaseType = externalDatabaseType
+                      SqlStorage         = Some storage }
             | _ ->
                 // Propagate underlying errors via `propagateOrFallback`.
                 // Substantive causes (e.g., `adapter.osm.unmappedDataType`
-                // from `parsePrimitiveType`) survive the attribute-level
+                // from `resolveAttributeType`) survive the attribute-level
                 // wrap.
                 propagateOrFallback
                     [ Result.errors nameDU
                       Result.errors key
-                      Result.errors primitive ]
+                      Result.errors typeEvidence ]
                     (fun () ->
                         adapterError
                             "attributeBuild"
@@ -1606,9 +1722,15 @@ module CatalogReader =
         : Result<Attribute> =
         let nameDU    = Name.create row.AttrName
         let key       = attributeSsKeyFromRow moduleName entityName row
-        let primitive = parsePrimitiveType row.DataType
-        match nameDU, key, primitive with
-        | Ok n, Ok k, Ok p ->
+        // Resolve semantic category + concrete SQL Server storage from
+        // the rowset's `Type` value (rt-prefix aware), the declared
+        // length / precision / scale, and any `ExternalColumnType`
+        // override. Same resolution as the JSON path.
+        let typeEvidence =
+            resolveAttributeType
+                row.DataType row.Length row.Precision row.Scale row.ExternalDatabaseType
+        match nameDU, key, typeEvidence with
+        | Ok n, Ok k, Ok (p, storage) ->
             Result.success
                 { SsKey        = k
                   Name         = n
@@ -1664,13 +1786,14 @@ module CatalogReader =
                           None
                   ExtendedProperties = []
                   OriginalName = row.OriginalName
-                  ExternalDatabaseType = row.ExternalDatabaseType }
+                  ExternalDatabaseType = row.ExternalDatabaseType
+                  SqlStorage   = Some storage }
         | _ ->
             // Propagate underlying errors via `propagateOrFallback`.
             propagateOrFallback
                 [ Result.errors nameDU
                   Result.errors key
-                  Result.errors primitive ]
+                  Result.errors typeEvidence ]
                 (fun () ->
                     adapterError
                         "attributeRowBuild"

--- a/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
@@ -1810,6 +1810,7 @@ module CatalogReader =
     /// Cross-module FK lifts the same deferral.
     let private parseReferenceRowFor
         (kindKeysByEntityId: Map<int, SsKey>)
+        (kindKeysByEntityName: Map<string, SsKey>)
         (moduleName: string)
         (entityName: string)
         (attrRow: AttributeRow)
@@ -1818,20 +1819,33 @@ module CatalogReader =
         let refKey     = referenceSsKey moduleName entityName attrRow.AttrName
         let refName    = Name.create attrRow.AttrName
         let srcAttrKey = attributeSsKeyFromRow moduleName entityName attrRow
-        // Chapter 5.0 slice γ — when the bundle carries the target's
-        // RefEntityId AND the target entity row has a resolved kind key
-        // in the global lookup, use it directly. This handles GUID-based
-        // EntitySsKey targets correctly (the fallback synthesized key
-        // produces a different SsKey shape that breaks the
-        // danglingTarget invariant). Falls back to the prior synthesized
-        // shape when the target ID is absent or unresolvable.
+        // Target-kind resolution for the reference (FK). The primary key
+        // is the CTE-resolved `RefEntityId` against the GLOBAL
+        // `kindKeysByEntityId` map — cross-module-correct, including for
+        // `bt<espace>*<entity>`-encoded references the rowset CTE
+        // resolves (the espace GUID names the target's module, the
+        // entity GUID its entity). Chapter 5.0 slice γ: this also handles
+        // GUID-based EntitySsKey targets, where the synthesized
+        // `(module, name)` key would have a different shape and break the
+        // danglingTarget invariant.
+        //
+        // Fallback when `RefEntityId` is absent: resolve by entity name
+        // across EVERY module (`kindKeysByEntityName`) rather than
+        // assuming the source module — a cross-module reference whose ID
+        // didn't resolve still finds its target by name. Only when the
+        // name is unknown bundle-wide does it degrade to same-module
+        // synthesis.
+        let resolveByName () : Result<SsKey> =
+            match Map.tryFind refRow.RefEntityName kindKeysByEntityName with
+            | Some key -> Result.success key
+            | None     -> kindSsKey moduleName refRow.RefEntityName
         let tgtKindKey =
             match refRow.RefEntityId with
             | Some id ->
                 match Map.tryFind id kindKeysByEntityId with
                 | Some key -> Result.success key
-                | None -> kindSsKey moduleName refRow.RefEntityName
-            | None -> kindSsKey moduleName refRow.RefEntityName
+                | None     -> resolveByName ()
+            | None -> resolveByName ()
         let onDelete   = parseDeleteRule refRow.DeleteRuleCode
         // Slice A.4.7'-prelude.row17-18-rowset-roundtrip — `OnUpdate`
         // carries SQL Server's `sys.foreign_keys.update_referential_action
@@ -1892,6 +1906,16 @@ module CatalogReader =
             /// synthesized identity per `kindSsKeyFromRow`). Used by
             /// `parseReferenceRowFor` for cross-module FK resolution.
             KindKeysByEntityId : Map<int, SsKey>
+            /// Entity NAME → kind's resolved V2 SsKey, spanning every
+            /// module in the bundle. The cross-module fallback for
+            /// `parseReferenceRowFor` when the resolved `RefEntityId`
+            /// is absent: a `bt<espace>*<entity>` reference whose target
+            /// lives in a different module resolves by name across the
+            /// whole bundle rather than being mis-synthesized into the
+            /// source module. Last-write-wins on the rare cross-module
+            /// name collision (deterministic in bundle order); the
+            /// primary `RefEntityId` path is unambiguous and preferred.
+            KindKeysByEntityName : Map<string, SsKey>
             /// EspaceId → kinds belonging to that module. Owned by
             /// `parseModuleRow`'s walk.
             KindsByEspace : Map<int, KindRow list>
@@ -2186,7 +2210,7 @@ module CatalogReader =
             |> List.collect (fun a ->
                 Map.tryFind a.AttrId ctx.ReferencesByAttr
                 |> Option.defaultValue []
-                |> List.map (parseReferenceRowFor ctx.KindKeysByEntityId moduleName kindRow.EntityName a))
+                |> List.map (parseReferenceRowFor ctx.KindKeysByEntityId ctx.KindKeysByEntityName moduleName kindRow.EntityName a))
         let foldedRefs = Result.aggregate refResults
         // Slice 5.13.ossys-rowsets-cluster — per-Kind index assembly
         // from `IndexesByEntity` × `IndexColumnsByIndex`. The JOIN
@@ -2362,8 +2386,18 @@ module CatalogReader =
                     | Ok key -> Some (k.EntityId, key)
                     | Error _ -> None)
             |> Map.ofList
+        // Global entity-name → kind-key map (spans every module). The
+        // cross-module fallback for `parseReferenceRowFor` when a
+        // bt-resolved reference carries no `RefEntityId`.
+        let kindKeysByEntityName =
+            bundle.Kinds
+            |> List.choose (fun k ->
+                Map.tryFind k.EntityId kindKeysByEntityId
+                |> Option.map (fun key -> k.EntityName, key))
+            |> Map.ofList
         let ctx : RowsetParseContext =
             { KindKeysByEntityId   = kindKeysByEntityId
+              KindKeysByEntityName = kindKeysByEntityName
               KindsByEspace        = kindsByEspace
               AttributesByEntity   = attributesByEntity
               ReferencesByAttr     = referencesByAttr

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
@@ -981,7 +981,19 @@ module MetadataSnapshotRunner =
                     EntityName        = e.EntityName
                     PhysicalTableName = e.PhysicalTableName
                     DbSchema          = dbSchema
-                    IsStatic          = false
+                    // V1 classifies static (lookup) entities via
+                    // `ossys_Entity.Data_Kind = 'staticEntity'`; derive
+                    // `IsStatic` from it so the rowset path marks
+                    // `Modality.Static` (matching the JSON path's
+                    // `isStatic` projection). Previously hardcoded false,
+                    // which silently dropped static-entity classification.
+                    IsStatic          =
+                        match e.DataKind with
+                        | Some dk ->
+                            System.String.Equals(
+                                dk, "staticEntity",
+                                System.StringComparison.OrdinalIgnoreCase)
+                        | None -> false
                     IsExternal        = e.IsExternal
                     IsSystemEntity    = e.IsSystemEntity
                     IsActive          = e.IsActive

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/ossys-edge-case.seed.sql
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/ossys-edge-case.seed.sql
@@ -66,6 +66,11 @@ CREATE TABLE [dbo].[ossys_Entity_Attr]
     [Delete_Rule] NVARCHAR(50) NULL,
     [Physical_Column_Name] NVARCHAR(200) NULL,
     [Database_Name] NVARCHAR(200) NULL,
+    -- `Type` is the OutSystems runtime/binding-type column: scalar attrs
+    -- carry `rt`-codes (rtText, ...) and reference attrs carry the
+    -- `bt<EspaceSsKey>*<EntitySsKey>` binding code. The extraction reads
+    -- it into the bt-resolving CTE (`#RefResolved`).
+    [Type] NVARCHAR(200) NULL,
     [Legacy_Type] NVARCHAR(200) NULL,
     [Decimals] INT NULL,
     [Original_Type] NVARCHAR(200) NULL,
@@ -91,24 +96,33 @@ VALUES
 GO
 
 INSERT INTO [dbo].[ossys_Entity_Attr]
-    ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Length], [Precision], [Scale], [Default_Value], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Referenced_Entity_Id], [Original_Name], [External_Column_Type], [Delete_Rule], [Physical_Column_Name], [Database_Name], [Legacy_Type], [Decimals], [Original_Type], [Description])
+    ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Length], [Precision], [Scale], [Default_Value], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Referenced_Entity_Id], [Original_Name], [External_Column_Type], [Delete_Rule], [Physical_Column_Name], [Database_Name], [Type], [Legacy_Type], [Decimals], [Original_Type], [Description])
 VALUES
-    (10001, 1000, N'Id', 'cccccccc-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, N'Customer identifier'),
-    (10002, 1000, N'Email', 'cccccccc-0000-0000-0000-000000000002', N'Text', 255, NULL, NULL, NULL, 1, 1, 0, 0, NULL, N'EmailAddress', NULL, NULL, N'EMAIL', NULL, NULL, NULL, NULL, N'Customer email'),
-    (10003, 1000, N'FirstName', 'cccccccc-0000-0000-0000-000000000003', N'Text', 100, NULL, NULL, N'''''' , 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'FIRSTNAME', NULL, NULL, NULL, NULL, N'Customer first name'),
-    (10004, 1000, N'LastName', 'cccccccc-0000-0000-0000-000000000004', N'Text', 100, NULL, NULL, N'''''' , 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'LASTNAME', NULL, NULL, NULL, NULL, N'Customer last name'),
-    (10005, 1000, N'CityId', 'cccccccc-0000-0000-0000-000000000005', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 0, 2001, NULL, NULL, N'Protect', N'CITYID', NULL, NULL, NULL, NULL, N'FK to City'),
-    (10006, 1000, N'LegacyCode', 'cccccccc-0000-0000-0000-000000000006', N'Text', 50, NULL, NULL, NULL, 0, 0, 0, 0, NULL, NULL, NULL, NULL, N'LEGACYCODE', NULL, NULL, NULL, NULL, NULL),
-    (20011, 2001, N'Id', 'dddddddd-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL),
-    (20012, 2001, N'Name', 'dddddddd-0000-0000-0000-000000000002', N'Text', 200, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'NAME', NULL, NULL, NULL, NULL, NULL),
-    (20013, 2001, N'IsActive', 'dddddddd-0000-0000-0000-000000000003', N'Boolean', NULL, NULL, NULL, N'1', 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'ISACTIVE', NULL, NULL, NULL, NULL, NULL),
-    (30021, 2002, N'Id', 'eeeeeeee-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, N'int', NULL, N'ID', NULL, NULL, NULL, NULL, NULL),
-    (30022, 2002, N'AccountNumber', 'eeeeeeee-0000-0000-0000-000000000002', N'Text', 50, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, N'varchar(50)', NULL, N'ACCOUNTNUMBER', NULL, NULL, NULL, NULL, NULL),
-    (30023, 2002, N'ExtRef', 'eeeeeeee-0000-0000-0000-000000000003', N'Text', 50, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, N'varchar(50)', NULL, N'EXTREF', NULL, NULL, NULL, NULL, NULL),
-    (40031, 4000, N'Id', 'ffffffff-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL),
-    (40032, 4000, N'TriggeredByUserId', 'ffffffff-0000-0000-0000-000000000002', N'Identifier', NULL, NULL, NULL, NULL, 0, 1, 0, 0, 3001, NULL, NULL, N'Ignore', N'TRIGGEREDBYUSERID', NULL, NULL, NULL, NULL, NULL),
-    (40033, 4000, N'CreatedOn', 'ffffffff-0000-0000-0000-000000000003', N'DateTime', NULL, NULL, NULL, N'getutcdate()', 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'CREATEDON', NULL, NULL, NULL, NULL, NULL),
-    (50041, 3001, N'Id', '99999999-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL);
+    (10001, 1000, N'Id', 'cccccccc-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL, N'Customer identifier'),
+    (10002, 1000, N'Email', 'cccccccc-0000-0000-0000-000000000002', N'Text', 255, NULL, NULL, NULL, 1, 1, 0, 0, NULL, N'EmailAddress', NULL, NULL, N'EMAIL', NULL, NULL, NULL, NULL, NULL, N'Customer email'),
+    (10003, 1000, N'FirstName', 'cccccccc-0000-0000-0000-000000000003', N'Text', 100, NULL, NULL, N'''''' , 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'FIRSTNAME', NULL, NULL, NULL, NULL, NULL, N'Customer first name'),
+    (10004, 1000, N'LastName', 'cccccccc-0000-0000-0000-000000000004', N'Text', 100, NULL, NULL, N'''''' , 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'LASTNAME', NULL, NULL, NULL, NULL, NULL, N'Customer last name'),
+    -- CityId: same-module FK (AppCore Customer -> AppCore City). The
+    -- `Type` column carries the `bt<EspaceSsKey>*<EntitySsKey>` binding
+    -- code and `Referenced_Entity_Id` is NULL, so the rowset CTE must
+    -- resolve the target by parsing the bt-code (the real OSSYS shape).
+    -- `Data_Type` keeps the resolved scalar (Identifier -> BIGINT).
+    (10005, 1000, N'CityId', 'cccccccc-0000-0000-0000-000000000005', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, N'Protect', N'CITYID', NULL, N'bt11111111-1111-1111-1111-111111111111*bbbbbbbb-0000-0000-0000-000000000002', NULL, NULL, NULL, N'FK to City'),
+    (10006, 1000, N'LegacyCode', 'cccccccc-0000-0000-0000-000000000006', N'Text', 50, NULL, NULL, NULL, 0, 0, 0, 0, NULL, NULL, NULL, NULL, N'LEGACYCODE', NULL, NULL, NULL, NULL, NULL, NULL),
+    (20011, 2001, N'Id', 'dddddddd-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL, NULL),
+    (20012, 2001, N'Name', 'dddddddd-0000-0000-0000-000000000002', N'Text', 200, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'NAME', NULL, NULL, NULL, NULL, NULL, NULL),
+    (20013, 2001, N'IsActive', 'dddddddd-0000-0000-0000-000000000003', N'Boolean', NULL, NULL, NULL, N'1', 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'ISACTIVE', NULL, NULL, NULL, NULL, NULL, NULL),
+    (30021, 2002, N'Id', 'eeeeeeee-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, N'int', NULL, N'ID', NULL, NULL, NULL, NULL, NULL, NULL),
+    (30022, 2002, N'AccountNumber', 'eeeeeeee-0000-0000-0000-000000000002', N'Text', 50, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, N'varchar(50)', NULL, N'ACCOUNTNUMBER', NULL, NULL, NULL, NULL, NULL, NULL),
+    (30023, 2002, N'ExtRef', 'eeeeeeee-0000-0000-0000-000000000003', N'Text', 50, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, N'varchar(50)', NULL, N'EXTREF', NULL, NULL, NULL, NULL, NULL, NULL),
+    (40031, 4000, N'Id', 'ffffffff-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL, NULL),
+    -- TriggeredByUserId: cross-module FK (Ops JobRun -> SystemUsers User).
+    -- The `Type` column's bt-code names a DIFFERENT espace (SystemUsers,
+    -- 300) than the source (Ops, 200) with a NULL Referenced_Entity_Id,
+    -- so resolving it exercises the cross-module reference path end-to-end.
+    (40032, 4000, N'TriggeredByUserId', 'ffffffff-0000-0000-0000-000000000002', N'Identifier', NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, N'Ignore', N'TRIGGEREDBYUSERID', NULL, N'bt33333333-3333-3333-3333-333333333333*bbbbbbbb-0000-0000-0000-000000000005', NULL, NULL, NULL, NULL),
+    (40033, 4000, N'CreatedOn', 'ffffffff-0000-0000-0000-000000000003', N'DateTime', NULL, NULL, NULL, N'getutcdate()', 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'CREATEDON', NULL, NULL, NULL, NULL, NULL, NULL),
+    (50041, 3001, N'Id', '99999999-0000-0000-0000-000000000001', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID', NULL, NULL, NULL, NULL, NULL, NULL);
 GO
 
 CREATE TABLE [dbo].[OSUSR_DEF_CITY]

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/ossys-edge-case.seed.sql
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/ossys-edge-case.seed.sql
@@ -216,3 +216,243 @@ BEGIN
 END;
 GO
 
+-- ===================================================================
+-- Comprehensive edge-case expansion. Adds four modules (Sales,
+-- Inventory, Integration[Extension], RefData) and a variegated entity
+-- set that deliberately exercises every extraction-contract surface
+-- the original five-entity fixture left untouched:
+--   * composite primary key (OrderLine)
+--   * self-referencing FK (Category.ParentCategoryId)
+--   * multiple FKs on one entity (SalesOrder -> Customer + Category)
+--   * referential actions: Cascade ('Delete'), SetNull, NoAction
+--     ('Protect'/'Ignore')
+--   * untrusted (WITH NOCHECK) FK (StockMovement.SupplierId)
+--   * computed column (Product.DisplayLabel PERSISTED)
+--   * CHECK constraint (Product.Price >= 0)
+--   * included (non-key) index columns (StockItem)
+--   * type variety: DECIMAL(p,s), Currency, Date, DateTimeOffset, Time,
+--     Float, BinaryData->VARBINARY(MAX), Text->NVARCHAR(MAX), Integer,
+--     LongInteger->BIGINT, GUID
+--   * Extension module (EspaceKind='Extension') + external entity ->
+--     ExternalViaIntegrationStudio origin (SyncLog)
+--   * cross-module FK in a second direction (Sales -> AppCore)
+--   * static (lookup) entities (Country, CurrencyCode)
+--   * multiple triggers on one entity, one enabled + one disabled
+-- Every entity carries a consistent physical OSUSR_*/billing table so the
+-- column/index/trigger/FK-reality joins enrich it. Reference attributes
+-- use the bt<EspaceSsKey>*<EntitySsKey> binding encoding in [Type] with a
+-- NULL Referenced_Entity_Id (the real OSSYS shape).
+-- ===================================================================
+
+INSERT INTO [dbo].[ossys_Espace] ([Id], [Name], [Is_System], [Is_Active], [EspaceKind], [SS_Key]) VALUES
+    (400, N'Sales',       0, 1, N'eSpace',    '44444444-4444-4444-4444-444444444444'),
+    (500, N'Inventory',   0, 1, N'eSpace',    '55555555-5555-5555-5555-555555555555'),
+    (600, N'Integration', 0, 1, N'Extension', '66666666-6666-6666-6666-666666666666'),
+    (700, N'RefData',     0, 1, N'eSpace',    '77777777-7777-7777-7777-777777777777');
+GO
+
+INSERT INTO [dbo].[ossys_Entity]
+    ([Id], [Name], [Physical_Table_Name], [Espace_Id], [Is_Active], [Is_System], [Is_External], [Data_Kind], [PrimaryKey_SS_Key], [SS_Key], [Description])
+VALUES
+    (5000, N'Product',       N'OSUSR_SAL_PRODUCT',   400, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000010', 'bbbbbbbb-0000-0000-0000-000000000010', N'Sellable product with rich type coverage'),
+    (5001, N'Category',      N'OSUSR_SAL_CATEGORY',  400, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000011', 'bbbbbbbb-0000-0000-0000-000000000011', N'Self-referencing category tree'),
+    (5002, N'SalesOrder',    N'OSUSR_SAL_ORDER',     400, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000012', 'bbbbbbbb-0000-0000-0000-000000000012', NULL),
+    (5003, N'OrderLine',     N'OSUSR_SAL_ORDERLINE', 400, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000013', 'bbbbbbbb-0000-0000-0000-000000000013', N'Composite-PK order line'),
+    (6000, N'StockItem',     N'OSUSR_INV_STOCKITEM', 500, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000020', 'bbbbbbbb-0000-0000-0000-000000000020', NULL),
+    (6001, N'Supplier',      N'OSUSR_INV_SUPPLIER',  500, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000021', 'bbbbbbbb-0000-0000-0000-000000000021', NULL),
+    (6002, N'StockMovement', N'OSUSR_INV_MOVEMENT',  500, 1, 0, 0, N'entity',       'aaaaaaaa-0000-0000-0000-000000000022', 'bbbbbbbb-0000-0000-0000-000000000022', NULL),
+    (6100, N'SyncLog',       N'OSUSR_INT_SYNCLOG',   600, 1, 0, 1, N'entity',       'aaaaaaaa-0000-0000-0000-000000000030', 'bbbbbbbb-0000-0000-0000-000000000030', N'External sync log via Integration Studio'),
+    (7000, N'Country',       N'OSUSR_REF_COUNTRY',   700, 1, 0, 0, N'staticEntity', 'aaaaaaaa-0000-0000-0000-000000000040', 'bbbbbbbb-0000-0000-0000-000000000040', N'Static country lookup'),
+    (7001, N'CurrencyCode',  N'OSUSR_REF_CURRENCY',  700, 1, 0, 0, N'staticEntity', 'aaaaaaaa-0000-0000-0000-000000000041', 'bbbbbbbb-0000-0000-0000-000000000041', N'Static currency lookup');
+GO
+
+INSERT INTO [dbo].[ossys_Entity_Attr]
+    ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Length], [Precision], [Scale], [Default_Value], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Referenced_Entity_Id], [Original_Name], [External_Column_Type], [Delete_Rule], [Physical_Column_Name], [Database_Name], [Type], [Legacy_Type], [Decimals], [Original_Type], [Description])
+VALUES
+    -- Product (5000): DECIMAL(18,2), Currency, Date, VARBINARY(MAX),
+    -- NVARCHAR(MAX), a computed column, and a CHECK constraint.
+    (50001, 5000, N'Id',           '00050001-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',           NULL, NULL, NULL, NULL, NULL, NULL),
+    (50002, 5000, N'Sku',          '00050002-0000-0000-0000-000000000000', N'Text',         40, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'SKU',          NULL, NULL, NULL, NULL, NULL, NULL),
+    (50003, 5000, N'Price',        '00050003-0000-0000-0000-000000000000', N'Decimal',    NULL,   18,    2, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'PRICE',        NULL, NULL, NULL, NULL, NULL, NULL),
+    (50004, 5000, N'Cost',         '00050004-0000-0000-0000-000000000000', N'Currency',   NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'COST',         NULL, NULL, NULL, NULL, NULL, NULL),
+    (50005, 5000, N'LaunchDate',   '00050005-0000-0000-0000-000000000000', N'Date',       NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'LAUNCHDATE',   NULL, NULL, NULL, NULL, NULL, NULL),
+    (50006, 5000, N'Photo',        '00050006-0000-0000-0000-000000000000', N'BinaryData', NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'PHOTO',        NULL, NULL, NULL, NULL, NULL, NULL),
+    (50007, 5000, N'Notes',        '00050007-0000-0000-0000-000000000000', N'Text',       NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'NOTES',        NULL, NULL, NULL, NULL, NULL, NULL),
+    (50008, 5000, N'DisplayLabel', '00050008-0000-0000-0000-000000000000', N'Text',         80, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'DISPLAYLABEL', NULL, NULL, NULL, NULL, NULL, N'Computed display label'),
+    -- Category (5001): self-referencing FK ParentCategoryId -> Category.
+    (50011, 5001, N'Id',               '00050011-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL,        N'ID',               NULL, NULL, NULL, NULL, NULL, NULL),
+    (50012, 5001, N'Name',             '00050012-0000-0000-0000-000000000000', N'Text',        100, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL,        N'NAME',             NULL, NULL, NULL, NULL, NULL, NULL),
+    (50013, 5001, N'ParentCategoryId', '00050013-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, N'Protect', N'PARENTCATEGORYID', NULL, N'bt44444444-4444-4444-4444-444444444444*bbbbbbbb-0000-0000-0000-000000000011', NULL, NULL, NULL, NULL),
+    -- SalesOrder (5002): cross-module FK -> Customer (Cascade) + same-module FK -> Category (Protect).
+    (50021, 5002, N'Id',         '00050021-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL,        N'ID',         NULL, NULL, NULL, NULL, NULL, NULL),
+    (50022, 5002, N'CustomerId', '00050022-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, N'Delete',  N'CUSTOMERID', NULL, N'bt11111111-1111-1111-1111-111111111111*bbbbbbbb-0000-0000-0000-000000000001', NULL, NULL, NULL, N'FK to AppCore Customer'),
+    (50023, 5002, N'CategoryId', '00050023-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, N'Protect', N'CATEGORYID', NULL, N'bt44444444-4444-4444-4444-444444444444*bbbbbbbb-0000-0000-0000-000000000011', NULL, NULL, NULL, NULL),
+    (50024, 5002, N'OrderTotal', '00050024-0000-0000-0000-000000000000', N'Currency',   NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL,        N'ORDERTOTAL', NULL, NULL, NULL, NULL, NULL, NULL),
+    (50025, 5002, N'PlacedAt',   '00050025-0000-0000-0000-000000000000', N'DateTime',   NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL,        N'PLACEDAT',   NULL, NULL, NULL, NULL, NULL, NULL),
+    -- OrderLine (5003): COMPOSITE PRIMARY KEY (OrderId + LineNo); OrderId also FK -> SalesOrder.
+    (50031, 5003, N'OrderId',  '00050031-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 1, NULL, NULL, NULL, N'Delete', N'ORDERID',  NULL, N'bt44444444-4444-4444-4444-444444444444*bbbbbbbb-0000-0000-0000-000000000012', NULL, NULL, NULL, N'Composite-PK part + FK'),
+    (50032, 5003, N'LineNo',   '00050032-0000-0000-0000-000000000000', N'Integer',    NULL, NULL, NULL, NULL, 1, 1, 0, 1, NULL, NULL, NULL, NULL,       N'LINENO',   NULL, NULL, NULL, NULL, NULL, N'Composite-PK part'),
+    (50033, 5003, N'Quantity', '00050033-0000-0000-0000-000000000000', N'Integer',    NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL,       N'QUANTITY', NULL, NULL, NULL, NULL, NULL, NULL),
+    -- StockItem (6000): Integer, LongInteger->BIGINT, GUID, DateTimeOffset, Time, Float.
+    (60001, 6000, N'Id',           '00060001-0000-0000-0000-000000000000', N'Identifier',     NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',           NULL, NULL, NULL, NULL, NULL, NULL),
+    (60002, 6000, N'ReorderLevel', '00060002-0000-0000-0000-000000000000', N'Integer',        NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'REORDERLEVEL', NULL, NULL, NULL, NULL, NULL, NULL),
+    (60003, 6000, N'WarehouseQty', '00060003-0000-0000-0000-000000000000', N'LongInteger',    NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'WAREHOUSEQTY', NULL, NULL, NULL, NULL, NULL, NULL),
+    (60004, 6000, N'PublicGuid',   '00060004-0000-0000-0000-000000000000', N'guid',           NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'PUBLICGUID',   NULL, NULL, NULL, NULL, NULL, NULL),
+    (60005, 6000, N'LastSyncedAt', '00060005-0000-0000-0000-000000000000', N'datetimeoffset', NULL, NULL,    7, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'LASTSYNCEDAT', NULL, NULL, NULL, NULL, NULL, NULL),
+    (60006, 6000, N'OpenTime',     '00060006-0000-0000-0000-000000000000', N'time',           NULL, NULL,    7, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'OPENTIME',     NULL, NULL, NULL, NULL, NULL, NULL),
+    (60007, 6000, N'AvgCost',      '00060007-0000-0000-0000-000000000000', N'Float',          NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'AVGCOST',      NULL, NULL, NULL, NULL, NULL, NULL),
+    -- Supplier (6001).
+    (60011, 6001, N'Id',   '00060011-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',   NULL, NULL, NULL, NULL, NULL, NULL),
+    (60012, 6001, N'Name', '00060012-0000-0000-0000-000000000000', N'Text',        150, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'NAME', NULL, NULL, NULL, NULL, NULL, NULL),
+    -- StockMovement (6002): FK -> StockItem (Protect) + nullable FK -> Supplier (SetNull, untrusted).
+    (60021, 6002, N'Id',          '00060021-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL,         N'ID',          NULL, NULL, NULL, NULL, NULL, NULL),
+    (60022, 6002, N'StockItemId', '00060022-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, N'Protect',  N'STOCKITEMID', NULL, N'bt55555555-5555-5555-5555-555555555555*bbbbbbbb-0000-0000-0000-000000000020', NULL, NULL, NULL, NULL),
+    (60023, 6002, N'SupplierId',  '00060023-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, N'SetNull',  N'SUPPLIERID',  NULL, N'bt55555555-5555-5555-5555-555555555555*bbbbbbbb-0000-0000-0000-000000000021', NULL, NULL, NULL, NULL),
+    (60024, 6002, N'MovedAt',     '00060024-0000-0000-0000-000000000000', N'DateTime',   NULL, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL,         N'MOVEDAT',     NULL, NULL, NULL, NULL, NULL, NULL),
+    -- SyncLog (6100): external entity inside an Extension module.
+    (61001, 6100, N'Id',      '00061001-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',      NULL, NULL, NULL, NULL, NULL, NULL),
+    (61002, 6100, N'Payload', '00061002-0000-0000-0000-000000000000', N'Text',       NULL, NULL, NULL, NULL, 0, 1, 0, 0, NULL, NULL, NULL, NULL, N'PAYLOAD', NULL, NULL, NULL, NULL, NULL, NULL),
+    -- Country (7000), CurrencyCode (7001): static lookup entities.
+    (70001, 7000, N'Id',   '00070001-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',   NULL, NULL, NULL, NULL, NULL, NULL),
+    (70002, 7000, N'Code', '00070002-0000-0000-0000-000000000000', N'Text',          3, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'CODE', NULL, NULL, NULL, NULL, NULL, NULL),
+    (70003, 7000, N'Name', '00070003-0000-0000-0000-000000000000', N'Text',        100, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'NAME', NULL, NULL, NULL, NULL, NULL, NULL),
+    (70011, 7001, N'Id',   '00070011-0000-0000-0000-000000000000', N'Identifier', NULL, NULL, NULL, NULL, 1, 1, 1, 1, NULL, NULL, NULL, NULL, N'ID',   NULL, NULL, NULL, NULL, NULL, NULL),
+    (70012, 7001, N'Code', '00070012-0000-0000-0000-000000000000', N'Text',          3, NULL, NULL, NULL, 1, 1, 0, 0, NULL, NULL, NULL, NULL, N'CODE', NULL, NULL, NULL, NULL, NULL, NULL);
+GO
+
+-- Physical tables for the comprehensive expansion. Ordered so FK
+-- targets precede their referencers.
+
+CREATE TABLE [dbo].[OSUSR_SAL_CATEGORY]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [NAME] NVARCHAR(100) NOT NULL,
+    [PARENTCATEGORYID] INT NULL,
+    CONSTRAINT [PK_Category_Id] PRIMARY KEY CLUSTERED ([ID]),
+    -- Self-referencing FK (category tree).
+    CONSTRAINT [FK_OSUSR_SAL_CATEGORY_PARENT] FOREIGN KEY ([PARENTCATEGORYID]) REFERENCES [dbo].[OSUSR_SAL_CATEGORY]([ID])
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_SAL_PRODUCT]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [SKU] NVARCHAR(40) NOT NULL,
+    [PRICE] DECIMAL(18,2) NOT NULL,
+    [COST] DECIMAL(37,8) NULL,
+    [LAUNCHDATE] DATE NULL,
+    [PHOTO] VARBINARY(MAX) NULL,
+    [NOTES] NVARCHAR(MAX) NULL,
+    -- Persisted computed column.
+    [DISPLAYLABEL] AS (CONCAT([SKU], N'-', CONVERT(NVARCHAR(20), [PRICE]))) PERSISTED,
+    CONSTRAINT [PK_Product_Id] PRIMARY KEY CLUSTERED ([ID]),
+    -- Column-level CHECK constraint.
+    CONSTRAINT [CK_OSUSR_SAL_PRODUCT_PRICE] CHECK ([PRICE] >= 0)
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_SAL_ORDER]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [CUSTOMERID] INT NOT NULL,
+    [CATEGORYID] INT NOT NULL,
+    [ORDERTOTAL] DECIMAL(37,8) NOT NULL,
+    [PLACEDAT] DATETIME2(7) NOT NULL,
+    CONSTRAINT [PK_SalesOrder_Id] PRIMARY KEY CLUSTERED ([ID]),
+    -- Cross-module FK to AppCore Customer, ON DELETE CASCADE.
+    CONSTRAINT [FK_OSUSR_SAL_ORDER_CUSTOMER] FOREIGN KEY ([CUSTOMERID]) REFERENCES [dbo].[OSUSR_ABC_CUSTOMER]([ID]) ON DELETE CASCADE,
+    -- Same-module FK to Category, NO ACTION.
+    CONSTRAINT [FK_OSUSR_SAL_ORDER_CATEGORY] FOREIGN KEY ([CATEGORYID]) REFERENCES [dbo].[OSUSR_SAL_CATEGORY]([ID])
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_SAL_ORDERLINE]
+(
+    [ORDERID] INT NOT NULL,
+    [LINENO] INT NOT NULL,
+    [QUANTITY] INT NOT NULL,
+    -- Composite PRIMARY KEY.
+    CONSTRAINT [PK_OrderLine] PRIMARY KEY CLUSTERED ([ORDERID], [LINENO]),
+    CONSTRAINT [FK_OSUSR_SAL_ORDERLINE_ORDER] FOREIGN KEY ([ORDERID]) REFERENCES [dbo].[OSUSR_SAL_ORDER]([ID]) ON DELETE CASCADE
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_INV_SUPPLIER]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [NAME] NVARCHAR(150) NOT NULL,
+    CONSTRAINT [PK_Supplier_Id] PRIMARY KEY CLUSTERED ([ID])
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_INV_STOCKITEM]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [REORDERLEVEL] INT NOT NULL,
+    [WAREHOUSEQTY] BIGINT NOT NULL,
+    [PUBLICGUID] UNIQUEIDENTIFIER NULL,
+    [LASTSYNCEDAT] DATETIMEOFFSET(7) NULL,
+    [OPENTIME] TIME(7) NULL,
+    [AVGCOST] FLOAT NULL,
+    CONSTRAINT [PK_StockItem_Id] PRIMARY KEY CLUSTERED ([ID])
+);
+GO
+
+-- Covering index with an INCLUDE (non-key) column.
+CREATE NONCLUSTERED INDEX [IDX_STOCKITEM_REORDER]
+ON [dbo].[OSUSR_INV_STOCKITEM]([REORDERLEVEL] ASC)
+INCLUDE ([WAREHOUSEQTY]);
+GO
+
+CREATE TABLE [dbo].[OSUSR_INV_MOVEMENT]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [STOCKITEMID] INT NOT NULL,
+    [SUPPLIERID] INT NULL,
+    [MOVEDAT] DATETIME2(7) NOT NULL,
+    CONSTRAINT [PK_StockMovement_Id] PRIMARY KEY CLUSTERED ([ID]),
+    -- FK with ON UPDATE CASCADE (exercises #FkReality.UpdateAction).
+    CONSTRAINT [FK_OSUSR_INV_MOVEMENT_STOCKITEM] FOREIGN KEY ([STOCKITEMID]) REFERENCES [dbo].[OSUSR_INV_STOCKITEM]([ID]) ON UPDATE CASCADE
+);
+GO
+
+-- Nullable FK added WITH NOCHECK so it lands untrusted (is_not_trusted=1),
+-- ON DELETE SET NULL.
+ALTER TABLE [dbo].[OSUSR_INV_MOVEMENT] WITH NOCHECK
+    ADD CONSTRAINT [FK_OSUSR_INV_MOVEMENT_SUPPLIER]
+    FOREIGN KEY ([SUPPLIERID]) REFERENCES [dbo].[OSUSR_INV_SUPPLIER]([ID]) ON DELETE SET NULL;
+GO
+
+-- Two triggers on one entity; the UPDATE trigger is disabled.
+EXEC (N'CREATE TRIGGER [dbo].[TR_OSUSR_INV_MOVEMENT_INS] ON [dbo].[OSUSR_INV_MOVEMENT] AFTER INSERT AS BEGIN SET NOCOUNT ON; END');
+GO
+EXEC (N'CREATE TRIGGER [dbo].[TR_OSUSR_INV_MOVEMENT_UPD] ON [dbo].[OSUSR_INV_MOVEMENT] AFTER UPDATE AS BEGIN SET NOCOUNT ON; END');
+GO
+DISABLE TRIGGER [dbo].[TR_OSUSR_INV_MOVEMENT_UPD] ON [dbo].[OSUSR_INV_MOVEMENT];
+GO
+
+CREATE TABLE [dbo].[OSUSR_INT_SYNCLOG]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [PAYLOAD] NVARCHAR(MAX) NULL,
+    CONSTRAINT [PK_SyncLog_Id] PRIMARY KEY CLUSTERED ([ID])
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_REF_COUNTRY]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [CODE] NVARCHAR(3) NOT NULL,
+    [NAME] NVARCHAR(100) NOT NULL,
+    CONSTRAINT [PK_Country_Id] PRIMARY KEY CLUSTERED ([ID])
+);
+GO
+
+CREATE TABLE [dbo].[OSUSR_REF_CURRENCY]
+(
+    [ID] INT IDENTITY(1,1) NOT NULL,
+    [CODE] NVARCHAR(3) NOT NULL,
+    CONSTRAINT [PK_Currency_Id] PRIMARY KEY CLUSTERED ([ID])
+);
+GO
+

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -388,6 +388,14 @@ module ReadSide =
                             // V1-source values where present.
                             OriginalName = None
                             ExternalDatabaseType = None
+                            // ReadSide reflects the deployed schema
+                            // structurally; the concrete storage type
+                            // is recoverable but unused here. The
+                            // semantic `Type` drives the canary's
+                            // PhysicalSchema comparison; `SqlStorage`
+                            // stays `None` (semantic fallback) so this
+                            // path's emission is unchanged.
+                            SqlStorage = None
                         }
 
     /// Format a SQL Server scalar value as the canonical raw

--- a/sidecar/projection/src/Projection.Core/Catalog.fs
+++ b/sidecar/projection/src/Projection.Core/Catalog.fs
@@ -508,6 +508,18 @@ type Attribute = {
     /// reconstruction and future external-entity DDL paths.
     /// Chapter 4.9 slice β.
     ExternalDatabaseType : string option
+    /// Concrete SQL Server storage type when source evidence names it.
+    /// `Type` (the semantic `PrimitiveType`) is always present; this
+    /// field carries the *concrete realization* the OSSYS adapter
+    /// resolves from `ossys_EntityAttr.Type` (`rtLongInteger` →
+    /// `BigInt`, `rtDateTime` → `DateTime`, ...) or from an
+    /// `external_dbType` override. `None` for sources that carry only
+    /// the semantic category (test fixtures; `ReadSide`'s structural
+    /// reflection); emitters then fall back to the `PrimitiveType` →
+    /// `SqlDataTypeOption` mapping. Invariant:
+    /// `SqlStorageType.toPrimitiveType storage = Type` whenever
+    /// `Some storage`.
+    SqlStorage : SqlStorageType option
 }
 
 
@@ -909,6 +921,7 @@ module Attribute =
     ///   - `DefaultValue = None`; `DefaultName = None`; `Computed = None`
     ///   - `ExtendedProperties = []`
     ///   - `OriginalName = None`; `ExternalDatabaseType = None`
+    ///   - `SqlStorage = None` (semantic fallback; emitters use `Type`)
     ///
     /// Consumers override via record-update: `{ Attribute.create k n
     /// Integer with IsPrimaryKey = true; IsMandatory = true }`.
@@ -932,6 +945,7 @@ module Attribute =
             ExtendedProperties   = []
             OriginalName         = None
             ExternalDatabaseType = None
+            SqlStorage           = None
         }
 
 

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -29,6 +29,7 @@
     <Compile Include="PrimitiveType.fs" />
     <Compile Include="RawValueCodec.fs" />
     <Compile Include="SqlTypeCorrespondence.fs" />
+    <Compile Include="SqlStorageType.fs" />
     <Compile Include="SqlLiteral.fs" />
     <Compile Include="Catalog.fs" />
     <Compile Include="ModuleFilter.fs" />

--- a/sidecar/projection/src/Projection.Core/SqlStorageType.fs
+++ b/sidecar/projection/src/Projection.Core/SqlStorageType.fs
@@ -1,0 +1,219 @@
+namespace Projection.Core
+
+/// Length facet for variable-width SQL Server types (`NVARCHAR`,
+/// `VARCHAR`, `NCHAR`, `CHAR`, `VARBINARY`, `BINARY`). `Max` is SQL
+/// Server's `(MAX)` open-ended marker; `Bounded n` is an explicit
+/// character / byte width.
+type SqlLength =
+    | Bounded of int
+    | Max
+
+/// Concrete SQL Server storage type — the evidence-bearing realization
+/// of *what physically lands in the DDL*. Distinct from `PrimitiveType`,
+/// which is the semantic OutSystems-domain category (A13). The two
+/// concepts diverge wherever the semantic vocabulary is coarser than
+/// the SQL Server emission vocabulary:
+///
+///   - `PrimitiveType.Integer` collapses OutSystems `Integer` and
+///     `LongInteger` to one variant; SQL emission must distinguish
+///     `INT` from `BIGINT`.
+///   - `PrimitiveType.DateTime` collapses `DateTime` / `DateTime2` /
+///     `SmallDateTime` / `DateTimeOffset`; SQL emission must keep them
+///     apart (a `datetime` column is not a `datetime2` column).
+///   - `Text` / `Binary` length and the `(MAX)` marker must survive
+///     the round-trip (`NVARCHAR(100)` ≠ `NVARCHAR(MAX)`).
+///   - Less-common SQL Server types (`MONEY`, `XML`, `IMAGE`,
+///     `FLOAT`) have no dedicated `PrimitiveType` variant but are
+///     legitimate OutSystems attribute realizations.
+///
+/// When source evidence names the concrete type — the OSSYS adapter
+/// reading `ossys_EntityAttr.Type` (`rtLongInteger`, `rtDateTime`,
+/// ...), or an `external_dbType` override — the carrier is `Some`;
+/// emitters prefer it. When evidence carries only the semantic
+/// category (test fixtures; `ReadSide`'s structural reflection), the
+/// carrier is `None` and emitters fall back to the canonical
+/// `PrimitiveType` mapping. Both halves of an attribute's typing stay
+/// consistent: `SqlStorageType.toPrimitiveType` projects any storage
+/// type back to its semantic category, so the `SqlStorage` evidence an
+/// adapter sets never disagrees with the `Type` it sets.
+[<RequireQualifiedAccess>]
+type SqlStorageType =
+    | BigInt
+    | Int
+    | SmallInt
+    | TinyInt
+    | Bit
+    | Decimal of precision: int * scale: int
+    | Numeric of precision: int * scale: int
+    | Money
+    | SmallMoney
+    | Float
+    | Real
+    | NVarChar of length: SqlLength
+    | VarChar of length: SqlLength
+    | NChar of length: int
+    | Char of length: int
+    | NText
+    | Text
+    | DateTime
+    | DateTime2 of scale: int option
+    | DateTimeOffset of scale: int option
+    | SmallDateTime
+    | Date
+    | Time of scale: int option
+    | VarBinary of length: SqlLength
+    | Binary of length: int
+    | Image
+    | UniqueIdentifier
+    | Xml
+
+[<RequireQualifiedAccess>]
+module SqlStorageType =
+
+    /// Project a concrete storage type back to its semantic
+    /// `PrimitiveType` category. The inverse of "narrow a semantic
+    /// category to a concrete realization"; used as the consistency
+    /// witness that an adapter's `(Type, SqlStorage)` pair agrees
+    /// (`toPrimitiveType storage = Type`). Closed-DU dispatch — adding
+    /// a storage variant lights up an exhaustiveness error here.
+    let toPrimitiveType (st: SqlStorageType) : PrimitiveType =
+        match st with
+        | SqlStorageType.BigInt
+        | SqlStorageType.Int
+        | SqlStorageType.SmallInt
+        | SqlStorageType.TinyInt -> Integer
+        | SqlStorageType.Decimal _
+        | SqlStorageType.Numeric _
+        | SqlStorageType.Money
+        | SqlStorageType.SmallMoney
+        | SqlStorageType.Float
+        | SqlStorageType.Real -> Decimal
+        | SqlStorageType.Bit -> Boolean
+        | SqlStorageType.NVarChar _
+        | SqlStorageType.VarChar _
+        | SqlStorageType.NChar _
+        | SqlStorageType.Char _
+        | SqlStorageType.NText
+        | SqlStorageType.Text
+        | SqlStorageType.Xml -> Text
+        | SqlStorageType.DateTime
+        | SqlStorageType.DateTime2 _
+        | SqlStorageType.DateTimeOffset _
+        | SqlStorageType.SmallDateTime -> DateTime
+        | SqlStorageType.Date -> Date
+        | SqlStorageType.Time _ -> Time
+        | SqlStorageType.VarBinary _
+        | SqlStorageType.Binary _
+        | SqlStorageType.Image -> Binary
+        | SqlStorageType.UniqueIdentifier -> Guid
+
+    /// The canonical concrete realization a bare `PrimitiveType`
+    /// implies when no source evidence narrows it further. This is the
+    /// semantic fallback emitters use today via the `PrimitiveType` →
+    /// `SqlDataTypeOption` table; naming it as a `SqlStorageType` keeps
+    /// the fallback equivalence checkable (`toPrimitiveType
+    /// (ofPrimitiveType pt) = pt`). The values mirror the existing
+    /// `SqlTypeCorrespondence.baseName` / `ScriptDomBuild` defaults:
+    /// `Integer → INT`, `DateTime → DATETIME2`, `Text → NVARCHAR(MAX)`.
+    let ofPrimitiveType (pt: PrimitiveType) : SqlStorageType =
+        match pt with
+        | Integer  -> SqlStorageType.Int
+        | Decimal  -> SqlStorageType.Decimal (18, 4)
+        | Text     -> SqlStorageType.NVarChar Max
+        | Boolean  -> SqlStorageType.Bit
+        | DateTime -> SqlStorageType.DateTime2 None
+        | Date     -> SqlStorageType.Date
+        | Time     -> SqlStorageType.Time None
+        | Binary   -> SqlStorageType.VarBinary Max
+        | Guid     -> SqlStorageType.UniqueIdentifier
+
+    /// Parse a SQL Server type expression into a concrete storage type.
+    /// Two evidence shapes converge here:
+    ///   - inline-parenthesized strings (`external_dbType` overrides
+    ///     such as `"NVARCHAR(MAX)"`, `"DECIMAL(18,2)"`, `"BIGINT"`);
+    ///   - bare base names with facets supplied separately (the
+    ///     `INFORMATION_SCHEMA.COLUMNS` shape: `DATA_TYPE = "nvarchar"`
+    ///     plus `CHARACTER_MAXIMUM_LENGTH` / `NUMERIC_PRECISION` /
+    ///     `NUMERIC_SCALE`).
+    ///
+    /// Parenthesized parameters take precedence; the `length` /
+    /// `precision` / `scale` arguments fill in when the string carries
+    /// no parens. A `length` of `-1` is SQL Server's `MAX` sentinel.
+    /// Returns `None` for an unrecognized base name — the caller keeps
+    /// the semantic fallback rather than emitting an unsupported type.
+    let ofSqlType
+        (dataType: string)
+        (length: int option)
+        (precision: int option)
+        (scale: int option)
+        : SqlStorageType option =
+        if System.String.IsNullOrWhiteSpace dataType then None
+        else
+            let trimmed = dataType.Trim()
+            let parenIdx = trimmed.IndexOf('(')
+            let baseName, parenParts =
+                if parenIdx >= 0 && trimmed.EndsWith(")") then
+                    let inner = trimmed.Substring(parenIdx + 1, trimmed.Length - parenIdx - 2)
+                    trimmed.Substring(0, parenIdx).Trim().ToLowerInvariant(),
+                    inner.Split(',') |> Array.map (fun p -> p.Trim())
+                else
+                    trimmed.ToLowerInvariant(), [||]
+            let parenInt (idx: int) : int option =
+                if idx < parenParts.Length then
+                    match System.Int32.TryParse parenParts.[idx] with
+                    | true, n -> Some n
+                    | _ -> None
+                else None
+            let parenIsMax () : bool =
+                parenParts.Length = 1
+                && System.String.Equals(parenParts.[0], "max", System.StringComparison.OrdinalIgnoreCase)
+            // Variable-length resolution: explicit `(MAX)` → Max;
+            // explicit `(n)` or facet column → Bounded n; `-1` sentinel
+            // or absent → Max.
+            let resolveLength () : SqlLength =
+                if parenIsMax () then Max
+                else
+                    match parenInt 0 |> Option.orElse length with
+                    | Some n when n > 0 -> Bounded n
+                    | _ -> Max
+            // Fixed-length resolution (NCHAR / CHAR / BINARY): explicit
+            // width or default 1 (SQL Server's CHAR/BINARY default).
+            let resolveFixed () : int =
+                match parenInt 0 |> Option.orElse length with
+                | Some n when n > 0 -> n
+                | _ -> 1
+            let resolvePrecisionScale () : int * int =
+                (parenInt 0 |> Option.orElse precision |> Option.defaultValue 18),
+                (parenInt 1 |> Option.orElse scale |> Option.defaultValue 0)
+            let resolveScale () : int option =
+                parenInt 0 |> Option.orElse scale
+            match baseName with
+            | "bigint"           -> Some SqlStorageType.BigInt
+            | "int"              -> Some SqlStorageType.Int
+            | "smallint"         -> Some SqlStorageType.SmallInt
+            | "tinyint"          -> Some SqlStorageType.TinyInt
+            | "bit"              -> Some SqlStorageType.Bit
+            | "decimal"          -> Some (SqlStorageType.Decimal (resolvePrecisionScale ()))
+            | "numeric"          -> Some (SqlStorageType.Numeric (resolvePrecisionScale ()))
+            | "money"            -> Some SqlStorageType.Money
+            | "smallmoney"       -> Some SqlStorageType.SmallMoney
+            | "float"            -> Some SqlStorageType.Float
+            | "real"             -> Some SqlStorageType.Real
+            | "nvarchar"         -> Some (SqlStorageType.NVarChar (resolveLength ()))
+            | "varchar"          -> Some (SqlStorageType.VarChar (resolveLength ()))
+            | "nchar"            -> Some (SqlStorageType.NChar (resolveFixed ()))
+            | "char"             -> Some (SqlStorageType.Char (resolveFixed ()))
+            | "ntext"            -> Some SqlStorageType.NText
+            | "text"             -> Some SqlStorageType.Text
+            | "datetime"         -> Some SqlStorageType.DateTime
+            | "datetime2"        -> Some (SqlStorageType.DateTime2 (resolveScale ()))
+            | "datetimeoffset"   -> Some (SqlStorageType.DateTimeOffset (resolveScale ()))
+            | "smalldatetime"    -> Some SqlStorageType.SmallDateTime
+            | "date"             -> Some SqlStorageType.Date
+            | "time"             -> Some (SqlStorageType.Time (resolveScale ()))
+            | "varbinary"        -> Some (SqlStorageType.VarBinary (resolveLength ()))
+            | "binary"           -> Some (SqlStorageType.Binary (resolveFixed ()))
+            | "image"            -> Some SqlStorageType.Image
+            | "uniqueidentifier" -> Some SqlStorageType.UniqueIdentifier
+            | "xml"              -> Some SqlStorageType.Xml
+            | _                  -> None

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -155,6 +155,91 @@ module ScriptDomBuild =
         | _ -> ()
         r :> DataTypeReference
 
+    /// Map a concrete `SqlStorageType` to its ScriptDom
+    /// `SqlDataTypeOption`. Closed-DU dispatch — adding a storage
+    /// variant lights up an exhaustiveness error here. `Xml` is absent
+    /// (it has no `SqlDataTypeOption`; `dataTypeReferenceFromStorage`
+    /// builds an `XmlDataTypeReference` instead).
+    let private storageDataTypeOption (st: SqlStorageType) : SqlDataTypeOption =
+        match st with
+        | SqlStorageType.BigInt           -> SqlDataTypeOption.BigInt
+        | SqlStorageType.Int              -> SqlDataTypeOption.Int
+        | SqlStorageType.SmallInt         -> SqlDataTypeOption.SmallInt
+        | SqlStorageType.TinyInt          -> SqlDataTypeOption.TinyInt
+        | SqlStorageType.Bit              -> SqlDataTypeOption.Bit
+        | SqlStorageType.Decimal _        -> SqlDataTypeOption.Decimal
+        | SqlStorageType.Numeric _        -> SqlDataTypeOption.Numeric
+        | SqlStorageType.Money            -> SqlDataTypeOption.Money
+        | SqlStorageType.SmallMoney       -> SqlDataTypeOption.SmallMoney
+        | SqlStorageType.Float            -> SqlDataTypeOption.Float
+        | SqlStorageType.Real             -> SqlDataTypeOption.Real
+        | SqlStorageType.NVarChar _       -> SqlDataTypeOption.NVarChar
+        | SqlStorageType.VarChar _        -> SqlDataTypeOption.VarChar
+        | SqlStorageType.NChar _          -> SqlDataTypeOption.NChar
+        | SqlStorageType.Char _           -> SqlDataTypeOption.Char
+        | SqlStorageType.NText            -> SqlDataTypeOption.NText
+        | SqlStorageType.Text             -> SqlDataTypeOption.Text
+        | SqlStorageType.DateTime         -> SqlDataTypeOption.DateTime
+        | SqlStorageType.DateTime2 _      -> SqlDataTypeOption.DateTime2
+        | SqlStorageType.DateTimeOffset _ -> SqlDataTypeOption.DateTimeOffset
+        | SqlStorageType.SmallDateTime    -> SqlDataTypeOption.SmallDateTime
+        | SqlStorageType.Date             -> SqlDataTypeOption.Date
+        | SqlStorageType.Time _           -> SqlDataTypeOption.Time
+        | SqlStorageType.VarBinary _      -> SqlDataTypeOption.VarBinary
+        | SqlStorageType.Binary _         -> SqlDataTypeOption.Binary
+        | SqlStorageType.Image            -> SqlDataTypeOption.Image
+        | SqlStorageType.UniqueIdentifier -> SqlDataTypeOption.UniqueIdentifier
+        | SqlStorageType.Xml              -> SqlDataTypeOption.None  // unreachable; Xml builds XmlDataTypeReference before this call
+
+    /// Build a `DataTypeReference` from a concrete `SqlStorageType` —
+    /// the evidence-bearing emission path. Preferred over
+    /// `dataTypeReference` (the `PrimitiveType` fallback) whenever the
+    /// source named the concrete type. `XML` builds an
+    /// `XmlDataTypeReference`; everything else builds a
+    /// `SqlDataTypeReference` carrying length / precision / scale
+    /// parameters faithful to the storage type (`NVARCHAR(MAX)` vs
+    /// `NVARCHAR(100)`; `DECIMAL(18,2)`; `DATETIME2(7)` vs bare
+    /// `DATETIME2`).
+    let dataTypeReferenceFromStorage (st: SqlStorageType) : DataTypeReference =
+        match st with
+        | SqlStorageType.Xml ->
+            // ScriptDom models XML separately (no SqlDataTypeOption).
+            XmlDataTypeReference() :> DataTypeReference
+        | _ ->
+            let r = SqlDataTypeReference()
+            r.SqlDataTypeOption <- storageDataTypeOption st
+            r.Name <- SchemaObjectName()
+            r.Name.Identifiers.Add(bracketed (string r.SqlDataTypeOption))
+            let addInt (n: int) =
+                let lit = IntegerLiteral()
+                lit.Value <- string n
+                r.Parameters.Add(lit)
+            let addLength (len: SqlLength) =
+                match len with
+                | Bounded n -> addInt n
+                | Max ->
+                    let mx = MaxLiteral()
+                    mx.Value <- "MAX"
+                    r.Parameters.Add(mx)
+            let addScale (scale: int option) =
+                match scale with
+                | Some n -> addInt n
+                | None   -> ()
+            match st with
+            | SqlStorageType.NVarChar len
+            | SqlStorageType.VarChar len
+            | SqlStorageType.VarBinary len -> addLength len
+            | SqlStorageType.NChar n
+            | SqlStorageType.Char n
+            | SqlStorageType.Binary n -> addInt n
+            | SqlStorageType.Decimal (p, s)
+            | SqlStorageType.Numeric (p, s) -> addInt p; addInt s
+            | SqlStorageType.DateTime2 scale
+            | SqlStorageType.DateTimeOffset scale
+            | SqlStorageType.Time scale -> addScale scale
+            | _ -> ()
+            r :> DataTypeReference
+
     /// Map a typed `SqlLiteral` value to a ScriptDom `ScalarExpression`
     /// (specifically a `Literal` subclass projected to its supertype
     /// for use in `RowValue.ColumnValues` + DEFAULT clauses). Per the
@@ -249,7 +334,14 @@ module ScriptDomBuild =
             if config.IsPersisted then
                 col.IsPersisted <- true
         | None ->
-            col.DataType <- dataTypeReference c.Type c.Length c.Precision c.Scale
+            // Prefer the concrete `SqlStorageType` evidence (faithful
+            // BIGINT / DATETIME / NVARCHAR(MAX)); fall back to the
+            // `PrimitiveType` → `SqlDataTypeOption` mapping when the
+            // source carried only the semantic category.
+            col.DataType <-
+                match c.SqlStorage with
+                | Some storage -> dataTypeReferenceFromStorage storage
+                | None         -> dataTypeReference c.Type c.Length c.Precision c.Scale
             // Nullability — ScriptDom NULL/NOT NULL constraint is a
             // `NullableConstraintDefinition` on `Constraints`.
             let nullCons = NullableConstraintDefinition()

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
@@ -98,6 +98,11 @@ module SsdtDdlEmitter =
         {
             Name         = a.Column.ColumnName
             Type         = a.Type
+            // Concrete SQL storage evidence (BIGINT / DATETIME /
+            // NVARCHAR(MAX)) when the OSSYS adapter resolved it from
+            // `ossys_EntityAttr.Type`; `None` falls back to the
+            // `PrimitiveType` mapping at the realization layer.
+            SqlStorage   = a.SqlStorage
             Length       = a.Length
             Precision    = a.Precision
             Scale        = a.Scale

--- a/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
@@ -37,6 +37,13 @@ type ColumnDef =
     {
         Name : string
         Type : PrimitiveType
+        /// Concrete SQL Server storage type when source evidence named
+        /// it (carried from `Attribute.SqlStorage`). The realization
+        /// layer prefers this over the `Type` / `Length` / `Precision`
+        /// / `Scale` fallback so `BIGINT` / `DATETIME` / `NVARCHAR(MAX)`
+        /// emit faithfully. `None` falls back to the `PrimitiveType` →
+        /// `SqlDataTypeOption` mapping.
+        SqlStorage : SqlStorageType option
         Length : int option
         Precision : int option
         Scale : int option

--- a/sidecar/projection/tests/Projection.Tests/BtReferenceFkFlowTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/BtReferenceFkFlowTests.fs
@@ -1,0 +1,141 @@
+module Projection.Tests.BtReferenceFkFlowTests
+
+open System.Threading.Tasks
+open Xunit
+open Projection.Core
+open Projection.Core.Passes
+open Projection.Pipeline
+open Projection.Adapters.Osm
+open Projection.Adapters.OssysSql
+open Projection.Targets.SSDT
+
+// ---------------------------------------------------------------------
+// bt<EspaceSsKey>*<EntitySsKey> reference encoding → foreign keys,
+// end-to-end through the live OSSYS rowset extraction path.
+//
+// OutSystems encodes reference (FK) attributes in `ossys_Entity_Attr.Type`
+// as a `bt<espace-guid>*<entity-guid>` binding type. The edge-case seed
+// now carries two such references with a NULL `Referenced_Entity_Id`, so
+// the rowset extraction CTE (`#RefResolved`) MUST parse the bt-code to
+// resolve the target:
+//   - Customer.CityId      → City  (same-module:  AppCore → AppCore)
+//   - JobRun.TriggeredByUserId → User (cross-module: Ops → SystemUsers)
+//
+// These tests assert the binding type flows into the V2 relational
+// structure (a `Reference` whose `TargetKind` resolves to a real kind)
+// and into the emitted SSDT DDL (a `FOREIGN KEY ... REFERENCES` clause).
+// Docker-gated like the sibling extraction canary.
+// ---------------------------------------------------------------------
+
+let private skipIfNoDocker (label: string) : bool =
+    if Deploy.Docker.ensureRunning () then true
+    else
+        printfn "SKIP %s: Docker daemon not reachable." label
+        false
+
+let private extractFromSeed () : Task<Result<Catalog>> =
+    task {
+        let seed = MetadataExtractionSql.readEdgeCaseSeed()
+        let! result =
+            Deploy.withBootstrappedDatabase "BtRefFk" seed (fun cnn ->
+                task {
+                    let! snapshotResult = MetadataSnapshotRunner.runAsync cnn MetadataSnapshotRunner.defaultParameters
+                    match snapshotResult with
+                    | Error errors -> return Result.failure errors
+                    | Ok snapshot ->
+                        let bundle = MetadataSnapshotRunner.toBundle snapshot
+                        let! catalog = CatalogReader.parse (CatalogReader.SnapshotRowsets bundle)
+                        return catalog
+                })
+        return result
+    }
+
+let private allKinds (c: Catalog) : Kind list =
+    c.Modules |> List.collect (fun m -> m.Kinds)
+
+let private kindNamed (name: string) (c: Catalog) : Kind =
+    allKinds c |> List.find (fun k -> Name.value k.Name = name)
+
+let private withCatalog (label: string) (assertion: Catalog -> unit) : unit =
+    if skipIfNoDocker label then
+        match (extractFromSeed ()).GetAwaiter().GetResult() with
+        | Error errors -> Assert.Fail (sprintf "bt-ref extraction failed: %A" errors)
+        | Ok catalog   -> assertion catalog
+
+// ---------------------------------------------------------------------
+// Relational structure — the bt-code resolves into a Reference whose
+// target is a real kind (no dangling), for both same- and cross-module.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``bt same-module reference resolves Customer.CityId to the City kind`` () =
+    withCatalog "bt-ref-same-module" (fun catalog ->
+        let customer = kindNamed "Customer" catalog
+        let city     = kindNamed "City" catalog
+        let cityRef =
+            customer.References
+            |> List.tryFind (fun r -> Name.value r.Name = "CityId")
+        match cityRef with
+        | None -> Assert.Fail "expected Customer.CityId reference resolved from the bt-code"
+        | Some r -> Assert.Equal(city.SsKey, r.TargetKind))
+
+[<Fact>]
+let ``bt cross-module reference resolves JobRun.TriggeredByUserId to the User kind`` () =
+    // JobRun lives in Ops (espace 200); the bt-code's espace GUID names
+    // SystemUsers (espace 300). Resolving the target proves cross-module
+    // bt-reference resolution end-to-end.
+    withCatalog "bt-ref-cross-module" (fun catalog ->
+        let jobRun = kindNamed "JobRun" catalog
+        let user   = kindNamed "User" catalog
+        let userRef =
+            jobRun.References
+            |> List.tryFind (fun r -> Name.value r.Name = "TriggeredByUserId")
+        match userRef with
+        | None -> Assert.Fail "expected JobRun.TriggeredByUserId reference resolved from the bt-code"
+        | Some r ->
+            Assert.Equal(user.SsKey, r.TargetKind)
+            // The target kind is in a different module than the source.
+            let jobRunModule =
+                catalog.Modules |> List.find (fun m -> m.Kinds |> List.exists (fun k -> k.SsKey = jobRun.SsKey))
+            let userModule =
+                catalog.Modules |> List.find (fun m -> m.Kinds |> List.exists (fun k -> k.SsKey = user.SsKey))
+            Assert.NotEqual<string>(Name.value jobRunModule.Name, Name.value userModule.Name))
+
+[<Fact>]
+let ``bt-resolved reference targets are never dangling`` () =
+    // Every Reference's TargetKind must name a kind that exists in the
+    // catalog — the structural invariant the topological order + bootstrap
+    // cycle-breaking rely on. A bt-code that failed to resolve would
+    // synthesize a target key with no matching kind (a dangling edge).
+    withCatalog "bt-ref-no-dangling" (fun catalog ->
+        let kindKeys = allKinds catalog |> List.map (fun k -> k.SsKey) |> Set.ofList
+        for k in allKinds catalog do
+            for r in k.References do
+                Assert.True(
+                    Set.contains r.TargetKind kindKeys,
+                    sprintf "reference %s on kind %s dangles (target not in catalog)"
+                        (Name.value r.Name) (Name.value k.Name)))
+
+// ---------------------------------------------------------------------
+// Emission — the bt-resolved reference becomes a FOREIGN KEY in the DDL.
+// ---------------------------------------------------------------------
+
+type private FsResult<'a, 'b> = Microsoft.FSharp.Core.Result<'a, 'b>
+
+[<Fact>]
+let ``bt-resolved reference emits a FOREIGN KEY referencing the target table`` () =
+    withCatalog "bt-ref-fk-emission" (fun catalog ->
+        let enriched =
+            (CanonicalizeIdentity.registered.Run catalog |> Lineage.map (fun d -> d.Value)).Value
+        match SsdtDdlEmitter.emitSlices enriched with
+        | FsResult.Error err -> Assert.Fail (sprintf "emit failed: %A" err)
+        | FsResult.Ok artifact ->
+            let customer = kindNamed "Customer" enriched
+            let body =
+                match Map.tryFind customer.SsKey (ArtifactByKind.toMap artifact) with
+                | Some f -> f.Body
+                | None   -> Assert.Fail "expected a slice for Customer"; ""
+            // The bt-resolved CityId reference must materialize as a real
+            // FK constraint pointing at City's physical table.
+            Assert.Contains("FOREIGN KEY", body)
+            Assert.Contains("OSUSR_DEF_CITY", body))

--- a/sidecar/projection/tests/Projection.Tests/Fixtures/FixtureGenerator.fs
+++ b/sidecar/projection/tests/Projection.Tests/Fixtures/FixtureGenerator.fs
@@ -608,11 +608,12 @@ module FixtureGenerator =
     /// Generate a fixture matching the spec. Deterministic per
     /// `spec.Seed`: same spec → same DDL byte-for-byte.
     let generate (spec: GenerateSpec) : GeneratedFixture =
-        // Note: Guid.NewGuid is non-deterministic. For static seed
-        // data we tolerate this — the canary's PhysicalSchema
-        // comparison doesn't include row data. If a future
-        // round-trip data canary requires byte-determinism, swap
-        // to a deterministic UUIDv5 per (spec.Seed, table, row).
+        // Fully deterministic: every random draw — structure, names,
+        // types, FK targets, AND static-seed-row SS_Key GUIDs (via
+        // `nextGuid`, which pulls from this same seeded `rng`) — flows
+        // from `spec.Seed`. No `Guid.NewGuid`, clock, or ambient state.
+        // Same spec → byte-identical `Ddl`, `SeedData`, and `Combined`
+        // (asserted by the determinism test in `GeneratorScaleTests`).
         let rng = Random(spec.Seed)
         let ddlSb = StringBuilder(64 * 1024)
         let dataSb = StringBuilder(16 * 1024)

--- a/sidecar/projection/tests/Projection.Tests/GeneratorScaleTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/GeneratorScaleTests.fs
@@ -310,6 +310,34 @@ let ``Generator: deterministic output — same seed produces byte-identical DDL`
     Assert.Equal(f1.TableCount, f2.TableCount)
 
 [<Fact>]
+let ``Generator: deterministic seed data — same seed produces byte-identical INSERTs and GUIDs`` () =
+    // The static-seed rows carry SS_Key GUIDs drawn from the seeded RNG
+    // (`nextGuid`). Byte-identity of `SeedData` / `Combined` proves the
+    // GUIDs (and every INSERT) are deterministic, not just the DDL.
+    let f1 = FixtureGenerator.generate GenerateSpec.medium
+    let f2 = FixtureGenerator.generate GenerateSpec.medium
+    Assert.Equal(f1.SeedData, f2.SeedData)
+    Assert.Equal(f1.Combined, f2.Combined)
+    Assert.Equal(f1.SeedRowCount, f2.SeedRowCount)
+
+[<Fact>]
+let ``Generator: deterministic OSSYS-metadata synthesis — byte-identical across runs`` () =
+    // The synthesized `ossys_*` seed (entity IDs + SS_Key GUIDs via
+    // SHA256-derived `deterministicGuid`) must be byte-identical so the
+    // generated comprehensive fixture is reproducible end-to-end.
+    let f1 = FixtureGenerator.generate GenerateSpec.medium
+    let f2 = FixtureGenerator.generate GenerateSpec.medium
+    Assert.Equal(OssysFixtureSynthesizer.synthesize f1, OssysFixtureSynthesizer.synthesize f2)
+
+[<Fact>]
+let ``Generator: distinct seeds produce distinct output`` () =
+    // Determinism is seed-keyed, not constant: a different seed must
+    // perturb the generated schema (otherwise the seed is inert).
+    let a = FixtureGenerator.generate GenerateSpec.medium
+    let b = FixtureGenerator.generate { GenerateSpec.medium with Seed = GenerateSpec.medium.Seed + 1 }
+    Assert.NotEqual<string>(a.Combined, b.Combined)
+
+[<Fact>]
 let ``Generator: spec scaling — table count matches Entities + StaticEntities`` () =
     let small = FixtureGenerator.generate GenerateSpec.small
     Assert.Equal(GenerateSpec.small.Entities + GenerateSpec.small.StaticEntities, small.TableCount)

--- a/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
@@ -128,8 +128,8 @@ let private expectedCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_USER"; Catalog = None }
           Attributes = [
-              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250 }
+              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 250)) }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
@@ -332,7 +332,7 @@ let private expectedReferenceCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_ACCOUNT"; Catalog = None }
           Attributes = [
-              { Attribute.create accountIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
+              { Attribute.create accountIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
@@ -343,8 +343,8 @@ let private expectedReferenceCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_USER"; Catalog = None }
           Attributes = [
-              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create userAccountIdAttrKey (mkName "AccountId") Integer with Column = { ColumnName = "ACCOUNTID"; IsNullable = false }; IsMandatory = true }
+              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create userAccountIdAttrKey (mkName "AccountId") Integer with Column = { ColumnName = "ACCOUNTID"; IsNullable = false }; IsMandatory = true; SqlStorage = Some SqlStorageType.BigInt }
           ]
           References = [
               { Reference.create userAccountReferenceKey (mkName "AccountId") userAccountIdAttrKey accountKindKey with HasDbConstraint = true }
@@ -471,7 +471,10 @@ let private expectedExternalCatalog : Catalog =
           Modality = []
           Physical = { Schema = "billing"; Table = "BILLING_ACCOUNT"; Catalog = None }
           Attributes = [
-              { Attribute.create billingAccountIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; ExternalDatabaseType = Some "int" }
+              // `external_dbType = "int"` is present, but `Identifier`
+              // forces the runtime mapping (v1 `TypeMappingPolicy`
+              // priority), so the storage stays BIGINT, not the override.
+              { Attribute.create billingAccountIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; ExternalDatabaseType = Some "int"; SqlStorage = Some SqlStorageType.BigInt }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
@@ -649,8 +652,8 @@ let private expectedMixedActiveCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_ACTIVE"; Catalog = None }
           Attributes = [
-              { Attribute.create activeEntityIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create activeEntityDeprecatedAttrKey (mkName "DeprecatedField") Text with Column = { ColumnName = "DEPRECATEDFIELD"; IsNullable = true }; Length = Some 100; IsActive = false }
+              { Attribute.create activeEntityIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create activeEntityDeprecatedAttrKey (mkName "DeprecatedField") Text with Column = { ColumnName = "DEPRECATEDFIELD"; IsNullable = true }; Length = Some 100; IsActive = false; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 100)) }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
@@ -661,7 +664,7 @@ let private expectedMixedActiveCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_RETIRED"; Catalog = None }
           Attributes = [
-              { Attribute.create retiredEntityIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
+              { Attribute.create retiredEntityIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = false; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
@@ -877,11 +880,11 @@ let private expectedIndexCatalog : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_USER"; Catalog = None }
           Attributes = [
-              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250 }
-              { Attribute.create userIndexLastNameAttrKey (mkName "LastName") Text with Column = { ColumnName = "LASTNAME"; IsNullable = false }; IsMandatory = true; Length = Some 100 }
-              { Attribute.create userIndexFirstNameAttrKey (mkName "FirstName") Text with Column = { ColumnName = "FIRSTNAME"; IsNullable = false }; IsMandatory = true; Length = Some 100 }
-              { Attribute.create userIndexEmailLowerAttrKey (mkName "EmailLower") Text with Column = { ColumnName = "EMAILLOWER"; IsNullable = true }; Length = Some 250 }
+              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 250)) }
+              { Attribute.create userIndexLastNameAttrKey (mkName "LastName") Text with Column = { ColumnName = "LASTNAME"; IsNullable = false }; IsMandatory = true; Length = Some 100; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 100)) }
+              { Attribute.create userIndexFirstNameAttrKey (mkName "FirstName") Text with Column = { ColumnName = "FIRSTNAME"; IsNullable = false }; IsMandatory = true; Length = Some 100; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 100)) }
+              { Attribute.create userIndexEmailLowerAttrKey (mkName "EmailLower") Text with Column = { ColumnName = "EMAILLOWER"; IsNullable = true }; Length = Some 250; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 250)) }
           ]
           References = []
           Indexes = [
@@ -1008,8 +1011,8 @@ let private expectedStaticEntityCatalog : Catalog =
           Modality = [ Static [] ]
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_COUNTRY"; Catalog = None }
           Attributes = [
-              { Attribute.create countryIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create countryCodeAttrKey (mkName "Code") Text with Column = { ColumnName = "CODE"; IsNullable = false }; IsMandatory = true; Length = Some 8 }
+              { Attribute.create countryIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create countryCodeAttrKey (mkName "Code") Text with Column = { ColumnName = "CODE"; IsNullable = false }; IsMandatory = true; Length = Some 8; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 8)) }
           ]
           References = []
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }

--- a/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
@@ -132,8 +132,8 @@ let private expectedCatalogSynthesized : Catalog =
           Modality = []
           Physical = { Schema = "dbo"; Table = "OSUSR_APPCORE_USER"; Catalog = None }
           Attributes = [
-              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true }
-              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250 }
+              { Attribute.create userIdAttrKey (mkName "Id") Integer with Column = { ColumnName = "ID"; IsNullable = false }; IsPrimaryKey = true; IsMandatory = true; IsIdentity = true; SqlStorage = Some SqlStorageType.BigInt }
+              { Attribute.create userEmailAttrKey (mkName "Email") Text with Column = { ColumnName = "EMAIL"; IsNullable = false }; IsMandatory = true; Length = Some 250; SqlStorage = Some (SqlStorageType.NVarChar (Bounded 250)) }
           ]
           References = []
           Indexes    = []

--- a/sidecar/projection/tests/Projection.Tests/OssysComprehensiveFixtureTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysComprehensiveFixtureTests.fs
@@ -1,0 +1,177 @@
+module Projection.Tests.OssysComprehensiveFixtureTests
+
+open System.Threading.Tasks
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Adapters.Osm
+open Projection.Adapters.OssysSql
+
+// ---------------------------------------------------------------------
+// Comprehensive edge-case fixture coverage. The expanded
+// `ossys-edge-case.seed.sql` deliberately exercises contract surfaces the
+// original five-entity fixture left untouched. These Docker-gated tests
+// assert each edge case extracts into the V2 Catalog with the right
+// shape — composite PKs, self-/cross-module/multi FKs, referential
+// actions, untrusted FKs, computed columns, CHECK constraints, the full
+// SqlStorageType vocabulary, the Extension-module origin, and static
+// entities.
+// ---------------------------------------------------------------------
+
+let private skipIfNoDocker (label: string) : bool =
+    if Deploy.Docker.ensureRunning () then true
+    else
+        printfn "SKIP %s: Docker daemon not reachable." label
+        false
+
+let private extractFromSeed () : Task<Result<Catalog>> =
+    task {
+        let seed = MetadataExtractionSql.readEdgeCaseSeed()
+        let! result =
+            Deploy.withBootstrappedDatabase "OssysComprehensive" seed (fun cnn ->
+                task {
+                    let! snapshotResult = MetadataSnapshotRunner.runAsync cnn MetadataSnapshotRunner.defaultParameters
+                    match snapshotResult with
+                    | Error errors -> return Result.failure errors
+                    | Ok snapshot ->
+                        let bundle = MetadataSnapshotRunner.toBundle snapshot
+                        let! catalog = CatalogReader.parse (CatalogReader.SnapshotRowsets bundle)
+                        return catalog
+                })
+        return result
+    }
+
+let private allKinds (c: Catalog) : Kind list =
+    c.Modules |> List.collect (fun m -> m.Kinds)
+
+let private kindNamed (name: string) (c: Catalog) : Kind =
+    allKinds c |> List.find (fun k -> Name.value k.Name = name)
+
+let private attrNamed (name: string) (k: Kind) : Attribute =
+    k.Attributes |> List.find (fun a -> Name.value a.Name = name)
+
+let private refNamed (name: string) (k: Kind) : Reference =
+    k.References |> List.find (fun r -> Name.value r.Name = name)
+
+let private withCatalog (label: string) (assertion: Catalog -> unit) : unit =
+    if skipIfNoDocker label then
+        match (extractFromSeed ()).GetAwaiter().GetResult() with
+        | Error errors -> Assert.Fail (sprintf "comprehensive fixture extraction failed: %A" errors)
+        | Ok catalog   -> assertion catalog
+
+// --- Composite primary key ------------------------------------------
+
+[<Fact>]
+let ``OrderLine carries a composite primary key (two PK attributes)`` () =
+    withCatalog "comp-composite-pk" (fun catalog ->
+        let orderLine = kindNamed "OrderLine" catalog
+        let pkAttrs = orderLine.Attributes |> List.filter (fun a -> a.IsPrimaryKey)
+        let pkNames = pkAttrs |> List.map (fun a -> Name.value a.Name) |> List.sort
+        Assert.Equal<string list>(["LineNo"; "OrderId"], pkNames))
+
+// --- Self-referencing FK --------------------------------------------
+
+[<Fact>]
+let ``Category has a self-referencing foreign key`` () =
+    withCatalog "comp-self-ref" (fun catalog ->
+        let category = kindNamed "Category" catalog
+        let parentRef = refNamed "ParentCategoryId" category
+        Assert.Equal(category.SsKey, parentRef.TargetKind))
+
+// --- Multiple FKs on one entity (cross-module + same-module) ---------
+
+[<Fact>]
+let ``SalesOrder carries two foreign keys to distinct targets`` () =
+    withCatalog "comp-multi-fk" (fun catalog ->
+        let order    = kindNamed "SalesOrder" catalog
+        let customer = kindNamed "Customer" catalog
+        let category = kindNamed "Category" catalog
+        Assert.Equal(customer.SsKey, (refNamed "CustomerId" order).TargetKind)
+        Assert.Equal(category.SsKey, (refNamed "CategoryId" order).TargetKind))
+
+// --- Referential actions --------------------------------------------
+
+[<Fact>]
+let ``Referential actions: Cascade, SetNull, and NoAction all resolve`` () =
+    withCatalog "comp-ref-actions" (fun catalog ->
+        let order    = kindNamed "SalesOrder" catalog
+        let movement = kindNamed "StockMovement" catalog
+        // 'Delete' -> Cascade
+        Assert.Equal(Cascade, (refNamed "CustomerId" order).OnDelete)
+        // 'Protect' -> NoAction
+        Assert.Equal(NoAction, (refNamed "CategoryId" order).OnDelete)
+        // 'SetNull' -> SetNull
+        Assert.Equal(SetNull, (refNamed "SupplierId" movement).OnDelete))
+
+[<Fact>]
+let ``Untrusted (WITH NOCHECK) FK lands with IsConstraintTrusted=false`` () =
+    withCatalog "comp-untrusted-fk" (fun catalog ->
+        let movement = kindNamed "StockMovement" catalog
+        Assert.False((refNamed "SupplierId" movement).IsConstraintTrusted))
+
+[<Fact>]
+let ``ON UPDATE CASCADE flows into Reference.OnUpdate`` () =
+    withCatalog "comp-on-update" (fun catalog ->
+        let movement = kindNamed "StockMovement" catalog
+        Assert.Equal<ReferenceAction option>(Some Cascade, (refNamed "StockItemId" movement).OnUpdate))
+
+// --- Computed column + CHECK constraint -----------------------------
+
+[<Fact>]
+let ``Product.DisplayLabel is extracted as a computed column`` () =
+    withCatalog "comp-computed" (fun catalog ->
+        let product = kindNamed "Product" catalog
+        let label = attrNamed "DisplayLabel" product
+        Assert.True(label.Computed.IsSome, "expected DisplayLabel to be a computed column"))
+
+[<Fact>]
+let ``Product carries a CHECK constraint on Price`` () =
+    withCatalog "comp-check" (fun catalog ->
+        let product = kindNamed "Product" catalog
+        Assert.NotEmpty(product.ColumnChecks))
+
+// --- SqlStorageType vocabulary coverage -----------------------------
+
+[<Fact>]
+let ``StockItem covers Integer / LongInteger / GUID / DateTimeOffset / Time / Float storage`` () =
+    withCatalog "comp-types-stockitem" (fun catalog ->
+        let s = kindNamed "StockItem" catalog
+        Assert.Equal(Some SqlStorageType.Int, (attrNamed "ReorderLevel" s).SqlStorage)
+        Assert.Equal(Some SqlStorageType.BigInt, (attrNamed "WarehouseQty" s).SqlStorage)
+        Assert.Equal(Some SqlStorageType.UniqueIdentifier, (attrNamed "PublicGuid" s).SqlStorage)
+        Assert.Equal(Some SqlStorageType.Float, (attrNamed "AvgCost" s).SqlStorage)
+        match (attrNamed "LastSyncedAt" s).SqlStorage with
+        | Some (SqlStorageType.DateTimeOffset _) -> ()
+        | other -> Assert.Fail (sprintf "expected DateTimeOffset storage, got %A" other)
+        match (attrNamed "OpenTime" s).SqlStorage with
+        | Some (SqlStorageType.Time _) -> ()
+        | other -> Assert.Fail (sprintf "expected Time storage, got %A" other))
+
+[<Fact>]
+let ``Product covers Decimal / Currency / Date / VARBINARY(MAX) / NVARCHAR(MAX) storage`` () =
+    withCatalog "comp-types-product" (fun catalog ->
+        let p = kindNamed "Product" catalog
+        Assert.Equal(Some (SqlStorageType.Decimal (18, 2)), (attrNamed "Price" p).SqlStorage)
+        Assert.Equal(Some (SqlStorageType.Decimal (37, 8)), (attrNamed "Cost" p).SqlStorage)
+        Assert.Equal(Some SqlStorageType.Date, (attrNamed "LaunchDate" p).SqlStorage)
+        Assert.Equal(Some (SqlStorageType.VarBinary Max), (attrNamed "Photo" p).SqlStorage)
+        Assert.Equal(Some (SqlStorageType.NVarChar Max), (attrNamed "Notes" p).SqlStorage))
+
+// --- Extension module origin ----------------------------------------
+
+[<Fact>]
+let ``External entity in an Extension module resolves to ExternalViaIntegrationStudio`` () =
+    withCatalog "comp-extension-origin" (fun catalog ->
+        let syncLog = kindNamed "SyncLog" catalog
+        Assert.Equal(ExternalViaIntegrationStudio, syncLog.Origin))
+
+// --- Static entities -------------------------------------------------
+
+[<Fact>]
+let ``Static lookup entities are marked with the Static modality`` () =
+    withCatalog "comp-static" (fun catalog ->
+        let country = kindNamed "Country" catalog
+        let isStatic =
+            country.Modality
+            |> List.exists (function Static _ -> true | _ -> false)
+        Assert.True(isStatic, "expected Country to carry Modality.Static"))

--- a/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
@@ -61,9 +61,11 @@ let ``Slice ε canary: OSSYS seed fixture extracts to a V2 Catalog with 3 module
         | Error errors ->
             Assert.Fail (sprintf "OSSYS canary extraction failed: %A" errors)
         | Ok catalog ->
-            // V1 fixture INSERTs 3 modules: AppCore (100), Ops (200), SystemUsers (300).
-            // All three carry IsActive=1; AppCore + Ops are user modules; SystemUsers is system.
-            Assert.Equal(3, List.length catalog.Modules)
+            // The seed defines 7 modules: AppCore (100), Ops (200),
+            // SystemUsers (300, system), Sales (400), Inventory (500),
+            // Integration (600, Extension), RefData (700). The original
+            // three are preserved; the comprehensive expansion adds four.
+            Assert.Equal(7, List.length catalog.Modules)
 
 [<Fact>]
 let ``Slice ε canary: OSSYS seed fixture extracts the AppCore module with 3 entities`` () =

--- a/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
@@ -118,8 +118,9 @@ let ``Slice ε canary: Customer entity carries six attributes including FK to Ci
                 appCore.Kinds
                 |> List.find (fun k -> Name.value k.Name = "Customer")
             Assert.Equal(6, List.length customer.Attributes)
-            // CityId attribute carries Referenced_Entity_Id=2001 (City);
-            // V2's RowsetBundle composes this into a Reference.
+            // CityId carries a `bt<espace>*<entity>` binding type in the
+            // `Type` column with a NULL Referenced_Entity_Id; the rowset
+            // CTE resolves the bt-code to City and V2 composes a Reference.
             let hasCityRef =
                 customer.References
                 |> List.exists (fun r ->

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -187,6 +187,7 @@
     <Compile Include="V1NullabilityParityTests.fs" />
     <Compile Include="SsdtDdlEmitterTests.fs" />
     <Compile Include="SqlStorageEmissionTests.fs" />
+    <Compile Include="BtReferenceFkFlowTests.fs" />
     <Compile Include="SsdtDdlEmitterPropertyTests.fs" />
     <Compile Include="SsdtSchemaFidelityPropertyTests.fs" />
     <Compile Include="DacpacEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -188,6 +188,7 @@
     <Compile Include="SsdtDdlEmitterTests.fs" />
     <Compile Include="SqlStorageEmissionTests.fs" />
     <Compile Include="BtReferenceFkFlowTests.fs" />
+    <Compile Include="OssysComprehensiveFixtureTests.fs" />
     <Compile Include="SsdtDdlEmitterPropertyTests.fs" />
     <Compile Include="SsdtSchemaFidelityPropertyTests.fs" />
     <Compile Include="DacpacEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="SummaryFormatterTests.fs" />
     <Compile Include="ComposeAtomicWriteTests.fs" />
     <Compile Include="SqlTypeCorrespondenceTests.fs" />
+    <Compile Include="SqlStorageTypeTests.fs" />
     <Compile Include="SqlLiteralTests.fs" />
     <Compile Include="LineageTests.fs" />
     <Compile Include="DiagnosticsTests.fs" />
@@ -185,6 +186,7 @@
     <Compile Include="EndToEndDifferentialTests.fs" />
     <Compile Include="V1NullabilityParityTests.fs" />
     <Compile Include="SsdtDdlEmitterTests.fs" />
+    <Compile Include="SqlStorageEmissionTests.fs" />
     <Compile Include="SsdtDdlEmitterPropertyTests.fs" />
     <Compile Include="SsdtSchemaFidelityPropertyTests.fs" />
     <Compile Include="DacpacEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ScriptDomRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ScriptDomRoundTripTests.fs
@@ -59,6 +59,7 @@ let private sampleColumns : ColumnDef list =
         {
             Name = "Id"
             Type = Integer
+            SqlStorage = None
             Length = None; Precision = None; Scale = None
             Nullable = false; IsIdentity = true; IsPrimaryKey = true
             DefaultValue = None; DefaultName = None
@@ -68,6 +69,7 @@ let private sampleColumns : ColumnDef list =
         {
             Name = "Name"
             Type = Text
+            SqlStorage = None
             Length = Some 100; Precision = None; Scale = None
             Nullable = false; IsIdentity = false; IsPrimaryKey = false
             DefaultValue = None; DefaultName = None
@@ -77,6 +79,7 @@ let private sampleColumns : ColumnDef list =
         {
             Name = "Score"
             Type = Decimal
+            SqlStorage = None
             Length = None; Precision = Some 18; Scale = Some 4
             Nullable = true; IsIdentity = false; IsPrimaryKey = false
             DefaultValue = None; DefaultName = None

--- a/sidecar/projection/tests/Projection.Tests/SqlStorageEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlStorageEmissionTests.fs
@@ -1,0 +1,215 @@
+module Projection.Tests.SqlStorageEmissionTests
+
+open Xunit
+open Projection.Core
+open Projection.Core.Passes
+open Projection.Targets.SSDT
+open Projection.Adapters.Osm
+
+// ---------------------------------------------------------------------------
+// Concrete SQL Server storage types end-to-end: the OSSYS adapter resolves
+// `ossys_EntityAttr.Type` (rt-prefix aware) into a concrete `SqlStorageType`,
+// and the SSDT emitter prefers it over the semantic `PrimitiveType` fallback.
+//
+// The bugs this fixes (per the v1 type-mapping donor table):
+//   - `longinteger` must emit BIGINT, not INT (the semantic category
+//     `Integer` collapses both).
+//   - `datetime` must emit DATETIME, not DATETIME2.
+//   - `rtText` / `rtEmail` / `rtPhoneNumber` were previously unmapped.
+// ---------------------------------------------------------------------------
+
+let private parseSync (source: CatalogReader.SnapshotSource) : Result<Catalog> =
+    (CatalogReader.parse source).GetAwaiter().GetResult()
+
+let private parseOk (json: string) : Catalog =
+    match parseSync (CatalogReader.SnapshotJson json) with
+    | Ok c        -> c
+    | Error errs  ->
+        Assert.Fail (sprintf "expected Ok catalog; got %A" errs)
+        Unchecked.defaultof<Catalog>
+
+let private findAttr (name: string) (c: Catalog) : Attribute =
+    c.Modules
+    |> List.collect (fun m -> m.Kinds)
+    |> List.collect (fun k -> k.Attributes)
+    |> List.find (fun a -> Name.value a.Name = name)
+
+// Build a one-attribute entity JSON. Keeps each storage-mapping case
+// isolated so the assertion names the exact OutSystems type under test.
+let private singleAttrJson (dataType: string) (length: string) (externalDbType: string) : string =
+    sprintf """{
+  "exportedAtUtc": "2026-05-23T00:00:00.0000000+00:00",
+  "modules": [
+    {
+      "name": "AppCore",
+      "isSystem": false,
+      "isActive": true,
+      "entities": [
+        {
+          "name": "Widget",
+          "physicalName": "OSUSR_APP_WIDGET",
+          "isStatic": false,
+          "isExternal": false,
+          "isActive": true,
+          "db_catalog": null,
+          "db_schema": "dbo",
+          "attributes": [
+            {
+              "name": "Id",
+              "physicalName": "ID",
+              "dataType": "Identifier",
+              "length": null, "precision": null, "scale": null,
+              "default": null,
+              "isMandatory": true, "isIdentifier": true, "isAutoNumber": true,
+              "isActive": true, "isReference": 0,
+              "external_dbType": null
+            },
+            {
+              "name": "Subject",
+              "physicalName": "SUBJECT",
+              "dataType": "%s",
+              "length": %s, "precision": null, "scale": null,
+              "default": null,
+              "isMandatory": false, "isIdentifier": false, "isAutoNumber": false,
+              "isActive": true, "isReference": 0,
+              "external_dbType": %s
+            }
+          ],
+          "relationships": [],
+          "indexes": [],
+          "triggers": []
+        }
+      ]
+    }
+  ]
+}""" dataType length externalDbType
+
+// ---------------------------------------------------------------------------
+// Adapter mapping — the resolved SqlStorageType per OutSystems type. These
+// assert the concrete realization on the IR (typed, exact).
+// ---------------------------------------------------------------------------
+
+[<Theory>]
+[<InlineData("LongInteger", "BigInt")>]
+[<InlineData("rtLongInteger", "BigInt")>]
+[<InlineData("Integer", "Int")>]
+[<InlineData("rtInteger", "Int")>]
+[<InlineData("Identifier", "BigInt")>]
+[<InlineData("rtBoolean", "Bit")>]
+let ``OSSYS adapter resolves integer-family storage (rt-prefix aware)`` (dataType: string) (expected: string) =
+    let cat = parseOk (singleAttrJson dataType "null" "null")
+    let attr = findAttr "Subject" cat
+    Assert.Equal (expected, sprintf "%A" attr.SqlStorage.Value)
+
+[<Fact>]
+let ``OSSYS adapter resolves longinteger to BigInt, not Int (semantic-collapse bug fix)`` () =
+    let cat = parseOk (singleAttrJson "longinteger" "null" "null")
+    let attr = findAttr "Subject" cat
+    // Semantic category stays Integer (PrimitiveType is coarse)...
+    Assert.Equal (Integer, attr.Type)
+    // ...but the concrete storage is BIGINT, not the INT the semantic
+    // fallback would have produced.
+    Assert.Equal (Some SqlStorageType.BigInt, attr.SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter resolves datetime to DateTime, not DateTime2 (v1 bug fix)`` () =
+    let cat = parseOk (singleAttrJson "datetime" "null" "null")
+    let attr = findAttr "Subject" cat
+    Assert.Equal (DateTime, attr.Type)
+    Assert.Equal (Some SqlStorageType.DateTime, attr.SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter maps entity-reference encodings to identifier storage`` () =
+    // Both the logical `rtEntityReference` code and the structural
+    // `bt<espace>*<entity>` binding encoding resolve to the target's
+    // identifier storage (BIGINT).
+    let refCat = parseOk (singleAttrJson "rtEntityReference" "null" "null")
+    Assert.Equal (Some SqlStorageType.BigInt, (findAttr "Subject" refCat).SqlStorage)
+    let btEncoding = "bt550e8400-e29b-41d4-a716-446655440000*6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+    let btCat = parseOk (singleAttrJson btEncoding "null" "null")
+    Assert.Equal (Some SqlStorageType.BigInt, (findAttr "Subject" btCat).SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter maps rtText / rtEmail / rtPhoneNumber (previously unmapped)`` () =
+    let textCat  = parseOk (singleAttrJson "rtText" "null" "null")
+    let emailCat = parseOk (singleAttrJson "rtEmail" "null" "null")
+    let phoneCat = parseOk (singleAttrJson "rtPhoneNumber" "null" "null")
+    Assert.Equal (Some (SqlStorageType.NVarChar Max), (findAttr "Subject" textCat).SqlStorage)
+    Assert.Equal (Some (SqlStorageType.VarChar (Bounded 250)), (findAttr "Subject" emailCat).SqlStorage)
+    Assert.Equal (Some (SqlStorageType.VarChar (Bounded 20)), (findAttr "Subject" phoneCat).SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter folds declared length into Text storage`` () =
+    let cat = parseOk (singleAttrJson "rtText" "100" "null")
+    Assert.Equal (Some (SqlStorageType.NVarChar (Bounded 100)), (findAttr "Subject" cat).SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter applies external_dbType override for non-runtime-forced types`` () =
+    let cat = parseOk (singleAttrJson "rtText" "null" "\"NVARCHAR(4000)\"")
+    Assert.Equal (Some (SqlStorageType.NVarChar (Bounded 4000)), (findAttr "Subject" cat).SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter keeps longinteger BIGINT even under external_dbType override`` () =
+    // V1 priority: identifier / autonumber / longinteger force runtime
+    // mapping, so an external override cannot demote a longinteger.
+    let cat = parseOk (singleAttrJson "longinteger" "null" "\"DATETIME\"")
+    Assert.Equal (Some SqlStorageType.BigInt, (findAttr "Subject" cat).SqlStorage)
+
+[<Fact>]
+let ``OSSYS adapter stays consistent: toPrimitiveType storage = Type`` () =
+    // The invariant the two-field design rests on — the concrete storage
+    // an adapter sets always projects back to the semantic Type it sets.
+    for dt in [ "longinteger"; "rtDateTime"; "rtText"; "rtEmail"; "Currency"; "Identifier" ] do
+        let attr = findAttr "Subject" (parseOk (singleAttrJson dt "null" "null"))
+        Assert.Equal (attr.Type, SqlStorageType.toPrimitiveType attr.SqlStorage.Value)
+
+// ---------------------------------------------------------------------------
+// Emission — the SSDT body prefers the concrete storage type. End-to-end:
+// adapter → enrich → SsdtDdlEmitter → rendered SQL text.
+// ---------------------------------------------------------------------------
+
+type private FsResult<'a, 'b> = Microsoft.FSharp.Core.Result<'a, 'b>
+
+let private ciRun (c: Catalog) : Catalog =
+    (CanonicalizeIdentity.registered.Run c |> Lineage.map (fun d -> d.Value)).Value
+
+let private emitBody (json: string) : string =
+    let enriched = ciRun (parseOk json)
+    match SsdtDdlEmitter.emitSlices enriched with
+    | FsResult.Error err -> Assert.Fail (sprintf "expected Ok; got %A" err); ""
+    | FsResult.Ok artifact ->
+        ArtifactByKind.toMap artifact
+        |> Map.toList
+        |> List.map (fun (_, f) -> f.Body)
+        |> String.concat "\n"
+
+[<Fact>]
+let ``Emission: longinteger renders BIGINT`` () =
+    let body = emitBody (singleAttrJson "longinteger" "null" "null")
+    Assert.Contains ("BIGINT", body)
+
+[<Fact>]
+let ``Emission: datetime renders DATETIME and not DATETIME2`` () =
+    let body = emitBody (singleAttrJson "datetime" "null" "null")
+    Assert.Contains ("DATETIME", body)
+    Assert.DoesNotContain ("DATETIME2", body)
+
+[<Fact>]
+let ``Emission: plain integer renders INT, not BIGINT (distinction is real)`` () =
+    // The Id column is Identifier→BIGINT; the Subject column is the
+    // semantic Integer→INT. Stripping every BIGINT occurrence must leave
+    // a bare INT for the Subject column, proving INT and BIGINT diverge.
+    let body = emitBody (singleAttrJson "Integer" "null" "null")
+    let withoutBigint = body.Replace("BIGINT", "")
+    Assert.Contains ("INT", withoutBigint)
+
+[<Fact>]
+let ``Emission: rtText with no length renders NVARCHAR (MAX)`` () =
+    let body = emitBody (singleAttrJson "rtText" "null" "null")
+    Assert.Contains ("NVARCHAR", body)
+    Assert.Contains ("MAX", body)
+
+[<Fact>]
+let ``Emission: external_dbType override renders the concrete type`` () =
+    let body = emitBody (singleAttrJson "rtText" "null" "\"NVARCHAR(4000)\"")
+    Assert.Contains ("4000", body)

--- a/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
@@ -1,0 +1,121 @@
+module Projection.Tests.SqlStorageTypeTests
+
+open Xunit
+open Projection.Core
+
+// ---------------------------------------------------------------------------
+// `SqlStorageType` — the concrete SQL Server realization, distinct from the
+// semantic `PrimitiveType`. These tests pin three contracts:
+//   1. `toPrimitiveType` projects every storage variant to the right
+//      semantic category (the adapter-consistency witness).
+//   2. `ofPrimitiveType` is a section of `toPrimitiveType` (round-trip).
+//   3. `ofSqlType` parses both inline-parenthesized strings (external_dbType)
+//      and bare-name + facet-column shapes (INFORMATION_SCHEMA).
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// toPrimitiveType — the semantic category each concrete storage type belongs
+// to. The collapse points the separation exists to preserve: BigInt and Int
+// both project to Integer; DateTime and DateTime2 both project to DateTime.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Integer family projects to PrimitiveType.Integer`` () =
+    Assert.Equal (Integer, SqlStorageType.toPrimitiveType SqlStorageType.BigInt)
+    Assert.Equal (Integer, SqlStorageType.toPrimitiveType SqlStorageType.Int)
+    Assert.Equal (Integer, SqlStorageType.toPrimitiveType SqlStorageType.SmallInt)
+    Assert.Equal (Integer, SqlStorageType.toPrimitiveType SqlStorageType.TinyInt)
+
+[<Fact>]
+let ``DateTime family projects to PrimitiveType.DateTime`` () =
+    Assert.Equal (DateTime, SqlStorageType.toPrimitiveType SqlStorageType.DateTime)
+    Assert.Equal (DateTime, SqlStorageType.toPrimitiveType (SqlStorageType.DateTime2 None))
+    Assert.Equal (DateTime, SqlStorageType.toPrimitiveType (SqlStorageType.DateTimeOffset (Some 7)))
+    Assert.Equal (DateTime, SqlStorageType.toPrimitiveType SqlStorageType.SmallDateTime)
+
+[<Fact>]
+let ``Text family projects to PrimitiveType.Text`` () =
+    Assert.Equal (Text, SqlStorageType.toPrimitiveType (SqlStorageType.NVarChar Max))
+    Assert.Equal (Text, SqlStorageType.toPrimitiveType (SqlStorageType.VarChar (Bounded 50)))
+    Assert.Equal (Text, SqlStorageType.toPrimitiveType SqlStorageType.NText)
+    Assert.Equal (Text, SqlStorageType.toPrimitiveType SqlStorageType.Xml)
+
+[<Fact>]
+let ``Decimal family projects to PrimitiveType.Decimal`` () =
+    Assert.Equal (Decimal, SqlStorageType.toPrimitiveType (SqlStorageType.Decimal (18, 2)))
+    Assert.Equal (Decimal, SqlStorageType.toPrimitiveType SqlStorageType.Money)
+    Assert.Equal (Decimal, SqlStorageType.toPrimitiveType SqlStorageType.Float)
+
+[<Fact>]
+let ``Binary family / Bit / Guid project to their categories`` () =
+    Assert.Equal (Binary, SqlStorageType.toPrimitiveType (SqlStorageType.VarBinary Max))
+    Assert.Equal (Binary, SqlStorageType.toPrimitiveType SqlStorageType.Image)
+    Assert.Equal (Boolean, SqlStorageType.toPrimitiveType SqlStorageType.Bit)
+    Assert.Equal (Guid, SqlStorageType.toPrimitiveType SqlStorageType.UniqueIdentifier)
+
+// ---------------------------------------------------------------------------
+// ofPrimitiveType — the canonical fallback storage. Round-trips through
+// toPrimitiveType for every PrimitiveType (the section law).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ofPrimitiveType is a section of toPrimitiveType over every PrimitiveType`` () =
+    for pt in SqlTypeCorrespondence.allPrimitives do
+        let recovered = SqlStorageType.toPrimitiveType (SqlStorageType.ofPrimitiveType pt)
+        Assert.Equal (pt, recovered)
+
+[<Fact>]
+let ``ofPrimitiveType mirrors the legacy SqlTypeCorrespondence defaults`` () =
+    // Integer → INT (semantic fallback keeps the v2 default; only the
+    // OSSYS adapter's longinteger evidence narrows to BIGINT).
+    Assert.Equal (SqlStorageType.Int, SqlStorageType.ofPrimitiveType Integer)
+    // DateTime → DATETIME2 (the existing fallback; the OSSYS adapter's
+    // `datetime` evidence narrows to DATETIME).
+    Assert.Equal (SqlStorageType.DateTime2 None, SqlStorageType.ofPrimitiveType DateTime)
+    Assert.Equal (SqlStorageType.NVarChar Max, SqlStorageType.ofPrimitiveType Text)
+
+// ---------------------------------------------------------------------------
+// ofSqlType — inline-parenthesized form (external_dbType override strings).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ofSqlType parses bare scalar SQL types`` () =
+    Assert.Equal (Some SqlStorageType.BigInt, SqlStorageType.ofSqlType "BIGINT" None None None)
+    Assert.Equal (Some SqlStorageType.DateTime, SqlStorageType.ofSqlType "datetime" None None None)
+    Assert.Equal (Some SqlStorageType.UniqueIdentifier, SqlStorageType.ofSqlType "UNIQUEIDENTIFIER" None None None)
+
+[<Fact>]
+let ``ofSqlType parses parenthesized length and MAX`` () =
+    Assert.Equal (Some (SqlStorageType.NVarChar Max), SqlStorageType.ofSqlType "NVARCHAR(MAX)" None None None)
+    Assert.Equal (Some (SqlStorageType.NVarChar (Bounded 255)), SqlStorageType.ofSqlType "NVARCHAR(255)" None None None)
+    Assert.Equal (Some (SqlStorageType.VarChar (Bounded 20)), SqlStorageType.ofSqlType "varchar(20)" None None None)
+
+[<Fact>]
+let ``ofSqlType parses parenthesized precision and scale`` () =
+    Assert.Equal (Some (SqlStorageType.Decimal (18, 2)), SqlStorageType.ofSqlType "DECIMAL(18,2)" None None None)
+    Assert.Equal (Some (SqlStorageType.Numeric (10, 0)), SqlStorageType.ofSqlType "numeric(10, 0)" None None None)
+
+// ---------------------------------------------------------------------------
+// ofSqlType — bare-name + facet-column form (INFORMATION_SCHEMA shape:
+// DATA_TYPE plus separate length / precision / scale columns).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``ofSqlType folds facet columns into the storage type`` () =
+    Assert.Equal (Some (SqlStorageType.NVarChar (Bounded 100)), SqlStorageType.ofSqlType "nvarchar" (Some 100) None None)
+    Assert.Equal (Some (SqlStorageType.Decimal (12, 4)), SqlStorageType.ofSqlType "decimal" None (Some 12) (Some 4))
+
+[<Fact>]
+let ``ofSqlType maps the -1 length sentinel to MAX`` () =
+    Assert.Equal (Some (SqlStorageType.NVarChar Max), SqlStorageType.ofSqlType "nvarchar" (Some -1) None None)
+
+[<Fact>]
+let ``ofSqlType returns None for empty and unknown types`` () =
+    Assert.Equal<SqlStorageType option> (None, SqlStorageType.ofSqlType "" None None None)
+    Assert.Equal<SqlStorageType option> (None, SqlStorageType.ofSqlType "   " None None None)
+    Assert.Equal<SqlStorageType option> (None, SqlStorageType.ofSqlType "HIERARCHYID" None None None)
+
+[<Fact>]
+let ``ofSqlType parenthesized parameters win over facet arguments`` () =
+    // External override "NVARCHAR(MAX)" beats a stray facet length.
+    Assert.Equal (Some (SqlStorageType.NVarChar Max), SqlStorageType.ofSqlType "NVARCHAR(MAX)" (Some 50) None None)


### PR DESCRIPTION
Introduce a typed `SqlStorageType` in Projection.Core that carries the
concrete SQL Server realization (BIGINT, DATETIME, NVARCHAR(MAX), ...)
distinct from the semantic OutSystems-domain `PrimitiveType`. The OSSYS
adapter resolves `ossys_EntityAttr.Type` into both: it strips the `rt`
runtime-type prefix (rtText / rtLongInteger / rtPhoneNumber, previously
unmapped), maps the complete v1 type-mapping donor table, and applies an
`external_dbType` override. SSDT emission prefers the concrete storage
when present and falls back to the PrimitiveType -> SqlDataTypeOption
mapping otherwise.

Fixes the type-collapse bugs: longinteger now emits BIGINT (not INT),
datetime now emits DATETIME (not DATETIME2), and identifier/autonumber
emit BIGINT per v1's identifier->bigint rule. Adds rtEntityReference and
the bt<espace>*<entity> reference encoding as identifier storage.

https://claude.ai/code/session_01SVoUGxMmRtda42jTRzWaYb