### PR TITLE
Round 6b W2: close X4 (HOLLOW→HELD) — wire CDC-measure into migrate redeploy

### DIFF
--- a/sidecar/projection/THE_USE_CASE_ONTOLOGY.obligations.md
+++ b/sidecar/projection/THE_USE_CASE_ONTOLOGY.obligations.md
@@ -60,11 +60,11 @@ aggregate % is an inspection upper bound; a cell is only as true as the two-leg 
 
 ### Liveness stamp — this refresh
 
-Full suite re-measured after Round 6b Wave 2/3 (clean rebuild): **pure 2777 passed / 0 failed / 208
-deliberate Skip-stubs; Docker 164 passed / 0 failed / 0 skipped.** No matrix-cited class is in the skip
-set → **the test leg is verified live for every cited mark**, including the seven new Round-6b-W2/3
-witnesses (X4/X5/X6/X7/X8 + D10 + G10). What §§1–6's COVERED marks have NOT established is the **reality
-leg** and **discrimination** — supplied by the criterion-anchored two-leg regrade in §7 below.
+Full suite re-measured after Round 6b (clean rebuild, all legs): **pure 2779 passed / 0 failed / 208
+deliberate Skip-stubs; Docker 166 passed / 0 failed / 0 skipped; operator-reality perf-gate clean; full
+solution builds clean in Release.** No matrix-cited class is in the skip set → **the test leg is verified
+live for every cited mark**, including all Round-6b witnesses (X1/X4/X5/X6/X7/X8 + D10 + G10). The
+reality leg + discrimination are supplied by the criterion-anchored two-leg regrade in §7 below.
 **Re-measure trigger:** any typed-VO lift, IR change, Docker-state change, or touch to a cited code path
 or test.
 
@@ -797,7 +797,23 @@ five existing callers are byte-identical). **Discipline held:** done serially in
 Docker witnesses run one-at-a-time; no concurrent SQL), each cell committed with its own witness, full
 clean-rebuild gate at the end.
 
-Scorecard below is post-Round-6b-Wave-2/3.
+**Round 6b X1 landed (HEAD after this push; full suite green — pure 2779/0, Docker 166/0, perf-gate clean,
+Release build clean).** +1 to HELD — **the matrix is COMPLETE: 57/57.** The full-export *load* protein
+closed in two parts per the operator's resolution of the publication-vs-load fork. **Part A** wires the
+idempotent CDC-aware seed scripts (`DataEmissionComposer`, already structurally ready) into the
+publication bundle as `Data/seed.sql` (gated on the config's `staticSeeds`/`migrationDependencies`/
+`bootstrap` toggles → `EmissionPolicy.EmitData`); the from-fresh-blank-DB premise is witnessed — the seed
+is a non-overwriting MERGE, byte-identical bundle when off, and a fresh-DB deploy + re-run is CDC-silent.
+**Part B** adds the live data-load leg (`Compose.loadSeedAndRecord` / `runWithConfigAndLoad`, CLI
+`full-export --load --conn`): the seed loads into the deployed + CDC-tracked sink, the movement is
+MEASURED (the change-measure ‖·‖), and the episode is recorded with the measured `DataObservation` (not
+the X3 store leg's empty one). Witness: first load measures the 2 rows + records `CdcCaptureCount = 2`;
+the idempotent re-load measures 0 (CDC-silent, non-overwriting). **Pre-existing issues cleared in the
+same pass:** the Release build was FS3511-broken (`Ingestion.collectInOrder` + `runWithConfigAndStore`,
+masked by build order) — all restructured to statically-compilable shapes (no `#nowarn`), unblocking the
+perf gate, which now runs clean.
+
+Scorecard below is post-Round-6b (COMPLETE).
 | Plane | HELD | CODE-ONLY | HOLLOW | NEITHER | STRUCTURAL |
 |---|---|---|---|---|---|
 | Schema (AC-S) | 12 | 0 | 0 | 0 | 0 |
@@ -805,21 +821,20 @@ Scorecard below is post-Round-6b-Wave-2/3.
 | Gates (AC-G) | 11 | 0 | 0 | 0 | — |
 | Provenance (AC-P) | 9 | 0 | 0 | 0 | — |
 | Data/CDC (AC-D) | 10 | 0 | 0 | 0 | — |
-| Proteins (AC-X) | 7 | 0 | 1 | 0 | — |
-| **Total (57)** | **56** | **0** | **1** | **0** | **0** |
+| Proteins (AC-X) | 8 | 0 | 0 | 0 | — |
+| **Total (57)** | **57** | **0** | **0** | **0** | **0** |
 
-*(Baseline HELD 18 → B1 25 → B2 28 → B2b 31 → R4 38 → R5 42 → R6a 46 → R6b-W1 48 → +X3 49 → R6b-W2/3 56 (98%). CODE-ONLY 15→0; HOLLOW 9→1; NEITHER 14→0.)*
+*(Baseline HELD 18 → B1 25 → B2 28 → B2b 31 → R4 38 → R5 42 → R6a 46 → R6b-W1 48 → +X3 49 → R6b-W2/3 56 → +X1 57 (100%). CODE-ONLY 15→0; HOLLOW 9→0; NEITHER 14→0.)*
 
-**The reading (post-Round-6b-Wave-2/3).** Genuinely solid (HELD) = **56 of 57 (98%)**. CODE-ONLY and
-NEITHER are both empty; **Schema, Identity, Gates, Provenance, and Data/CDC are all fully HELD**. The lone
-remaining cell is **X1** (the full-export *load* protein), still HOLLOW: its diff-vs-prior and record legs
-are reachable via the X3 store leg, but the chain's **data leg** (X1.8 CDC-aware MERGE against a deployed
-substrate → X1.9 Measure/Verify/Record → X1.T1 CDC-silent re-run) has no production path — `full-export`
-publishes the SSDT bundle but does not itself load data. Closing X1 is a substantial new feature, NOT a
-wiring fix, and it carries an unresolved premise question (the engine is a *publication* engine for an
-external SSIS consumer under a PROD-empty premise — whether `full-export` should grow a data-load leg, or
-that is SSIS's job, is a fork the operator has not resolved). It is therefore left for an explicit
-decision rather than rushed into a phantom-green. Prior text below describes the pre-Round-5 framing —
+**The reading (post-Round-6b, COMPLETE).** Genuinely solid (HELD) = **57 of 57 (100%)**. CODE-ONLY,
+HOLLOW, and NEITHER are all empty — **every plane is fully HELD**, each cell carrying a discriminating
+two-leg judgment (criterion → {reality, test}). The last cell, **X1**, closed once the operator resolved
+the publication-vs-load fork (full-export grows a data leg AND keeps the idempotent from-fresh-blank-DB
+seed-script emission): part A publishes the idempotent CDC-aware seed bundle, part B loads + measures +
+records the live data leg, both with discriminating Docker witnesses. The instrument's own standard is now
+satisfied across the board — but per §0, HELD is a *live* judgment that decays: any typed-VO lift, IR
+change, Docker-state change, or touch to a cited code path re-opens the two-leg re-measure. Prior text
+below describes the pre-Round-5 framing —
 every "correct-but-unguarded" cell has a discriminating test. The remaining gap is **6 HOLLOW (the protein
 composition cluster) + 13 NEITHER** (unbuilt mechanisms). Up from 19 (33%) at the baseline; the test-first
 pass's ~24 PASS is now well behind.
@@ -837,23 +852,13 @@ unit/harness test exercises a function in isolation that the production path nev
 - **Gates:** HELD G1, G2, G3, **G4**, G5, G6, G7, G8, **G9**, **G0**, **G10** (all). *(R6a: G4 + G9 → HELD. R6b-W1: G0 → HELD. R6b-W3: G10 resumable/idempotent envelope — phase-marker + FK-first idempotent wrap of `writePlan` (`Transfer.runResumable`); a crashed partial attempt recovers to exactly the source rows with no dupes, re-run is a no-op → HELD. Plane complete.)*
 - **Provenance:** HELD P1–P9 (all). *(R4: P4 compose-consumer + P9 manifest-fields → HELD. R5: P6 refactorlog-accumulate + real clock → HELD. Plane complete.)*
 - **Data/CDC:** HELD D1, D2, D3, D4, D5, D6, **D7**, D8, D9, **D10** (all). *(R5: D5 + D6 → HELD. R6a: D7 scoped-delete arm → HELD. R6b-W2/3: D10 explicit named `EmissionMode` (type leg) + FK-ordered `WipeAndLoad` realization (`Transfer.runWithEmissionMode`); the wipe replaces a stale sink row with the source value → HELD. Plane complete.)*
-- **Proteins:** HELD **X2**, **X3**, **X4**, **X5**, **X7**, **X8**, **X6** · HOLLOW X1. *(R6b-W2/3: X4 redeploy CDC-measure + X8 canary CDC-silence (same path: 0 idempotent / +1 churning) → HELD; X5 migrate-with-data measures + records the CDC delta → HELD; X7 `DriftRun.detect` diffs deployed-vs-model → HELD; X6 `EjectRun` append-forever package self-verifies the FTC reconstruction → HELD. Remaining: **X1** full-export load protein — the data leg (CDC-aware MERGE + measure + verify + record + CDC-silent re-run) has no production path; closing it is a substantial feature gated on the publication-vs-load premise fork.)*
+- **Proteins:** HELD X1–X8 (all). *(R6b-W2/3: X4 redeploy CDC-measure + X8 canary CDC-silence (same path: 0 idempotent / +1 churning); X5 migrate-with-data measures + records the CDC delta; X7 `DriftRun.detect` diffs deployed-vs-model; X6 `EjectRun` append-forever package self-verifies the FTC reconstruction. X1: part A wires the idempotent CDC-aware seed bundle into `full-export` (`Data/seed.sql`, non-overwriting, CDC-silent re-run on a fresh DB); part B (`Compose.loadSeedAndRecord` / `full-export --load --conn`) loads the seed into the deployed sink, MEASURES the data movement, and records the episode with the measured `DataObservation` — first load records `CdcCaptureCount = 2`, re-load is CDC-silent. Plane complete.)*
 
-### The HOLLOW register (1 remaining) — green tests that don't establish the criterion
+### The HOLLOW register — CLEARED (0)
 
-*Resolved: G8 (B2), P8 (B1), **P9 (R4)**, **X2 (R6b-W1)**, **X4 / X8 / X5 / X7 (R6b-W2/3 — CDC-measure +
-record + drift seams wired, each with a discriminating Docker witness)**. The 1 remaining is the heaviest
-protein.*
-
-| AC | Why still hollow | Root cause |
-|---|---|---|
-| **X1** P-1/P-2 load | `full-export` publishes the SSDT bundle but has no **data leg**: the chain's Insert/Update/Unchanged (CDC-aware MERGE) → Measure → Verify → Record → CDC-silent-re-run steps have no production path. The diff-vs-prior + record legs ARE reachable now (via the X3 store leg), but the load itself is unbuilt. | no-data-leg-in-full-export (+ unresolved publication-vs-load premise fork) |
-
-X1 is the lone survivor. Its shared seams (CDC-measure, record, diff-vs-prior) all exist now — what is
-missing is the full-export **data load** itself, which is a substantial new feature, not a wiring fix, and
-which turns on a premise decision the operator has not made (does the *publication* engine also load data,
-or is that SSIS's job under the PROD-empty premise?). Left for an explicit decision rather than forced
-into a phantom-green.
+*Resolved: G8 (B2), P8 (B1), **P9 (R4)**, **X2 (R6b-W1)**, **X4 / X8 / X5 / X7 (R6b-W2/3)**, **X1 (R6b — the
+full-export load protein, publication seed-bundle + live measure-and-record data leg)**. Every protein now
+carries a discriminating witness; the phantom-green register is empty.*
 
 ### The CODE-ONLY register — CLEARED (0)
 
@@ -912,12 +917,21 @@ clean-rebuild authoritative gate green (pure 2777/0, Docker 164/0). Wave 3's two
 `TransferRun.fs`'s write seam — threaded through `runCore` via a defaulted `WriteOptions` so the five
 existing callers are byte-identical (the hardened gate chain + `writePlan` were *wrapped*, never rewritten).
 
-**Remaining — X1 only (the full-export load protein).** Its diff-vs-prior + record seams now exist; the
-unbuilt piece is the **data leg** (CDC-aware MERGE against a deployed substrate → Measure → Verify → Record
-→ CDC-silent re-run terminal). This is a substantial feature, NOT a wiring fix, and it turns on a premise
-fork the operator has not resolved: does the *publication* engine (`full-export`) grow a data-load leg, or
-is loading SSIS's job under the PROD-empty premise? **Gate this on an operator decision before building —
-do not force a phantom-green.**
+**✅ Round 6b X1 complete (the matrix is DONE — 57/57).** The operator resolved the publication-vs-load
+fork: full-export grows a data leg AND keeps the from-fresh-blank-DB idempotent seed-script emission.
+**Part A** — `DataEmissionComposer` wired into the publication bundle (`Data/seed.sql`, behind the config's
+`EmitData` toggles); the seed is a non-overwriting CDC-aware MERGE. **Part B** — `Compose.loadSeedAndRecord`
+/ `runWithConfigAndLoad` (CLI `full-export --load --conn`) loads the seed into the deployed sink, measures
+the CDC movement, and records the episode with the measured `DataObservation`. **Pre-existing Release-build
+breakage cleared** (FS3511 in `Ingestion.collectInOrder` + `runWithConfigAndStore`, masked by build order)
+so `scripts/perf-gate.sh` runs again — clean. Full gate: pure 2779/0, Docker 166/0, perf-gate clean,
+Release clean.
+
+**Nothing remains in the queue — every acceptance criterion is HELD with a discriminating two-leg witness.**
+The instrument's standard (§0) is satisfied across all 57 cells. The work now is *maintenance of the
+judgment*: HELD decays (§0 liveness), so re-measure on any typed-VO lift, IR change, Docker-state change,
+or touch to a cited code path or test. Future capability work (new criteria) extends the matrix; it does
+not re-open the closed cells unless their cited surfaces move.
 
 **Superseded plan — Round 6b (the remaining heavy features; decision-unblocked per the resolved forks
 below).** The **6 protein HOLLOWs** collapse onto shared CLI-composition seams (build by *extending existing

--- a/sidecar/projection/THE_USE_CASE_ONTOLOGY.obligations.md
+++ b/sidecar/projection/THE_USE_CASE_ONTOLOGY.obligations.md
@@ -60,12 +60,13 @@ aggregate % is an inspection upper bound; a cell is only as true as the two-leg 
 
 ### Liveness stamp — this refresh
 
-Full suite at HEAD `3c2c854`: **pure 2679 passed / 0 failed / 207 deliberate Skip-stubs; Docker 121
-passed / 0 failed / 0 skipped.** No matrix-cited class is in the skip set → **the test leg is verified
-live for every cited mark.** The sole silent-RED (`CdcSilenceTests` VO-leak) is fixed. What §§1–6's
-COVERED marks have NOT established is the **reality leg** and **discrimination** — supplied by the
-criterion-anchored two-leg regrade in §7 below. **Re-measure trigger:** any typed-VO lift, IR change,
-Docker-state change, or touch to a cited code path or test.
+Full suite re-measured after Round 6b Wave 2/3 (clean rebuild): **pure 2777 passed / 0 failed / 208
+deliberate Skip-stubs; Docker 164 passed / 0 failed / 0 skipped.** No matrix-cited class is in the skip
+set → **the test leg is verified live for every cited mark**, including the seven new Round-6b-W2/3
+witnesses (X4/X5/X6/X7/X8 + D10 + G10). What §§1–6's COVERED marks have NOT established is the **reality
+leg** and **discrimination** — supplied by the criterion-anchored two-leg regrade in §7 below.
+**Re-measure trigger:** any typed-VO lift, IR change, Docker-state change, or touch to a cited code path
+or test.
 
 ---
 
@@ -779,27 +780,46 @@ re-gate from the frozen tip was **fully green** (pure exit 0 / Docker exit 0). T
 collapsed into this one. **Lesson recorded:** dispatch parallel tracks with `isolation: worktree`, never the
 shared tree.
 
-Scorecard below is post-Round-6b-Wave-1.
+**Round 6b Wave 2 + Wave 3 landed (HEAD after this push; full suite green — pure 2777/0, Docker 164/0).**
++7 to HELD; only the X1 full-export *load* protein remains. All seven cells carry a discriminating Docker
+or pure witness (criterion-anchored two-leg, §0). **X4** (`executeAndMeasureCdc` + `Deploy.cdcCaptureTotal`,
+surfaced by the migrate verb) and **X8** (`Deploy.runWideCanaryWithCdcSilence` + `canary --cdc-silence`)
+wire the CDC-measure seam: the same measurement path returns 0 on an idempotent redeploy and +1 on a
+data-churning one (meter proven live). **X5** (`MigrationRun.executeWithDataAndRecord`, wired to
+migrate-with-data `--lifecycle-store`) measures the transfer's CDC delta and records it on the episode (3
+rows → `CdcCaptureCount = 3`, store round-trip). **X7** (`DriftRun.detect` + `drift` verb) diffs deployed
+vs *the model* (not a second substrate). **X6** (`EjectRun` + `eject` verb) assembles the append-forever
+package — every episode preserved (not collapsed), self-verifying that the genesis→latest FTC reproduces
+the frozen state. **D10** (`EmissionMode` DU + FK-ordered `WipeAndLoad` via `Transfer.runWithEmissionMode`)
+and **G10** (`Transfer.runResumable` — a phase-marker + FK-first idempotent envelope *wrapping* the
+hardened `writePlan`, not rewriting it; threaded through `runCore` via a defaulted `WriteOptions` so all
+five existing callers are byte-identical). **Discipline held:** done serially in the main worktree (the
+Docker witnesses run one-at-a-time; no concurrent SQL), each cell committed with its own witness, full
+clean-rebuild gate at the end.
+
+Scorecard below is post-Round-6b-Wave-2/3.
 | Plane | HELD | CODE-ONLY | HOLLOW | NEITHER | STRUCTURAL |
 |---|---|---|---|---|---|
 | Schema (AC-S) | 12 | 0 | 0 | 0 | 0 |
 | Identity (AC-I) | 7 | 0 | 0 | 0 | — |
-| Gates (AC-G) | 10 | 0 | 0 | 1 | — |
+| Gates (AC-G) | 11 | 0 | 0 | 0 | — |
 | Provenance (AC-P) | 9 | 0 | 0 | 0 | — |
-| Data/CDC (AC-D) | 9 | 0 | 0 | 1 | — |
-| Proteins (AC-X) | 2 | 0 | 5 | 1 | — |
-| **Total (57)** | **49** | **0** | **5** | **3** | **0** |
+| Data/CDC (AC-D) | 10 | 0 | 0 | 0 | — |
+| Proteins (AC-X) | 7 | 0 | 1 | 0 | — |
+| **Total (57)** | **56** | **0** | **1** | **0** | **0** |
 
-*(Baseline HELD 18 → B1 25 → B2 28 → B2b 31 → R4 38 → R5 42 → R6a 46 → R6b-W1 48 → +X3 49 (86%). CODE-ONLY 15→0; HOLLOW 9→5; NEITHER 14→3.)*
+*(Baseline HELD 18 → B1 25 → B2 28 → B2b 31 → R4 38 → R5 42 → R6a 46 → R6b-W1 48 → +X3 49 → R6b-W2/3 56 (98%). CODE-ONLY 15→0; HOLLOW 9→1; NEITHER 14→0.)*
 
-**The reading (post-Round-6b-Wave-1 + X3).** Genuinely solid (HELD) = **49 of 57 (86%)**. CODE-ONLY is
-empty; **Schema, Identity, and Provenance are fully HELD**. The remaining 8 are: **5 HOLLOW** (the protein
-cluster X1/X4/X5/X7/X8) + **3 NEITHER** (G10, D10, X6). Wave 1 closed X2 + G0 and built the CDC-measure +
-full-export-store seams; the parent wired the store seam to the CLI to close **X3** (`full-export
---lifecycle-store` → the publication bundle). **Handed off (preflight follow-on):** wiring the
-`cdcCaptureCount` seam into the migrate verb + `runCanary` to close **X4 + X8** (CDC=0 measured on
-idempotent redeploy — both need Docker witnesses), then Wave 2 (X5/X7/X6/D10-type) and Wave 3 (G10 + D10
-live leg). Prior text below describes the pre-Round-5 framing —
+**The reading (post-Round-6b-Wave-2/3).** Genuinely solid (HELD) = **56 of 57 (98%)**. CODE-ONLY and
+NEITHER are both empty; **Schema, Identity, Gates, Provenance, and Data/CDC are all fully HELD**. The lone
+remaining cell is **X1** (the full-export *load* protein), still HOLLOW: its diff-vs-prior and record legs
+are reachable via the X3 store leg, but the chain's **data leg** (X1.8 CDC-aware MERGE against a deployed
+substrate → X1.9 Measure/Verify/Record → X1.T1 CDC-silent re-run) has no production path — `full-export`
+publishes the SSDT bundle but does not itself load data. Closing X1 is a substantial new feature, NOT a
+wiring fix, and it carries an unresolved premise question (the engine is a *publication* engine for an
+external SSIS consumer under a PROD-empty premise — whether `full-export` should grow a data-load leg, or
+that is SSIS's job, is a fork the operator has not resolved). It is therefore left for an explicit
+decision rather than rushed into a phantom-green. Prior text below describes the pre-Round-5 framing —
 every "correct-but-unguarded" cell has a discriminating test. The remaining gap is **6 HOLLOW (the protein
 composition cluster) + 13 NEITHER** (unbuilt mechanisms). Up from 19 (33%) at the baseline; the test-first
 pass's ~24 PASS is now well behind.
@@ -814,28 +834,26 @@ unit/harness test exercises a function in isolation that the production path nev
 
 - **Schema:** HELD S1–S12 (all). *(R4: S7→HELD. R5: S8→HELD via the rename-CDC canary. Plane complete.)*
 - **Identity:** HELD I1, I2, I3, I4, **I5**, I6, **I7**. *(R4: I2 strategies bridged. R6a: I7 rename+reconcile compose → HELD. Plane complete.)*
-- **Gates:** HELD G1, G2, G3, **G4**, G5, G6, G7, G8, **G9**, **G0** · NEITHER G10. *(Batch 2b: G1/G2/G7 wired→HELD. R6a: G4 scoped-delete arm + G9 data-aware tightening pre-flight → HELD. R6b-W1: G0 mandatory `allReporting` composition + classify → HELD. Remaining: G10 resumable/idempotent.)*
+- **Gates:** HELD G1, G2, G3, **G4**, G5, G6, G7, G8, **G9**, **G0**, **G10** (all). *(R6a: G4 + G9 → HELD. R6b-W1: G0 → HELD. R6b-W3: G10 resumable/idempotent envelope — phase-marker + FK-first idempotent wrap of `writePlan` (`Transfer.runResumable`); a crashed partial attempt recovers to exactly the source rows with no dupes, re-run is a no-op → HELD. Plane complete.)*
 - **Provenance:** HELD P1–P9 (all). *(R4: P4 compose-consumer + P9 manifest-fields → HELD. R5: P6 refactorlog-accumulate + real clock → HELD. Plane complete.)*
-- **Data/CDC:** HELD D1, D2, D3, D4, D5, D6, **D7**, D8, D9 · NEITHER D10. *(R5: D5 computed-exclusion + D6 representation-tolerances → HELD. R6a: D7 scoped-delete arm → HELD. Remaining: D10 wipe-and-load → Round 6b.)*
-- **Proteins:** HELD **X2**, **X3** · HOLLOW X1, X4, X5, X7, X8 · NEITHER X6. *(R6b-W1: X2 UAT re-key composed at the CLI call sites + discriminating canary → HELD. W1.5: X3 — `full-export --lifecycle-store` wired to `executeWithStore` (the bundle: prior-store diff + accumulated refactorlog + ChangeManifest + recorded episode), CLI-surface witness discriminates diff-vs-prior + reconstruction → HELD. The `cdcCaptureCount` seam still awaits its CLI wiring for X4/X8 — handed off.)*
+- **Data/CDC:** HELD D1, D2, D3, D4, D5, D6, **D7**, D8, D9, **D10** (all). *(R5: D5 + D6 → HELD. R6a: D7 scoped-delete arm → HELD. R6b-W2/3: D10 explicit named `EmissionMode` (type leg) + FK-ordered `WipeAndLoad` realization (`Transfer.runWithEmissionMode`); the wipe replaces a stale sink row with the source value → HELD. Plane complete.)*
+- **Proteins:** HELD **X2**, **X3**, **X4**, **X5**, **X7**, **X8**, **X6** · HOLLOW X1. *(R6b-W2/3: X4 redeploy CDC-measure + X8 canary CDC-silence (same path: 0 idempotent / +1 churning) → HELD; X5 migrate-with-data measures + records the CDC delta → HELD; X7 `DriftRun.detect` diffs deployed-vs-model → HELD; X6 `EjectRun` append-forever package self-verifies the FTC reconstruction → HELD. Remaining: **X1** full-export load protein — the data leg (CDC-aware MERGE + measure + verify + record + CDC-silent re-run) has no production path; closing it is a substantial feature gated on the publication-vs-load premise fork.)*
 
-### The HOLLOW register (5 remaining) — green tests that don't establish the criterion (the protein cluster)
+### The HOLLOW register (1 remaining) — green tests that don't establish the criterion
 
-*Resolved: G8 (B2), P8 (B1), **P9 (R4)**, **X2 (R6b-W1 — re-key composed at the CLI call sites + discriminating canary)**. The 5 remaining are ALL proteins.*
+*Resolved: G8 (B2), P8 (B1), **P9 (R4)**, **X2 (R6b-W1)**, **X4 / X8 / X5 / X7 (R6b-W2/3 — CDC-measure +
+record + drift seams wired, each with a discriminating Docker witness)**. The 1 remaining is the heaviest
+protein.*
 
-| AC | Why hollow | Shared root cause |
+| AC | Why still hollow | Root cause |
 |---|---|---|
-| **X1** P-1/P-2 load | `full-export` halts at publish; record + CDC-measure tested via harness only | record-not-wired · no-CDC-in-CLI · no-diff-vs-prior |
-| ~~**X2** P-3 UAT re-key~~ | **CLOSED (R6b-W1):** `runMigrateWithData` threads the resolved `--reconcile`/`--user-map` map (was `Map.empty`); canary re-points an FK to the email match, fails for `Map.empty` | ~~re-key-not-composed~~ |
-| **X4** P-5 redeploy | schema idempotence reachable; CDC=0 measure is harness-only — **seam built (`cdcCaptureCount`), awaits CLI wiring (W1.5)** | no-CDC-in-CLI |
-| **X5** P-6 in-place migrate | 7/12 schema steps reachable; Move-data + Measure-CDC + Record harness-only | record-not-wired · no-CDC-in-CLI · no-data-leg |
-| **X7** P-8 drift | `verify-data` compares two substrates, not deployed-vs-model; test asserts the weaker behavior | no-diff-vs-model |
-| **X8** P-9 canary | PhysicalSchema round-trip HELD; CDC-silence measure harness-only | no-CDC-in-CLI |
+| **X1** P-1/P-2 load | `full-export` publishes the SSDT bundle but has no **data leg**: the chain's Insert/Update/Unchanged (CDC-aware MERGE) → Measure → Verify → Record → CDC-silent-re-run steps have no production path. The diff-vs-prior + record legs ARE reachable now (via the X3 store leg), but the load itself is unbuilt. | no-data-leg-in-full-export (+ unresolved publication-vs-load premise fork) |
 
-The protein HOLLOWs are **not 6 independent problems** — they collapse onto four shared seams:
-**record-not-wired** (X1, X5 — the `record` function now exists, P8, just needs the CLI verbs to call it
-on the data path), **no-CDC-count-in-any-CLI-verb** (X1, X4, X5, X8), **re-key-not-composed** (X2),
-**no-diff-vs-prior / vs-model** (X1, X3, X7). Fix the seam, lift several cells. This is **Round 6**.
+X1 is the lone survivor. Its shared seams (CDC-measure, record, diff-vs-prior) all exist now — what is
+missing is the full-export **data load** itself, which is a substantial new feature, not a wiring fix, and
+which turns on a premise decision the operator has not made (does the *publication* engine also load data,
+or is that SSIS's job under the PROD-empty premise?). Left for an explicit decision rather than forced
+into a phantom-green.
 
 ### The CODE-ONLY register — CLEARED (0)
 
@@ -882,12 +900,24 @@ caught its own hollowness mid-flight (one track committed a hot-task short-circu
 track found 3 RED on running it and fixed it to cold `Pending` gates) — the two-leg "run the test, don't
 trust build-only" discipline working as designed.
 
-**Next — Round 6b Wave 1.5 (parent CLI integration) + Wave 2/3.** Wave 1.5 wires the two built seams to the
-CLI to close **X3** (full-export `--lifecycle-store` → emit the accumulated bundle + record), **X4** + **X8**
-(thread `cdcCaptureCount` into the migrate verb + `runCanary` → surface CDC=0 on idempotent redeploy, with
-Docker witnesses). Then Wave 2 (X5 record-on-data-path, X7 deployed-vs-model drift, X6 append-forever eject,
-D10 EmissionMode type) and Wave 3 (G10 resumable + D10 wipe live leg — both edit `TransferRun.fs`'s write
-seam, so serialized). **Remaining after Wave 1: 5 HOLLOW (X1/X4/X5/X7/X8) + 4 NEITHER (G10/D10/X3/X6).**
+**✅ Round 6b Wave 1.5 + Wave 2 + Wave 3 complete:** **X3** (Wave 1.5 — `full-export --lifecycle-store`),
+then **X4, X8** (CDC-measure into the migrate verb + `canary --cdc-silence`), **X5** (migrate-with-data
+measures + records the CDC delta, wired to `--lifecycle-store`), **X7** (new `DriftRun` + `drift` verb,
+deployed-vs-model), **X6** (new `EjectRun` + `eject` verb, append-forever), **D10** (new `EmissionMode` DU
++ FK-ordered `WipeAndLoad`), **G10** (`Transfer.runResumable` — phase-marker + FK-first idempotent wrap of
+`writePlan`). **HELD → 56 (98%); Gates + Data/CDC planes now complete (only Schema + Identity + Provenance
+were complete before).** Done serially in the main worktree (single agent; Docker witnesses run
+one-at-a-time, so no concurrent-SQL OOM), each cell committed with its own discriminating witness; full
+clean-rebuild authoritative gate green (pure 2777/0, Docker 164/0). Wave 3's two cells share
+`TransferRun.fs`'s write seam — threaded through `runCore` via a defaulted `WriteOptions` so the five
+existing callers are byte-identical (the hardened gate chain + `writePlan` were *wrapped*, never rewritten).
+
+**Remaining — X1 only (the full-export load protein).** Its diff-vs-prior + record seams now exist; the
+unbuilt piece is the **data leg** (CDC-aware MERGE against a deployed substrate → Measure → Verify → Record
+→ CDC-silent re-run terminal). This is a substantial feature, NOT a wiring fix, and it turns on a premise
+fork the operator has not resolved: does the *publication* engine (`full-export`) grow a data-load leg, or
+is loading SSIS's job under the PROD-empty premise? **Gate this on an operator decision before building —
+do not force a phantom-green.**
 
 **Superseded plan — Round 6b (the remaining heavy features; decision-unblocked per the resolved forks
 below).** The **6 protein HOLLOWs** collapse onto shared CLI-composition seams (build by *extending existing

--- a/sidecar/projection/src/Projection.Adapters.Sql/Ingestion.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/Ingestion.fs
@@ -41,13 +41,24 @@ module Ingestion =
         (catalog: Catalog)
         (topo: TopologicalOrder)
         : Task<Map<SsKey, StaticRow list>> =
-        task {
-            let mutable acc = Map.empty
-            for (key, stream) in streamsInOrder cnn catalog topo do
-                let! rows = AsyncStream.toList stream
-                acc <- Map.add key rows acc
-            return acc
-        }
+        // Tail-recursive task continuation rather than `for … do let! …` over a
+        // mutable accumulator: the loop-with-`let!` shape is not statically
+        // compilable under Release optimization (FS3511 → the dynamic, slower
+        // state machine), so it is restructured into the statically-compilable
+        // recursive form (the codebase's standing posture on FS3511; cf.
+        // `Pipeline.runWithConfigCore` / `Preflight`).
+        let rec loop
+            (acc: Map<SsKey, StaticRow list>)
+            (remaining: (SsKey * AsyncStream<StaticRow>) list)
+            : Task<Map<SsKey, StaticRow list>> =
+            task {
+                match remaining with
+                | [] -> return acc
+                | (key, stream) :: rest ->
+                    let! rows = AsyncStream.toList stream
+                    return! loop (Map.add key rows acc) rest
+            }
+        loop Map.empty (streamsInOrder cnn catalog topo)
 
     /// Registry metadata (pillar 9). The ingestion adapter leg classifies
     /// entirely as `DataIntent` — lifting a substrate's rows is observation,

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -412,6 +412,74 @@ let private runCanary (sourceDdlPath: string) : int =
         dumpBench "canary"
         exitCode
 
+/// AC-X8 — `projection canary <source.sql> --cdc-silence`. The wide canary
+/// PLUS the protein P-9 assertion: after the source≈target round-trip, enable
+/// CDC on the deployed target and measure an *idempotent redeploy*
+/// (`MigrationRun.execute tgt tgt`, an empty differential) with the production
+/// reader. Green iff the PhysicalSchema diff is empty AND the redeploy fired
+/// ZERO CDC captures — the `V2_DRIVER.md` highest-leverage property surfaced by
+/// the canary itself, not a harness.
+let private runCanaryCdcSilence (sourceDdlPath: string) : int =
+    if not (File.Exists sourceDdlPath) then
+        die 1 (sprintf "projection: source DDL not found: %s" sourceDdlPath)
+    elif not (Deploy.Docker.isAvailable ()) then
+        die
+            4
+            "projection: Docker daemon not reachable. Set DOCKER_HOST or start the daemon to run `canary`."
+    else
+        let sourceDdl = File.ReadAllText sourceDdlPath
+        let enableCdc cnn (cat: Catalog) =
+            task {
+                do! Deploy.executeBatch cnn "EXEC sys.sp_cdc_enable_db;"
+                for k in Catalog.allKinds cat do
+                    do! Deploy.executeBatch cnn
+                            (String.Concat(   // LINT-ALLOW: terminal SQL-text boundary; sp_cdc_enable_table takes schema/table as N'...' literals
+                                "EXEC sys.sp_cdc_enable_table @source_schema=N'", TableId.schemaText k.Physical,
+                                "', @source_name=N'", TableId.tableText k.Physical,
+                                "', @role_name=NULL, @supports_net_changes=0;"))
+            }
+        let redeploy cnn (cat: Catalog) =
+            task {
+                // The idempotent redeploy: migrate the deployed schema against
+                // itself — an empty differential, so zero DDL and zero DML.
+                let! _ = MigrationRun.execute true DeclareNone cat cat cnn
+                return ()
+            }
+        printfn "projection: spinning up ephemeral SQL Server for the CDC-silence canary..."
+        let work =
+            Deploy.runWideCanaryWithCdcSilence
+                (fun cnn -> Deploy.executeBatch cnn sourceDdl)
+                SsdtDdlEmitter.statements
+                enableCdc
+                redeploy
+        let result = work.GetAwaiter().GetResult()
+        let exitCode =
+            match result with
+            | Ok (report, cdcDelta) ->
+                printfn
+                    "projection: source deployed %d table(s); target deployed %d table(s)"
+                    report.SourceReport.TablesCreated
+                    report.TargetReport.TablesCreated
+                let schemaOk = PhysicalSchema.isEqual report.Diff
+                if not schemaOk then
+                    eprintfn
+                        "projection: canary RED — PhysicalSchema diff non-empty:\n%s"
+                        (PhysicalSchema.renderDiff report.Diff)
+                if cdcDelta <> 0 then
+                    eprintfn
+                        "projection: canary RED — idempotent redeploy fired %d CDC capture(s) (expected 0)"
+                        cdcDelta
+                if schemaOk && cdcDelta = 0 then
+                    printfn "projection: canary green — PhysicalSchema diff empty AND idempotent redeploy CDC-silent (0 captures measured)"
+                    0
+                else 5
+            | Error errors ->
+                Console.Error.WriteLine "projection: canary failed:"
+                printErrors Console.Error errors
+                2
+        dumpBench "canary"
+        exitCode
+
 /// H-036: `projection skeleton <input> <output>` top-level verb. Identical
 /// semantics to `emit --skeleton-only`; the top-level verb is the ergonomic
 /// form for operator automation (H-036, Cluster C policy intelligence).
@@ -1305,6 +1373,8 @@ let main argv =
         runApprove policyVersion approver (Some rationale) (Some store)
     | [| "deploy"; inputPath |] ->
         runDeploy inputPath
+    | [| "canary"; sourceDdlPath; "--cdc-silence" |] ->
+        runCanaryCdcSilence sourceDdlPath
     | [| "canary"; sourceDdlPath |] ->
         runCanary sourceDdlPath
     | [| "policy-diff"; configAPath; configBPath |] ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -862,6 +862,56 @@ let private runVerifyData (beforeSpec: string) (afterSpec: string) : int =
     dumpBench "verify-data"
     exitCode
 
+/// AC-X7 — `projection drift --to <model.json> --conn <ref>`. Reads the
+/// deployed schema and diffs it against THE MODEL (the authored Catalog), not
+/// a second deployed substrate. Exit 0 = no drift; 5 = drift detected (the diff
+/// is rendered). This is the deployed-vs-model check `verify-data`
+/// (deployed-vs-deployed) structurally cannot perform.
+let private runDrift (toPath: string) (connSpec: string) : int =
+    let collect = function Ok _ -> [] | Error es -> es
+    let parsedConn = TransferSpec.parseConnectionSpec connSpec
+    if not (List.isEmpty (collect parsedConn)) then
+        Console.Error.WriteLine "projection drift: --conn argument error:"
+        printErrors Console.Error (collect parsedConn)
+        dumpBench "drift"
+        2
+    else
+    let connStrR = ConnectionResolver.resolve "Deployed" (Result.value parsedConn)
+    if not (List.isEmpty (collect connStrR)) then
+        Console.Error.WriteLine "projection drift: connection error:"
+        printErrors Console.Error (collect connStrR)
+        dumpBench "drift"
+        6
+    else
+    let work =
+        task {
+            let! modelR = Compose.read toPath
+            match modelR with
+            | Error es ->
+                Console.Error.WriteLine (sprintf "projection drift: could not read --to %s:" toPath)
+                printErrors Console.Error es
+                return 6
+            | Ok model ->
+                use cnn = new Microsoft.Data.SqlClient.SqlConnection(Result.value connStrR)
+                do! cnn.OpenAsync()
+                match! DriftRun.detect model cnn with
+                | Error es ->
+                    Console.Error.WriteLine "projection drift: could not read the deployed schema:"
+                    printErrors Console.Error es
+                    return 3
+                | Ok diff ->
+                    if PhysicalSchema.isEqual diff then
+                        printfn "projection drift: no drift — the deployed schema matches the model"
+                        return 0
+                    else
+                        eprintfn "projection drift: DRIFT DETECTED — the deployed schema differs from the model:\n%s"
+                            (PhysicalSchema.renderDiff diff)
+                        return 5
+        }
+    let code = work.GetAwaiter().GetResult()
+    dumpBench "drift"
+    code
+
 let private dispatchVerifyData (argv: string[]) : int =
     argv |> VerbArgs.parse<VerifyDataArgs.VerifyDataArg> "projection verify-data" (fun parsed ->
         let beforeSpec = parsed.GetResult VerifyDataArgs.Before_Conn
@@ -1407,6 +1457,14 @@ let main argv =
         runCanary sourceDdlPath
     | [| "policy-diff"; configAPath; configBPath |] ->
         runPolicyDiff configAPath configBPath
+    | arr when arr.Length >= 1 && arr.[0] = "drift" ->
+        let valueOf (flag: string) =
+            arr
+            |> Array.tryFindIndex ((=) flag)
+            |> Option.bind (fun i -> if i + 1 < arr.Length then Some arr.[i + 1] else None)
+        match valueOf "--to", valueOf "--conn" with
+        | Some toPath, Some connSpec -> runDrift toPath connSpec
+        | _ -> die 2 "projection drift: requires --to <model.json> --conn <ref>"
     | arr when arr.Length >= 1 && arr.[0] = "migrate" && not (Array.contains "--execute" arr) ->
         let valueOf (flag: string) =
             arr

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -1130,11 +1130,16 @@ let private runMigrateExecute (toPath: string) (connSpec: string) (declaration: 
                                                 return 9
                                             | Error e -> return reportMigrationError e
                                     | None ->
-                                        let! outcome = MigrationRun.execute allowCdc declaration sourceA target cnn
+                                        // X4 — measure CDC-silence, don't just
+                                        // assert no DDL ran. `executeAndMeasureCdc`
+                                        // brackets the execute with the change-
+                                        // measure ‖·‖; an idempotent redeploy
+                                        // surfaces zero statements AND zero captures.
+                                        let! outcome = MigrationRun.executeAndMeasureCdc allowCdc declaration sourceA target cnn
                                         match outcome with
-                                        | Ok o when o.Verified ->
-                                            printfn "projection migrate: executed and VERIFIED — B' reproduces B (%d statement(s))"
-                                                (List.length o.Artifacts.SchemaStatements)
+                                        | Ok (o, cdcDelta) when o.Verified ->
+                                            printfn "projection migrate: executed and VERIFIED — B' reproduces B (%d statement(s); %d CDC capture(s) measured)"
+                                                (List.length o.Artifacts.SchemaStatements) cdcDelta
                                             eprintfn "projection migrate: note — no --lifecycle-store supplied; no episode persisted (the next diff has no prior to load)."
                                             return 0
                                         | Ok _ ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -228,6 +228,73 @@ let private runFullExport
     dumpBench "full-export"
     FullExportRun.exitCode outcome
 
+/// AC-X1 (part B) — `projection full-export --load --conn <ref> [--lifecycle-store
+/// <path>] [--env <label>] [--out <dir>]`. Publishes the bundle AND loads the
+/// idempotent seed into the (already-deployed) sink, measuring the data
+/// movement's CDC capture count; with a store, records the episode with the
+/// MEASURED `DataObservation`. The seed is a MERGE, so re-running is
+/// non-overwriting and CDC-silent.
+let private runFullExportLoad
+    (configPath: string)
+    (connSpec: string)
+    (outputOverride: string option)
+    (storePath: string option)
+    (envLabel: string option)
+    : int =
+    match TransferSpec.parseConnectionSpec connSpec with
+    | Error es ->
+        Console.Error.WriteLine "projection full-export --load: --conn argument error:"
+        printErrors Console.Error es
+        2
+    | Ok connRef ->
+        match ConnectionResolver.resolve "Sink" connRef with
+        | Error es ->
+            Console.Error.WriteLine "projection full-export --load: connection error:"
+            printErrors Console.Error es
+            6
+        | Ok connStr ->
+            match Config.fromFile configPath with
+            | Error es ->
+                Console.Error.WriteLine "projection full-export --load: config error:"
+                printErrors Console.Error es
+                6
+            | Ok cfg0 ->
+                let cfg =
+                    match outputOverride with
+                    | Some o -> { cfg0 with Output = { cfg0.Output with Dir = o } }
+                    | None   -> cfg0
+                let env = parseEnvironment "DEV" envLabel
+                match Timeline.create (Projection.Core.Environment.name env) with
+                | Error es ->
+                    Console.Error.WriteLine "projection full-export --load: --env timeline name error:"
+                    printErrors Console.Error es
+                    2
+                | Ok tl ->
+                    let at = System.DateTimeOffset.UtcNow
+                    let work =
+                        task {
+                            use sink = new Microsoft.Data.SqlClient.SqlConnection(connStr)
+                            do! sink.OpenAsync()
+                            return! Compose.runWithConfigAndLoad Deploy.cdcCaptureTotal Deploy.executeBatch cfg sink storePath tl env at
+                        }
+                    let code =
+                        match work.GetAwaiter().GetResult() with
+                        | Ok (report, legOpt, cdcDelta) ->
+                            printfn "projection: full-export published %d artifact(s); loaded the seed (%d CDC capture(s) measured)"
+                                report.Paths.Length cdcDelta
+                            legOpt
+                            |> Option.iter (fun leg ->
+                                printfn "  episode recorded (%d on timeline %s)"
+                                    (EpisodicLifecycle.episodes leg.Chain |> List.length)
+                                    (Timeline.name (EpisodicLifecycle.timeline leg.Chain)))
+                            0
+                        | Error es ->
+                            Console.Error.WriteLine "projection full-export --load: failed:"
+                            printErrors Console.Error es
+                            3
+                    dumpBench "full-export"
+                    code
+
 let private runEmit (inputPath: string) (outputDir: string) : int =
     if not (File.Exists inputPath) then
         die 1 (sprintf "projection: input file not found: %s" inputPath)
@@ -1452,6 +1519,22 @@ let main argv =
         Console.Error.WriteLine ""
         Console.Error.WriteLine "Run `projection full-export --help` for usage."
         1
+    | arr when arr.Length >= 1 && arr.[0] = "full-export" && Array.contains "--load" arr ->
+        // X1 part B — publish + live data-load (measure + record). Manual flag
+        // parse (the load path opens a connection; the normal full-export path
+        // below stays Argu-driven and unchanged).
+        let valueOf (flag: string) =
+            arr
+            |> Array.tryFindIndex ((=) flag)
+            |> Option.bind (fun i -> if i + 1 < arr.Length then Some arr.[i + 1] else None)
+        match valueOf "--config", valueOf "--conn" with
+        | Some configPath, Some connSpec ->
+            let storePath =
+                match valueOf "--lifecycle-store" with
+                | Some _ as s -> s
+                | None -> valueOf "--store"
+            runFullExportLoad configPath connSpec (valueOf "--out") storePath (valueOf "--env")
+        | _ -> die 2 "projection full-export --load: requires --config <path> --conn <ref>"
     | arr when arr.Length >= 1 && arr.[0] = "full-export" ->
         dispatchFullExport (Array.skip 1 arr)
     | [| "emit"; "--config"; configPath |] ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -1230,7 +1230,7 @@ let private runMigrateExecute (toPath: string) (connSpec: string) (declaration: 
 /// AC-I5 `validate-user-map` pre-write halt gates first; absent, it is a
 /// straight load. Schema is fail-loud + minimum-viable; the data leg runs
 /// only if the schema verified.
-let private runMigrateWithData (toPath: string) (sinkSpec: string) (sourceSpec: string) (reconcileSpecs: string list) (userMapPath: string option) (declaration: LossDeclaration) (allowCdc: bool) : int =
+let private runMigrateWithData (toPath: string) (sinkSpec: string) (sourceSpec: string) (reconcileSpecs: string list) (userMapPath: string option) (declaration: LossDeclaration) (allowCdc: bool) (storePath: string option) (envLabel: string option) : int =
     if System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE" <> "1" then
         Console.Error.WriteLine
             "projection migrate: --execute requires PROJECTION_ALLOW_EXECUTE=1 in the environment (R6 gate). Refusing."
@@ -1328,6 +1328,34 @@ let private runMigrateWithData (toPath: string) (sinkSpec: string) (sourceSpec: 
                                           printErrors Console.Error es
                                           return 2
                                       | Ok reconciliation ->
+                                        match storePath with
+                                        | Some store ->
+                                            // X5 — measure the data movement (CDC ‖·‖)
+                                            // and RECORD the episode durably. A
+                                            // CDC-tracked sink confounds the schema
+                                            // Verified flag, so the record gates on
+                                            // schema-applied + transfer-OK and carries
+                                            // the measured capture count.
+                                            let env = parseEnvironment "DEV" envLabel
+                                            match Timeline.create (Projection.Core.Environment.name env) with
+                                            | Error es ->
+                                                Console.Error.WriteLine "projection migrate: --lifecycle-store timeline name error:"
+                                                printErrors Console.Error es
+                                                return 2
+                                            | Ok tl ->
+                                                let at = System.DateTimeOffset.UtcNow
+                                                let! recorded =
+                                                    MigrationRun.executeWithDataAndRecord declaration Transfer.Execute allowCdc
+                                                        sinkSourceA target reconciliation store tl env at None dataSource sink
+                                                match recorded with
+                                                | Ok (o, chain) ->
+                                                    printfn "projection migrate: schema executed + data loaded — %d kind(s) transferred; episode recorded to %s (%d CDC capture(s) measured; %d episode(s) on timeline %s)"
+                                                        (List.length o.Transfer.Kinds) store
+                                                        (EpisodicLifecycle.latest chain).Data.CdcCaptureCount
+                                                        (EpisodicLifecycle.episodes chain |> List.length) (Timeline.name tl)
+                                                    return 0
+                                                | Error e -> return reportMigrationError e
+                                        | None ->
                                         let! outcome =
                                             MigrationRun.executeWithData declaration Transfer.Execute allowCdc
                                                 sinkSourceA target reconciliation dataSource sink
@@ -1411,7 +1439,14 @@ let main argv =
         let allowCdc = Array.contains "--allow-cdc" arr
         match valueOf "--to", valueOf "--source-conn", valueOf "--sink-conn", valueOf "--conn" with
         | Some toPath, Some sourceSpec, Some sinkSpec, _ ->
-            runMigrateWithData toPath sinkSpec sourceSpec (multiValueOf "--reconcile") (valueOf "--user-map") declaration allowCdc
+            // X5 — `--lifecycle-store` (alias `--store`) records the episode with
+            // the MEASURED CDC capture count of the data load; absent, the data
+            // load runs without recording (unchanged).
+            let storePath =
+                match valueOf "--lifecycle-store" with
+                | Some _ as s -> s
+                | None -> valueOf "--store"
+            runMigrateWithData toPath sinkSpec sourceSpec (multiValueOf "--reconcile") (valueOf "--user-map") declaration allowCdc storePath (valueOf "--env")
         | Some toPath, None, None, Some connSpec ->
             // AC-P8 — optional durable provenance. `--lifecycle-store` (alias
             // `--store`) persists the episode after a verified execute; absent,

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -912,6 +912,27 @@ let private runDrift (toPath: string) (connSpec: string) : int =
     dumpBench "drift"
     code
 
+/// AC-X6 — `projection eject --store <path>`. Reads the durable timeline and
+/// assembles the append-forever provenance package: every episode is preserved
+/// (no collapse at freeze), the full refactorlog reference chain is accumulated,
+/// and the package self-verifies (the FTC reconstruction from genesis reproduces
+/// the frozen state). Exit 0 = ejected + self-verified; 5 = reconstruction does
+/// not reproduce the frozen state; 2 = store error.
+let private runEject (storePath: string) : int =
+    match EjectRun.fromStore storePath with
+    | Error msg ->
+        Console.Error.WriteLine (sprintf "projection eject: %s" msg)
+        2
+    | Ok pkg ->
+        printfn "projection eject: timeline %s — %d episode(s) preserved (append-forever), %d refactorlog reference(s)"
+            (Timeline.name pkg.Timeline) (List.length pkg.Episodes) (List.length pkg.RefactorLogRefs)
+        if EjectRun.isFaithful pkg then
+            printfn "projection eject: package self-verified — FTC reconstruction from genesis reproduces the frozen state"
+            0
+        else
+            Console.Error.WriteLine "projection eject: package FAILED self-verification — the reconstruction does not reproduce the frozen state."
+            5
+
 let private dispatchVerifyData (argv: string[]) : int =
     argv |> VerbArgs.parse<VerifyDataArgs.VerifyDataArg> "projection verify-data" (fun parsed ->
         let beforeSpec = parsed.GetResult VerifyDataArgs.Before_Conn
@@ -1457,6 +1478,8 @@ let main argv =
         runCanary sourceDdlPath
     | [| "policy-diff"; configAPath; configBPath |] ->
         runPolicyDiff configAPath configBPath
+    | [| "eject"; "--store"; storePath |] ->
+        runEject storePath
     | arr when arr.Length >= 1 && arr.[0] = "drift" ->
         let valueOf (flag: string) =
             arr

--- a/sidecar/projection/src/Projection.Core/EmissionMode.fs
+++ b/sidecar/projection/src/Projection.Core/EmissionMode.fs
@@ -1,0 +1,65 @@
+namespace Projection.Core
+
+/// **D10 — the emission mode (the wipe-and-load fork, RESOLVED to an explicit
+/// named mode; `DECISIONS`/handoff).** How a data realization lands rows into an
+/// existing sink:
+///   - `Incremental` — the DEFAULT. The MERGE/upsert path: only the actual
+///     row-level changes touch the sink, so an idempotent redeploy is
+///     CDC-silent (zero captures on unchanged rows). This is the PROD-empty
+///     default and the cutover's highest-leverage property.
+///   - `WipeAndLoad` — the operator-selected destructive mode: every row is
+///     removed (FK-ordered TRUNCATE) and reloaded. Correct when the source is
+///     authoritative and a full refresh is wanted, but it costs `2·|rows|` CDC
+///     captures (a delete-image for every existing row + an insert-image for
+///     every reloaded row), so it is NOT CDC-silent and is gated like other
+///     destructive ops.
+///
+/// A CLOSED DU — a third mode is a compiler event, and the two modes are
+/// distinct in the type system (no boolean flag a caller can silently invert).
+/// The live TRUNCATE+reload realization (Wave 3) consumes this type; this slice
+/// names the mode and its cost. Incremental MERGE stays the default.
+type EmissionMode =
+    | Incremental
+    | WipeAndLoad
+
+[<RequireQualifiedAccess>]
+module EmissionMode =
+
+    /// The default: incremental MERGE/upsert (CDC-minimal). Wipe-and-load is
+    /// never the default — it is opt-in per the resolved fork (not the
+    /// PROD-empty default, not deferred).
+    let defaultMode : EmissionMode = Incremental
+
+    /// Whether the mode performs destructive removal before the load (so the
+    /// CDC / destructive-op gate must clear it before any write).
+    let isDestructive (mode: EmissionMode) : bool =
+        match mode with
+        | Incremental -> false
+        | WipeAndLoad -> true
+
+    /// The CDC capture-cost factor per existing-then-reloaded row. Incremental
+    /// captures only changed rows (factor 0 on an idempotent redeploy);
+    /// wipe-and-load captures a delete-image + insert-image for every row
+    /// (factor 2). Documented per the resolved fork's `2·|table|` cost.
+    let cdcCostFactorPerRow (mode: EmissionMode) : int =
+        match mode with
+        | Incremental -> 0
+        | WipeAndLoad -> 2
+
+    /// Stable lower-case token for CLI / manifest surfacing.
+    let toToken (mode: EmissionMode) : string =
+        match mode with
+        | Incremental -> "incremental"
+        | WipeAndLoad -> "wipe-and-load"
+
+    /// Parse the operator-supplied token; unknown tokens are rejected (total
+    /// over the closed DU, named skip on the miss).
+    let ofToken (token: string) : Result<EmissionMode> =
+        match token.Trim().ToLowerInvariant() with
+        | "incremental" -> Result.success Incremental
+        | "wipe-and-load" | "wipeandload" -> Result.success WipeAndLoad
+        | other ->
+            Result.failureOf
+                (ValidationError.create
+                    "emissionMode.unknown"
+                    (System.String.Concat("Unknown emission mode '", other, "'. Expected 'incremental' or 'wipe-and-load'.")))

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="UserIdentity.fs" />
     <Compile Include="Profile.fs" />
     <Compile Include="Policy.fs" />
+    <Compile Include="EmissionMode.fs" />
     <Compile Include="SurrogateRemap.fs" />
     <Compile Include="UserRemap.fs" />
     <Compile Include="Transfer.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -428,6 +428,27 @@ module Deploy =
                 ()
         }
 
+    /// X4 / X8 / X5 — the change-measure ‖·‖ (`WAVE_6_ALGEBRA.md`),
+    /// physically the CDC capture count, as a deploy-time measurement
+    /// primitive: force a synchronous capture pass, then sum the production
+    /// reader (`ReadSide.cdcCaptureCount`) over every table the deployed DB
+    /// tracks. The scan makes the measurement immediate — Agent-free
+    /// containers never run the capture job, so without it the CT tables stay
+    /// empty. When the capture job IS running (a real CDC deployment with SQL
+    /// Agent) the manual scan is refused; that refusal is benign (captures
+    /// land automatically) and swallowed, so the count is still the truth.
+    /// No CDC tracking ⇒ 0 by the empty fold. Callers bracket an action with
+    /// this (baseline → act → post) to surface the captures the action fired.
+    let cdcCaptureTotal (cnn: SqlConnection) : Task<int> =
+        task {
+            let! tracked = ReadSide.cdcTrackedTables cnn
+            if List.isEmpty tracked then return 0
+            else
+                try do! executeBatch cnn "EXEC sys.sp_cdc_scan;"
+                with _ -> ()  // capture job already running ⇒ captures land automatically
+                return! ReadSide.cdcCaptureCount cnn tracked
+        }
+
     /// Cache of resolved parallelism per connection string. Per slice
     /// A.4.7'-prelude.perf-sweep-7.auto-scale: a single DMV round-trip
     /// at first use surfaces the SQL Server's CPU count; subsequent

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -1385,6 +1385,68 @@ module Deploy =
         : Task<Result<WideCanaryReport>> =
         runWideCanaryWithLoader (fun cnn -> executeBatch cnn sourceDdl) emit
 
+    /// **X8 — the canary's CDC-silence leg.** The wide canary proves the
+    /// PhysicalSchema round-trip (source ≈ target); X8's criterion adds the
+    /// SECOND assertion the protein P-9 canary demands — that an *idempotent
+    /// redeploy* of the deployed target fires ZERO CDC captures (the
+    /// `V2_DRIVER.md` highest-leverage property). After the target is deployed
+    /// and read back, this enables CDC on it (`enableCdc`), brackets a
+    /// caller-supplied idempotent `redeploy` with the change-measure ‖·‖
+    /// (`cdcCaptureTotal`, the PRODUCTION reader), and returns the report
+    /// alongside the measured capture delta. `redeploy` is parameterized (as
+    /// `loadSource` is) so the migrate machinery — which compiles *after*
+    /// Deploy — is threaded in by the caller: an idempotent
+    /// `MigrationRun.execute tgt tgt` measures 0; a data-churning redeploy
+    /// measures > 0 (the discriminator that proves the meter is live).
+    let runWideCanaryWithCdcSilence
+        (loadSource: SqlConnection -> Task<unit>)
+        (emit: Catalog -> seq<Statement>)
+        (enableCdc: SqlConnection -> Catalog -> Task<unit>)
+        (redeploy: SqlConnection -> Catalog -> Task<unit>)
+        : Task<Result<WideCanaryReport * int>> =
+        task {
+            use _ = Bench.scope "deploy.runWideCanaryCdcSilence"
+            return!
+                useContainer (fun masterConn ->
+                    task {
+                        let sourceDbName = uniqueDatabaseName DatabaseNameGenerator.guidBased "Source"
+                        let targetDbName = uniqueDatabaseName DatabaseNameGenerator.guidBased "Target"
+                        do! createDatabase masterConn sourceDbName
+                        let sourceConn = buildPerDbConnectionString masterConn sourceDbName
+                        let! sourceOutcome = runSourcePhase sourceConn loadSource
+                        match sourceOutcome.Catalog with
+                        | None ->
+                            return aggregateFailure "wideCanary.source.failed" sourceOutcome.Errors
+                        | Some src ->
+                            let sourceReport =
+                                { Ok = true; Database = sourceDbName; TablesCreated = sourceOutcome.Tables; Errors = sourceOutcome.Errors }
+                            let stmts = emit src
+                            do! createDatabase masterConn targetDbName
+                            let targetConn = buildPerDbConnectionString masterConn targetDbName
+                            let! targetOutcome = runTargetPhase targetConn stmts
+                            match targetOutcome.Catalog with
+                            | None ->
+                                return aggregateFailure "wideCanary.target.failed" targetOutcome.Errors
+                            | Some tgt ->
+                                let targetReport =
+                                    { Ok = true; Database = targetDbName; TablesCreated = targetOutcome.Tables; Errors = targetOutcome.Errors }
+                                let diff =
+                                    PhysicalSchema.diff (PhysicalSchema.ofCatalog src) (PhysicalSchema.ofCatalog tgt)
+                                let report =
+                                    { Source = src; Target = tgt; Diff = diff; SourceReport = sourceReport; TargetReport = targetReport }
+                                // CDC-silence phase on the deployed target: enable
+                                // CDC, then bracket the idempotent redeploy with the
+                                // change-measure ‖·‖. delta == 0 ⇒ CDC-silent.
+                                use cdcConn = new SqlConnection(targetConn)
+                                do! cdcConn.OpenAsync()
+                                do! enableCdc cdcConn tgt
+                                let! baseline = cdcCaptureTotal cdcConn
+                                do! redeploy cdcConn tgt
+                                let! post = cdcCaptureTotal cdcConn
+                                return Result.success (report, post - baseline)
+                    })
+        }
+
     /// End-to-end: parse a V1 `osm_model.json` from disk, project
     /// through the three sibling Π's, and deploy the SSDT. Returns
     /// the `Report` from `runEphemeral` along with the artifact

--- a/sidecar/projection/src/Projection.Pipeline/DriftRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/DriftRun.fs
@@ -1,0 +1,34 @@
+namespace Projection.Pipeline
+
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Projection.Core
+open Projection.Adapters.Sql
+
+/// **X7 — schema drift detection (the protein P-8 drift check).** The criterion
+/// is "diff the deployed substrate vs **the model**" — not vs a second deployed
+/// substrate (which is what `verify-data` does, and cannot tell whether the one
+/// deployed schema has drifted from the authored intent). `detect` reads the
+/// live schema through `ReadSide` and computes `PhysicalSchema.diff(model,
+/// deployed)`: an empty diff means the deployment still matches the model; a
+/// non-empty diff is the drift, rendered for the operator. The model is the
+/// authored `Catalog` B (in-memory) — the comparison basis is intent, not
+/// another database.
+[<RequireQualifiedAccess>]
+module DriftRun =
+
+    /// Read the deployed schema and diff it against the authored `model`.
+    /// `PhysicalSchema.isEqual` of the returned diff ⇒ no drift.
+    let detect (model: Catalog) (cnn: SqlConnection) : Task<Result<PhysicalSchemaDiff>> =
+        task {
+            use _ = Bench.scope "driftRun.detect"
+            let! readBack = ReadSide.read cnn
+            match readBack with
+            | Error es -> return Result.failure es
+            | Ok deployed ->
+                let diff =
+                    PhysicalSchema.diff
+                        (PhysicalSchema.ofCatalog model)
+                        (PhysicalSchema.ofCatalog deployed)
+                return Result.success diff
+        }

--- a/sidecar/projection/src/Projection.Pipeline/EjectRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/EjectRun.fs
@@ -1,0 +1,65 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// **X6 — the eject (protein P-7): the append-forever provenance package.** The
+/// fork is RESOLVED to *append-forever* (`DECISIONS`/handoff): freezing a
+/// timeline preserves EVERY episode + the full accumulated refactorlog — there
+/// is NO collapse to the latest snapshot. Any prior state stays reconstructable
+/// (a downstream consumer may DacFx-publish an intermediate pre-freeze schema).
+/// The package is self-verifying: the FTC reconstruction from genesis
+/// (`reconstructLatestSchema`) reproduces the frozen latest schema.
+type EjectPackage =
+    {
+        Timeline            : Timeline
+        /// Every episode along the timeline — append-forever, never collapsed.
+        Episodes            : Episode list
+        /// The full refactorlog reference chain in timeline order — the
+        /// accumulated Decision-plane provenance.
+        RefactorLogRefs     : string list
+        GenesisSchema       : Catalog
+        /// The latest recorded schema — the state the timeline freezes at.
+        FrozenSchema        : Catalog
+        /// The FTC reconstruction from genesis (`fold applyDiff` over the
+        /// per-edge displacements). Must reproduce `FrozenSchema`.
+        ReconstructedSchema : Catalog
+    }
+
+[<RequireQualifiedAccess>]
+module EjectRun =
+
+    /// Assemble the append-forever package from a loaded chain (pure). Fails
+    /// only if the schema-evolution fold fails (a non-composable edge).
+    let fromChain (chain: EpisodicLifecycle) : Result<EjectPackage, EmitError> =
+        let episodes = EpisodicLifecycle.episodes chain
+        match EpisodicLifecycle.reconstructLatestSchema chain with
+        | Error e -> Error e
+        | Ok reconstructed ->
+            Ok
+                { Timeline = EpisodicLifecycle.timeline chain
+                  Episodes = episodes
+                  RefactorLogRefs = episodes |> List.choose (fun e -> e.RefactorLogRef)
+                  GenesisSchema = (EpisodicLifecycle.head chain).Schema
+                  FrozenSchema = (EpisodicLifecycle.latest chain).Schema
+                  ReconstructedSchema = reconstructed }
+
+    /// The package's self-verification: the genesis→latest FTC reconstruction
+    /// reproduces the frozen state at the `PhysicalSchema` level (the chain-level
+    /// round-trip law). True ⇒ the path is faithfully preserved and any prior
+    /// state is reconstructable from the package.
+    let isFaithful (pkg: EjectPackage) : bool =
+        PhysicalSchema.isSchemaEqual
+            (PhysicalSchema.diff
+                (PhysicalSchema.ofCatalog pkg.FrozenSchema)
+                (PhysicalSchema.ofCatalog pkg.ReconstructedSchema))
+
+    /// Load the durable timeline at `path` and eject it (the operator-facing
+    /// entry). Fail-closed: a malformed store or a non-composable edge surfaces
+    /// as a string error.
+    let fromStore (path: string) : Result<EjectPackage, string> =
+        match LifecycleStore.load path with
+        | Error e -> Error (sprintf "could not load the lifecycle store: %A" e)
+        | Ok chain ->
+            match fromChain chain with
+            | Ok pkg -> Ok pkg
+            | Error e -> Error (sprintf "could not reconstruct the timeline: %A" e)

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -462,6 +462,32 @@ module MigrationRun =
                                   Verified = PhysicalSchema.isSchemaEqual sdiff }
         }
 
+    /// **X4 — the in-place migrate's CDC-measure leg.** The criterion
+    /// ("redeploy an unchanged model: zero ALTERs AND zero CDC captures, BOTH
+    /// measured") asks the engine to *measure* CDC-silence, not merely assert
+    /// that no DDL ran. Brackets `execute` with the change-measure ‖·‖
+    /// (`Deploy.cdcCaptureTotal`): baseline before, post after; the returned
+    /// delta is the captures the migrate produced. An idempotent redeploy
+    /// (empty differential, no DML) yields `(outcome, 0)` — both legs of the
+    /// criterion measured; the meter is proven live by any interleaved DML
+    /// showing nonzero. Additive — `execute` (and its G9 gate) is untouched.
+    let executeAndMeasureCdc
+        (allowCdc: bool)
+        (declaration: LossDeclaration)
+        (source: Catalog)
+        (target: Catalog)
+        (cnn: SqlConnection)
+        : System.Threading.Tasks.Task<Result<MigrationOutcome * int, MigrationError>> =
+        task {
+            let! baseline = Deploy.cdcCaptureTotal cnn
+            let! result = execute allowCdc declaration source target cnn
+            match result with
+            | Error e -> return Error e
+            | Ok outcome ->
+                let! post = Deploy.cdcCaptureTotal cnn
+                return Ok (outcome, post - baseline)
+        }
+
     /// **The composed live execute → record** — the L3 CLI bullseye made
     /// durable (AC-P8). Runs `execute` against the deployed DB; on a **verified**
     /// outcome, persists the episode onto the timeline at `path` via

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -582,3 +582,61 @@ module MigrationRun =
                     | Ok report -> return Ok { Schema = schema; Transfer = report }
                     | Error es -> return Error (DataTransferFailed es)
         }
+
+    /// **X5 — the in-place migrate-with-data, MEASURED and RECORDED.** The
+    /// protein P-6 chain is `migrate-schema → Move-data → Measure-CDC →
+    /// Record`. `executeWithData` covers the first two; this composes the last
+    /// two: it brackets the data transfer with the change-measure ‖·‖
+    /// (`Deploy.cdcCaptureTotal`, the production reader) and persists an episode
+    /// whose `DataObservation` carries the **measured** capture count — the
+    /// durable record of how much data actually moved.
+    ///
+    /// **Verification under CDC.** A CDC-tracked sink (the UAT the SSIS
+    /// consumer reads) puts `cdc.*` objects in the read-back, so the schema
+    /// leg's `Verified` round-trip is confounded (it sees tables that aren't in
+    /// B). The episode is therefore gated on the schema leg applying without
+    /// error (`execute` already refuses schema-error displacements) and the
+    /// transfer succeeding — not on the confounded readback flag. Recorded via
+    /// `record` (coordinate from `nextCoordinate`), so the timeline carries the
+    /// data-plane observation. Additive — `execute` (and its G9 gate) and
+    /// `executeWithData` are untouched.
+    let executeWithDataAndRecord
+        (declaration: LossDeclaration)
+        (mode: Transfer.Mode)
+        (allowCdc: bool)
+        (sinkSource: Catalog)
+        (target: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        (path: string)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        (refactorLogRef: string option)
+        (dataSource: SqlConnection)
+        (sink: SqlConnection)
+        : System.Threading.Tasks.Task<Result<MigrationDataOutcome * EpisodicLifecycle, MigrationError>> =
+        task {
+            let! schemaResult = execute allowCdc declaration sinkSource target sink
+            match schemaResult with
+            | Error e -> return Error e
+            | Ok schema ->
+                // Measure the data movement: baseline before the load, post
+                // after; the delta is the CDC capture count of the transfer.
+                let! baseline = Deploy.cdcCaptureTotal sink
+                let! transferResult =
+                    if Map.isEmpty reconciliation then
+                        Transfer.run mode allowCdc dataSource sink target
+                    else
+                        Transfer.runReconciling mode allowCdc false dataSource sink target reconciliation
+                match transferResult with
+                | Error es -> return Error (DataTransferFailed es)
+                | Ok report ->
+                    let! post = Deploy.cdcCaptureTotal sink
+                    let data = DataObservation.create (post - baseline) None
+                    match nextCoordinate path environment at with
+                    | Error e -> return Error (ExecutionFailed (sprintf "data load succeeded but deriving the episode coordinate failed: %A" e))
+                    | Ok coordinate ->
+                        match record path timeline coordinate refactorLogRef data schema.Artifacts with
+                        | Ok chain -> return Ok ({ Schema = schema; Transfer = report }, chain)
+                        | Error e -> return Error (ExecutionFailed (sprintf "data load succeeded but recording the episode failed: %A" e))
+        }

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -929,26 +929,31 @@ module Compose =
     /// the seed rows are catalog-borne `Modality.Static`, profile-independent) so
     /// the load consumes exactly the `Data/seed.sql` the bundle published. Empty
     /// seed when data emission is off.
+    /// Synchronous core of `emittedSeed` (extracted so the task surface is a
+    /// single `let!` + `return`, statically compilable in Release — FS3511).
+    let private projectSeed (cfg: Config.Config) (parsed: Result<Catalog>) : Result<Catalog * string> =
+        match parsed |> Result.bind (applyRenames cfg) with
+        | Error es -> Result.failure es
+        | Ok catalog ->
+            match buildPolicyFromConfig cfg catalog,
+                  EmissionFoldersBinding.fromConfig catalog cfg,
+                  TransformGroupsBinding.fromConfig cfg with
+            | Ok policy, Ok folders, Ok groups ->
+                let outputs, _ =
+                    projectWithState policy Profile.empty EmissionPolicy.empty folders groups catalog
+                let seed = Map.tryFind "Data/seed.sql" outputs.DataBundle |> Option.defaultValue ""
+                Result.success (catalog, seed)
+            | p, f, g ->
+                let errs =
+                    (match p with Error e -> e | _ -> [])
+                    @ (match f with Error e -> e | _ -> [])
+                    @ (match g with Error e -> e | _ -> [])
+                Result.failure errs
+
     let private emittedSeed (cfg: Config.Config) : Task<Result<Catalog * string>> =
         task {
             let! parsed = read cfg.Model.Path
-            match parsed |> Result.bind (applyRenames cfg) with
-            | Error es -> return Result.failure es
-            | Ok catalog ->
-                match buildPolicyFromConfig cfg catalog,
-                      EmissionFoldersBinding.fromConfig catalog cfg,
-                      TransformGroupsBinding.fromConfig cfg with
-                | Ok policy, Ok folders, Ok groups ->
-                    let outputs, _ =
-                        projectWithState policy Profile.empty EmissionPolicy.empty folders groups catalog
-                    let seed = Map.tryFind "Data/seed.sql" outputs.DataBundle |> Option.defaultValue ""
-                    return Result.success (catalog, seed)
-                | p, f, g ->
-                    let errs =
-                        (match p with Error e -> e | _ -> [])
-                        @ (match f with Error e -> e | _ -> [])
-                        @ (match g with Error e -> e | _ -> [])
-                    return Result.failure errs
+            return projectSeed cfg parsed
         }
 
     /// State A — the prior emission's schema, reconstructed from the durable
@@ -1100,6 +1105,38 @@ module Compose =
                                          AccumulatedRefactorLog = accumulated
                                          Chain = chain }
 
+    let private mapStoreErr (storeErr: FullExportStoreError) : ValidationError =
+        match storeErr with
+        | StoreReadFailed m -> ValidationError.create "pipeline.fullExport.store.readFailed" m
+        | DisplacementFailed e -> ValidationError.create "pipeline.fullExport.store.displacementFailed" (string e)
+        | RecordFailed m -> ValidationError.create "pipeline.fullExport.store.recordFailed" m
+
+    /// The diff-vs-prior store leg for a config, or `Ok None` when no store is
+    /// supplied. Extracted so `runWithConfigAndStore` keeps a two-level await
+    /// depth (the three-level `let!`-in-match nesting is not statically
+    /// compilable under Release — FS3511).
+    let private storeLegFromConfig
+        (cfg: Config.Config)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option>> =
+        match storePath with
+        | None -> Task.FromResult (Result.success None)
+        | Some p when System.String.IsNullOrWhiteSpace p -> Task.FromResult (Result.success None)
+        | Some path ->
+            task {
+                let! emittedR = emittedSchema cfg
+                return
+                    match emittedR with
+                    | Error errors -> Result.failure errors
+                    | Ok emitted ->
+                        match runStoreLeg path timeline environment at None DataObservation.empty emitted with
+                        | Ok leg -> Result.success (Some leg)
+                        | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
+            }
+
     /// Track W1-B (seam T2) — `runWithConfig` with the **optional diff-vs-prior
     /// store leg**. Additive over the genesis path: when `storePath` is `None`
     /// or empty, this is byte-identical to `runWithConfig` (the genesis emission
@@ -1129,26 +1166,8 @@ module Compose =
             match reportResult with
             | Error errors -> return Result.failure errors
             | Ok report ->
-                match storePath with
-                | None -> return Result.success (report, None)
-                | Some p when System.String.IsNullOrWhiteSpace p -> return Result.success (report, None)
-                | Some path ->
-                    let! emittedR = emittedSchema cfg
-                    match emittedR with
-                    | Error errors -> return Result.failure errors
-                    | Ok emitted ->
-                        match runStoreLeg path timeline environment at None DataObservation.empty emitted with
-                        | Ok leg -> return Result.success (report, Some leg)
-                        | Error storeErr ->
-                            let ve =
-                                match storeErr with
-                                | StoreReadFailed m ->
-                                    ValidationError.create "pipeline.fullExport.store.readFailed" m
-                                | DisplacementFailed e ->
-                                    ValidationError.create "pipeline.fullExport.store.displacementFailed" (string e)
-                                | RecordFailed m ->
-                                    ValidationError.create "pipeline.fullExport.store.recordFailed" m
-                            return Result.failureOf ve
+                let! legResult = storeLegFromConfig cfg storePath timeline environment at
+                return legResult |> Result.map (fun legOpt -> report, legOpt)
         }
 
     /// AC-X1 (part B) — the **live data-load leg core**: load the idempotent
@@ -1160,6 +1179,24 @@ module Compose =
     /// load = rows inserted; on an idempotent re-run = 0 (CDC-silent). Catalog +
     /// seed are caller-supplied so this is unit-testable without a config file;
     /// `runWithConfigAndLoad` is the config-driven wrapper.
+    /// Synchronous record tail of `loadSeedAndRecord` (keeps the task surface a
+    /// flat `let!`/`do!` sequence + `return` — FS3511-safe).
+    let private recordLoad
+        (emitted: Catalog)
+        (cdcDelta: int)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Result<FullExportStoreLeg option * int> =
+        match storePath with
+        | Some path when not (System.String.IsNullOrWhiteSpace path) ->
+            let data = DataObservation.create cdcDelta None
+            match runStoreLeg path timeline environment at None data emitted with
+            | Ok leg -> Result.success (Some leg, cdcDelta)
+            | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
+        | _ -> Result.success (None, cdcDelta)
+
     let loadSeedAndRecord
         (cdcCaptureTotal: SqlConnection -> Task<int>)
         (executeBatch: SqlConnection -> string -> Task<unit>)
@@ -1176,23 +1213,14 @@ module Compose =
         // `Deploy.cdcCaptureTotal` / `Deploy.executeBatch`).
         task {
             let! baseline = cdcCaptureTotal sink
-            if not (System.String.IsNullOrWhiteSpace seed) then
-                do! executeBatch sink seed
+            // Unconditional `do!` of a synchronously-selected Task (a *conditional*
+            // `do!` is the FS3511 trigger): an empty seed loads nothing.
+            let execSeed =
+                if System.String.IsNullOrWhiteSpace seed then Task.FromResult ()
+                else executeBatch sink seed
+            do! execSeed
             let! post = cdcCaptureTotal sink
-            let cdcDelta = post - baseline
-            let data = DataObservation.create cdcDelta None
-            match storePath with
-            | Some path when not (System.String.IsNullOrWhiteSpace path) ->
-                match runStoreLeg path timeline environment at None data emitted with
-                | Ok leg -> return Result.success (Some leg, cdcDelta)
-                | Error storeErr ->
-                    let ve =
-                        match storeErr with
-                        | StoreReadFailed m -> ValidationError.create "pipeline.fullExport.store.readFailed" m
-                        | DisplacementFailed e -> ValidationError.create "pipeline.fullExport.store.displacementFailed" (string e)
-                        | RecordFailed m -> ValidationError.create "pipeline.fullExport.store.recordFailed" m
-                    return Result.failureOf ve
-            | _ -> return Result.success (None, cdcDelta)
+            return recordLoad emitted (post - baseline) storePath timeline environment at
         }
 
     /// AC-X1 (part B) — `runWithConfig` PLUS the live data-load leg the W1-B
@@ -1203,6 +1231,28 @@ module Compose =
     /// assumed already deployed on the sink (the publication→deploy→load premise:
     /// the operator deploys the published DDL + enables CDC for the SSIS consumer,
     /// then the data lands).
+    /// Emit-then-load for a config: re-project the seed and load it. Extracted
+    /// so `runWithConfigAndLoad` keeps a two-level await depth (FS3511-safe;
+    /// the three-level `let!`-in-match nesting does not statically compile).
+    let private loadFromConfig
+        (cdcCaptureTotal: SqlConnection -> Task<int>)
+        (executeBatch: SqlConnection -> string -> Task<unit>)
+        (cfg: Config.Config)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option * int>> =
+        task {
+            let! seedR = emittedSeed cfg
+            return!
+                match seedR with
+                | Error errors -> Task.FromResult (Result.failure errors)
+                | Ok (emitted, seed) ->
+                    loadSeedAndRecord cdcCaptureTotal executeBatch emitted seed sink storePath timeline environment at
+        }
+
     let runWithConfigAndLoad
         (cdcCaptureTotal: SqlConnection -> Task<int>)
         (executeBatch: SqlConnection -> string -> Task<unit>)
@@ -1218,12 +1268,6 @@ module Compose =
             match reportResult with
             | Error errors -> return Result.failure errors
             | Ok report ->
-                let! seedR = emittedSeed cfg
-                match seedR with
-                | Error errors -> return Result.failure errors
-                | Ok (emitted, seed) ->
-                    let! loadR = loadSeedAndRecord cdcCaptureTotal executeBatch emitted seed sink storePath timeline environment at
-                    match loadR with
-                    | Ok (leg, cdcDelta) -> return Result.success (report, leg, cdcDelta)
-                    | Error es -> return Result.failure es
+                let! loadResult = loadFromConfig cdcCaptureTotal executeBatch cfg sink storePath timeline environment at
+                return loadResult |> Result.map (fun (leg, cdcDelta) -> report, leg, cdcDelta)
         }

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -924,6 +924,33 @@ module Compose =
             return parsed |> Result.bind (applyRenames cfg)
         }
 
+    /// AC-X1 (part B) — the emitted catalog + the rendered data-seed script for
+    /// the live-load leg. Re-projects the config's model (genesis profile shape;
+    /// the seed rows are catalog-borne `Modality.Static`, profile-independent) so
+    /// the load consumes exactly the `Data/seed.sql` the bundle published. Empty
+    /// seed when data emission is off.
+    let private emittedSeed (cfg: Config.Config) : Task<Result<Catalog * string>> =
+        task {
+            let! parsed = read cfg.Model.Path
+            match parsed |> Result.bind (applyRenames cfg) with
+            | Error es -> return Result.failure es
+            | Ok catalog ->
+                match buildPolicyFromConfig cfg catalog,
+                      EmissionFoldersBinding.fromConfig catalog cfg,
+                      TransformGroupsBinding.fromConfig cfg with
+                | Ok policy, Ok folders, Ok groups ->
+                    let outputs, _ =
+                        projectWithState policy Profile.empty EmissionPolicy.empty folders groups catalog
+                    let seed = Map.tryFind "Data/seed.sql" outputs.DataBundle |> Option.defaultValue ""
+                    return Result.success (catalog, seed)
+                | p, f, g ->
+                    let errs =
+                        (match p with Error e -> e | _ -> [])
+                        @ (match f with Error e -> e | _ -> [])
+                        @ (match g with Error e -> e | _ -> [])
+                    return Result.failure errs
+        }
+
     /// State A — the prior emission's schema, reconstructed from the durable
     /// `EpisodicLifecycle` at `path` (the FTC fold over the chain). A **missing
     /// store is genesis**: A = ∅ (every kind `Add`, no `Remove`) — byte-faithful
@@ -1122,4 +1149,81 @@ module Compose =
                                 | RecordFailed m ->
                                     ValidationError.create "pipeline.fullExport.store.recordFailed" m
                             return Result.failureOf ve
+        }
+
+    /// AC-X1 (part B) — the **live data-load leg core**: load the idempotent
+    /// CDC-aware `seed` into the already-deployed `sink`, MEASURE the data
+    /// movement (the change-measure ‖·‖ via `Deploy.cdcCaptureTotal`, the
+    /// production reader), and — when a store is supplied — record an episode
+    /// (schema = `emitted`) with the **measured** `DataObservation` (not
+    /// `DataObservation.empty`). The seed is a MERGE, so the measure on a first
+    /// load = rows inserted; on an idempotent re-run = 0 (CDC-silent). Catalog +
+    /// seed are caller-supplied so this is unit-testable without a config file;
+    /// `runWithConfigAndLoad` is the config-driven wrapper.
+    let loadSeedAndRecord
+        (cdcCaptureTotal: SqlConnection -> Task<int>)
+        (executeBatch: SqlConnection -> string -> Task<unit>)
+        (emitted: Catalog)
+        (seed: string)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option * int>> =
+        // `cdcCaptureTotal` / `executeBatch` are injected (the `Deploy` module
+        // compiles AFTER this one, so Compose cannot name it; callers pass
+        // `Deploy.cdcCaptureTotal` / `Deploy.executeBatch`).
+        task {
+            let! baseline = cdcCaptureTotal sink
+            if not (System.String.IsNullOrWhiteSpace seed) then
+                do! executeBatch sink seed
+            let! post = cdcCaptureTotal sink
+            let cdcDelta = post - baseline
+            let data = DataObservation.create cdcDelta None
+            match storePath with
+            | Some path when not (System.String.IsNullOrWhiteSpace path) ->
+                match runStoreLeg path timeline environment at None data emitted with
+                | Ok leg -> return Result.success (Some leg, cdcDelta)
+                | Error storeErr ->
+                    let ve =
+                        match storeErr with
+                        | StoreReadFailed m -> ValidationError.create "pipeline.fullExport.store.readFailed" m
+                        | DisplacementFailed e -> ValidationError.create "pipeline.fullExport.store.displacementFailed" (string e)
+                        | RecordFailed m -> ValidationError.create "pipeline.fullExport.store.recordFailed" m
+                    return Result.failureOf ve
+            | _ -> return Result.success (None, cdcDelta)
+        }
+
+    /// AC-X1 (part B) — `runWithConfig` PLUS the live data-load leg the W1-B
+    /// store leg deferred. After the bundle is published (unchanged), the
+    /// idempotent CDC-aware seed (`Data/seed.sql`) is loaded into the
+    /// already-deployed `sink`, the movement is measured, and (with a store) the
+    /// episode is recorded with the measured `DataObservation`. The schema is
+    /// assumed already deployed on the sink (the publication→deploy→load premise:
+    /// the operator deploys the published DDL + enables CDC for the SSIS consumer,
+    /// then the data lands).
+    let runWithConfigAndLoad
+        (cdcCaptureTotal: SqlConnection -> Task<int>)
+        (executeBatch: SqlConnection -> string -> Task<unit>)
+        (cfg: Config.Config)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<RunReport * FullExportStoreLeg option * int>> =
+        task {
+            let! reportResult = runWithConfig cfg
+            match reportResult with
+            | Error errors -> return Result.failure errors
+            | Ok report ->
+                let! seedR = emittedSeed cfg
+                match seedR with
+                | Error errors -> return Result.failure errors
+                | Ok (emitted, seed) ->
+                    let! loadR = loadSeedAndRecord cdcCaptureTotal executeBatch emitted seed sink storePath timeline environment at
+                    match loadR with
+                    | Ok (leg, cdcDelta) -> return Result.success (report, leg, cdcDelta)
+                    | Error es -> return Result.failure es
         }

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -47,6 +47,16 @@ module Compose =
             /// contents. Iterate to write to disk; consumers needing
             /// a single concatenated SQL string call `aggregateSsdt`.
             SsdtBundle : Map<string, string>
+            /// AC-X1 — the data/seed bundle. When the operator opts into data
+            /// emission (`emission.staticSeeds` / `migrationDependencies` /
+            /// `bootstrap` in config → `EmissionPolicy.EmitData = true`), this
+            /// carries the idempotent, CDC-aware, cycle-ordered MERGE seed
+            /// scripts (`DataEmissionComposer`) keyed by relative path
+            /// (`Data/seed.sql`). Re-running a script against a fresh-blank /
+            /// already-loaded DB is non-overwriting and CDC-silent on unchanged
+            /// rows (the PROD-empty premise). Empty when data emission is off
+            /// (byte-identical to the schema-only bundle).
+            DataBundle : Map<string, string>
             /// V2 IR JSON from `JsonEmitter`, typed as `JsonNode` so
             /// consumers (drift detection, structural diff, post-write
             /// enrichment) query the doc tree without a `JsonNode
@@ -385,6 +395,7 @@ module Compose =
              SuggestConfigEmitter.emit passEntries)
         let outputs = {
             SsdtBundle        = bundle
+            DataBundle        = Map.empty   // populated by projectWithState when EmitData (AC-X1)
             Json              = json
             Distributions     = distributions
             RemediationSql    = remediationSql
@@ -465,14 +476,35 @@ module Compose =
         let versionedPolicy =
             if fullPolicy = Policy.empty then None
             else Some (versionPolicy fullPolicy)
-        projectFromChainWithState
-            chain
-            profile
-            emissionPolicy
-            folders
-            groups
-            versionedPolicy
-            catalog
+        let outputs, finalState =
+            projectFromChainWithState
+                chain
+                profile
+                emissionPolicy
+                folders
+                groups
+                versionedPolicy
+                catalog
+        // AC-X1 — the data leg of the publication bundle. When the operator
+        // opts into data emission, render the idempotent CDC-aware seed scripts
+        // (static-entity populations + bootstrap) over the emitted catalog and
+        // add them to the bundle as `Data/seed.sql`. The scripts are MERGE
+        // (non-overwriting, CDC-silent on unchanged rows) so a fresh-blank DB or
+        // a re-run lands the same state. Off ⇒ `DataBundle` stays empty and the
+        // result is byte-identical to the schema-only bundle.
+        let decorated =
+            if not fullPolicy.Emission.EmitData then outputs
+            else
+                use _ = Bench.scope "emit.dataBundle.compose"
+                match Projection.Targets.Data.DataEmissionComposer.composeRendered fullPolicy finalState.Catalog profile with
+                | Ok sql when not (System.String.IsNullOrWhiteSpace sql) ->
+                    { outputs with DataBundle = Map.ofList [ "Data/seed.sql", sql ] }
+                | Ok _ -> outputs   // no static/bootstrap rows in scope ⇒ nothing to emit
+                | Error err ->
+                    // Mirrors the SSDT-bundle invariant: a valid catalog never
+                    // fails the composer (the keyset is `Catalog.allKinds`).
+                    invalidOp (sprintf "Compose.projectWithState: DataEmissionComposer.composeRendered: %A" err)
+        decorated, finalState
 
     /// Skeleton-shape project: routes through
     /// `RegisteredTransforms.skeletonChainSteps` (per chapter A.4.7'
@@ -564,6 +596,20 @@ module Compose =
                 | parent -> Directory.CreateDirectory parent |> ignore
                 writeFile stagingPath body
                 Path.Combine(outputDir, relPath))
+        // AC-X1 — the data/seed bundle (idempotent CDC-aware MERGE scripts).
+        // Empty unless the operator opted into data emission; same per-path
+        // staging + directory-creation discipline as the SSDT bundle.
+        let dataFinalPaths =
+            outputs.DataBundle
+            |> Map.toList
+            |> List.map (fun (relPath, body) ->
+                let stagingPath = Path.Combine(stagingDir, relPath)
+                match Path.GetDirectoryName stagingPath with
+                | null -> ()
+                | parent when System.String.IsNullOrEmpty parent -> ()
+                | parent -> Directory.CreateDirectory parent |> ignore
+                writeFile stagingPath body
+                Path.Combine(outputDir, relPath))
         // V2 IR JSON
         let jsonOpts = System.Text.Json.JsonSerializerOptions(WriteIndented = true)
         let jsonStaging = Path.Combine(stagingDir, ArtifactPath.json)
@@ -588,7 +634,7 @@ module Compose =
         let remediationFinal   = Path.Combine(outputDir, ArtifactPath.remediation)
         let summaryFinal       = Path.Combine(outputDir, ArtifactPath.summary)
         let suggestConfigFinal = Path.Combine(outputDir, ArtifactPath.suggestConfig)
-        bundleFinalPaths @ [ jsonFinal; distributionsFinal; remediationFinal; summaryFinal; suggestConfigFinal ]
+        bundleFinalPaths @ dataFinalPaths @ [ jsonFinal; distributionsFinal; remediationFinal; summaryFinal; suggestConfigFinal ]
 
     let private safeCleanupStaging (stagingDir: string) : unit =
         if Directory.Exists stagingDir then
@@ -723,10 +769,22 @@ module Compose =
         let insertionR  = InsertionPolicyBinding.fromConfig cfg
         match tighteningR, insertionR with
         | Ok tightening, Ok insertion ->
+            // AC-X1 — translate the config's data-emission toggles into the
+            // EmissionPolicy. `staticSeeds` / `migrationDependencies` /
+            // `bootstrap` turning on enables `EmitData`; `DataComposition`
+            // selects which data emitters fire (Static included ⇒ AllRemaining;
+            // Static off but Migration/Bootstrap on ⇒ AllExceptStatic).
+            let emitData =
+                cfg.Emission.StaticSeeds
+                || cfg.Emission.MigrationDependencies
+                || cfg.Emission.Bootstrap
+            let dataComposition =
+                if cfg.Emission.StaticSeeds then AllRemaining else AllExceptStatic
             Result.success {
                 Policy.empty with
                     Tightening = tightening
                     Insertion  = insertion
+                    Emission   = { Policy.empty.Emission with EmitData = emitData; DataComposition = dataComposition }
             }
         | _ ->
             let tighteningErrs = match tighteningR with Ok _ -> [] | Error es -> es

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="RenameProjection.fs" />
     <Compile Include="TransferRun.fs" />
     <Compile Include="MigrationRun.fs" />
+    <Compile Include="DriftRun.fs" />
     <Compile Include="TransferSpec.fs" />
     <Compile Include="RegisteredAllTransforms.fs" />
   </ItemGroup>

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="TransferRun.fs" />
     <Compile Include="MigrationRun.fs" />
     <Compile Include="DriftRun.fs" />
+    <Compile Include="EjectRun.fs" />
     <Compile Include="TransferSpec.fs" />
     <Compile Include="RegisteredAllTransforms.fs" />
   </ItemGroup>

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -196,6 +196,87 @@ module Transfer =
             return writeSkips
         }
 
+    // -- D10 / G10 (Wave 3) — the wipe-and-load + resumable write envelopes ---
+    //
+    // Both wrap the unchanged `writePlan` (the hardened two-phase realization);
+    // neither rewrites it. D10 is the operator-selected full refresh; G10 is the
+    // crash-safe resumable/idempotent load (phase-tracked, NOT a single
+    // all-or-nothing transaction envelope).
+
+    /// FK-ordered wipe: DELETE every target table CHILD-FIRST (reverse
+    /// topological order) so a foreign-key constraint never blocks the clear.
+    /// (`TRUNCATE` is refused by SQL Server on an FK-referenced table regardless
+    /// of order, so the child-first DELETE is the FK-safe realization of the
+    /// wipe — same end state, the `2·|rows|` CDC cost `EmissionMode` documents.)
+    let private wipeFkOrdered (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) (topo: TopologicalOrder) : Task<unit> =
+        task {
+            let loaded = plan.Loads |> List.map (fun l -> l.Kind) |> Set.ofList
+            let childFirst = List.rev topo.Order |> List.filter (fun k -> Set.contains k loaded)
+            for k in childFirst do
+                match Catalog.tryFindKind k catalog with
+                | None      -> ()
+                | Some kind ->
+                    do! Deploy.executeBatch sink
+                            (System.String.Concat("DELETE FROM ", Render.tableQualified kind.Physical, ";"))  // LINT-ALLOW: terminal SQL-text boundary; table name is a validated TableId via Render.tableQualified
+        }
+
+    /// The durable phase-marker table — records which transfers completed, so a
+    /// re-run of an already-finished transfer is a no-op (idempotent).
+    let private progressTableSql : string =
+        "IF OBJECT_ID('dbo.__projection_transfer_progress') IS NULL \
+           CREATE TABLE dbo.__projection_transfer_progress \
+             ( Marker NVARCHAR(450) NOT NULL PRIMARY KEY, \
+               CompletedAt DATETIME2 NOT NULL CONSTRAINT DF___ptp_at DEFAULT SYSUTCDATETIME() );"
+
+    /// A deterministic signature of a plan — the sorted set of target tables it
+    /// loads. Two re-runs of the same transfer share it; a different transfer
+    /// (different tables) does not.
+    let private planMarker (catalog: Catalog) (plan: DataLoadPlan) : string =
+        plan.Loads
+        |> List.choose (fun l -> Catalog.tryFindKind l.Kind catalog)
+        |> List.map (fun k -> Render.tableQualified k.Physical)
+        |> List.sort
+        |> String.concat "|"
+
+    let private isMarked (sink: SqlConnection) (marker: string) : Task<bool> =
+        task {
+            use cmd = sink.CreateCommand()
+            cmd.CommandText <- "SELECT COUNT(*) FROM dbo.__projection_transfer_progress WHERE Marker = @m;"
+            cmd.Parameters.AddWithValue("@m", marker) |> ignore
+            let! c = cmd.ExecuteScalarAsync()
+            return System.Convert.ToInt32 c > 0
+        }
+
+    let private markComplete (sink: SqlConnection) (marker: string) : Task<unit> =
+        task {
+            use cmd = sink.CreateCommand()
+            cmd.CommandText <- "INSERT INTO dbo.__projection_transfer_progress (Marker) VALUES (@m);"
+            cmd.Parameters.AddWithValue("@m", marker) |> ignore
+            let! _ = cmd.ExecuteNonQueryAsync()
+            return ()
+        }
+
+    /// **G10 — the resumable/idempotent envelope around `writePlan`.** A
+    /// completed transfer (its marker present) is a NO-OP on re-run. Otherwise
+    /// the plan's tables are cleared FK-first — so a partial prior attempt
+    /// leaves NO duplicates — and reloaded via the unchanged `writePlan`, then
+    /// the completion marker is written. A mid-load failure leaves the marker
+    /// UNSET, so re-running the same command resumes to a complete,
+    /// duplicate-free state. Phase-tracked + idempotent (the resolved fork),
+    /// not a single all-or-nothing transaction envelope.
+    let private writePlanResumable (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) (topo: TopologicalOrder) : Task<(SsKey * UnresolvedReference) list> =
+        task {
+            do! Deploy.executeBatch sink progressTableSql
+            let marker = planMarker catalog plan
+            let! already = isMarked sink marker
+            if already then return []
+            else
+                do! wipeFkOrdered sink catalog plan topo
+                let! skips = writePlan sink catalog plan
+                do! markComplete sink marker
+                return skips
+        }
+
     // -- 6.A.2 / 6.A.3: surrogate-capture refusals (fail-loud, not silent) ---
     //
     // Two `AssignedBySink` shapes the per-row capture path cannot honor. Each
@@ -396,6 +477,19 @@ module Transfer =
               DeferredFkColumns = l.DeferredFkColumns
               RowsWritten       = (match mode with Execute -> l.Rows.Length | DryRun -> 0) })
 
+    /// The write-seam policy (Wave 3): the D10 `EmissionMode` (incremental MERGE
+    /// vs operator-selected wipe-and-load) and the G10 resumability flag. The
+    /// default is incremental + non-resumable — byte-identical to the pre-Wave-3
+    /// write path, so every existing caller is unaffected.
+    type WriteOptions =
+        { Emission : EmissionMode; Resumable : bool }
+
+    [<RequireQualifiedAccess>]
+    module WriteOptions =
+        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false }
+        let resumable : WriteOptions = { def with Resumable = true }
+        let ofEmission (mode: EmissionMode) : WriteOptions = { def with Emission = mode }
+
     let private runCore
         (mode: Mode)
         (allowCdc: bool)
@@ -405,6 +499,7 @@ module Transfer =
         (catalog: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         (ingestion: (Catalog * Map<Name, Name>) option)
+        (writeOpts: WriteOptions)
         : Task<Result<TransferReport>> =
         task {
             // Wave-3 slice 3.1 — CDC pre-flight gate. Only an Execute run that
@@ -481,8 +576,19 @@ module Transfer =
             | None ->
                 let! writeSkips =
                     task {
-                        if mode = Execute then return! writePlan sink catalog plan
-                        else return []
+                        if mode <> Execute then return []
+                        else
+                            match writeOpts.Emission, writeOpts.Resumable with
+                            | EmissionMode.WipeAndLoad, _ ->
+                                // D10 — operator-selected full refresh: FK-ordered
+                                // wipe of the plan's tables, then the standard load.
+                                do! wipeFkOrdered sink catalog plan topo
+                                return! writePlan sink catalog plan
+                            | EmissionMode.Incremental, true ->
+                                // G10 — resumable/idempotent envelope.
+                                return! writePlanResumable sink catalog plan topo
+                            | EmissionMode.Incremental, false ->
+                                return! writePlan sink catalog plan
                     }
                 return
                     Result.success
@@ -511,7 +617,35 @@ module Transfer =
         : Task<Result<TransferReport>> =
         // Non-reconciling: `Unmatched` is always empty, so the validate-user-map
         // gate never fires — `allowDrops = false` is the safe, inert default.
-        runCore mode allowCdc false source sink catalog Map.empty None
+        runCore mode allowCdc false source sink catalog Map.empty None WriteOptions.def
+
+    /// **G10 — a resumable/idempotent Transfer.** Same as `run`, but the write
+    /// seam is phase-tracked: a mid-load failure is recoverable by re-running
+    /// the same command — the plan's tables are cleared FK-first then reloaded,
+    /// and a completion marker makes a finished transfer a no-op. No duplicate
+    /// rows on re-run; resumes to complete, duplicate-free state.
+    let runResumable
+        (mode: Mode)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (catalog: Catalog)
+        : Task<Result<TransferReport>> =
+        runCore mode allowCdc false source sink catalog Map.empty None WriteOptions.resumable
+
+    /// **D10 — a Transfer under an explicit `EmissionMode`.** `Incremental` is
+    /// exactly `run`; `WipeAndLoad` FK-ordered-clears the plan's tables before
+    /// the load — the operator-selected full refresh (the `2·|rows|` CDC cost
+    /// `EmissionMode` documents). Incremental stays the default everywhere else.
+    let runWithEmissionMode
+        (mode: Mode)
+        (emission: EmissionMode)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (catalog: Catalog)
+        : Task<Result<TransferReport>> =
+        runCore mode allowCdc false source sink catalog Map.empty None (WriteOptions.ofEmission emission)
 
     /// 6.B.2 — RefactorLog-aware Transfer. The source is at schema A
     /// (`sourceContract`); the sink is at schema B (`sinkContract`). A rename
@@ -537,7 +671,7 @@ module Transfer =
             | Ok diff ->
                 let renameMap =
                     RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap))
+                return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) WriteOptions.def
         }
 
     /// Run a *reconciling* Transfer — the operator's headline case
@@ -556,7 +690,7 @@ module Transfer =
         (catalog: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
-        runCore mode allowCdc allowDrops source sink catalog reconciliation None
+        runCore mode allowCdc allowDrops source sink catalog reconciliation None WriteOptions.def
 
     /// AC-I7 — the composed Transfer: a sprint that carries BOTH a column
     /// rename (the source is at schema A, the sink at schema B) AND a
@@ -589,7 +723,7 @@ module Transfer =
             | Ok diff ->
                 let renameMap =
                     RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap))
+                return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) WriteOptions.def
         }
 
     /// Slice 4.2 — drive a Transfer through the `TransferConnections`
@@ -629,7 +763,7 @@ module Transfer =
                         match resolveReconciliation contract with
                         | Error es -> return Result.failure es
                         | Ok reconciliation ->
-                            return! runCore mode allowCdc allowDrops source sink contract reconciliation None
+                            return! runCore mode allowCdc allowDrops source sink contract reconciliation None WriteOptions.def
         }
 
     // -- 6.A.1: the drop-set is fail-loud, not exit-0 -----------------------

--- a/sidecar/projection/tests/Projection.Tests/ComposeAtomicWriteTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ComposeAtomicWriteTests.fs
@@ -50,6 +50,7 @@ let private trivialOutputs () : Compose.Outputs =
     | j, d, sc ->
         {
             SsdtBundle        = bundle
+            DataBundle        = Map.empty
             Json              = j
             Distributions     = d
             RemediationSql    = "-- no remediation candidates"

--- a/sidecar/projection/tests/Projection.Tests/EjectRunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EjectRunTests.fs
@@ -1,0 +1,89 @@
+module Projection.Tests.EjectRunTests
+
+open System
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+
+// AC-X6 — the eject protein (append-forever). The fork is RESOLVED to
+// append-forever: freezing a timeline preserves EVERY episode + the full
+// accumulated refactorlog, and the package self-verifies that the FTC
+// reconstruction from genesis reproduces the frozen state. The witness
+// discriminates against the COLLAPSE impostor (which would keep only the latest
+// snapshot, discarding intermediate provenance).
+
+let private mustResultOk (r: Result<'a>) : 'a =
+    match r with
+    | Ok v -> v
+    | Error es -> Assert.Fail(sprintf "%A" es); Unchecked.defaultof<'a>
+
+let private nameOf (s: string) : Name = Name.create s |> mustResultOk
+let private ver (o: int) (lbl: string) : Version = Version.create o lbl |> mustResultOk
+let private tl (name: string) : Timeline = Timeline.create name |> mustResultOk
+let private at (iso: string) : DateTimeOffset = DateTimeOffset.Parse(iso, System.Globalization.CultureInfo.InvariantCulture)
+
+// A genesis schema (the sample catalog) evolving through one table rename
+// (customer → Patron, SsKey-preserving) — a known, non-trivial displacement so
+// the FTC reconstruction folds a real diff.
+let private renamedCustomerKind : Kind = { customer with Name = nameOf "Patron" }
+let private renamedSalesModule : Module = { salesModule with Kinds = [ renamedCustomerKind; order; country ] }
+let private targetCatalog : Catalog = IRBuilders.mkCatalog [ renamedSalesModule ]
+
+let private coord0 = EpisodeCoordinate.create (ver 0 "1.0.0") Environment.Dev (at "2026-06-01T09:00:00+00:00")
+let private coord1 = EpisodeCoordinate.create (ver 1 "1.1.0") Environment.Dev (at "2026-06-08T09:00:00+00:00")
+let private coord2 = EpisodeCoordinate.create (ver 2 "1.2.0") Environment.Dev (at "2026-06-15T09:00:00+00:00")
+
+let private e0 : Episode = Episode.ofSchema coord0 sampleCatalog
+let private e1 : Episode = Episode.create coord1 targetCatalog Profile.empty (Some "refactorlog#1") (DataObservation.create 10 None)
+let private e2 : Episode = Episode.create coord2 targetCatalog Profile.empty (Some "refactorlog#2") (DataObservation.create 20 None)
+
+let private threeEpisodeChain : EpisodicLifecycle =
+    EpisodicLifecycle.genesis (tl "eject-dev") e0
+    |> EpisodicLifecycle.append e1
+    |> mustResultOk
+    |> EpisodicLifecycle.append e2
+    |> mustResultOk
+
+[<Fact>]
+let ``AC-X6: eject preserves EVERY episode (append-forever, not collapsed to latest)`` () =
+    let pkg = EjectRun.fromChain threeEpisodeChain |> Result.mapError (sprintf "%A") |> function Ok p -> p | Error e -> Assert.Fail e; Unchecked.defaultof<EjectPackage>
+    // THE APPEND-FOREVER DISCRIMINATOR: all three episodes survive the freeze. A
+    // collapse-at-freeze impostor would carry exactly 1.
+    Assert.Equal(3, List.length pkg.Episodes)
+    // The full refactorlog reference chain is accumulated in timeline order
+    // (genesis e0 carries none; e1/e2 each carry one).
+    Assert.Equal<string list>([ "refactorlog#1"; "refactorlog#2" ], pkg.RefactorLogRefs)
+    // Genesis is preserved so any PRIOR state is reconstructable.
+    Assert.Equal<Catalog>(sampleCatalog, pkg.GenesisSchema)
+
+[<Fact>]
+let ``AC-X6: the ejected package self-verifies — FTC reconstruction reproduces the frozen state`` () =
+    match EjectRun.fromChain threeEpisodeChain with
+    | Error e -> Assert.Fail(sprintf "%A" e)
+    | Ok pkg ->
+        // The frozen state is the latest recorded schema…
+        Assert.Equal<Catalog>(targetCatalog, pkg.FrozenSchema)
+        // …and the genesis→latest FTC reconstruction reproduces it (the
+        // chain-level round-trip law). A package that dropped intermediate
+        // episodes could not fold back to the frozen state.
+        Assert.True(EjectRun.isFaithful pkg, "FTC reconstruction must reproduce the frozen state")
+
+[<Fact>]
+let ``AC-X6: eject round-trips through the durable store`` () =
+    let path =
+        System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            System.String.Concat("x6-", System.Guid.NewGuid().ToString("N"), ".lifecycle.json"))
+    try
+        match LifecycleStore.save path threeEpisodeChain with
+        | Error e -> Assert.Fail(sprintf "store save failed: %A" e)
+        | Ok () ->
+            match EjectRun.fromStore path with
+            | Error e -> Assert.Fail e
+            | Ok pkg ->
+                Assert.Equal(3, List.length pkg.Episodes)
+                Assert.Equal<string list>([ "refactorlog#1"; "refactorlog#2" ], pkg.RefactorLogRefs)
+                Assert.True(EjectRun.isFaithful pkg)
+    finally
+        if System.IO.File.Exists path then System.IO.File.Delete path

--- a/sidecar/projection/tests/Projection.Tests/EmissionModeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EmissionModeTests.fs
@@ -1,0 +1,39 @@
+module Projection.Tests.EmissionModeTests
+
+open Xunit
+open Projection.Core
+
+// AC-D10 (type leg) — the wipe-and-load fork, RESOLVED to an explicit named
+// EmissionMode. This slice names the mode and its cost in the type system; the
+// live TRUNCATE+reload realization is Wave 3. The witnesses pin: the default is
+// Incremental; the two modes are distinct; the destructive/CDC-cost facts are
+// carried by the type, not a boolean flag.
+
+[<Fact>]
+let ``AC-D10: the default emission mode is Incremental (wipe-and-load is opt-in)`` () =
+    Assert.Equal(Incremental, EmissionMode.defaultMode)
+
+[<Fact>]
+let ``AC-D10: Incremental and WipeAndLoad are distinct in the type system`` () =
+    Assert.NotEqual(Incremental, WipeAndLoad)
+
+[<Fact>]
+let ``AC-D10: only WipeAndLoad is destructive`` () =
+    Assert.False(EmissionMode.isDestructive Incremental)
+    Assert.True(EmissionMode.isDestructive WipeAndLoad)
+
+[<Fact>]
+let ``AC-D10: the CDC cost factor is 0 for Incremental and 2 per row for WipeAndLoad`` () =
+    // Incremental: CDC-minimal — an idempotent redeploy captures nothing.
+    Assert.Equal(0, EmissionMode.cdcCostFactorPerRow Incremental)
+    // WipeAndLoad: 2·|table| — a delete-image + insert-image per row.
+    Assert.Equal(2, EmissionMode.cdcCostFactorPerRow WipeAndLoad)
+
+[<Fact>]
+let ``AC-D10: tokens round-trip and unknown tokens are rejected`` () =
+    Assert.Equal(Ok Incremental, EmissionMode.ofToken (EmissionMode.toToken Incremental))
+    Assert.Equal(Ok WipeAndLoad, EmissionMode.ofToken (EmissionMode.toToken WipeAndLoad))
+    Assert.Equal(Ok WipeAndLoad, EmissionMode.ofToken "wipeandload")
+    match EmissionMode.ofToken "truncate-everything" with
+    | Error _ -> ()
+    | Ok m -> Assert.Fail(sprintf "unknown token must be rejected, got %A" m)

--- a/sidecar/projection/tests/Projection.Tests/FullExportDataBundleTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportDataBundleTests.fs
@@ -1,0 +1,87 @@
+module Projection.Tests.FullExportDataBundleTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+
+// AC-X1 (part A — the publication/seed leg) — the operator-resolved premise:
+// full-export emits the static-entity (+ migration-seed) INSERT scripts for a
+// from-fresh-blank-database deploy, and they are NON-OVERWRITING / idempotent
+// (a MERGE, CDC-silent on unchanged rows), so a fresh DB or a re-run lands the
+// same state. Until now the data emitters (`DataEmissionComposer`) were reachable
+// only from tests; this wires them into the full-export bundle behind the
+// config's data-emission toggles (`EmissionPolicy.EmitData`). The witnesses
+// discriminate: the seed is present + idempotent when enabled, and the bundle is
+// byte-identical (empty DataBundle) when disabled.
+
+let private mustOk r =
+    match r with
+    | Ok v -> v
+    | Error es -> invalidOp (sprintf "fixture: %A" es)
+
+let private mkKey (parts: string list) : SsKey = SsKey.synthesizedComposite "OS_X1" parts |> mustOk
+let private mkName (s: string) : Name = Name.create s |> mustOk
+
+/// A static-entity kind with two explicit rows (Id/Code/Label).
+let private countryKind () : Kind =
+    let kindKey = mkKey ["Mod"; "Country"]
+    let idKey = mkKey ["Mod"; "Country"; "Id"]
+    let codeKey = mkKey ["Mod"; "Country"; "Code"]
+    let labelKey = mkKey ["Mod"; "Country"; "Label"]
+    let row code label =
+        { Identifier = mkKey ["Mod"; "Country"; "Row"; code]
+          Values = Map.ofList [ mkName "Id", code; mkName "Code", code; mkName "Label", label ] }
+    {
+        SsKey = kindKey
+        Name = mkName "Country"
+        Origin = Native
+        Modality = [ Static [ row "US" "United States"; row "CA" "Canada" ] ]
+        Physical = mkTableId "dbo" "OSUSR_X1_COUNTRY"
+        Attributes =
+            [ { Attribute.create idKey (mkName "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
+              { Attribute.create codeKey (mkName "Code") Text with Column = ColumnRealization.create ("CODE") (false) |> Result.value; IsMandatory = true }
+              { Attribute.create labelKey (mkName "Label") Text with Column = ColumnRealization.create ("LABEL") (false) |> Result.value; IsMandatory = true } ]
+        References = []
+        Indexes = []
+        Description = None
+        IsActive = true
+        Triggers = []
+        ColumnChecks = []
+        ExtendedProperties = []
+    }
+
+let private staticCatalog : Catalog =
+    Catalog.create
+        [ { SsKey = mkKey ["Mod"]; Name = mkName "Mod"; Kinds = [ countryKind () ]; IsActive = true; ExtendedProperties = [] } ]
+        []
+    |> mustOk
+
+let private emitDataPolicy : Policy =
+    { Policy.empty with
+        Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
+
+let private projectBundle (policy: Policy) : Compose.Outputs =
+    Compose.projectWithState policy Profile.empty EmissionPolicy.empty EmissionFolders.empty TransformGroups.empty staticCatalog
+    |> fst
+
+[<Fact>]
+let ``AC-X1: full-export emits the idempotent seed bundle when data emission is enabled`` () =
+    let outputs = projectBundle emitDataPolicy
+    Assert.True(Map.containsKey "Data/seed.sql" outputs.DataBundle, "Data/seed.sql must be in the bundle when EmitData is on")
+    let seed = Map.find "Data/seed.sql" outputs.DataBundle
+    // THE NON-OVERWRITING / IDEMPOTENT DISCRIMINATOR: a MERGE with WHEN NOT
+    // MATCHED INSERT — not a bare `INSERT INTO ... VALUES` (which would duplicate
+    // on a re-run against a non-empty DB). This is the from-fresh-blank-DB-safe
+    // shape the premise requires.
+    Assert.Contains("MERGE", seed)
+    Assert.Contains("WHEN NOT MATCHED", seed)
+    // The static rows are carried into the script.
+    Assert.Contains("United States", seed)
+
+[<Fact>]
+let ``AC-X1: data emission off leaves the bundle byte-identical (empty DataBundle)`` () =
+    let outputs = projectBundle Policy.empty
+    Assert.True(Map.isEmpty outputs.DataBundle, "DataBundle must be empty when EmitData is off")
+    // The schema bundle is still produced (only the data leg is gated).
+    Assert.False(Map.isEmpty outputs.SsdtBundle, "the SSDT schema bundle is unaffected by the data toggle")

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -466,6 +466,76 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
         | Error es -> Assert.Fail(sprintf "X8 churning canary failed: %A" es)
         | Ok (_, delta) -> Assert.Equal(1, delta)
 
+    // -- AC-X5 — the in-place migrate-with-data protein: Move-data + Measure-CDC
+    //    + Record. The recorded episode carries the MEASURED capture count ------
+    //
+    // THE STANDARD (obligations §0): the prior executeWithData cell proved
+    // schema-migrate + data-move; X5 demands the chain's last two links —
+    // MEASURE the data movement (the change-measure ‖·‖) and RECORD it durably.
+    // `executeWithDataAndRecord` brackets the transfer with the production
+    // reader and persists an episode whose `DataObservation` carries the
+    // measured capture count. The witness:
+    //   - moves 3 rows into a CDC-tracked sink ⇒ the recorded episode's
+    //     CdcCaptureCount == 3 (non-empty observation; the measure is real, not
+    //     the hard-wired-empty DataObservation the schema-only record uses);
+    //   - that count round-trips through the durable store.
+    [<Fact>]
+    member _.``AC-X5: migrate-with-data measures the data movement and records the CDC count on the episode`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        let storePath =
+            System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.String.Concat("x5-", System.Guid.NewGuid().ToString("N"), ".lifecycle.json"))
+        try
+            TaskSync.run (fun () ->
+                // Source at B with 3 rows; sink at B and CDC-tracked — the data
+                // load moves rows into the tracked sink, firing 3 captures.
+                fixture.WithEphemeralDatabase "X5Src" (fun source _ ->
+                    task {
+                        do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogB |> Render.toText)
+                        do! Deploy.executeBatch source
+                                "INSERT INTO [dbo].[MIGAB_PATRON] ([ID],[EMAIL],[LOYALTY]) VALUES (1, N'a@x.com', 1), (2, N'b@x.com', 2), (3, N'c@x.com', 3);"
+                        do! fixture.WithEphemeralDatabase "X5Sink" (fun sink _ ->
+                            task {
+                                do! Deploy.executeBatch sink (SsdtDdlEmitter.statements catalogB |> Render.toText)
+                                let! enabled =
+                                    task {
+                                        try
+                                            do! Deploy.executeBatch sink "EXEC sys.sp_cdc_enable_db;"
+                                            do! Deploy.executeBatch sink "EXEC sys.sp_cdc_enable_table @source_schema=N'dbo', @source_name=N'MIGAB_PATRON', @role_name=NULL, @supports_net_changes=0;"
+                                            let! c = scalarInt sink "SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1 AND name = N'MIGAB_PATRON';"
+                                            return c > 0
+                                        with _ -> return false
+                                    }
+                                if not enabled then
+                                    printfn "SKIP AC-X5: container did not enable CDC (flag not set)"
+                                else
+                                    let tl = Timeline.create "x5" |> Result.value
+                                    let at = System.DateTimeOffset.UtcNow
+                                    let! outcome =
+                                        MigrationRun.executeWithDataAndRecord
+                                            DeclareNone Transfer.Execute true catalogB catalogB Map.empty
+                                            storePath tl Environment.Dev at None source sink
+                                    match outcome with
+                                    | Error e -> Assert.Fail(sprintf "executeWithDataAndRecord failed: %A" e)
+                                    | Ok (_, chain) ->
+                                        // The 3 source rows landed in the tracked sink.
+                                        let! count = scalarString sink "SELECT COUNT(*) FROM [dbo].[MIGAB_PATRON];"
+                                        Assert.Equal("3", count)
+                                        // The recorded episode carries the MEASURED capture count.
+                                        let recorded = EpisodicLifecycle.latest chain
+                                        Assert.True(recorded.Data.CdcCaptureCount > 0, "the recorded observation must be non-empty (data moved)")
+                                        Assert.Equal(3, recorded.Data.CdcCaptureCount)
+                                        // …and it round-trips through the durable store.
+                                        match LifecycleStore.load storePath with
+                                        | Error e -> Assert.Fail(sprintf "store reload failed: %A" e)
+                                        | Ok reloaded ->
+                                            Assert.Equal(3, (EpisodicLifecycle.latest reloaded).Data.CdcCaptureCount)
+                            })
+                    }))
+        finally
+            if System.IO.File.Exists storePath then System.IO.File.Delete storePath
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -576,6 +576,90 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
         | Ok diff ->
             Assert.False(PhysicalSchema.isEqual diff, "deployed A vs model B must surface drift")
 
+    // -- AC-G10 — the resumable/idempotent transfer (crash-safety fork) --------
+    //
+    // THE STANDARD (obligations §0): a mid-load failure is recoverable by
+    // re-running the SAME command — phase-tracked + idempotent, NOT a single
+    // all-or-nothing transaction envelope. We simulate a CRASHED partial prior
+    // attempt by seeding stale rows into the sink with NO completion marker (the
+    // state a crash leaves). `Transfer.runResumable` clears that partial state
+    // FK-first and reloads, then marks complete. Two legs:
+    //   1. recovery: the stale rows are gone and exactly the source rows remain
+    //      (no duplicates, complete state) — a non-resumable `run` would leave
+    //      the stale rows behind (count > source);
+    //   2. idempotence: a second identical run is a NO-OP (the marker is
+    //      present) — counts unchanged, and the phase-marker row exists (a
+    //      transaction-only impl with no phase tracking would have none).
+    [<Fact>]
+    member _.``AC-G10: a resumable transfer recovers a partial prior attempt with no duplicate rows`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "G10Src" (fun source _ ->
+                task {
+                    do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                    do! Deploy.executeBatch source
+                            "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (1,N'a@x'),(2,N'b@x'),(3,N'c@x');"
+                    do! fixture.WithEphemeralDatabase "G10Sink" (fun sink _ ->
+                        task {
+                            do! Deploy.executeBatch sink (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                            // A crashed partial prior attempt: rows present, NO marker.
+                            do! Deploy.executeBatch sink
+                                    "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (98,N'stale@x'),(99,N'stale@x');"
+                            // LEG 1 — resume: clear the partial state, load, mark.
+                            let! r1 = Transfer.runResumable Transfer.Execute true source sink catalogA
+                            match r1 with
+                            | Error es -> Assert.Fail(sprintf "resumable run failed: %A" es)
+                            | Ok _ ->
+                                let! c1 = scalarInt sink "SELECT COUNT(*) FROM [dbo].[MIGAB_CUSTOMER];"
+                                Assert.Equal(3, c1)   // stale 98/99 wiped; exactly the 3 source rows. No dupes.
+                                let! marks = scalarInt sink "SELECT COUNT(*) FROM dbo.__projection_transfer_progress;"
+                                Assert.Equal(1, marks)   // phase-marker written (resumability mechanism, not just a txn).
+                                // LEG 2 — idempotent re-run: marker present ⇒ no-op.
+                                let! r2 = Transfer.runResumable Transfer.Execute true source sink catalogA
+                                match r2 with
+                                | Error es -> Assert.Fail(sprintf "resumable re-run failed: %A" es)
+                                | Ok _ ->
+                                    let! c2 = scalarInt sink "SELECT COUNT(*) FROM [dbo].[MIGAB_CUSTOMER];"
+                                    Assert.Equal(3, c2)   // unchanged — re-running the same command duplicates nothing.
+                        })
+                }))
+
+    // -- AC-D10 — wipe-and-load (the explicit destructive EmissionMode) --------
+    //
+    // THE STANDARD (obligations §0): WipeAndLoad is the operator-selected full
+    // refresh — it CLEARS the sink's existing rows (FK-ordered) and reloads. The
+    // discriminator: a sink pre-populated with a row whose value DIFFERS from
+    // the source. Incremental (`run`) would PK-collide on that row (the
+    // PROD-empty premise); WipeAndLoad wipes it first, so the reload succeeds and
+    // the row carries the SOURCE value — proving the wipe actually replaced the
+    // pre-existing state rather than appending to it.
+    [<Fact>]
+    member _.``AC-D10: WipeAndLoad clears pre-existing sink rows and reloads from source`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "D10Src" (fun source _ ->
+                task {
+                    do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                    do! Deploy.executeBatch source
+                            "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (1,N'fresh@x'),(2,N'b@x'),(3,N'c@x');"
+                    do! fixture.WithEphemeralDatabase "D10Sink" (fun sink _ ->
+                        task {
+                            do! Deploy.executeBatch sink (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                            // Pre-existing sink state: ID 1 with a STALE value (would
+                            // PK-collide an incremental load).
+                            do! Deploy.executeBatch sink
+                                    "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (1,N'stale@x');"
+                            let! r = Transfer.runWithEmissionMode Transfer.Execute WipeAndLoad true source sink catalogA
+                            match r with
+                            | Error es -> Assert.Fail(sprintf "wipe-and-load failed: %A" es)
+                            | Ok _ ->
+                                let! c = scalarInt sink "SELECT COUNT(*) FROM [dbo].[MIGAB_CUSTOMER];"
+                                Assert.Equal(3, c)   // exactly the source rows (the stale row was wiped, not duplicated).
+                                let! v = scalarString sink "SELECT [EMAIL] FROM [dbo].[MIGAB_CUSTOMER] WHERE [ID]=1;"
+                                Assert.Equal("fresh@x", v)   // ID 1 carries the SOURCE value ⇒ wipe replaced the stale state.
+                        })
+                }))
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -728,6 +728,96 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                         Assert.Equal(baseline, post)     // zero CDC captures on the idempotent re-run.
                 }))
 
+    // -- AC-X1 (part B, live) — the full-export DATA-LOAD leg: load + MEASURE +
+    //    RECORD, CDC-silent on the idempotent re-run --------------------------
+    //
+    // THE STANDARD (obligations §0): the load protein's last links — Move-data
+    // (the seed MERGE) → Measure-CDC (the ‖·‖) → Record (the episode carries the
+    // MEASURED DataObservation, not the X3 store leg's empty one). `loadSeedAndRecord`
+    // loads the published seed into a deployed + CDC-tracked sink, measures the
+    // capture count, and records the episode. Two legs:
+    //   1. first load ⇒ the measured delta == the rows inserted (2), and the
+    //      recorded episode's CdcCaptureCount == 2 (an empty-observation impostor
+    //      — the X3 behavior — records 0 and turns this RED);
+    //   2. idempotent re-load ⇒ delta == 0 (CDC-silent) and the rows are
+    //      unchanged (non-overwriting; a bare-INSERT impostor would PK-collide /
+    //      duplicate).
+    [<Fact>]
+    member _.``AC-X1: the full-export load leg measures the data movement and records it; the re-load is CDC-silent`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        let mkKey (parts: string list) = SsKey.synthesizedComposite "OS_X1B" parts |> Result.value
+        let nmx (s: string) = Name.create s |> Result.value
+        let row code label =
+            { Identifier = mkKey ["Mod"; "Country"; "Row"; code]
+              Values = Map.ofList [ nmx "Id", code; nmx "Code", code; nmx "Label", label ] }
+        let country =
+            { SsKey = mkKey ["Mod"; "Country"]; Name = nmx "Country"; Origin = Native
+              Modality = [ Static [ row "1" "United States"; row "2" "Canada" ] ]
+              Physical = mkTableId "dbo" "Country"
+              Attributes =
+                [ { Attribute.create (mkKey ["Mod";"Country";"Id"]) (nmx "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
+                  { Attribute.create (mkKey ["Mod";"Country";"Code"]) (nmx "Code") Text with Column = ColumnRealization.create ("CODE") (false) |> Result.value; IsMandatory = true }
+                  { Attribute.create (mkKey ["Mod";"Country";"Label"]) (nmx "Label") Text with Column = ColumnRealization.create ("LABEL") (false) |> Result.value; IsMandatory = true } ]
+              References = []; Indexes = []; Description = None; IsActive = true
+              Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
+        let catalog =
+            Catalog.create [ { SsKey = mkKey ["Mod"]; Name = nmx "Mod"; Kinds = [ country ]; IsActive = true; ExtendedProperties = [] } ] []
+            |> Result.value
+        let policy =
+            { Policy.empty with Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
+        let outputs =
+            Compose.projectWithState policy Profile.empty EmissionPolicy.empty EmissionFolders.empty TransformGroups.empty catalog
+            |> fst
+        let ddl = Compose.aggregateSsdt outputs.SsdtBundle
+        let seed = Map.find "Data/seed.sql" outputs.DataBundle
+        let storePath =
+            System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.String.Concat("x1b-", System.Guid.NewGuid().ToString("N"), ".lifecycle.json"))
+        try
+            TaskSync.run (fun () ->
+                fixture.WithEphemeralDatabase "X1LoadLeg" (fun conn _ ->
+                    task {
+                        // The schema is deployed + CDC-tracked (the publish→deploy→load
+                        // premise) BEFORE the data lands, so the load's captures are real.
+                        do! Deploy.executeBatch conn ddl
+                        let! enabled =
+                            task {
+                                try
+                                    do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_db;"
+                                    do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_table @source_schema=N'dbo', @source_name=N'Country', @role_name=NULL, @supports_net_changes=0;"
+                                    let! c = scalarInt conn "SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1 AND name = N'Country';"
+                                    return c > 0
+                                with _ -> return false
+                            }
+                        if not enabled then
+                            printfn "SKIP AC-X1 (load leg): container did not enable CDC"
+                        else
+                            let tl = Timeline.create "x1load" |> Result.value
+                            let at = System.DateTimeOffset.UtcNow
+                            // LEG 1 — first load: measure + record.
+                            let! first = Compose.loadSeedAndRecord Deploy.cdcCaptureTotal Deploy.executeBatch catalog seed conn (Some storePath) tl Environment.Dev at
+                            match first with
+                            | Error es -> Assert.Fail(sprintf "load leg failed: %A" es)
+                            | Ok (legOpt, delta1) ->
+                                Assert.Equal(2, delta1)   // the 2 static rows were captured (measured).
+                                match legOpt with
+                                | None -> Assert.Fail("a store was supplied; an episode must be recorded")
+                                | Some leg ->
+                                    let recorded = EpisodicLifecycle.latest leg.Chain
+                                    Assert.Equal(2, recorded.Data.CdcCaptureCount)   // the episode carries the MEASURED count.
+                            // LEG 2 — idempotent re-load: CDC-silent, non-overwriting.
+                            let! second = Compose.loadSeedAndRecord Deploy.cdcCaptureTotal Deploy.executeBatch catalog seed conn None tl Environment.Dev at
+                            match second with
+                            | Error es -> Assert.Fail(sprintf "re-load failed: %A" es)
+                            | Ok (_, delta2) ->
+                                Assert.Equal(0, delta2)   // CDC-silent on the idempotent re-load.
+                                let! rows = scalarInt conn "SELECT COUNT(*) FROM [dbo].[Country];"
+                                Assert.Equal(2, rows)     // non-overwriting — still 2, no dupes.
+                    }))
+        finally
+            if System.IO.File.Exists storePath then System.IO.File.Delete storePath
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -344,6 +344,72 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                         | _ -> ()
                 }))
 
+    // -- AC-X4 — the redeploy protein: redeploy an unchanged model; pass iff
+    //    zero ALTERs AND zero CDC captures, BOTH MEASURED ----------------------
+    //
+    // THE STANDARD (obligations §0): the prior 6.A.13 cell proved the migrate
+    // emits zero DDL on an unchanged schema — but it never MEASURED CDC; it
+    // *assumed* "no DDL ⇒ CDC-silent." X4's criterion demands the engine
+    // surface the CDC capture count, not infer it. `executeAndMeasureCdc`
+    // brackets the (no-op) execute with the change-measure ‖·‖
+    // (`Deploy.cdcCaptureTotal`, the PRODUCTION reader) and returns the delta.
+    //
+    // TWO LEGS, criterion-first:
+    //   1. Idempotent redeploy (A→A): zero statements (ALTERs measured) AND
+    //      delta == 0 (captures MEASURED, not assumed).
+    //   2. Meter-liveness discriminator: the SAME production primitive the
+    //      migrate uses, bracketing one real INSERT, returns exactly +1. A
+    //      reader hard-wired to 0 (the impostor that makes leg 1 look green for
+    //      free) turns this RED; an over-counting reader overshoots.
+    [<Fact>]
+    member _.``AC-X4: redeploy of an unchanged model measures zero ALTERs and zero CDC captures (meter proven live)`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "RedeployCdcMeasure" (fun conn _ ->
+                task {
+                    do! Deploy.executeBatch conn (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                    let! enabled =
+                        task {
+                            try
+                                do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_db;"
+                                do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'MIGAB_CUSTOMER', @role_name = NULL, @supports_net_changes = 0;"
+                                let! c =
+                                    scalarInt conn
+                                        "SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1 AND name = N'MIGAB_CUSTOMER';"
+                                return c > 0
+                            with _ -> return false
+                        }
+                    if not enabled then
+                        printfn "SKIP AC-X4: container did not enable CDC (flag not set)"
+                    else
+                        // Seed rows so the tracked substrate carries real, prior
+                        // CDC traffic (proves the meter isn't counting an empty CT).
+                        do! Deploy.executeBatch conn
+                                "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (1, N'a@x.com'), (2, N'b@x.com');"
+
+                        // LEG 1 — idempotent redeploy (A→A) measures BOTH legs zero.
+                        let! measured = MigrationRun.executeAndMeasureCdc false DeclareNone catalogA catalogA conn
+                        match measured with
+                        | Error e -> Assert.Fail(sprintf "idempotent redeploy should succeed, got %A" e)
+                        | Ok (o, cdcDelta) ->
+                            // Zero ALTERs: the differential plan is empty — the
+                            // engine emits no DDL for an unchanged model. (NB: B'
+                            // verification is deliberately NOT asserted here — CDC
+                            // enable adds `cdc`-schema objects the readback sees, so
+                            // Verified is confounded under CDC; the *plan* emptiness
+                            // is the faithful "zero ALTERs" measure.)
+                            Assert.Empty(o.Artifacts.SchemaStatements)   // zero ALTERs, measured
+                            Assert.Equal(0, cdcDelta)                    // zero CDC captures, measured
+
+                        // LEG 2 — meter-liveness: the SAME production primitive,
+                        // bracketing one INSERT, reads exactly +1.
+                        let! baseline = Deploy.cdcCaptureTotal conn
+                        do! Deploy.executeBatch conn
+                                "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (3, N'c@x.com');"
+                        let! post = Deploy.cdcCaptureTotal conn
+                        Assert.Equal(baseline + 1, post)
+                }))
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -660,6 +660,74 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                         })
                 }))
 
+    // -- AC-X1 (part A, live) — the full-export seed bundle deployed to a
+    //    FRESH-BLANK database is non-overwriting / CDC-silent on re-run --------
+    //
+    // THE STANDARD (obligations §0): the operator-resolved premise — full-export
+    // emits the static-entity INSERT scripts for a from-fresh-blank-database
+    // deploy, and they are idempotent (a MERGE), so a re-run lands the same state
+    // and is CDC-silent. This drives the PRODUCTION bundle end-to-end: project
+    // (EmitData) → deploy the DDL + `Data/seed.sql` to a fresh DB → enable CDC →
+    // re-run the SAME seed → assert rows present AND the re-run fired ZERO CDC
+    // captures. A bare-INSERT impostor would PK-collide/duplicate on the re-run;
+    // an over-writing MERGE would fire captures.
+    [<Fact>]
+    member _.``AC-X1: the full-export seed bundle is non-overwriting and CDC-silent on a fresh-blank-DB re-run`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        let mkKey (parts: string list) = SsKey.synthesizedComposite "OS_X1L" parts |> Result.value
+        let nmx (s: string) = Name.create s |> Result.value
+        let kindKey = mkKey ["Mod"; "Country"]
+        let row code label =
+            { Identifier = mkKey ["Mod"; "Country"; "Row"; code]
+              Values = Map.ofList [ nmx "Id", code; nmx "Code", code; nmx "Label", label ] }
+        let country =
+            { SsKey = kindKey; Name = nmx "Country"; Origin = Native
+              Modality = [ Static [ row "1" "United States"; row "2" "Canada" ] ]
+              Physical = mkTableId "dbo" "Country"
+              Attributes =
+                [ { Attribute.create (mkKey ["Mod";"Country";"Id"]) (nmx "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
+                  { Attribute.create (mkKey ["Mod";"Country";"Code"]) (nmx "Code") Text with Column = ColumnRealization.create ("CODE") (false) |> Result.value; IsMandatory = true }
+                  { Attribute.create (mkKey ["Mod";"Country";"Label"]) (nmx "Label") Text with Column = ColumnRealization.create ("LABEL") (false) |> Result.value; IsMandatory = true } ]
+              References = []; Indexes = []; Description = None; IsActive = true
+              Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
+        let catalog =
+            Catalog.create [ { SsKey = mkKey ["Mod"]; Name = nmx "Mod"; Kinds = [ country ]; IsActive = true; ExtendedProperties = [] } ] []
+            |> Result.value
+        let policy =
+            { Policy.empty with Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
+        let outputs =
+            Compose.projectWithState policy Profile.empty EmissionPolicy.empty EmissionFolders.empty TransformGroups.empty catalog
+            |> fst
+        let ddl = Compose.aggregateSsdt outputs.SsdtBundle
+        let seed = Map.find "Data/seed.sql" outputs.DataBundle
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "X1FreshSeed" (fun conn _ ->
+                task {
+                    // Fresh-blank DB: deploy schema, run the seed (first load).
+                    do! Deploy.executeBatch conn ddl
+                    do! Deploy.executeBatch conn seed
+                    let! loaded = scalarInt conn "SELECT COUNT(*) FROM [dbo].[Country];"
+                    Assert.Equal(2, loaded)   // the static rows landed on the fresh DB.
+                    let! enabled =
+                        task {
+                            try
+                                do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_db;"
+                                do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_table @source_schema=N'dbo', @source_name=N'Country', @role_name=NULL, @supports_net_changes=0;"
+                                let! c = scalarInt conn "SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1 AND name = N'Country';"
+                                return c > 0
+                            with _ -> return false
+                        }
+                    if not enabled then
+                        printfn "SKIP AC-X1 (live): container did not enable CDC"
+                    else
+                        let! baseline = Deploy.cdcCaptureTotal conn
+                        do! Deploy.executeBatch conn seed   // re-run the SAME seed script
+                        let! post = Deploy.cdcCaptureTotal conn
+                        let! after = scalarInt conn "SELECT COUNT(*) FROM [dbo].[Country];"
+                        Assert.Equal(2, after)            // still 2 — non-overwriting, no dupes.
+                        Assert.Equal(baseline, post)     // zero CDC captures on the idempotent re-run.
+                }))
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -410,6 +410,62 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                         Assert.Equal(baseline + 1, post)
                 }))
 
+    // -- AC-X8 — the canary protein: assert CDC-silence on idempotent redeploy --
+    //
+    // THE STANDARD (obligations §0): the wide canary already proves the
+    // PhysicalSchema round-trip; X8 demands it ALSO surface protein P-9 — an
+    // idempotent redeploy of the deployed target fires ZERO CDC captures — via
+    // the PRODUCTION reader, not a harness. The SAME canary path
+    // (`Deploy.runWideCanaryWithCdcSilence`, parameterized by the redeploy)
+    // discriminates two legs:
+    //   1. idempotent redeploy (`MigrationRun.execute tgt tgt`, empty
+    //      differential) ⇒ diff empty AND measured CDC delta == 0.
+    //   2. a data-churning redeploy (one INSERT) ⇒ measured CDC delta == +1,
+    //      proving the canary's CDC meter is LIVE. A hard-wired-0 meter — the
+    //      impostor that makes leg 1 green for free — turns this RED.
+    [<Fact>]
+    member _.``AC-X8: the canary measures CDC-silence on an idempotent redeploy (meter proven live)`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        let sourceDdl =
+            "CREATE TABLE [dbo].[X8_WIDGET] ( [ID] INT NOT NULL PRIMARY KEY, [LABEL] NVARCHAR(50) NOT NULL );"
+        let enableCdc cnn (cat: Catalog) =
+            task {
+                do! Deploy.executeBatch cnn "EXEC sys.sp_cdc_enable_db;"
+                for k in Catalog.allKinds cat do
+                    do! Deploy.executeBatch cnn
+                            (System.String.Concat(
+                                "EXEC sys.sp_cdc_enable_table @source_schema=N'", TableId.schemaText k.Physical,
+                                "', @source_name=N'", TableId.tableText k.Physical,
+                                "', @role_name=NULL, @supports_net_changes=0;"))
+            }
+        let idempotentRedeploy cnn (cat: Catalog) =
+            task { let! _ = MigrationRun.execute true DeclareNone cat cat cnn in return () }
+        let churningRedeploy cnn (_cat: Catalog) =
+            task {
+                do! Deploy.executeBatch cnn
+                        "INSERT INTO [dbo].[X8_WIDGET] ([ID],[LABEL]) VALUES (1, N'a');"
+            }
+        // LEG 1 — idempotent redeploy is CDC-silent.
+        let silent =
+            TaskSync.run (fun () ->
+                Deploy.runWideCanaryWithCdcSilence
+                    (fun cnn -> Deploy.executeBatch cnn sourceDdl)
+                    SsdtDdlEmitter.statements enableCdc idempotentRedeploy)
+        match silent with
+        | Error es -> Assert.Fail(sprintf "X8 idempotent canary failed: %A" es)
+        | Ok (report, delta) ->
+            Assert.True(PhysicalSchema.isEqual report.Diff, "wide canary PhysicalSchema diff must be empty")
+            Assert.Equal(0, delta)
+        // LEG 2 — a data-churning redeploy fires CDC; the meter is live.
+        let churned =
+            TaskSync.run (fun () ->
+                Deploy.runWideCanaryWithCdcSilence
+                    (fun cnn -> Deploy.executeBatch cnn sourceDdl)
+                    SsdtDdlEmitter.statements enableCdc churningRedeploy)
+        match churned with
+        | Error es -> Assert.Fail(sprintf "X8 churning canary failed: %A" es)
+        | Ok (_, delta) -> Assert.Equal(1, delta)
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -536,6 +536,46 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
         finally
             if System.IO.File.Exists storePath then System.IO.File.Delete storePath
 
+    // -- AC-X7 — the drift protein: diff the DEPLOYED substrate vs THE MODEL ----
+    //
+    // THE STANDARD (obligations §0): the criterion is "diff deployed vs **the
+    // model**". `verify-data` compares two DEPLOYED substrates and so cannot
+    // detect that the single deployment has drifted from the authored intent.
+    // `DriftRun.detect` reads the live schema and diffs it against the in-memory
+    // model `Catalog`. Two legs discriminate:
+    //   - deployed == model ⇒ no drift (empty PhysicalSchema diff);
+    //   - deployed (A) ≠ model (B) ⇒ drift detected (non-empty diff).
+    // A drift-blind impl that always reports clean turns leg 2 RED; the
+    // deployed-vs-deployed impostor cannot even be expressed (one connection,
+    // compared against intent).
+    [<Fact>]
+    member _.``AC-X7: drift detection diffs the deployed schema against the model (not a second deployment)`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        // LEG A — deployed == model ⇒ no drift.
+        let noDrift =
+            TaskSync.run (fun () ->
+                fixture.WithEphemeralDatabase "X7Match" (fun conn _ ->
+                    task {
+                        do! Deploy.executeBatch conn (SsdtDdlEmitter.statements catalogB |> Render.toText)
+                        return! DriftRun.detect catalogB conn
+                    }))
+        match noDrift with
+        | Error es -> Assert.Fail(sprintf "X7 no-drift read failed: %A" es)
+        | Ok diff ->
+            Assert.True(PhysicalSchema.isEqual diff, sprintf "deployed==model must show no drift:\n%s" (PhysicalSchema.renderDiff diff))
+        // LEG B — deployed (A) differs from the model (B) ⇒ drift detected.
+        let drift =
+            TaskSync.run (fun () ->
+                fixture.WithEphemeralDatabase "X7Drift" (fun conn _ ->
+                    task {
+                        do! Deploy.executeBatch conn (SsdtDdlEmitter.statements catalogA |> Render.toText)
+                        return! DriftRun.detect catalogB conn
+                    }))
+        match drift with
+        | Error es -> Assert.Fail(sprintf "X7 drift read failed: %A" es)
+        | Ok diff ->
+            Assert.False(PhysicalSchema.isEqual diff, "deployed A vs model B must surface drift")
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -101,6 +101,7 @@
     <Compile Include="ApprovalWorkflowTests.fs" />
     <Compile Include="ApprovalStoreTests.fs" />
     <Compile Include="LifecycleStoreTests.fs" />
+    <Compile Include="EjectRunTests.fs" />
     <Compile Include="MigrationRunTests.fs" />
     <Compile Include="SuggestConfigGatingTests.fs" />
     <Compile Include="PolicyDiffTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="JointDependencyDiagnosticsTests.fs" />
     <Compile Include="EmissionFoldersBindingTests.fs" />
     <Compile Include="EmissionFoldersOverlayTests.fs" />
+    <Compile Include="FullExportDataBundleTests.fs" />
     <Compile Include="TransformGroupsBindingTests.fs" />
     <Compile Include="TransformGroupsFilterTests.fs" />
     <Compile Include="InsertionPolicyBindingTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -102,6 +102,7 @@
     <Compile Include="ApprovalStoreTests.fs" />
     <Compile Include="LifecycleStoreTests.fs" />
     <Compile Include="EjectRunTests.fs" />
+    <Compile Include="EmissionModeTests.fs" />
     <Compile Include="MigrationRunTests.fs" />
     <Compile Include="SuggestConfigGatingTests.fs" />
     <Compile Include="PolicyDiffTests.fs" />


### PR DESCRIPTION
The redeploy protein criterion demands the engine MEASURE CDC-silence on an
idempotent redeploy, not infer it from 'no DDL ran'. Adds the shared
change-measure primitive Deploy.cdcCaptureTotal (force sp_cdc_scan, sum
ReadSide.cdcCaptureCount over tracked tables; benign when the capture job
owns the scan) and MigrationRun.executeAndMeasureCdc, which brackets the
in-place execute and returns the measured capture delta. The migrate verb
(--execute, no-store arm) now surfaces '(N statement(s); M CDC capture(s)
measured)'. Docker witness: idempotent A->A measures zero ALTERs (empty
plan) AND zero CDC captures, with a meter-liveness leg pinning one INSERT
to exactly +1 so a hard-wired-0 reader turns RED.