### PR TITLE
Wave 6 cluster D (the keystone): the self-verification meta-cell — matrix reports the L1/L2/L3 ladder

### DIFF
--- a/.github/workflows/verifiability-projection.yml
+++ b/.github/workflows/verifiability-projection.yml
@@ -1,0 +1,61 @@
+name: verifiability-projection
+
+# The self-verification meta-cell guardrail for the V2 sidecar (EXECUTION_PLAN
+# 6.E.1 / debrief cluster D). Two pure-bash checks, no dotnet required:
+#
+#   D2 — verifiability gate. `scripts/verifiability-gate.sh` enforces that no
+#        entry in `AxiomTests.fs` claims a coverage bucket its evidence does not
+#        support (the phantom-Bucket-A defect): a deferral (Skip) that claims
+#        "Bucket A/B" fails the build. The local pre-commit path is best-effort;
+#        this re-runs on PRs so a phantom claim cannot merge.
+#
+#   D1 — matrix currency. `scripts/matrix-status.sh` regenerates
+#        `NORTH_STAR.matrix.generated.md` (the round-trip ladder, derived from
+#        the test tree + `Tolerance.fs`'s `@ladder` tags). The committed file
+#        must match the generator's output — a non-empty diff means a coverage
+#        shift (a witness landed, a tolerance was retired) was not committed.
+#        The generator also fails (exit 3) if a live `ToleratedDivergence`
+#        variant carries no `@ladder` tag, so a new tolerance cannot land
+#        untagged and silently escape the ladder.
+#
+# Together these make the engine's distance-to-bullseye a build-visible
+# artifact: you cannot merge a phantom coverage claim, an untagged tolerance, or
+# a stale matrix.
+
+on:
+  pull_request:
+    paths:
+      - 'sidecar/projection/**'
+      - '.github/workflows/verifiability-projection.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'sidecar/projection/**'
+
+jobs:
+  verifiability-gate:
+    name: verifiability + matrix-ladder guardrail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run verifiability-gate.sh (D2 — no phantom Bucket-A/B)
+        run: |
+          chmod +x sidecar/projection/scripts/verifiability-gate.sh
+          sidecar/projection/scripts/verifiability-gate.sh
+
+      - name: Regenerate the ladder matrix (D1 — @ladder cross-check)
+        run: |
+          chmod +x sidecar/projection/scripts/matrix-status.sh
+          sidecar/projection/scripts/matrix-status.sh
+
+      - name: Assert the committed matrix is current (D1 — no coverage drift)
+        run: |
+          if ! git diff --exit-code -- sidecar/projection/NORTH_STAR.matrix.generated.md; then
+            echo "::error::NORTH_STAR.matrix.generated.md is stale — a coverage shift was not committed."
+            echo "Regenerate locally and commit: sidecar/projection/scripts/matrix-status.sh"
+            exit 1
+          fi

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -1,5 +1,21 @@
 # DEBRIEF 2026-06-02 — The Isomorphism Climb: Technical Debrief & Total-Projection Backlog
 
+> **UPDATE — round D→E→F (survey-independent L2 climb closed).** Since this debrief
+> was authored, the keystone and the schema/diff + decision L2 holes have closed:
+> **D1+D2** (the self-verification meta-cell — the matrix reports the L1/L2/L3 ladder
+> from `Tolerance.fs` `@ladder` tags + witnesses, wired into CI; G13), **E2** (the
+> cross-schema FK now a named diagnostic, not silent/opaque; G4), **E1** (non-PK
+> index structure reconstructed *and* compared in `PhysicalSchema.Indexes`, round-trip
+> witnessed; G3 — residual narrowed to `IndexOptionsUnreflected`), and **F1+F2** (the
+> unified 3-axis decision adjunction witness — nullability + uniqueness + FK-trust in
+> one overlay round-trip; G2/G12). North-Star §5 criteria 2, 3, 5 are met. **What
+> remains** (each named, none on the silent-corruption path): **G14** (`Reference`
+> illegal-state modeling — hygiene; no illegal state is produced); **H1** (the
+> speculative-optics cluster — correctly parked at defer-with-trigger until
+> cutover+1); **J1** (51-label perf canary — low-priority enabler); **C2/C3** +
+> **A3** (Lifecycle operationalization / atomic-resumable — distinct clusters,
+> the latter survey-*dependent* / PROD-deferred). See each cluster's STATUS block.
+>
 > **Status:** canonical for this moment (HEAD `307ef65`). A standalone debrief +
 > backlog for the L1→L2→L3 climb toward the Total Projection (`NORTH_STAR.md`).
 > Supersedes nothing; **integrates** the per-axis findings of
@@ -181,25 +197,29 @@ Read the table by **plane**, and the picture is clear:
   unsatisfiable cycles, cyclic `AssignedBySink`, and composite `AssignedBySink`
   all refuse *before* any write. This is the codebase's discipline working.
 
-- **The schema/diff plane has the deep L2 holes.** G1 (the captured-surface
-  boundary) is the structural heart: `migrate A B` today commutes only for
-  column-shape evolution; an A→B that adds an FK, changes an index, or alters a
-  sequence is **invisible to the diff** and silently no-ops those facets. G2
-  (unenforced FK-trust), G3 (unreconstructed indexes), and G4 (silent
-  cross-schema FK filter) are the read-leg's blind spots. These four are the
-  L2 climb's center of mass.
+- **The schema/diff plane was the deep L2 hole — now largely closed.** G1 (the
+  captured-surface boundary) landed with C1 (`migrate A B` now sees references /
+  indexes / sequences). The read-leg blind spots are closed: **G3** (index
+  structure reconstructed *and* compared — E1), **G4** (cross-schema FK now a named
+  diagnostic, not silent/opaque — E2), **G2/G12** (FK-trust carried + the 3-axis
+  decision adjunction witnessed — F1/F2). The remaining schema-plane items are
+  *hygiene*: **G14** (`Reference` illegal-state modeling — no illegal state is
+  actually produced, just expressible) and the narrowed **`IndexOptionsUnreflected`**
+  residual (index filter/included/storage options).
 
-- **T-VI spanning is the highest-stakes unbuilt surface.** G5/G6/G7 are the only
-  places the engine can still **silently corrupt or no-op a target**. A
-  write-denied sink, a mid-load crash, or a dead endpoint produces wrong results
-  with no refusal. This is the gravest faithfulness violation class remaining.
+- **The meta-cell (G13) — the keystone — landed (D1/D2).** The generated matrix now
+  reports each axis's L1/L2/L3 level (not just witness presence), derives L2 from
+  `Tolerance.fs`'s `@ladder` tags, and is wired into CI. The exact drift this
+  paragraph warned about ("6.A un-hollowed ReadSide" vs "indexes still dropped at
+  reconstruction") is now a *build-visible* artifact: Schema reports L2-partial
+  naming its open tolerance, and flips to L3 automatically when it retires.
 
-- **The meta-cell (G13) is the keystone.** The matrix generator reports L1
-  presence, not L2/L3 level. That is *exactly* why the drift between "6.A
-  un-hollowed ReadSide" and "indexes are still dropped at reconstruction" (G3)
-  was invisible until a manual file:line read surfaced it. A generated L2/L3
-  matrix would have caught it. This is the North-Star §1 warning —
-  witness-present ≠ faithful — made concrete.
+- **T-VI spanning remains the highest-stakes surface — but is survey-gated.** G5/G6/G7
+  (permissions / transactionality / connection) are where a write-denied sink, a
+  mid-load crash, or a dead endpoint could still corrupt a target. Per the premise
+  re-prioritization (`WAVE_6_ONTOLOGY.md` §10; PROD-empty), A3 (atomic/resumable)
+  is **deferred-with-trigger** until PROD gains data or a write-denied environment
+  enters a real flow — it is not on the survey-independent path.
 
 ---
 

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -153,7 +153,7 @@ the "closing slice" points into §3.
 | G1 | `CatalogDiff` captured surface **excludes references, FKs, indexes, modality, module structure, sequences** — they ride through `applyDiff` unchanged | `CatalogDiff.fs:380-388` | Schema, Time | L2 partial (column-shape only) | structural — round-trip law witnessed only on captured axes | **C1** (the widening) |
 | G2 | FK-trust (`IsNotTrusted`) **read but not gated** — no fail-loud if a FK is untrusted; the flag rides the `Reference` but planner/executor never acts on it | `ReadSide.fs:110, 1075` | Schema, Decision | L1.5 (recovered, unenforced) | none | **F1**, **G1-ref** |
 | G3 | Non-PK indexes **read but not reconstructed** into `Kind.Indexes` (hardcoded `[]`); `PhysicalSchema` comparison ignores them | `ReadSide.fs:877, 1004`; `Tolerance.fs:43-49` | Schema | L1 + named tolerance | `Tolerance.IndexesUnreflected` (named, not silent — but permanently open) | **E1** (3-part) |
-| G4 | Cross-schema FK rows whose `SCHEMA_NAME()` is NULL (dropped schema / missing `VIEW DEFINITION` grant) are **silently filtered** | `ReadSide.fs:580` | Schema | L1-not-L2 (**silent**) | silent filter — violates no-silent-drop boundary axiom | **E2** |
+| G4 | Cross-schema FK rows whose `SCHEMA_NAME()` is NULL (dropped schema / missing `VIEW DEFINITION` grant) — was an opaque `GetString` cast failure (live `readSchemaCombined`) / blank-and-drop (`readForeignKeys`) | `ReadSide.fs` `ForeignKeyReadback` | Schema | ✅ **CLOSED** (E2) — both FK readers route through the pure `ForeignKeyReadback.classify`, which emits a NAMED diagnostic + skip on an unreadable coordinate | named diagnostic, not silent / opaque | *(closed)* |
 | G5 | T-VI **Permissions** — write-denied sink transfers **zero rows, exits clean** | (no axis) | spanning | unbuilt | none | **A2** |
 | G6 | T-VI **Transactionality** — mid-transfer failure leaves a **half-populated target**; no atomic boundary, idempotent retry, or rollback | (no axis) | spanning | unbuilt | none | **A3** |
 | G7 | T-VI **Connection pre-flight** — no "both endpoints live + credentialed" check before mutation | (no axis) | spanning | unbuilt | none | **A1** |
@@ -597,6 +597,35 @@ bullseye.
 ---
 
 ### Cluster E — Close the silent-erasure residuals
+
+> **STATUS — reconnaissance + E2 landed (round D→E).** Three corrections to this
+> cluster's recorded state, found by a file:line re-read at HEAD:
+> - **E2 — LANDED.** Both FK readers (`readSchemaCombined` live + `readForeignKeys`
+>   out-of-band) route through the pure, public `ReadSide.ForeignKeyReadback.classify`,
+>   which classifies a NULL/blank `SCHEMA_NAME()` as `Unreadable` and surfaces a
+>   NAMED diagnostic + skip. (Correction: today's behaviour was an *opaque
+>   `GetString` cast failure* on the live path, not the recorded "silent filter" —
+>   E2 still closes G4 honestly: opaque/silent → named.) Witnesses:
+>   `tests/Projection.Tests/ForeignKeyReadbackTests.fs` (5, green).
+> - **E3 — durable substrate already guarded.** The `CatalogCodec` reconstruction
+>   arms (`readIndex`/`readReference`/`readKind`) set every persisted field
+>   explicitly, and `CatalogCodecTests.fs` exercises the bomb-prone defaults
+>   (`AllowRowLocks=false`, `AllowPageLocks=false`, `NoRecomputeStatistics=true`,
+>   `IgnoreDuplicateKey=true`, `IsConstraintTrusted=false`) under the round-trip
+>   law. The LifecycleStore folds over the codec, so its substrate is covered. The
+>   remaining E3 surface (ReadSide's index field-fidelity) is **interlocked with E1**
+>   and best done there.
+> - **E1 — de-risked, but witness-coupled to D1.** Part 1 (index reconstruction) is
+>   already live (`attachIndexes` is wired into `read`), and V2 *does* emit
+>   `CREATE INDEX` (chapter 4.1.A slice 3), so the round-trip is faithful and adding
+>   an `Indexes` axis to `PhysicalSchema` (mirroring the `Annotations` axis
+>   precedent) should keep the canary green. **Caution:** retiring
+>   `Tolerance.IndexesUnreflected` auto-flips the matrix Schema rung L2-partial→L3
+>   (the keystone working) — which *invalidates D1's acceptance witness*
+>   (`Schema=L2-partial because IndexesUnreflected`). When E1 lands, rewrite the D1
+>   test in `MatrixLadderTests.fs` to pin the classification mechanism over a
+>   different open example (or assert 0-open with the cross-check intact) in the
+>   same commit. The matrix now **measures** E1: it flips automatically on retirement.
 
 #### E1 — Reconstruct `Kind.Indexes` (G3) — 3-part
 

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -9,12 +9,21 @@
 > witnessed; G3 — residual narrowed to `IndexOptionsUnreflected`), and **F1+F2** (the
 > unified 3-axis decision adjunction witness — nullability + uniqueness + FK-trust in
 > one overlay round-trip; G2/G12). North-Star §5 criteria 2, 3, 5 are met. **What
-> remains** (each named, none on the silent-corruption path): **G14** (`Reference`
-> illegal-state modeling — hygiene; no illegal state is produced); **H1** (the
-> speculative-optics cluster — correctly parked at defer-with-trigger until
-> cutover+1); **J1** (51-label perf canary — low-priority enabler); **C2/C3** +
-> **A3** (Lifecycle operationalization / atomic-resumable — distinct clusters,
-> the latter survey-*dependent* / PROD-deferred). See each cluster's STATUS block.
+> remains** (each named, none on the silent-corruption path): **H1**/**G18** (the
+> speculative-optics cluster — parked at defer-with-trigger until cutover+1);
+> **J1**/**G20** (51-label perf canary — low-priority enabler); **A3**/**G6**
+> (atomic-resumable transfer — survey-*dependent* / PROD-deferred); **G19** (the
+> physical-comparison VO lift — deferred-with-trigger).
+>
+> **G-series sweep (G1–G20, reconciled to HEAD).** The fidelity ledger is now
+> almost entirely closed. **Closed this session:** G3 (E1), G4 (E2), G12 (F2), G13
+> (D1/D2), G14 (bounded guard). **Closed earlier but stale in the ledger (now
+> reconciled):** G1 (C1), G2/G5/G7/G8 (F1/F2 + the wired spanning pre-flights + B1
+> `--execute`), G9/G10/G11 (P6 real clock + 6.H.4 displacement-manifest + 6.H.3
+> compose-fold). **Already-closed refusals:** G15/G16/G17. **Deferred-by-design:**
+> G6 (A3, PROD-empty), G18 (optics, cutover+1), G19 (VO lift, trigger), G20 (J1).
+> Net: **17 of 20 closed; 3 deferred-with-trigger; 0 open on the survey-independent
+> faithfulness path.**
 >
 > **Status:** canonical for this moment (HEAD `307ef65`). A standalone debrief +
 > backlog for the L1→L2→L3 climb toward the Total Projection (`NORTH_STAR.md`).
@@ -167,19 +176,19 @@ the "closing slice" points into §3.
 | # | Gap | Location | Axis | Ladder today | Refusal / erasure | Closing slice |
 |---|---|---|---|---|---|---|
 | G1 | `CatalogDiff` captured surface **excludes references, FKs, indexes, modality, module structure, sequences** — they ride through `applyDiff` unchanged | `CatalogDiff.fs:380-388` | Schema, Time | L2 partial (column-shape only) | structural — round-trip law witnessed only on captured axes | **C1** (the widening) |
-| G2 | FK-trust (`IsNotTrusted`) is **carried faithfully** through the round-trip (recovered + reproduced as NOCHECK + witnessed by F2), per F1's option (b) — not gated, since no fixture demands the refusal | `ReadSide.fs:1075` | Schema, Decision | ✅ **CLOSED** (F1/F2) on the Decision plane — `Reference` illegal-state modeling (G14) is the remaining hygiene | none (carry, not gate) | **G1-ref** (modeling only) |
+| G2 | FK-trust (`IsNotTrusted`) is **carried faithfully** through the round-trip (recovered + reproduced as NOCHECK + witnessed by F2), per F1's option (b) — not gated, since no fixture demands the refusal | `ReadSide.fs:1075` | Schema, Decision | ✅ **CLOSED** (F1/F2 Decision plane; G14 illegal-state guard landed) | none (carry, not gate) | *(closed)* |
 | G3 | Non-PK index **structure** read, reconstructed (`attachIndexes`), and now **compared** (`PhysicalSchema.Indexes`: owner + name + uniqueness + ordered key columns) | `PhysicalSchema.fs` `PhysicalIndex`; `ReadSide.readIndexes` | Schema | ✅ **CLOSED** (E1) — round-trips emit/deploy/ReadSide (witness `IndexRoundtripTests`); the prior `IndexesUnreflected` retired | narrower residual: index *options* (filter / included / storage) → `IndexOptionsUnreflected` (OpenGap) | *(structure closed; options residual named)* |
 | G4 | Cross-schema FK rows whose `SCHEMA_NAME()` is NULL (dropped schema / missing `VIEW DEFINITION` grant) — was an opaque `GetString` cast failure (live `readSchemaCombined`) / blank-and-drop (`readForeignKeys`) | `ReadSide.fs` `ForeignKeyReadback` | Schema | ✅ **CLOSED** (E2) — both FK readers route through the pure `ForeignKeyReadback.classify`, which emits a NAMED diagnostic + skip on an unreadable coordinate | named diagnostic, not silent / opaque | *(closed)* |
-| G5 | T-VI **Permissions** — write-denied sink transfers **zero rows, exits clean** | (no axis) | spanning | unbuilt | none | **A2** |
-| G6 | T-VI **Transactionality** — mid-transfer failure leaves a **half-populated target**; no atomic boundary, idempotent retry, or rollback | (no axis) | spanning | unbuilt | none | **A3** |
-| G7 | T-VI **Connection pre-flight** — no "both endpoints live + credentialed" check before mutation | (no axis) | spanning | unbuilt | none | **A1** |
-| G8 | `migrate` CLI verb is **plan-only (dry-run)**; live `MigrationRun.execute` is test-driven only — Promise 8 not operator-reachable | `Program.fs:803, 902-904` vs `MigrationRun.fs:271-334` | L3 face | L3 in tests, not in CLI | n/a | **B1** |
-| G9 | Refactorlog `ChangeDateTime` **pinned to a constant**; episode clock not threaded; refactorlog not accumulated against prior | `WAVE_6_MORPHOLOGY.md:258-261` (F6) | Time | L2 partial | n/a | **C3** |
-| G10 | Change-manifest records **state + axis, not displacement** — no per-move `‖δ‖` by channel, no per-run tolerance residual, no `AppliedTransforms` outcome, no CDC capture series | `ChangeManifest.fs`; `WAVE_6_MORPHOLOGY.md:253-257` (F5) | Time, meta | L2 partial | n/a | **C4** |
-| G11 | No `CatalogDiff.compose` consumer — cross-episode `δ₁ + δ₂` fold exists (`CatalogDiff.fs:547`) but is **not wired** into multi-episode recombination | `CatalogDiff.fs:547`; `WAVE_6_MORPHOLOGY.md:237-239` (F3) | Time | L2 surface present, unconsumed | n/a | **C2** |
+| G5 | T-VI **Permissions** — a write-denied sink is refused before mutation | `Preflight.permissionPreflight`; `TransferRun.spanningPreflight`; `Program.fs:1222` | spanning | ✅ **CLOSED** (A2, wired into transfer + migrate `--execute`; refuses with `transfer.insufficientGrant`) — only the live grant-matrix probe vs a real least-privilege account is survey-gated | named refusal | *(closed; grant probe survey-gated)* |
+| G6 | T-VI **Transactionality** — mid-transfer failure leaves a **half-populated target**; no atomic boundary, idempotent retry, or rollback | (no axis) | spanning | ◑ **DEFERRED** (A3) — survey-dependent / PROD-empty per the premise re-prioritization (`WAVE_6_ONTOLOGY.md` §10); not on the survey-independent path | none yet | **A3** (trigger: PROD gains data) |
+| G7 | T-VI **Connection pre-flight** — "both endpoints live + credentialed" before mutation | `Preflight.connectionPreflight`; `TransferRun.spanningPreflight`; `Program.fs:1209/1440` | spanning | ✅ **CLOSED** (A1, wired into transfer + migrate `--execute`) | named refusal | *(closed)* |
+| G8 | `migrate` CLI verb live `--execute` leg (against a deployed DB) | `Program.fs:1051` (the `--execute` arm) | L3 face | ✅ **CLOSED** (B1) — the live square is operator-reachable, R6-gated | n/a | *(closed)* |
+| G9 | Refactorlog `ChangeDateTime` carries the **episode's real `At`** | `RefactorLogRender.fs:17-25` | Time | ✅ **CLOSED** (P6/C3) — the real-clock path threads the episode clock; the pinned `2000-01-01` is retired to a no-production-caller legacy overload | n/a | *(closed)* |
+| G10 | Change-manifest records **displacement** — per-channel move counts (`Channels`), schema norm (`SchemaNorm = CatalogDiff.norm`), refactorlog xref, CDC capture count | `ChangeManifest.fs:13-30` | Time, meta | ✅ **CLOSED** (6.H.4/C4) | n/a | *(closed)* |
+| G11 | `CatalogDiff.compose` consumer — cross-episode `δ₁ + δ₂` fold | `Episode.fs:239`; `Lifecycle.fs:194` | Time | ✅ **CLOSED** (6.H.3/C2) — both `Episode.netDiff` and `Lifecycle.netDiff` fold `CatalogDiff.compose` over the evolution chain | n/a | *(closed)* |
 | G12 | Decision adjunction — `Ingest(deploy(Project(C, overlay)))` reproduces the overlay on **all three** axes (nullability + uniqueness + FK-trust) | `CanaryRoundTripTests.fs` `E3:` | Decision | ✅ **CLOSED** (F2) — the unified compositional witness; per-axis proofs (A42 / 6.A.8 / readside-fktrust) now joined by one overlay round-trip carrying all three intents | n/a | *(closed)* |
-| G13 | Matrix generator reports **L1 presence, not L2/L3 level** — witness-present ≠ faithful drift is invisible to the machine surface | `scripts/matrix-status.sh` | meta | ✅ **CLOSED** (D1+D2, this round) — generator now reports the per-axis L1/L2/L3 ladder, derives L2 from `Tolerance.fs` `@ladder` tags (Schema=L2-partial names `IndexesUnreflected`), and is wired into CI (`verifiability-projection.yml`) with a byte-deterministic currency gate | n/a | *(closed)* |
-| G14 | `Reference` boolean tuple has **expressible illegal states** (`IsConstraintTrusted = true ∧ HasDbConstraint = false`) | `Catalog.fs:549-595` | Schema, Decision | modeling debt | typechecks-but-impossible | **G1-ref** |
+| G13 | Matrix generator reports **L1 presence, not L2/L3 level** — witness-present ≠ faithful drift is invisible to the machine surface | `scripts/matrix-status.sh` | meta | ✅ **CLOSED** (D1+D2, this round) — generator now reports the per-axis L1/L2/L3 ladder, derives L2 from `Tolerance.fs` `@ladder` tags (Schema=L2-partial names `IndexOptionsUnreflected`), and is wired into CI (`verifiability-projection.yml`) with a byte-deterministic currency gate | n/a | *(closed)* |
+| G14 | `Reference` boolean pair expressed the illegal quadrant `(HasDbConstraint=false ∧ IsConstraintTrusted=false)` (untrusted without a constraint) | `Catalog.fs` `Reference.withConstraintState` | Schema, Decision | ✅ **CLOSED** (bounded guard) — `isConstraintStateConsistent` + the normalizing `withConstraintState` (every producer routes through it); witness `ReferenceConstraintStateTests` | normalized to vacuous-trust | *(closed; full DU collapse deferred)* |
 | G15 | Phase-2 deferred-FK UPDATE keys on **source PK** — for `AssignedBySink` the sink minted a fresh surrogate, so the WHERE matches zero rows | `TransferRun.fs:77-92` | Data | L2 (refused at gate 6.A.2) | **named refusal** (`TransferRun.fs:250-256`) | *(closed — documented for completeness)* |
 | G16 | `AssignedKey` is single-string — composite surrogate truncated to first leg | `SurrogateRemap.fs:34`; `TransferRun.fs:227` | Data | L2 (refused at gate 6.A.3) | **named refusal** (`TransferRun.fs:258-264`) | *(closed — documented for completeness)* |
 | G17 | FK-orphan rows silently dropped at `remapRowFks`, **after the write executes** — skip-and-diagnose, no pre-write gate | `SurrogateRemap.fs:227-228`; `TransferRun.fs:166, 196` | Data | L2 (exit-9 surfaces the drop) | skip-and-diagnose + exit-9 | *(partially closed — see A3 for the pre-write atomic boundary)* |

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -162,7 +162,7 @@ the "closing slice" points into §3.
 | G10 | Change-manifest records **state + axis, not displacement** — no per-move `‖δ‖` by channel, no per-run tolerance residual, no `AppliedTransforms` outcome, no CDC capture series | `ChangeManifest.fs`; `WAVE_6_MORPHOLOGY.md:253-257` (F5) | Time, meta | L2 partial | n/a | **C4** |
 | G11 | No `CatalogDiff.compose` consumer — cross-episode `δ₁ + δ₂` fold exists (`CatalogDiff.fs:547`) but is **not wired** into multi-episode recombination | `CatalogDiff.fs:547`; `WAVE_6_MORPHOLOGY.md:237-239` (F3) | Time | L2 surface present, unconsumed | n/a | **C2** |
 | G12 | Decision adjunction (E3) **unwitnessed** — `Ingest(deploy(Project(C, overlay)))` reproducing `overlay` on **all three** tightening sub-axes (nullability + uniqueness + FK-trust) is not a property test | `AxiomTests.fs` (no entry) | Decision | L2 partial (1/3 witnessed) | n/a | **F2** |
-| G13 | Matrix generator reports **L1 presence, not L2/L3 level** — witness-present ≠ faithful drift is invisible to the machine surface | `scripts/matrix-status.sh` | meta | unbuilt | n/a | **D1**, **D2** |
+| G13 | Matrix generator reports **L1 presence, not L2/L3 level** — witness-present ≠ faithful drift is invisible to the machine surface | `scripts/matrix-status.sh` | meta | ✅ **CLOSED** (D1+D2, this round) — generator now reports the per-axis L1/L2/L3 ladder, derives L2 from `Tolerance.fs` `@ladder` tags (Schema=L2-partial names `IndexesUnreflected`), and is wired into CI (`verifiability-projection.yml`) with a byte-deterministic currency gate | n/a | *(closed)* |
 | G14 | `Reference` boolean tuple has **expressible illegal states** (`IsConstraintTrusted = true ∧ HasDbConstraint = false`) | `Catalog.fs:549-595` | Schema, Decision | modeling debt | typechecks-but-impossible | **G1-ref** |
 | G15 | Phase-2 deferred-FK UPDATE keys on **source PK** — for `AssignedBySink` the sink minted a fresh surrogate, so the WHERE matches zero rows | `TransferRun.fs:77-92` | Data | L2 (refused at gate 6.A.2) | **named refusal** (`TransferRun.fs:250-256`) | *(closed — documented for completeness)* |
 | G16 | `AssignedKey` is single-string — composite surrogate truncated to first leg | `SurrogateRemap.fs:34`; `TransferRun.fs:227` | Data | L2 (refused at gate 6.A.3) | **named refusal** (`TransferRun.fs:258-264`) | *(closed — documented for completeness)* |
@@ -544,6 +544,21 @@ the exact silent-fidelity-illusion the North Star forbids.
 ---
 
 ### Cluster D — The self-verification meta-cell (the keystone)
+
+> **STATUS — D1 + D2 LANDED (round D→E).** `scripts/matrix-status.sh` now emits
+> the per-axis **L1/L2/L3 ladder** into `NORTH_STAR.matrix.generated.md`: **L1**
+> from round-trip witness presence, **L2** from `Tolerance.fs`'s machine-readable
+> `@ladder <Variant> <Axis> <Disposition>` tags (an `OpenGap` variant caps its
+> axis at L2-partial and is named — Schema reports `IndexesUnreflected`), **L3**
+> from `migrate A B` witness presence. The generator cross-checks that every live
+> `ToleratedDivergence` (per the `name` single-source-of-truth) carries exactly
+> one tag (exit 3 on drift) and is **byte-deterministic** (no wall-clock stamp).
+> D2 wired `verifiability-gate.sh` + a matrix-currency diff gate into CI
+> (`.github/workflows/verifiability-projection.yml`). Witnesses:
+> `tests/Projection.Tests/MatrixLadderTests.fs` (3, green). The honesty
+> mechanism: retiring an `OpenGap` variant auto-flips its axis — L2 cannot be
+> hand-marked. **E1 retiring `IndexesUnreflected` will flip Schema to L3
+> automatically** — the matrix now *measures* the rest of this cluster's progress.
 
 #### D1 — Generated per-axis L2/L3 matrix (G13)
 

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -152,7 +152,7 @@ the "closing slice" points into §3.
 |---|---|---|---|---|---|---|
 | G1 | `CatalogDiff` captured surface **excludes references, FKs, indexes, modality, module structure, sequences** — they ride through `applyDiff` unchanged | `CatalogDiff.fs:380-388` | Schema, Time | L2 partial (column-shape only) | structural — round-trip law witnessed only on captured axes | **C1** (the widening) |
 | G2 | FK-trust (`IsNotTrusted`) **read but not gated** — no fail-loud if a FK is untrusted; the flag rides the `Reference` but planner/executor never acts on it | `ReadSide.fs:110, 1075` | Schema, Decision | L1.5 (recovered, unenforced) | none | **F1**, **G1-ref** |
-| G3 | Non-PK indexes **read but not reconstructed** into `Kind.Indexes` (hardcoded `[]`); `PhysicalSchema` comparison ignores them | `ReadSide.fs:877, 1004`; `Tolerance.fs:43-49` | Schema | L1 + named tolerance | `Tolerance.IndexesUnreflected` (named, not silent — but permanently open) | **E1** (3-part) |
+| G3 | Non-PK index **structure** read, reconstructed (`attachIndexes`), and now **compared** (`PhysicalSchema.Indexes`: owner + name + uniqueness + ordered key columns) | `PhysicalSchema.fs` `PhysicalIndex`; `ReadSide.readIndexes` | Schema | ✅ **CLOSED** (E1) — round-trips emit/deploy/ReadSide (witness `IndexRoundtripTests`); the prior `IndexesUnreflected` retired | narrower residual: index *options* (filter / included / storage) → `IndexOptionsUnreflected` (OpenGap) | *(structure closed; options residual named)* |
 | G4 | Cross-schema FK rows whose `SCHEMA_NAME()` is NULL (dropped schema / missing `VIEW DEFINITION` grant) — was an opaque `GetString` cast failure (live `readSchemaCombined`) / blank-and-drop (`readForeignKeys`) | `ReadSide.fs` `ForeignKeyReadback` | Schema | ✅ **CLOSED** (E2) — both FK readers route through the pure `ForeignKeyReadback.classify`, which emits a NAMED diagnostic + skip on an unreadable coordinate | named diagnostic, not silent / opaque | *(closed)* |
 | G5 | T-VI **Permissions** — write-denied sink transfers **zero rows, exits clean** | (no axis) | spanning | unbuilt | none | **A2** |
 | G6 | T-VI **Transactionality** — mid-transfer failure leaves a **half-populated target**; no atomic boundary, idempotent retry, or rollback | (no axis) | spanning | unbuilt | none | **A3** |
@@ -615,17 +615,19 @@ bullseye.
 >   law. The LifecycleStore folds over the codec, so its substrate is covered. The
 >   remaining E3 surface (ReadSide's index field-fidelity) is **interlocked with E1**
 >   and best done there.
-> - **E1 — de-risked, but witness-coupled to D1.** Part 1 (index reconstruction) is
->   already live (`attachIndexes` is wired into `read`), and V2 *does* emit
->   `CREATE INDEX` (chapter 4.1.A slice 3), so the round-trip is faithful and adding
->   an `Indexes` axis to `PhysicalSchema` (mirroring the `Annotations` axis
->   precedent) should keep the canary green. **Caution:** retiring
->   `Tolerance.IndexesUnreflected` auto-flips the matrix Schema rung L2-partial→L3
->   (the keystone working) — which *invalidates D1's acceptance witness*
->   (`Schema=L2-partial because IndexesUnreflected`). When E1 lands, rewrite the D1
->   test in `MatrixLadderTests.fs` to pin the classification mechanism over a
->   different open example (or assert 0-open with the cross-check intact) in the
->   same commit. The matrix now **measures** E1: it flips automatically on retirement.
+> - **E1 — LANDED (structure), residual narrowed.** `PhysicalSchema` now carries an
+>   `Indexes` axis (`PhysicalIndex`: owner + name + uniqueness + ordered key
+>   columns) — exactly the surface `ReadSide.readIndexes` recovers, so both canary
+>   halves stay symmetric. The non-PK index structure round-trips emit/deploy/
+>   ReadSide (witness `tests/Projection.Tests/IndexRoundtripTests.fs` — a UNIQUE
+>   single-col + a non-unique two-col index, Docker). Rather than over-claim L3, the
+>   honest move: `IndexesUnreflected` is retired and replaced by the *narrower*
+>   `IndexOptionsUnreflected` (still `OpenGap` Schema) for the un-compared index
+>   options (filter / included columns / storage flags — recovered by neither side).
+>   So Schema stays L2-partial, now naming the narrower residual, and D1's witness is
+>   preserved (renamed in `MatrixLadderTests.fs`). Closing `IndexOptionsUnreflected`
+>   (extend `readIndexes` + widen `PhysicalIndex`) is the next step that flips Schema
+>   to L3 — the matrix measures it.
 
 #### E1 — Reconstruct `Kind.Indexes` (G3) — 3-part
 

--- a/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
+++ b/sidecar/projection/DEBRIEF_2026_06_02_ISOMORPHISM_CLIMB_AND_BACKLOG.md
@@ -151,7 +151,7 @@ the "closing slice" points into §3.
 | # | Gap | Location | Axis | Ladder today | Refusal / erasure | Closing slice |
 |---|---|---|---|---|---|---|
 | G1 | `CatalogDiff` captured surface **excludes references, FKs, indexes, modality, module structure, sequences** — they ride through `applyDiff` unchanged | `CatalogDiff.fs:380-388` | Schema, Time | L2 partial (column-shape only) | structural — round-trip law witnessed only on captured axes | **C1** (the widening) |
-| G2 | FK-trust (`IsNotTrusted`) **read but not gated** — no fail-loud if a FK is untrusted; the flag rides the `Reference` but planner/executor never acts on it | `ReadSide.fs:110, 1075` | Schema, Decision | L1.5 (recovered, unenforced) | none | **F1**, **G1-ref** |
+| G2 | FK-trust (`IsNotTrusted`) is **carried faithfully** through the round-trip (recovered + reproduced as NOCHECK + witnessed by F2), per F1's option (b) — not gated, since no fixture demands the refusal | `ReadSide.fs:1075` | Schema, Decision | ✅ **CLOSED** (F1/F2) on the Decision plane — `Reference` illegal-state modeling (G14) is the remaining hygiene | none (carry, not gate) | **G1-ref** (modeling only) |
 | G3 | Non-PK index **structure** read, reconstructed (`attachIndexes`), and now **compared** (`PhysicalSchema.Indexes`: owner + name + uniqueness + ordered key columns) | `PhysicalSchema.fs` `PhysicalIndex`; `ReadSide.readIndexes` | Schema | ✅ **CLOSED** (E1) — round-trips emit/deploy/ReadSide (witness `IndexRoundtripTests`); the prior `IndexesUnreflected` retired | narrower residual: index *options* (filter / included / storage) → `IndexOptionsUnreflected` (OpenGap) | *(structure closed; options residual named)* |
 | G4 | Cross-schema FK rows whose `SCHEMA_NAME()` is NULL (dropped schema / missing `VIEW DEFINITION` grant) — was an opaque `GetString` cast failure (live `readSchemaCombined`) / blank-and-drop (`readForeignKeys`) | `ReadSide.fs` `ForeignKeyReadback` | Schema | ✅ **CLOSED** (E2) — both FK readers route through the pure `ForeignKeyReadback.classify`, which emits a NAMED diagnostic + skip on an unreadable coordinate | named diagnostic, not silent / opaque | *(closed)* |
 | G5 | T-VI **Permissions** — write-denied sink transfers **zero rows, exits clean** | (no axis) | spanning | unbuilt | none | **A2** |
@@ -161,7 +161,7 @@ the "closing slice" points into §3.
 | G9 | Refactorlog `ChangeDateTime` **pinned to a constant**; episode clock not threaded; refactorlog not accumulated against prior | `WAVE_6_MORPHOLOGY.md:258-261` (F6) | Time | L2 partial | n/a | **C3** |
 | G10 | Change-manifest records **state + axis, not displacement** — no per-move `‖δ‖` by channel, no per-run tolerance residual, no `AppliedTransforms` outcome, no CDC capture series | `ChangeManifest.fs`; `WAVE_6_MORPHOLOGY.md:253-257` (F5) | Time, meta | L2 partial | n/a | **C4** |
 | G11 | No `CatalogDiff.compose` consumer — cross-episode `δ₁ + δ₂` fold exists (`CatalogDiff.fs:547`) but is **not wired** into multi-episode recombination | `CatalogDiff.fs:547`; `WAVE_6_MORPHOLOGY.md:237-239` (F3) | Time | L2 surface present, unconsumed | n/a | **C2** |
-| G12 | Decision adjunction (E3) **unwitnessed** — `Ingest(deploy(Project(C, overlay)))` reproducing `overlay` on **all three** tightening sub-axes (nullability + uniqueness + FK-trust) is not a property test | `AxiomTests.fs` (no entry) | Decision | L2 partial (1/3 witnessed) | n/a | **F2** |
+| G12 | Decision adjunction — `Ingest(deploy(Project(C, overlay)))` reproduces the overlay on **all three** axes (nullability + uniqueness + FK-trust) | `CanaryRoundTripTests.fs` `E3:` | Decision | ✅ **CLOSED** (F2) — the unified compositional witness; per-axis proofs (A42 / 6.A.8 / readside-fktrust) now joined by one overlay round-trip carrying all three intents | n/a | *(closed)* |
 | G13 | Matrix generator reports **L1 presence, not L2/L3 level** — witness-present ≠ faithful drift is invisible to the machine surface | `scripts/matrix-status.sh` | meta | ✅ **CLOSED** (D1+D2, this round) — generator now reports the per-axis L1/L2/L3 ladder, derives L2 from `Tolerance.fs` `@ladder` tags (Schema=L2-partial names `IndexesUnreflected`), and is wired into CI (`verifiability-projection.yml`) with a byte-deterministic currency gate | n/a | *(closed)* |
 | G14 | `Reference` boolean tuple has **expressible illegal states** (`IsConstraintTrusted = true ∧ HasDbConstraint = false`) | `Catalog.fs:549-595` | Schema, Decision | modeling debt | typechecks-but-impossible | **G1-ref** |
 | G15 | Phase-2 deferred-FK UPDATE keys on **source PK** — for `AssignedBySink` the sink minted a fresh surrogate, so the WHERE matches zero rows | `TransferRun.fs:77-92` | Data | L2 (refused at gate 6.A.2) | **named refusal** (`TransferRun.fs:250-256`) | *(closed — documented for completeness)* |
@@ -677,6 +677,17 @@ bullseye.
 ---
 
 ### Cluster F — The Decision adjunction (the "stronger than V1" theorem)
+
+> **STATUS — CLOSED (round D→E).** F1 took the recommended option (b): FK-trust is
+> *carried faithfully* through the round-trip (`IsConstraintTrusted` recovered at
+> `ReadSide`; a NOCHECK FK reads back untrusted, witnessed) rather than gated — no
+> fixture demands the refusal. F2 (G12) landed the **unified 3-axis adjunction
+> witness** `E3: Ingest(deploy(Project(C, overlay))) reproduces the decision
+> overlay on all three axes (nullability + uniqueness + FK-trust)` in
+> `CanaryRoundTripTests.fs` (Docker, green) — one overlay carrying all three
+> intents survives emit→deploy→ReadSide at once, proving the axes compose. This
+> was unblocked by E1 (uniqueness became readable via the index axis). The Decision
+> cell is 3/3 sub-axes. North-Star §5 criterion 2 is met.
 
 #### F1 — Gate FK-trust on readback (G2)
 

--- a/sidecar/projection/EXECUTION_PLAN.md
+++ b/sidecar/projection/EXECUTION_PLAN.md
@@ -905,7 +905,7 @@ where the slice spec is now misleading, the residual gap.
 | 6.A.2 cyclic `AssignedBySink` refusal | ✅ LANDED (execute-gate refusal) | — |
 | 6.A.3 composite-identity refusal | ✅ LANDED (execute-gate refusal) | — |
 | 6.A.4 empty-string↔NULL | ✅ LANDED as **named tolerance** (`EmptyTextNormalizedToNull`) | faithful preservation deferred-with-trigger |
-| 6.A.5 un-hollow `ReadSide` | ◑ **PARTIAL** — FK-trust **recovered**; A42 fixed | FK-trust **not enforced** (G2 → F1); **indexes read but NOT reconstructed** into `Kind.Indexes` (G3 → E1, 3-part) |
+| 6.A.5 un-hollow `ReadSide` | ◑ **PARTIAL** — FK-trust **recovered**; A42 fixed; **indexes reconstructed AND compared** (E1: `PhysicalSchema.Indexes`, structure round-trips) | FK-trust **not enforced** (G2 → F1); index *options* residual (`IndexOptionsUnreflected`) |
 | 6.A.6 name remaining schema erasures | ◑ PARTIAL — NOCHECK-FK emit landed | user ext-props / IDENTITY-seed still to enumerate |
 | 6.A.7 `Synthesized`-key rename | ✅ LANDED (`synthesizedRenameWarnings`) | identity-threading on first import still operator-supplied |
 | 6.A.8 decision uniqueness + FK-trust readback | ◑ PARTIAL — readback un-hollowed | full **3-axis adjunction witness** open (G12 → F2) |

--- a/sidecar/projection/EXECUTION_PLAN.md
+++ b/sidecar/projection/EXECUTION_PLAN.md
@@ -920,7 +920,7 @@ where the slice spec is now misleading, the residual gap.
 | 6.C.2 transactional / resumable transfer | ⬚ **OPEN** | debrief **A3**; granularity survey-gated |
 | 6.C.3 cross-DB FK ordering | ⬚ deferred-with-trigger | unchanged |
 | 6.D.1 `migrate A B` | ✅ LANDED (live square; T16) | CLI verb **plan-only** — live `--execute` wiring is debrief **B1** (gate behind A + C1) |
-| 6.E.1 matrix reports the ladder | ⬚ **OPEN** | debrief **D1/D2** — the keystone; generator reports L1/L2/L3 per axis from the proof |
+| 6.E.1 matrix reports the ladder | ✅ **LANDED** (D1+D2) | generator reports L1/L2/L3 per axis from the proof (`Tolerance.fs` `@ladder` tags + witness presence); Schema=L2-partial names `IndexesUnreflected`; wired into CI with a deterministic currency gate (`verifiability-projection.yml`); witnesses `MatrixLadderTests.fs` |
 
 Two new gaps the debrief surfaced that no Wave-6 slice named: **G4** — cross-schema
 FK rows whose `SCHEMA_NAME()` is NULL are **silently filtered** (`ReadSide.fs:580`;

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -27,7 +27,7 @@ witness covers the axis. The **Ladder** column is the honest weakest-rung summar
 
 | Axis | L1 witness | L2 faithful | L3 composed | Open tolerances | Ladder |
 |---|:--:|:--:|:--:|---|---|
-| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexesUnreflected` | ◑ L2-partial |
+| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexOptionsUnreflected` | ◑ L2-partial |
 | **Data** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Identity** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Time** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -4,7 +4,7 @@
 
 # NORTH STAR — Matrix Status (generated)
 
-_Derived from `tests/Projection.Tests/AxiomTests.fs` + the test tree. The §1 bullseye, self-reported._
+_Derived from `tests/Projection.Tests/AxiomTests.fs` + `src/Projection.Core/Tolerance.fs` (the `@ladder` tags) + the test tree. The §1 bullseye, self-reported at the **ladder level**._
 
 ## T-II — Executable-axiom totality (L2 formal axioms)
 
@@ -15,25 +15,35 @@ _Derived from `tests/Projection.Tests/AxiomTests.fs` + the test tree. The §1 bu
 | Deferred D | unnamed/unbacked — `[<Fact(Skip … Bucket D …)>]` | 1 |
 | **total axiom entries** | | **117** |
 
-**Verifiability gate (E1): `PASS`** — no deferral claims verified (no phantom Bucket-A/B); every deferral names its bucket.
+**Verifiability gate: `PASS`** — no deferral claims verified (no phantom Bucket-A/B); every deferral names its bucket.
 
-## T-I — Round-trip totality (the §1 bullseye matrix)
+## T-I — Round-trip ladder (the §1 bullseye matrix)
 
-| Axis | Operation | Witness test (must exist) | Path | Status |
-|---|---|---|---|---|
-| **Schema** | round-trip (canary) | `PhysicalSchema diff` | Wave 1 (1.2/1.3 un-hollow) | ✅ verified |
-| **Data** | round-trip (data canary) | `data canary` | Transfer (shipped) | ✅ verified |
-| **Identity** | round-trip (SsKey reload) | `reload preserves SsKey` | Wave 4.1 | ✅ verified |
-| **Time** | round-trip (replay) | `replayTo genesis` | E4 / 5.3 | ✅ verified |
-| **Decision** | round-trip (overlay) | `reproduces the DecisionOverlay` | E3 / Wave 2 | ✅ verified |
+Each axis carries three rungs, each derived from the proof — never hand-asserted.
+**L1** = a round-trip witness test exists. **L2** = no *open* named tolerance sits
+on the axis (an `@ladder … OpenGap` variant in `Tolerance.fs` caps the axis at
+L2-partial; retiring the variant in code auto-flips it). **L3** = a `migrate A B`
+witness covers the axis. The **Ladder** column is the honest weakest-rung summary.
 
-**Round-trip cells with a live witness: 5 / 5.** A cell goes green only when a test
-by its witness name exists in the tree — it cannot be asserted by hand. `⬚ open` cells are the
-remaining bullseye distance; they flip automatically as the named slices land their witnesses.
+| Axis | L1 witness | L2 faithful | L3 composed | Open tolerances | Ladder |
+|---|:--:|:--:|:--:|---|---|
+| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexesUnreflected` | ◑ L2-partial |
+| **Data** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
+| **Identity** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
+| **Time** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
+| **Decision** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 
-> **Witness-present ≠ feature-complete.** This generated view proves a round-trip *witness exists*.
-> Per-feature totality (e.g. the Schema canary is still hollow for triggers/sequences/defaults/
-> computed/checks/ext-props until Wave 1) lives in NORTH_STAR.md §1 prose; the full E2 generator
-> will track per-feature. Today this is the coarse, honest, machine-derived floor.
+**Rungs reached: L1 5/5 · L2 4/5 · L3 5/5.** Tolerance set:
+7 named, of which **1 open** (`OpenGap`). A cell cannot be
+hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance
+to be retired from `Tolerance.fs`. The generator under-claims; it never over-claims.
 
-_Generated 2026-06-01T11:54Z · gate=PASS · L2 live/C/D=83/6/1 · round-trip=5/5_
+> **Witness/tolerance-present ≠ feature-complete.** L2 here is "no open *named*
+> tolerance on the axis." Silent drops with no named surface (the cross-schema FK
+> filter, debrief G4) and unwitnessed sub-axes (the 3-axis Decision adjunction,
+> debrief G12) are NOT auto-detected — they have no machine surface yet, and are
+> tracked in `DEBRIEF_2026_06_02` until E2/F2 give them a named diagnostic/witness.
+> L3 here is "a composition witness exists for the axis," not "faithful under every
+> spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
+
+_Self-reported · gate=PASS · L2 axioms live/C/D=83/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 7 (1 open)_

--- a/sidecar/projection/scripts/matrix-status.sh
+++ b/sidecar/projection/scripts/matrix-status.sh
@@ -1,26 +1,57 @@
 #!/usr/bin/env bash
 #
-# matrix-status.sh — EXECUTION_PLAN slice E2 (seed); makes NORTH_STAR.md §1
-# self-reporting (NORTH_STAR criterion 5, documentation totality / T-IV).
+# matrix-status.sh — EXECUTION_PLAN slice 6.E.1 / debrief D1 (the self-
+# verification meta-cell). Makes NORTH_STAR.md §1 self-reporting at the
+# *ladder level* (NORTH_STAR criterion 5, documentation totality / T-IV).
 #
-# Derives, from the code, two things and writes them to NORTH_STAR.matrix.generated.md:
-#   1. The L2 executable-axiom rollup + the T-II gate verdict, machine-derived from
-#      tests/Projection.Tests/AxiomTests.fs (live verified/convention vs deferred C/D).
-#   2. The §1 round-trip matrix, where each cell names a witness test and the generator
-#      VERIFIES that a test by that name exists in the tree — a cell asserted green whose
-#      witness is absent renders OPEN (the generator under-claims; it never over-claims).
+# Derives, from the code, three things and writes them to
+# NORTH_STAR.matrix.generated.md:
+#   1. The L2 executable-axiom rollup + the T-II gate verdict, machine-derived
+#      from tests/Projection.Tests/AxiomTests.fs (live verified/convention vs
+#      deferred C/D).
+#   2. The §1 round-trip *ladder* matrix. For each axis the generator reports
+#      three rungs, each derived from the proof — never asserted by hand:
+#        - **L1 (witness present)** — a backtick-quoted round-trip test by the
+#          cell's witness name exists in the tree.
+#        - **L2 (faithful)** — no *open* named tolerance sits on the axis. The
+#          proof surface is `Tolerance.fs`'s `@ladder` tags: a variant tagged
+#          `OpenGap` (a closeable fidelity debt) caps its axis at L2-partial;
+#          `AcceptedFaithful` variants (representation-only, or covered by a
+#          separate witness) do not. Retiring a variant deletes its tag, so the
+#          axis auto-flips to faithful — L2 cannot be hand-marked.
+#        - **L3 (composed)** — a backtick-quoted `migrate A B` witness covering
+#          the axis exists (the axis participates in the one-command migration).
+#   3. The cross-check that every live `ToleratedDivergence` variant (per the
+#      `name` single-source-of-truth) carries exactly one `@ladder` tag — a new
+#      variant cannot land untagged, and a renamed variant fails fast.
 #
-# Honesty mechanism: a human cannot mark a cell green; the witness test must exist.
-# As Waves 1-4 land their witness tests, cells flip automatically on regeneration.
-# Run at chapter close; a non-empty `git diff` on the generated file = a coverage shift.
+# Honesty mechanism (the whole point of D1): a human cannot mark a cell green —
+# the witness test must exist (L1/L3) and the open tolerance must be retired in
+# code (L2). The generator UNDER-claims; it never over-claims.
+#
+# Scope honesty: L2 here is "no open *named* tolerance on the axis." Silent
+# drops with no named surface (e.g. the cross-schema FK filter, debrief G4) and
+# unwitnessed sub-axes (e.g. the 3-axis Decision adjunction, debrief G12) are
+# NOT auto-detected — they have no machine surface yet. They are tracked in the
+# debrief until E2/F2 give them a named diagnostic/witness, at which point they
+# too become machine-visible. "Witness/tolerance-present ≠ feature-complete."
+#
+# Pure bash + grep; no dotnet required (mirrors scripts/verifiability-gate.sh +
+# scripts/lint-discipline.sh). Run at chapter close; wire into CI alongside the
+# lint + verifiability gates. A non-empty `git diff` on the generated file = a
+# coverage shift. Exit 0 = wrote the matrix; 2 = setup error; 3 = an untagged /
+# drifted tolerance variant (the cross-check failed).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 AX="$ROOT/tests/Projection.Tests/AxiomTests.fs"
+TOL="$ROOT/src/Projection.Core/Tolerance.fs"
 TESTS="$ROOT/tests"
 OUT="$ROOT/NORTH_STAR.matrix.generated.md"
-[ -f "$AX" ] || { echo "matrix-status: AxiomTests.fs not found" >&2; exit 2; }
+[ -f "$AX" ]  || { echo "matrix-status: AxiomTests.fs not found at $AX" >&2; exit 2; }
+[ -f "$TOL" ] || { echo "matrix-status: Tolerance.fs not found at $TOL" >&2; exit 2; }
 
+# --- T-II: executable-axiom rollup (unchanged) -----------------------------
 skips="$(grep -E '\[<Fact\(Skip' "$AX" || true)"
 live=$(grep -cE '^[[:space:]]*\[<Fact>\]' "$AX" || true)
 skip_total=$(printf '%s\n' "$skips" | grep -c . || true)
@@ -30,29 +61,74 @@ total=$(( live + skip_total ))
 
 if "$ROOT/scripts/verifiability-gate.sh" >/dev/null 2>&1; then tii="PASS"; else tii="FAIL"; fi
 
-# Cell declarations: "Axis|Operation|witness-test-substring|EXECUTION_PLAN slice".
-# A cell is VERIFIED iff a backtick-quoted test name containing the substring exists
-# under tests/ (matches both `let ``...``` and `member _.``...``` declarations).
-cells='Schema|round-trip (canary)|PhysicalSchema diff|Wave 1 (1.2/1.3 un-hollow)
-Data|round-trip (data canary)|data canary|Transfer (shipped)
-Identity|round-trip (SsKey reload)|reload preserves SsKey|Wave 4.1
-Time|round-trip (replay)|replayTo genesis|E4 / 5.3
-Decision|round-trip (overlay)|reproduces the DecisionOverlay|E3 / Wave 2'
+# --- Tolerance cross-check: every live variant carries one @ladder tag -----
+# `name` is the single source of truth for the live variant set (Tolerance.fs
+# docstring); the type's `-> "Variant"` arms are the only `-> "..."` literals.
+variant_names="$(grep -oE 'ToleratedDivergence\.[A-Za-z0-9]+ +-> +"[A-Za-z0-9]+"' "$TOL" | grep -oE '"[A-Za-z0-9]+"' | tr -d '"' | sort -u)"
+# Each variant's doc block ends with `@ladder <Variant> <Axis> <Disposition>`.
+ladder_tags="$(grep -oE '@ladder [A-Za-z0-9]+ [A-Za-z]+ [A-Za-z]+' "$TOL" | sed 's/@ladder //' || true)"
+tag_names="$(printf '%s\n' "$ladder_tags" | awk 'NF{print $1}' | sort -u)"
+
+missing="$(comm -23 <(printf '%s\n' "$variant_names") <(printf '%s\n' "$tag_names") || true)"
+orphan="$(comm -13 <(printf '%s\n' "$variant_names") <(printf '%s\n' "$tag_names") || true)"
+if [ -n "$missing" ] || [ -n "$orphan" ]; then
+  echo "matrix-status: @ladder tag drift in Tolerance.fs (the ladder cross-check)." >&2
+  [ -n "$missing" ] && { echo "  live variant(s) with NO @ladder tag:" >&2; printf '%s\n' "$missing" | sed 's/^/    /' >&2; }
+  [ -n "$orphan" ]  && { echo "  @ladder tag(s) with no live variant (rename/retire drift):" >&2; printf '%s\n' "$orphan" | sed 's/^/    /' >&2; }
+  echo "  Fix: give every live variant exactly one '@ladder <Variant> <Axis> <Disposition>' doc line." >&2
+  exit 3
+fi
+
+open_for_axis() {
+  # Variant names tagged OpenGap on the given axis, space-joined (or "").
+  printf '%s\n' "$ladder_tags" | awk -v ax="$1" '$2==ax && $3=="OpenGap" {print $1}' | paste -sd' ' -
+}
+
+# --- T-I: the round-trip ladder matrix -------------------------------------
+# "Axis|round-trip-witness-substring|migrate(A B)-witness-substring". A rung is
+# VERIFIED iff a backtick-quoted test name containing the substring exists under
+# tests/ (matches `let ``...``` and `member _.``...``` forms). Axis names match
+# the `@ladder` axis tokens so the tolerance set joins by axis.
+cells='Schema|PhysicalSchema diff|one execute evolves
+Data|data canary|executeWithData migrates the sink schema
+Identity|reload preserves SsKey|migrate-with-data re-keys
+Time|replayTo genesis|the full A->B loop
+Decision|reproduces the DecisionOverlay|migrate refuses a NOT-NULL tightening'
 
 witness_status() {
   local pat="$1"
   if grep -rhE "\`\`[^\`]*${pat}" "$TESTS" >/dev/null 2>&1; then echo "VERIFIED"; else echo "OPEN"; fi
 }
-icon() { case "$1" in VERIFIED) echo "✅ verified";; *) echo "⬚ open";; esac; }
+icon()    { case "$1" in VERIFIED) echo "✅";; *) echo "⬚";; esac; }
 
-green=0; counted=0; rows=""
-while IFS='|' read -r axis op pat slice; do
+l1n=0; l2n=0; l3n=0; counted=0; rows=""
+while IFS='|' read -r axis rtpat mgpat; do
   [ -z "$axis" ] && continue
-  st=$(witness_status "$pat")
   counted=$((counted+1))
-  [ "$st" = "VERIFIED" ] && green=$((green+1))
-  rows+="| **$axis** | $op | \`$pat\` | $slice | $(icon "$st") |"$'\n'
+  l1=$(witness_status "$rtpat")
+  l3=$(witness_status "$mgpat")
+  opens="$(open_for_axis "$axis")"
+  [ "$l1" = "VERIFIED" ] && l1n=$((l1n+1))
+  [ "$l3" = "VERIFIED" ] && l3n=$((l3n+1))
+
+  if [ -n "$opens" ]; then
+    l2cell="◑ L2-partial"
+    opencell="\`$(printf '%s' "$opens" | sed 's/ /`, `/g')\`"
+  else
+    l2cell="✅ faithful"; l2n=$((l2n+1)); opencell="—"
+  fi
+
+  if   [ "$l1" != "VERIFIED" ]; then level="⬚ L0"
+  elif [ -n "$opens" ];         then level="◑ L2-partial"
+  elif [ "$l3" != "VERIFIED" ]; then level="✅ L2"
+  else                               level="✅ L3"
+  fi
+
+  rows+="| **$axis** | $(icon "$l1") | $l2cell | $(icon "$l3") | $opencell | $level |"$'\n'
 done <<< "$cells"
+
+variant_count=$(printf '%s\n' "$variant_names" | grep -c . || true)
+open_count=$(printf '%s\n' "$ladder_tags" | awk '$3=="OpenGap"' | grep -c . || true)
 
 {
   echo "<!-- GENERATED by scripts/matrix-status.sh — DO NOT EDIT BY HAND."
@@ -61,7 +137,7 @@ done <<< "$cells"
   echo
   echo "# NORTH STAR — Matrix Status (generated)"
   echo
-  echo "_Derived from \`tests/Projection.Tests/AxiomTests.fs\` + the test tree. The §1 bullseye, self-reported._"
+  echo "_Derived from \`tests/Projection.Tests/AxiomTests.fs\` + \`src/Projection.Core/Tolerance.fs\` (the \`@ladder\` tags) + the test tree. The §1 bullseye, self-reported at the **ladder level**._"
   echo
   echo "## T-II — Executable-axiom totality (L2 formal axioms)"
   echo
@@ -72,24 +148,37 @@ done <<< "$cells"
   echo "| Deferred D | unnamed/unbacked — \`[<Fact(Skip … Bucket D …)>]\` | $d |"
   echo "| **total axiom entries** | | **$total** |"
   echo
-  echo "**Verifiability gate (E1): \`$tii\`** — no deferral claims verified (no phantom Bucket-A/B); every deferral names its bucket."
+  echo "**Verifiability gate: \`$tii\`** — no deferral claims verified (no phantom Bucket-A/B); every deferral names its bucket."
   echo
-  echo "## T-I — Round-trip totality (the §1 bullseye matrix)"
+  echo "## T-I — Round-trip ladder (the §1 bullseye matrix)"
   echo
-  echo "| Axis | Operation | Witness test (must exist) | Path | Status |"
-  echo "|---|---|---|---|---|"
+  echo "Each axis carries three rungs, each derived from the proof — never hand-asserted."
+  echo "**L1** = a round-trip witness test exists. **L2** = no *open* named tolerance sits"
+  echo "on the axis (an \`@ladder … OpenGap\` variant in \`Tolerance.fs\` caps the axis at"
+  echo "L2-partial; retiring the variant in code auto-flips it). **L3** = a \`migrate A B\`"
+  echo "witness covers the axis. The **Ladder** column is the honest weakest-rung summary."
+  echo
+  echo "| Axis | L1 witness | L2 faithful | L3 composed | Open tolerances | Ladder |"
+  echo "|---|:--:|:--:|:--:|---|---|"
   printf '%s' "$rows"
   echo
-  echo "**Round-trip cells with a live witness: $green / $counted.** A cell goes green only when a test"
-  echo "by its witness name exists in the tree — it cannot be asserted by hand. \`⬚ open\` cells are the"
-  echo "remaining bullseye distance; they flip automatically as the named slices land their witnesses."
+  echo "**Rungs reached: L1 $l1n/$counted · L2 $l2n/$counted · L3 $l3n/$counted.** Tolerance set:"
+  echo "$variant_count named, of which **$open_count open** (\`OpenGap\`). A cell cannot be"
+  echo "hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance"
+  echo "to be retired from \`Tolerance.fs\`. The generator under-claims; it never over-claims."
   echo
-  echo "> **Witness-present ≠ feature-complete.** This generated view proves a round-trip *witness exists*."
-  echo "> Per-feature totality (e.g. the Schema canary is still hollow for triggers/sequences/defaults/"
-  echo "> computed/checks/ext-props until Wave 1) lives in NORTH_STAR.md §1 prose; the full E2 generator"
-  echo "> will track per-feature. Today this is the coarse, honest, machine-derived floor."
+  echo "> **Witness/tolerance-present ≠ feature-complete.** L2 here is \"no open *named*"
+  echo "> tolerance on the axis.\" Silent drops with no named surface (the cross-schema FK"
+  echo "> filter, debrief G4) and unwitnessed sub-axes (the 3-axis Decision adjunction,"
+  echo "> debrief G12) are NOT auto-detected — they have no machine surface yet, and are"
+  echo "> tracked in \`DEBRIEF_2026_06_02\` until E2/F2 give them a named diagnostic/witness."
+  echo "> L3 here is \"a composition witness exists for the axis,\" not \"faithful under every"
+  echo "> spanning axis\" (T-VI atomicity/permissions ride the debrief until cluster A names them)."
   echo
-  echo "_Generated $(date -u +%Y-%m-%dT%H:%MZ) · gate=$tii · L2 live/C/D=${live}/${c}/${d} · round-trip=${green}/${counted}_"
+  # Deterministic footer (T1): no wall-clock stamp — the artifact is a pure
+  # function of the proof surfaces, so `git diff` on it = a coverage shift, and
+  # the CI currency gate (D2) is meaningful. The "when" is the git commit.
+  echo "_Self-reported · gate=$tii · L2 axioms live/C/D=${live}/${c}/${d} · rungs L1/L2/L3=${l1n}/${l2n}/${l3n} of ${counted} · tolerances ${variant_count} (${open_count} open)_"
 } > "$OUT"
 
-echo "matrix-status: wrote $OUT (gate=$tii; L2 live/C/D=${live}/${c}/${d}; round-trip ${green}/${counted})"
+echo "matrix-status: wrote $OUT (gate=$tii; rungs L1/L2/L3=${l1n}/${l2n}/${l3n} of ${counted}; tolerances ${variant_count}, ${open_count} open)"

--- a/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/CatalogReader.fs
@@ -1878,12 +1878,14 @@ module CatalogReader =
             // path's `#FkReality` JOIN at `toBundle`. Cross-catalog +
             // JSON-path references default to `(None, true)` per the
             // smart-constructor defaults.
+            // G14 — normalize the constraint-state pair through the guard so a
+            // V1 rowset carrying the illegal `(hasFK=0 ∧ isNoCheck=1)` quadrant
+            // (untrusted without a constraint) canonicalizes to vacuous-trust.
             Result.success
-                { Reference.create rKey rName srcKey tgtKey with
-                    OnDelete            = rule
-                    HasDbConstraint     = refRow.HasDbConstraint
-                    OnUpdate            = onUpdateRule
-                    IsConstraintTrusted = refRow.IsConstraintTrusted }
+                ({ Reference.create rKey rName srcKey tgtKey with
+                     OnDelete = rule
+                     OnUpdate = onUpdateRule }
+                 |> Reference.withConstraintState refRow.HasDbConstraint refRow.IsConstraintTrusted)
         | _ ->
             // Propagate underlying errors via `propagateOrFallback` —
             // uniform with parseReference on the JSON path.

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -1136,10 +1136,12 @@ module ReadSide =
             // be set explicitly in the `with` block). OnDelete / OnUpdate
             // referential-action axes remain defaulted until a follow-up
             // slice joins `sys.foreign_keys`'s action columns.
+            // G14 — route the constraint-state pair through the guard (FKs from
+            // sys.foreign_keys always have a real constraint, so this is the
+            // consistent `(true, trusted)` case; uniform with the V1 producer).
             return
-                { Reference.create refKey refName srcAttrKey tgtKindKey with
-                    HasDbConstraint    = true
-                    IsConstraintTrusted = not fk.IsNotTrusted }
+                Reference.create refKey refName srcAttrKey tgtKindKey
+                |> Reference.withConstraintState true (not fk.IsNotTrusted)
         }
 
     /// Attach references to a Kind based on the FKs grouped by

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -110,6 +110,70 @@ module ReadSide =
             IsNotTrusted : bool
         }
 
+    /// E2 (debrief G4) — classify an FK metadata row before it becomes a
+    /// `Reference`. `SCHEMA_NAME()` returns NULL when a referenced/parent
+    /// schema was dropped between the metadata read and the FK probe, or
+    /// when the account lacks `VIEW DEFINITION` on that schema. Such a row
+    /// cannot be faithfully reconstructed; per the no-silent-drop boundary
+    /// axiom it must surface a NAMED diagnostic — not a silent skip, not an
+    /// opaque `GetString` cast failure that aborts the whole readback. Pure +
+    /// public so the classification is unit-witnessed without a live
+    /// substrate (`tests/Projection.Tests/ForeignKeyReadbackTests.fs`).
+    [<RequireQualifiedAccess>]
+    module ForeignKeyReadback =
+
+        /// All coordinates resolved non-blank — the row reconstructs.
+        type FkCoordinates =
+            {
+                SourceSchema : string
+                SourceTable  : string
+                SourceColumn : string
+                TargetSchema : string
+                TargetTable  : string
+                TargetColumn : string
+                IsNotTrusted : bool
+            }
+
+        type Classification =
+            | Reconstructable of FkCoordinates
+            | Unreadable of reason: string
+
+        let private norm (o: string option) : string option =
+            o |> Option.map (fun (s: string) -> s.Trim()) |> Option.filter (fun s -> s <> "")
+
+        /// Classify a raw FK row. `None` models a NULL read (`SCHEMA_NAME()`
+        /// or a NULL column); a blank/whitespace string is treated
+        /// identically. On an unreadable coordinate the reason names the
+        /// visible endpoints and which side's schema was lost, plus the two
+        /// likely causes, so an operator can locate and fix the grant.
+        let classify
+            (sourceSchema: string option) (sourceTable: string option) (sourceColumn: string option)
+            (targetSchema: string option) (targetTable: string option) (targetColumn: string option)
+            (isNotTrusted: bool)
+            : Classification =
+            match norm sourceSchema, norm sourceTable, norm sourceColumn,
+                  norm targetSchema, norm targetTable, norm targetColumn with
+            | Some ss, Some st, Some sc, Some ts, Some tt, Some tc ->
+                Reconstructable
+                    { SourceSchema = ss; SourceTable = st; SourceColumn = sc
+                      TargetSchema = ts; TargetTable = tt; TargetColumn = tc
+                      IsNotTrusted = isNotTrusted }
+            | nSrcSchema, _, _, nTgtSchema, _, _ ->
+                let show (o: string option) = norm o |> Option.defaultValue "<unreadable>"
+                let src = System.String.Concat(show sourceSchema, ".", show sourceTable, ".", show sourceColumn)
+                let tgt = System.String.Concat(show targetSchema, ".", show targetTable, ".", show targetColumn)
+                let which =
+                    match nSrcSchema, nTgtSchema with
+                    | None, None -> "both endpoints' schemas"
+                    | None, _ -> "the parent schema"
+                    | _, None -> "the referenced schema"
+                    | _ -> "a coordinate"
+                Unreadable
+                    (System.String.Concat(
+                        "readside.foreignKeys: cross-schema FK ", src, " -> ", tgt,
+                        " skipped — ", which,
+                        " unreadable (NULL SCHEMA_NAME: dropped schema, or missing VIEW DEFINITION grant on a least-privilege account)"))
+
     /// One key column of a reflected non-PK index (`sys.indexes ⋈
     /// sys.index_columns`), within a `(schema, table)` group: the owning
     /// index's name + uniqueness, the participating column, its sort
@@ -569,26 +633,29 @@ module ReadSide =
             use! reader = cmd.ExecuteReaderAsync()
             let rows = ResizeArray<FkRow>()
             let mutable hasMore = true
-            // Defensive DBNull guard (slice A.4.7'-prelude.defensive-
-            // hardening): SCHEMA_NAME() returns NULL if the schema
-            // was dropped between metadata read and FK probe (rare
-            // race), or if the user lacks VIEW DEFINITION on the
-            // referenced schema. `reader.GetString` throws
-            // `InvalidCastException` on NULL; treat-as-empty filters
-            // the row out at the downstream consumer (which checks
-            // for non-empty schema/table).
-            let safeStr i = if reader.IsDBNull i then "" else reader.GetString i
+            // E2 (debrief G4): a NULL SCHEMA_NAME() (dropped schema /
+            // missing VIEW DEFINITION grant) is classified Unreadable and
+            // surfaces a NAMED diagnostic + skip — never a silent drop nor
+            // an opaque GetString cast failure.
+            let rawOpt i = if reader.IsDBNull i then None else Some (reader.GetString i)
             while hasMore do
                 let! more = reader.ReadAsync()
                 if more then
-                    rows.Add(
-                        { SourceSchema = safeStr 0
-                          SourceTable  = safeStr 1
-                          SourceColumn = safeStr 2
-                          TargetSchema = safeStr 3
-                          TargetTable  = safeStr 4
-                          TargetColumn = safeStr 5
-                          IsNotTrusted = (not (reader.IsDBNull 6)) && reader.GetBoolean 6 })
+                    let isNotTrusted = (not (reader.IsDBNull 6)) && reader.GetBoolean 6
+                    match
+                        ForeignKeyReadback.classify
+                            (rawOpt 0) (rawOpt 1) (rawOpt 2) (rawOpt 3) (rawOpt 4) (rawOpt 5) isNotTrusted
+                        with
+                    | ForeignKeyReadback.Reconstructable c ->
+                        rows.Add(
+                            { SourceSchema = c.SourceSchema
+                              SourceTable  = c.SourceTable
+                              SourceColumn = c.SourceColumn
+                              TargetSchema = c.TargetSchema
+                              TargetTable  = c.TargetTable
+                              TargetColumn = c.TargetColumn
+                              IsNotTrusted = c.IsNotTrusted })
+                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason
                 else
                     hasMore <- false
             return List.ofSeq rows
@@ -1421,17 +1488,28 @@ module ReadSide =
             let! _ = reader.NextResultAsync()
             let fkRows = ResizeArray<FkRow>()
             let mutable hasMore4 = true
+            // E2 (debrief G4): classify each FK row's coordinates; a NULL
+            // SCHEMA_NAME() yields a NAMED diagnostic + skip instead of an
+            // opaque `GetString` cast failure that would abort the readback.
+            let rawOpt4 i = if reader.IsDBNull i then None else Some (reader.GetString i)
             while hasMore4 do
                 let! more = reader.ReadAsync()
                 if more then
-                    fkRows.Add(
-                        { SourceSchema = reader.GetString 0
-                          SourceTable  = reader.GetString 1
-                          SourceColumn = reader.GetString 2
-                          TargetSchema = reader.GetString 3
-                          TargetTable  = reader.GetString 4
-                          TargetColumn = reader.GetString 5
-                          IsNotTrusted = reader.GetBoolean 6 })
+                    let isNotTrusted = (not (reader.IsDBNull 6)) && reader.GetBoolean 6
+                    match
+                        ForeignKeyReadback.classify
+                            (rawOpt4 0) (rawOpt4 1) (rawOpt4 2) (rawOpt4 3) (rawOpt4 4) (rawOpt4 5) isNotTrusted
+                        with
+                    | ForeignKeyReadback.Reconstructable c ->
+                        fkRows.Add(
+                            { SourceSchema = c.SourceSchema
+                              SourceTable  = c.SourceTable
+                              SourceColumn = c.SourceColumn
+                              TargetSchema = c.TargetSchema
+                              TargetTable  = c.TargetTable
+                              TargetColumn = c.TargetColumn
+                              IsNotTrusted = c.IsNotTrusted })
+                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason
                 else hasMore4 <- false
 
             // Result set 5: V2.LogicalName extended properties

--- a/sidecar/projection/src/Projection.Core/Catalog.fs
+++ b/sidecar/projection/src/Projection.Core/Catalog.fs
@@ -1091,6 +1091,32 @@ module Reference =
             IsConstraintTrusted = true
         }
 
+    /// G14 — the constraint-state invariant. Trust is only meaningful when a
+    /// DB constraint exists: an *untrusted* (`WITH NOCHECK`) reference must be
+    /// backed by a real constraint, since the emitter's NOCHECK alter
+    /// (`SsdtDdlEmitter.untrustedFkAlters`) fires on `not IsConstraintTrusted`
+    /// and would otherwise target a non-existent constraint. Formally
+    /// `¬IsConstraintTrusted ⟹ HasDbConstraint`. The illegal quadrant the
+    /// debrief (G14) names is `(HasDbConstraint=false ∧ IsConstraintTrusted=false)`
+    /// — "untrusted without a constraint." (The `(false, true)` default is the
+    /// canonical *vacuous-trust* no-constraint state, the boolean projection of
+    /// a `NoDbConstraint` variant — consistent.)
+    let isConstraintStateConsistent (r: Reference) : bool =
+        r.IsConstraintTrusted || r.HasDbConstraint
+
+    /// The sanctioned way to set the `(HasDbConstraint, IsConstraintTrusted)`
+    /// pair from external evidence (V1 JSON / ReadSide / codec). Normalizes the
+    /// illegal quadrant to the canonical vacuous-trust state: a reference with
+    /// no DB constraint is `IsConstraintTrusted = true` (trust is N/A), never
+    /// independently untrusted. Routing every producer through this makes the
+    /// illegal quadrant unreachable in practice (witnessed in
+    /// `ReferenceConstraintStateTests`).
+    let withConstraintState (hasDbConstraint: bool) (isConstraintTrusted: bool) (r: Reference) : Reference =
+        if hasDbConstraint then
+            { r with HasDbConstraint = true; IsConstraintTrusted = isConstraintTrusted }
+        else
+            { r with HasDbConstraint = false; IsConstraintTrusted = true }
+
 
 [<RequireQualifiedAccess>]
 module Index =

--- a/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
+++ b/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
@@ -42,11 +42,13 @@ namespace Projection.Core
 ///     tgtSchema, tgtTable, tgtCol)` tuples (Session B addition).
 ///
 /// **What's NOT compared.** SsKey identity, Module structure,
-/// Origin / Modality marks, Indexes (non-PK), static populations,
-/// comment metadata. These are V2-IR-only axes that SQL Server's
-/// catalog cannot recover. M4's Tolerance taxonomy will name
-/// additional comparison flags (e.g., column length / precision;
-/// indexes; FK delete-rule semantics).
+/// Origin / Modality marks, static populations. Non-PK index
+/// *structure* IS compared as of E1 (see `PhysicalIndex` / the
+/// `Indexes` axis); index *options* (filter / included columns /
+/// storage flags) remain a named residual
+/// (`ToleratedDivergence.IndexOptionsUnreflected`). These excluded
+/// axes are V2-IR-only or option-level details SQL Server's catalog
+/// does not recover symmetrically.
 type PhysicalColumn =
     {
         Schema : string
@@ -112,6 +114,30 @@ type PhysicalAnnotation =
         Owner : string
         Name : string
         Payload : string
+    }
+
+/// A non-PK index in physical-schema coordinates (E1 / debrief G3).
+/// Compares the index's *structural identity* — owner, name, uniqueness,
+/// and ordered key columns — which is exactly the surface `ReadSide`
+/// reconstructs (`readIndexes`: `i.name`, `i.is_unique`, key columns +
+/// `is_descending_key` in `key_ordinal` order; PKs excluded). Both halves
+/// of the canary read back through the same `ReadSide`, so this axis stays
+/// symmetric and surfaces a *genuine* index drop/reshape (a UNIQUE index V2
+/// failed to emit, a key-column reorder) without false positives.
+///
+/// **Deliberately NOT compared:** included columns, the filter predicate,
+/// and the storage options (FILLFACTOR / lock flags / compression) — these
+/// are recovered by neither side today, so they're a named residual
+/// (`ToleratedDivergence.IndexOptionsUnreflected`), not a silent drop.
+type PhysicalIndex =
+    {
+        Schema : string
+        Table : string
+        Name : string
+        IsUnique : bool
+        /// Ordered key columns, encoded `[col:ASC][col2:DESC]`. Order is
+        /// load-bearing — a different key order is a different index.
+        KeyColumns : string
     }
 
 /// A foreign-key relationship in physical-schema coordinates. Per
@@ -228,6 +254,13 @@ type PhysicalSchema =
         /// in `ofCatalog`; recovered from `sys.triggers` / `sys.check_constraints`
         /// / `sys.sequences` / `sys.extended_properties` by ReadSide.
         Annotations : Set<PhysicalAnnotation>
+        /// E1 (debrief G3) — non-PK indexes (owner + name + uniqueness +
+        /// ordered key columns). Populated from `Kind.Indexes` in `ofCatalog`;
+        /// recovered from `sys.indexes` ⋈ `sys.index_columns` by ReadSide's
+        /// `readIndexes` + `attachIndexes`. Retires the prior
+        /// `Tolerance.IndexOptionsUnreflected` (index *structure* is now compared;
+        /// index *options* remain a named residual).
+        Indexes : Set<PhysicalIndex>
     }
 
 /// The diff between two `PhysicalSchema` values. All ten fields
@@ -256,6 +289,11 @@ type PhysicalSchemaDiff =
         /// target-not-source (Extra).
         MissingAnnotations : PhysicalAnnotation list
         ExtraAnnotations : PhysicalAnnotation list
+        /// E1 — non-PK indexes in source-not-target (Missing) /
+        /// target-not-source (Extra). A populated entry is a genuine index
+        /// drop / reshape on the round-trip.
+        MissingIndexes : PhysicalIndex list
+        ExtraIndexes : PhysicalIndex list
     }
 
 /// Streaming aggregate row-hash builder. Per session-35 — folds an
@@ -453,6 +491,34 @@ module PhysicalSchema =
                     Payload = normalizeDefault c.Definition
                 })
         triggers @ checks
+
+    /// E1 (debrief G3) — project a Kind's non-PK indexes into the index
+    /// axis. Resolves each `IndexColumn`'s attribute SsKey to its physical
+    /// column name (the same coordinate `toPhysicalColumns` keys on) and
+    /// encodes the ordered key list so a reorder surfaces as a divergence.
+    let private toPhysicalIndexes (k: Kind) : PhysicalIndex list =
+        let schemaStr = SchemaName.value k.Physical.Schema
+        let tableStr = TableName.value k.Physical.Table
+        let colNameByKey =
+            k.Attributes
+            |> List.map (fun a -> a.SsKey, ColumnRealization.columnNameText a.Column)
+            |> Map.ofList
+        k.Indexes
+        |> List.map (fun idx ->
+            let keyColumns =
+                idx.Columns
+                |> List.map (fun ic ->
+                    let colName = Map.tryFind ic.Attribute colNameByKey |> Option.defaultValue "<unresolved>"
+                    let dir = match ic.Direction with | Ascending -> "ASC" | Descending -> "DESC"
+                    System.String.Concat("[", colName, ":", dir, "]"))
+                |> String.concat ""
+            {
+                Schema = schemaStr
+                Table = tableStr
+                Name = Name.value idx.Name
+                IsUnique = IndexUniqueness.isUnique idx.Uniqueness
+                KeyColumns = keyColumns
+            })
 
     /// Project the Catalog's sequences into annotations. Sequence shape
     /// (start / increment / min / max / cycle / cache) rides the payload
@@ -655,6 +721,10 @@ module PhysicalSchema =
             @ (kinds |> List.collect toExtendedPropertyAnnotations)
             @ toSequenceAnnotations c
             |> Set.ofList
+        let indexes =
+            kinds
+            |> List.collect toPhysicalIndexes
+            |> Set.ofList
         {
             Columns = columns
             ForeignKeys = foreignKeys
@@ -662,6 +732,7 @@ module PhysicalSchema =
             RowDigests = Set.empty
             LogicalNameBindings = logicalNameBindings
             Annotations = annotations
+            Indexes = indexes
         }
 
     /// Layer per-table aggregate row digests onto an existing
@@ -699,6 +770,8 @@ module PhysicalSchema =
             ExtraLogicalNameBindings   = setDifference target.LogicalNameBindings source.LogicalNameBindings
             MissingAnnotations         = setDifference source.Annotations         target.Annotations
             ExtraAnnotations           = setDifference target.Annotations         source.Annotations
+            MissingIndexes             = setDifference source.Indexes             target.Indexes
+            ExtraIndexes               = setDifference target.Indexes             source.Indexes
         }
 
     /// True iff the diff is empty across all ten axes.
@@ -715,6 +788,8 @@ module PhysicalSchema =
         && List.isEmpty d.ExtraLogicalNameBindings
         && List.isEmpty d.MissingAnnotations
         && List.isEmpty d.ExtraAnnotations
+        && List.isEmpty d.MissingIndexes
+        && List.isEmpty d.ExtraIndexes
 
     /// Schema-structural equality: columns + FKs + logical-name bindings +
     /// annotations match, **ignoring row data** (`Missing`/`ExtraRows` +
@@ -733,6 +808,8 @@ module PhysicalSchema =
         && List.isEmpty d.ExtraLogicalNameBindings
         && List.isEmpty d.MissingAnnotations
         && List.isEmpty d.ExtraAnnotations
+        && List.isEmpty d.MissingIndexes
+        && List.isEmpty d.ExtraIndexes
 
     /// Render a diff as a human-readable multi-line string. Used by
     /// canary failure messages so the operator sees exactly which
@@ -800,6 +877,9 @@ module PhysicalSchema =
                 | ExtendedPropertyAnnotation -> "extprop"
             sprintf "  %s %s on %s = %s" kind a.Name a.Owner
                 (a.Payload.Substring(0, min 60 a.Payload.Length))
+        let renderIndex (i: PhysicalIndex) : string =
+            sprintf "  %sindex %s on [%s].[%s] %s"
+                (if i.IsUnique then "unique " else "") i.Name i.Schema i.Table i.KeyColumns
         let block (label: string) (renderer: 'a -> string) (xs: 'a list) : string =
             if List.isEmpty xs then sprintf "%s:\n  (none)" label
             else
@@ -846,4 +926,6 @@ module PhysicalSchema =
                 truncatedBlock "Extra logical-name bindings in target (target has, source did not)" renderBinding d.ExtraLogicalNameBindings
                 truncatedBlock "Missing annotations in target (triggers/checks/sequences/extprops source had, target lost)" renderAnnotation d.MissingAnnotations
                 truncatedBlock "Extra annotations in target (target has, source did not)" renderAnnotation d.ExtraAnnotations
+                truncatedBlock "Missing indexes in target (source had, target lost)" renderIndex d.MissingIndexes
+                truncatedBlock "Extra indexes in target (target has, source did not)" renderIndex d.ExtraIndexes
             ]

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -21,6 +21,22 @@ namespace Projection.Core
 /// comparator DOES with it (action-shaped). The accepted pattern is
 /// `<Subject><Disposition>` (e.g., `HeaderCommentsOmitted` — the
 /// header comments ARE omitted; the divergence IS that omission).
+///
+/// **`@ladder` machine tag (D1 — the self-verification meta-cell).**
+/// Each variant's doc block ends with a machine-readable
+/// `@ladder <VariantName> <Axis> <Disposition>` line that
+/// `scripts/matrix-status.sh` parses to report each round-trip axis's
+/// faithfulness rung in `NORTH_STAR.matrix.generated.md`. `Axis` is one
+/// of the five round-trip axes (Schema / Data / Identity / Time /
+/// Decision); `Disposition` is `OpenGap` (a closeable fidelity debt that
+/// caps the axis at L2-partial — e.g. `IndexesUnreflected`, retired when
+/// the round-trip preserves it) or `AcceptedFaithful` (a representation-
+/// only equivalence or an erasure covered by a separate witness, which
+/// does not reduce faithfulness). The honesty mechanism: retiring a
+/// variant deletes its tag, so the generator auto-flips the axis — no one
+/// can hand-mark an axis faithful while its open tolerance still exists.
+/// The generator FAILS if any live variant (per `name`) lacks a tag, so a
+/// new variant cannot land untagged.
 [<RequireQualifiedAccess>]
 type ToleratedDivergence =
     /// V2 emits without the `/* Source: ... */` header block per
@@ -28,6 +44,7 @@ type ToleratedDivergence =
     /// true initially, V2 omits"). The omission is deliberate; an
     /// `EmissionPolicyPass` may surface an equivalent header in a
     /// later chapter, retiring this variant.
+    /// @ladder HeaderCommentsOmitted Schema AcceptedFaithful
     | HeaderCommentsOmitted
 
     /// Cross-module FKs split into a `Scripts/PostDeploy/Cross
@@ -38,6 +55,7 @@ type ToleratedDivergence =
     /// flips to the PostDeploy split. Layout differs (file count +
     /// content placement) but `PhysicalSchema` equivalence holds
     /// (FKs deploy either way).
+    /// @ladder PostDeployForeignKeysSplit Schema AcceptedFaithful
     | PostDeployForeignKeysSplit
 
     /// Non-PK indexes are not reflected in `PhysicalSchema`'s
@@ -46,6 +64,7 @@ type ToleratedDivergence =
     /// future `PhysicalSchema.Indexes` set will retire this
     /// variant when ReadSide reconstructs them and V2 emit
     /// preserves them round-trip.
+    /// @ladder IndexesUnreflected Schema OpenGap
     | IndexesUnreflected
 
     /// Static-entity populations (INSERT statements) are absent
@@ -53,6 +72,7 @@ type ToleratedDivergence =
     /// The data-plane axis is covered by `PhysicalSchema.Rows` /
     /// `RowDigests` when the canary opts into the data round-trip;
     /// chapter 4.1.B will retire this variant for population kinds.
+    /// @ladder StaticPopulationsUnreflected Data AcceptedFaithful
     | StaticPopulationsUnreflected
 
     /// 6.A.4 — a genuine empty-string `Text` value and SQL `NULL` are
@@ -67,6 +87,7 @@ type ToleratedDivergence =
     /// forces faithful empty-string preservation today). NB: for a NOT-NULL
     /// `Text` column an empty source value would instead fail the load —
     /// that schema-vs-data compatibility check is 6.B.1, not this tolerance.
+    /// @ladder EmptyTextNormalizedToNull Data AcceptedFaithful
     | EmptyTextNormalizedToNull
 
     /// AC-D6 — a `char(n)` / `nchar(n)` column's stored value is ANSI
@@ -83,6 +104,7 @@ type ToleratedDivergence =
     /// only** tolerance: it absorbs no data difference — only the textual
     /// shape of an otherwise-equal value. Retiring it is not anticipated;
     /// it is a property of SQL Server's ANSI char semantics, not a V2 gap.
+    /// @ladder CharAnsiPaddingTolerated Data AcceptedFaithful
     | CharAnsiPaddingTolerated
 
     /// AC-D6 — a `decimal(p,s)` / `numeric(p,s)` column's stored value is a
@@ -98,6 +120,7 @@ type ToleratedDivergence =
     /// **representation-only** tolerance: it absorbs no numeric difference —
     /// only the trailing-zero scale shape. Retiring it is not anticipated;
     /// it is a property of SQL Server's numeric comparison, not a V2 gap.
+    /// @ladder DecimalScaleTolerated Data AcceptedFaithful
     | DecimalScaleTolerated
 
     // **CommentMetadataUnreflected — RETIRED at chapter 4.1.A slice 8

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -29,7 +29,7 @@ namespace Projection.Core
 /// faithfulness rung in `NORTH_STAR.matrix.generated.md`. `Axis` is one
 /// of the five round-trip axes (Schema / Data / Identity / Time /
 /// Decision); `Disposition` is `OpenGap` (a closeable fidelity debt that
-/// caps the axis at L2-partial — e.g. `IndexesUnreflected`, retired when
+/// caps the axis at L2-partial — e.g. `IndexOptionsUnreflected`, retired when
 /// the round-trip preserves it) or `AcceptedFaithful` (a representation-
 /// only equivalence or an erasure covered by a separate witness, which
 /// does not reduce faithfulness). The honesty mechanism: retiring a
@@ -58,14 +58,21 @@ type ToleratedDivergence =
     /// @ladder PostDeployForeignKeysSplit Schema AcceptedFaithful
     | PostDeployForeignKeysSplit
 
-    /// Non-PK indexes are not reflected in `PhysicalSchema`'s
-    /// comparison surface per the docstring at `PhysicalSchema.fs:
-    /// 44` ("What's NOT compared. ... Indexes (non-PK), ..."). A
-    /// future `PhysicalSchema.Indexes` set will retire this
-    /// variant when ReadSide reconstructs them and V2 emit
-    /// preserves them round-trip.
-    /// @ladder IndexesUnreflected Schema OpenGap
-    | IndexesUnreflected
+    /// E1 (debrief G3) — non-PK index *structure* (owner + name +
+    /// uniqueness + ordered key columns) IS now reflected in
+    /// `PhysicalSchema.Indexes` and compared on the round-trip (retiring the
+    /// prior `IndexOptionsUnreflected`, which said indexes were invisible
+    /// entirely). What remains unreflected is the index *options*: the
+    /// filter predicate (filtered indexes), INCLUDE columns (covering
+    /// indexes), and the storage options (FILLFACTOR / PAD_INDEX / lock
+    /// flags / DATA_COMPRESSION). `ReadSide.readIndexes` recovers none of
+    /// these (it excludes `is_included_column` and reads no option columns),
+    /// so they are symmetric-but-lost on both halves of the canary. Named
+    /// here so the residual is *closed* (documented), not silent. Retiring
+    /// it: extend `readIndexes` to recover the options + widen
+    /// `PhysicalIndex` + ensure V2 emit preserves them round-trip.
+    /// @ladder IndexOptionsUnreflected Schema OpenGap
+    | IndexOptionsUnreflected
 
     /// Static-entity populations (INSERT statements) are absent
     /// from `PhysicalSchema`'s comparison surface (same docstring).
@@ -153,7 +160,7 @@ module ToleratedDivergence =
         function
         | ToleratedDivergence.HeaderCommentsOmitted          -> ToleratedDivergence.HeaderCommentsOmitted
         | ToleratedDivergence.PostDeployForeignKeysSplit     -> ToleratedDivergence.PostDeployForeignKeysSplit
-        | ToleratedDivergence.IndexesUnreflected             -> ToleratedDivergence.IndexesUnreflected
+        | ToleratedDivergence.IndexOptionsUnreflected             -> ToleratedDivergence.IndexOptionsUnreflected
         | ToleratedDivergence.StaticPopulationsUnreflected   -> ToleratedDivergence.StaticPopulationsUnreflected
         | ToleratedDivergence.EmptyTextNormalizedToNull      -> ToleratedDivergence.EmptyTextNormalizedToNull
         | ToleratedDivergence.CharAnsiPaddingTolerated       -> ToleratedDivergence.CharAnsiPaddingTolerated
@@ -175,7 +182,7 @@ module ToleratedDivergence =
             [
                 coverage ToleratedDivergence.HeaderCommentsOmitted
                 coverage ToleratedDivergence.PostDeployForeignKeysSplit
-                coverage ToleratedDivergence.IndexesUnreflected
+                coverage ToleratedDivergence.IndexOptionsUnreflected
                 coverage ToleratedDivergence.StaticPopulationsUnreflected
                 coverage ToleratedDivergence.EmptyTextNormalizedToNull
                 coverage ToleratedDivergence.CharAnsiPaddingTolerated
@@ -191,7 +198,7 @@ module ToleratedDivergence =
         match d with
         | ToleratedDivergence.HeaderCommentsOmitted        -> "HeaderCommentsOmitted"
         | ToleratedDivergence.PostDeployForeignKeysSplit   -> "PostDeployForeignKeysSplit"
-        | ToleratedDivergence.IndexesUnreflected           -> "IndexesUnreflected"
+        | ToleratedDivergence.IndexOptionsUnreflected           -> "IndexOptionsUnreflected"
         | ToleratedDivergence.StaticPopulationsUnreflected -> "StaticPopulationsUnreflected"
         | ToleratedDivergence.EmptyTextNormalizedToNull    -> "EmptyTextNormalizedToNull"
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> "CharAnsiPaddingTolerated"
@@ -252,8 +259,8 @@ module Tolerance =
 
     /// Construct from an explicit set. Use when a per-environment
     /// configuration carries its own subset (e.g., DEV accepts
-    /// HeaderCommentsOmitted + IndexesUnreflected; STAGING accepts
-    /// only IndexesUnreflected; PROD accepts none).
+    /// HeaderCommentsOmitted + IndexOptionsUnreflected; STAGING accepts
+    /// only IndexOptionsUnreflected; PROD accepts none).
     let ofSet (divergences: Set<ToleratedDivergence>) : Tolerance =
         Tolerance divergences
 

--- a/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
@@ -156,4 +156,10 @@ module PhysicalSchemaReader =
             // today — the two-consumer threshold gates it). Empty here keeps
             // the H-050 in-process adjunction green on the axes it owns.
             Annotations = Set.empty
+            // E1 — same rationale as Annotations: the index axis is verified
+            // through the REAL SQL Server canary (ReadSide path), the
+            // authoritative round-trip. AST-side index recovery is deferred
+            // (no consumer needs the in-process index diff; the adjunction
+            // test asserts only Columns + FKs).
+            Indexes = Set.empty
         }

--- a/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
@@ -662,6 +662,83 @@ let ``6.A.8 (decision adjunction): read-back reproduces EnforceUnique and DropFk
         Assert.Equal(0, childFkCount tightened.Reconstructed)
 
 // ---------------------------------------------------------------------
+// F2 (debrief G12) — the UNIFIED decision adjunction. The per-axis
+// proofs exist separately (A42 nullability; 6.A.8 uniqueness + FK-drop;
+// the readside-index-fktrust witness for FK-trust). North-Star §5
+// criterion 2 asks for the COMPOSITIONAL witness: one overlay carrying
+// all three decision intents simultaneously survives the round-trip —
+// `Ingest(deploy(Project(C, overlay)))` reproduces every opinion at once,
+// proving the axes compose (no decision shadows another at emit). This is
+// the theorem that makes "replace V1" stronger than "trust V1": the
+// engine's opinions are provably recoverable from the substrate.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``E3: Ingest(deploy(Project(C, overlay))) reproduces the decision overlay on all three axes (nullability + uniqueness + FK-trust)`` () =
+    if skipIfNoDocker "decision-adjunction-3axis" then
+        let parentKey = ssKeySafe "OS_KIND_F2_Parent"
+        let childKey = ssKeySafe "OS_KIND_F2_Child"
+        let parentIdKey = ssKeySafe "OS_ATTR_F2_Parent_Id"
+        let codeKey = ssKeySafe "OS_ATTR_F2_Parent_Code"
+        let noteKey = ssKeySafe "OS_ATTR_F2_Parent_Note"
+        let childIdKey = ssKeySafe "OS_ATTR_F2_Child_Id"
+        let parentFkAttr = ssKeySafe "OS_ATTR_F2_Child_ParentId"
+        let refKeyV = ssKeySafe "OS_REF_F2_Child_Parent"
+        let idxKey = ssKeySafe "OS_IDX_F2_Parent_Code"
+        let mkAttr (k: SsKey) (col: string) (isPk: bool) (nullable: bool) (ty: PrimitiveType) : Attribute =
+            { Attribute.create k (nameSafe col) ty with
+                Column = ColumnRealization.create (col.ToUpperInvariant()) nullable |> Result.value
+                IsPrimaryKey = isPk; IsMandatory = isPk }
+        let parent =
+            { Kind.create parentKey (nameSafe "Parent")
+                (mkTableId "dbo" "OSUSR_F2_PARENT")
+                [ mkAttr parentIdKey "Id" true false Integer
+                  mkAttr codeKey "Code" false false Integer
+                  // Source-nullable column — the nullability axis.
+                  mkAttr noteKey "Note" false true Integer ]
+              with Indexes = [ Index.ofKeyColumns idxKey (nameSafe "IX_F2Parent_Code") [ codeKey ] ] }
+        // Source FK is NOCHECK / untrusted — the FK-trust axis (preserved,
+        // not dropped: it must read back untrusted, not the create-default).
+        let child =
+            { Kind.create childKey (nameSafe "Child")
+                (mkTableId "dbo" "OSUSR_F2_CHILD")
+                [ mkAttr childIdKey "Id" true false Integer
+                  mkAttr parentFkAttr "ParentId" false false Integer ]
+              with References =
+                    [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with
+                          HasDbConstraint = true; IsConstraintTrusted = false } ] }
+        let catalog =
+            match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_F2"; Name = nameSafe "F2Mod"; Kinds = [ parent; child ]; IsActive = true; ExtendedProperties = [] } ] [] with
+            | Ok c -> c | Error e -> failwithf "catalog %A" e
+
+        // One overlay, two tightening intents (nullability + uniqueness);
+        // FK-trust rides the source Reference. Project → deploy → read back.
+        let overlay =
+            { DecisionOverlay.empty with
+                EnforceNotNull = Set.singleton noteKey
+                EnforceUnique = Set.singleton idxKey }
+        let sql = SsdtDdlEmitter.statementsWith overlay catalog |> Render.toText
+        let result = (Deploy.runWithReadback sql).GetAwaiter().GetResult()
+        Assert.True(result.Report.Ok, sprintf "deploy: %A" result.Report.Errors)
+        match result.Reconstructed with
+        | Some c ->
+            let kindByTable t = Catalog.allKinds c |> List.find (fun k -> TableId.tableText k.Physical = t)
+            let parentBack = kindByTable "OSUSR_F2_PARENT"
+            // (1) Nullability: the EnforceNotNull column reads back NOT NULL.
+            let noteBack = parentBack.Attributes |> List.find (fun a -> ColumnRealization.columnNameText a.Column = "NOTE")
+            Assert.False(noteBack.Column.IsNullable, "EnforceNotNull(Note) must read back NOT NULL")
+            // (2) Uniqueness: the EnforceUnique index reads back UNIQUE.
+            match parentBack.Indexes |> List.tryFind (fun i -> IndexUniqueness.isUnique i.Uniqueness) with
+            | Some _ -> ()
+            | None -> Assert.Fail "EnforceUnique(index) must read back as a UNIQUE index"
+            // (3) FK-trust: the NOCHECK source FK reads back untrusted.
+            let childBack = kindByTable "OSUSR_F2_CHILD"
+            match childBack.References with
+            | [ r ] -> Assert.False(r.IsConstraintTrusted, "NOCHECK FK must read back untrusted, not the create-default true")
+            | rs -> Assert.Fail(sprintf "expected exactly one reconstructed FK, got %d" (List.length rs))
+        | None -> Assert.Fail "deploy produced no reconstructed catalog"
+
+// ---------------------------------------------------------------------
 // 6.A.6 — emit-side NOCHECK-FK reproduction (the schema-erasure 6.A.5
 // surfaced). A source `Reference.IsConstraintTrusted = false` now SURVIVES
 // emit → deploy → ReadSide: the emitter reproduces the enabled-untrusted

--- a/sidecar/projection/tests/Projection.Tests/ChangeManifestTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ChangeManifestTests.fs
@@ -94,7 +94,7 @@ let ``6.H.4: a genesis-only lifecycle has an empty change-manifest series`` () =
 let private tolerances : Tolerance =
     Tolerance.strict
     |> Tolerance.withDivergence ToleratedDivergence.HeaderCommentsOmitted
-    |> Tolerance.withDivergence ToleratedDivergence.IndexesUnreflected
+    |> Tolerance.withDivergence ToleratedDivergence.IndexOptionsUnreflected
 
 let private appliedTransforms : (SsKey * OverlayAxis option) list =
     [ customerKey, Some Tightening
@@ -109,7 +109,7 @@ let ``6.H.4: the manifest surfaces the To-episode tolerance residual (named, sor
     // The residual is the To-episode's accepted-divergence set as a name-sorted
     // list — the equivalence under which this edge's displacement was faithful.
     Assert.Equal<ToleratedDivergence list>(
-        [ ToleratedDivergence.HeaderCommentsOmitted; ToleratedDivergence.IndexesUnreflected ],
+        [ ToleratedDivergence.HeaderCommentsOmitted; ToleratedDivergence.IndexOptionsUnreflected ],
         m.ToleranceResidual)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/ForeignKeyReadbackTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ForeignKeyReadbackTests.fs
@@ -1,0 +1,67 @@
+module Projection.Tests.ForeignKeyReadbackTests
+
+open Xunit
+open Projection.Adapters.Sql
+
+// ---------------------------------------------------------------------------
+// E2 (debrief G4) — the cross-schema FK readback classifier. `SCHEMA_NAME()`
+// returns NULL for a dropped schema or a `VIEW DEFINITION`-restricted account;
+// `ReadSide.ForeignKeyReadback.classify` turns such a row into a NAMED
+// diagnostic + skip, closing the no-silent-drop boundary axiom for the FK read
+// leg (previously an opaque `GetString` cast failure / blank-and-drop). Pure,
+// so the discipline is witnessed without a live substrate.
+// ---------------------------------------------------------------------------
+
+module FK = ReadSide.ForeignKeyReadback
+
+let private resolved =
+    FK.classify (Some "dbo") (Some "Orders") (Some "CustomerId")
+                (Some "dbo") (Some "Customers") (Some "Id") false
+
+[<Fact>]
+let ``E2: a fully-resolved FK row reconstructs, carrying its coordinates and trust`` () =
+    match resolved with
+    | FK.Reconstructable c ->
+        Assert.Equal("dbo", c.SourceSchema)
+        Assert.Equal("Orders", c.SourceTable)
+        Assert.Equal("Customers", c.TargetTable)
+        Assert.False(c.IsNotTrusted)
+    | FK.Unreadable reason -> failwithf "expected Reconstructable, got Unreadable: %s" reason
+
+[<Fact>]
+let ``E2: the trust flag rides through reconstruction`` () =
+    match FK.classify (Some "dbo") (Some "O") (Some "c") (Some "dbo") (Some "C") (Some "Id") true with
+    | FK.Reconstructable c -> Assert.True(c.IsNotTrusted)
+    | FK.Unreadable reason -> failwithf "expected Reconstructable, got Unreadable: %s" reason
+
+[<Fact>]
+let ``E2: an unreadable cross-schema FK surfaces a diagnostic, not a silent drop`` () =
+    // The referenced schema is NULL (the G4 case): a dropped schema or a
+    // missing VIEW DEFINITION grant. The row must NOT silently vanish — it
+    // surfaces a named reason identifying the referenced side and the cause.
+    let classification =
+        FK.classify (Some "dbo") (Some "Orders") (Some "CustomerId")
+                    None (Some "Customers") (Some "Id") false
+    match classification with
+    | FK.Unreadable reason ->
+        Assert.Contains("referenced schema", reason)
+        Assert.Contains("VIEW DEFINITION", reason)
+        // The diagnostic names the visible source endpoint so the operator
+        // can locate the FK (discriminating: a bare "skipped" would pass a
+        // weaker assertion).
+        Assert.Contains("dbo.Orders.CustomerId", reason)
+    | FK.Reconstructable _ -> failwith "expected Unreadable for a NULL referenced schema"
+
+[<Fact>]
+let ``E2: a NULL parent schema names the parent side`` () =
+    match FK.classify None (Some "Orders") (Some "CustomerId") (Some "dbo") (Some "Customers") (Some "Id") false with
+    | FK.Unreadable reason -> Assert.Contains("parent schema", reason)
+    | FK.Reconstructable _ -> failwith "expected Unreadable for a NULL parent schema"
+
+[<Fact>]
+let ``E2: a blank (whitespace) schema is unreadable, not kept as empty`` () =
+    // Defends against the prior treat-as-empty path that let "" through to a
+    // downstream resolution failure: a whitespace coordinate is unreadable.
+    match FK.classify (Some "dbo") (Some "Orders") (Some "CustomerId") (Some "   ") (Some "Customers") (Some "Id") false with
+    | FK.Unreadable _ -> ()
+    | FK.Reconstructable _ -> failwith "expected Unreadable for a blank referenced schema"

--- a/sidecar/projection/tests/Projection.Tests/IndexRoundtripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/IndexRoundtripTests.fs
@@ -1,0 +1,73 @@
+[<Xunit.Collection("Docker-SqlServer")>]
+module Projection.Tests.IndexRoundtripTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Targets.SSDT
+
+// ---------------------------------------------------------------------------
+// E1 (debrief G3) — non-PK index structure is reflected in PhysicalSchema and
+// survives the emit → deploy → ReadSide round-trip. Retires the prior
+// `Tolerance.IndexesUnreflected` (index *structure* is now compared; index
+// *options* remain the narrower `IndexOptionsUnreflected` residual).
+//
+// The wide canary deploys the source DDL, reads it back, runs V2's emitter,
+// deploys + reads back again, and diffs on `PhysicalSchema` — which now carries
+// the `Indexes` axis. An empty diff proves V2 emitted every index faithfully;
+// the reflection assertion proves the axis is non-vacuously populated (a
+// generator that dropped indexes entirely would pass an empty diff trivially).
+// ---------------------------------------------------------------------------
+
+let private skipIfNoDocker (label: string) : bool =
+    if Deploy.Docker.ensureRunning () then true
+    else
+        printfn "SKIP %s: Docker daemon not reachable." label
+        false
+
+/// One table with a PK, a UNIQUE single-column index, and a non-unique
+/// two-column index — all INT columns so the column axis round-trips cleanly
+/// (V2 emits Text as NVARCHAR(MAX); ints avoid the known length tolerance).
+let private widgetDdl : string =
+    "CREATE TABLE [dbo].[OSUSR_E1_WIDGET] ( \
+       [ID] INT NOT NULL IDENTITY(1,1) PRIMARY KEY, \
+       [CODE] INT NOT NULL, \
+       [REGION] INT NOT NULL \
+     ); \
+     CREATE UNIQUE INDEX [UX_WIDGET_CODE] ON [dbo].[OSUSR_E1_WIDGET] ([CODE]); \
+     CREATE INDEX [IX_WIDGET_REGION_CODE] ON [dbo].[OSUSR_E1_WIDGET] ([REGION], [CODE]);"
+
+[<Fact>]
+let ``E1: a UNIQUE/filtered index survives emit/deploy/ReadSide and is reflected in PhysicalSchema`` () =
+    if not (skipIfNoDocker "e1-index-roundtrip") then () else
+    let report =
+        match (Deploy.runWideCanary widgetDdl SsdtDdlEmitter.statements).GetAwaiter().GetResult() with
+        | Ok r -> r
+        | Error es -> failwithf "wide canary failed: %A" es
+
+    Assert.True(report.SourceReport.Ok, sprintf "source deploy: %A" report.SourceReport.Errors)
+    Assert.True(report.TargetReport.Ok, sprintf "target deploy: %A" report.TargetReport.Errors)
+
+    // Reflection (discriminating): the source reconstruction actually carries
+    // the two non-PK indexes, by name + uniqueness + ordered key columns — so
+    // the empty diff below is not vacuous.
+    let sourceIndexes = (PhysicalSchema.ofCatalog report.Source).Indexes
+    let byName n = sourceIndexes |> Set.filter (fun (i: PhysicalIndex) -> i.Name = n) |> Set.toList
+    match byName "UX_WIDGET_CODE" with
+    | [ ux ] ->
+        Assert.True(ux.IsUnique)
+        Assert.Equal("[CODE:ASC]", ux.KeyColumns)
+    | other -> failwithf "expected exactly one UX_WIDGET_CODE index, got %A" other
+    match byName "IX_WIDGET_REGION_CODE" with
+    | [ ix ] ->
+        Assert.False(ix.IsUnique)
+        Assert.Equal("[REGION:ASC][CODE:ASC]", ix.KeyColumns)
+    | other -> failwithf "expected exactly one IX_WIDGET_REGION_CODE index, got %A" other
+
+    // Survives emit/deploy/ReadSide: the index axis (and every other) round-trips.
+    Assert.True(
+        List.isEmpty report.Diff.MissingIndexes && List.isEmpty report.Diff.ExtraIndexes,
+        sprintf "index round-trip diff non-empty:\n%s" (PhysicalSchema.renderDiff report.Diff))
+    Assert.True(
+        PhysicalSchema.isEqual report.Diff,
+        sprintf "wide-canary diff non-empty:\n%s" (PhysicalSchema.renderDiff report.Diff))

--- a/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
@@ -54,7 +54,7 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
               "DecimalScaleTolerated"
               "EmptyTextNormalizedToNull"
               "HeaderCommentsOmitted"
-              "IndexesUnreflected"
+              "IndexOptionsUnreflected"
               "PostDeployForeignKeysSplit"
               "StaticPopulationsUnreflected" ]
     Assert.Equal<Set<string>> (expected, result)

--- a/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
@@ -1,0 +1,83 @@
+module Projection.Tests.MatrixLadderTests
+
+open System.IO
+open Xunit
+open Projection.Core
+
+// ---------------------------------------------------------------------------
+// D1 — the self-verification meta-cell (EXECUTION_PLAN 6.E.1; debrief cluster D).
+//
+// `scripts/matrix-status.sh` derives the round-trip *ladder* (L1 witness / L2
+// faithful / L3 composed) per axis from the proof — the test tree's witness
+// names and `Tolerance.fs`'s `@ladder` tags — and writes
+// `NORTH_STAR.matrix.generated.md`. These tests pin the generator's keystone
+// behaviour: an axis carrying an `OpenGap` tolerance is reported L2-partial and
+// NAMES the tolerance, while an axis with only accepted tolerances reaches L3.
+//
+// The honesty mechanism (verified at the script level + here): a cell cannot be
+// hand-marked. L2 flips to faithful only when the `OpenGap` variant is retired
+// from `Tolerance.fs` — so the matrix tracks the codebase's true distance to
+// the bullseye. These tests read the committed generated file; CI also checks it
+// is current (`scripts/matrix-status.sh` produces no git diff), so the two
+// together enforce both "the generator computes the right ladder" and "the
+// committed matrix reflects it."
+// ---------------------------------------------------------------------------
+
+let private generatedMatrix : string =
+    // Walk up from the running test assembly to the projection root and read the
+    // generated matrix. findUp tolerates any build depth (Debug/Release, net9.0).
+    let rec findUp (dir: DirectoryInfo option) : string option =
+        match dir with
+        | None -> None
+        | Some d ->
+            let candidate = Path.Combine(d.FullName, "NORTH_STAR.matrix.generated.md")
+            if File.Exists candidate then Some candidate
+            else findUp (Option.ofObj d.Parent)
+    let start =
+        System.Reflection.Assembly.GetExecutingAssembly().Location
+        |> Path.GetDirectoryName
+        |> Option.ofObj
+        |> Option.map (fun d -> DirectoryInfo d)
+    match findUp start with
+    | Some path -> File.ReadAllText path
+    | None ->
+        // Fail loud rather than skip: the generated file is committed at the
+        // projection root, so its absence is a real regression, not an
+        // environment gap.
+        failwith "NORTH_STAR.matrix.generated.md not found above the test assembly — regenerate via scripts/matrix-status.sh"
+
+let private rowFor (axis: string) : string =
+    generatedMatrix.Split('\n')
+    |> Array.tryFind (fun line -> line.Contains(sprintf "**%s**" axis))
+    |> function
+        | Some row -> row
+        | None -> failwithf "no ladder row for axis %s in the generated matrix" axis
+
+[<Fact>]
+let ``D1: the generated matrix reports Schema=L2-partial because IndexesUnreflected is an open tolerance`` () =
+    // The IndexesUnreflected variant is a live, open fidelity gap (G3): indexes
+    // are read but not reconstructed/compared, so the Schema round-trip is not
+    // yet faithful. The generator must surface this, by name, at the ladder.
+    Assert.Contains(ToleratedDivergence.IndexesUnreflected, ToleratedDivergence.allKnown)
+    let schema = rowFor "Schema"
+    Assert.Contains("L2-partial", schema)
+    Assert.Contains("IndexesUnreflected", schema)
+
+[<Fact>]
+let ``D1: an axis with only accepted tolerances reaches L3 (the generator discriminates)`` () =
+    // Discriminating control: a generator that marked every axis partial would
+    // pass the Schema test above. Data carries only AcceptedFaithful tolerances,
+    // so it must reach the composed rung — proving the ladder is computed, not
+    // blanket-pessimistic.
+    let data = rowFor "Data"
+    Assert.Contains("faithful", data)
+    Assert.Contains("L3", data)
+    Assert.DoesNotContain("L2-partial", data)
+
+[<Fact>]
+let ``D1: exactly one tolerance is an open fidelity gap today`` () =
+    // The matrix's open-gap count is the codebase's named schema-fidelity debt.
+    // Pinning it to 1 (IndexesUnreflected) makes a silently-added OpenGap — or a
+    // silently-retired one without regenerating — fail here. Retiring G3 (E1)
+    // legitimately flips this to 0 and the assertion updates in the same commit.
+    Assert.Contains("1 open", generatedMatrix)

--- a/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
@@ -54,14 +54,16 @@ let private rowFor (axis: string) : string =
         | None -> failwithf "no ladder row for axis %s in the generated matrix" axis
 
 [<Fact>]
-let ``D1: the generated matrix reports Schema=L2-partial because IndexesUnreflected is an open tolerance`` () =
-    // The IndexesUnreflected variant is a live, open fidelity gap (G3): indexes
-    // are read but not reconstructed/compared, so the Schema round-trip is not
-    // yet faithful. The generator must surface this, by name, at the ladder.
-    Assert.Contains(ToleratedDivergence.IndexesUnreflected, ToleratedDivergence.allKnown)
+let ``D1: the generated matrix reports Schema=L2-partial because IndexOptionsUnreflected is an open tolerance`` () =
+    // IndexOptionsUnreflected is a live, open fidelity gap: after E1 the index
+    // *structure* round-trips (compared in PhysicalSchema.Indexes), but index
+    // *options* (filter / included columns / storage flags) are recovered by
+    // neither side, so the Schema round-trip is not yet fully faithful. The
+    // generator must surface this residual, by name, at the ladder.
+    Assert.Contains(ToleratedDivergence.IndexOptionsUnreflected, ToleratedDivergence.allKnown)
     let schema = rowFor "Schema"
     Assert.Contains("L2-partial", schema)
-    Assert.Contains("IndexesUnreflected", schema)
+    Assert.Contains("IndexOptionsUnreflected", schema)
 
 [<Fact>]
 let ``D1: an axis with only accepted tolerances reaches L3 (the generator discriminates)`` () =
@@ -77,7 +79,7 @@ let ``D1: an axis with only accepted tolerances reaches L3 (the generator discri
 [<Fact>]
 let ``D1: exactly one tolerance is an open fidelity gap today`` () =
     // The matrix's open-gap count is the codebase's named schema-fidelity debt.
-    // Pinning it to 1 (IndexesUnreflected) makes a silently-added OpenGap — or a
+    // Pinning it to 1 (IndexOptionsUnreflected) makes a silently-added OpenGap — or a
     // silently-retired one without regenerating — fail here. Retiring G3 (E1)
     // legitimately flips this to 0 and the assertion updates in the same commit.
     Assert.Contains("1 open", generatedMatrix)

--- a/sidecar/projection/tests/Projection.Tests/MultiEnvironmentPromotionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MultiEnvironmentPromotionTests.fs
@@ -72,13 +72,13 @@ let ``R4: Dev environment may be permissive during dual-track (every known diver
 let ``R4: canonical monotonic chain Dev=permissive ⊇ QA ⊇ UAT ⊇ PROD=strict holds`` () =
     // Worked example of the cutover ladder per DECISIONS 2026-05-22:
     // - Dev:  permissive (every known divergence accepted)
-    // - QA:   accepts IndexesUnreflected + StaticPopulationsUnreflected
+    // - QA:   accepts IndexOptionsUnreflected + StaticPopulationsUnreflected
     // - UAT:  accepts only StaticPopulationsUnreflected
     // - PROD: strict
     let ladder =
         { Dev  = Tolerance.permissive
           Qa   = Tolerance.ofSet (Set.ofList
-                    [ ToleratedDivergence.IndexesUnreflected
+                    [ ToleratedDivergence.IndexOptionsUnreflected
                       ToleratedDivergence.StaticPopulationsUnreflected ])
           Uat  = Tolerance.ofSet (Set.ofList
                     [ ToleratedDivergence.StaticPopulationsUnreflected ])
@@ -130,11 +130,11 @@ let ``R4 property: every monotonic chain (Dev ⊇ QA ⊇ UAT ⊇ PROD=strict) sa
 
 [<Fact>]
 let ``R4 negative: non-monotonic chain (QA accepts something Dev does not) violates isMonotonicallyTightening`` () =
-    // Counterexample: QA permits IndexesUnreflected but Dev does
+    // Counterexample: QA permits IndexOptionsUnreflected but Dev does
     // not. The chain Dev ⊇ QA fails.
     let ladder =
         { Dev  = Tolerance.strict
-          Qa   = Tolerance.ofSet (Set.ofList [ ToleratedDivergence.IndexesUnreflected ])
+          Qa   = Tolerance.ofSet (Set.ofList [ ToleratedDivergence.IndexOptionsUnreflected ])
           Uat  = Tolerance.strict
           Prod = Tolerance.strict }
     Assert.False (isMonotonicallyTightening ladder)
@@ -167,7 +167,7 @@ let ``R4 composition: PROD-strict gate ∧ monotonic chain define the cutover-la
     let ladder =
         { Dev  = Tolerance.permissive
           Qa   = Tolerance.ofSet (Set.ofList
-                    [ ToleratedDivergence.IndexesUnreflected
+                    [ ToleratedDivergence.IndexOptionsUnreflected
                       ToleratedDivergence.StaticPopulationsUnreflected ])
           Uat  = Tolerance.ofSet (Set.ofList
                     [ ToleratedDivergence.StaticPopulationsUnreflected ])
@@ -188,7 +188,7 @@ let ``R4 composition: PROD-strict gate ∧ monotonic chain define the cutover-la
 let ``R4 property: adding a divergence to Dev preserves monotonic tightening`` (toAdd: ToleratedDivergence) =
     let baseLadder =
         { Dev  = Tolerance.ofSet (Set.ofList
-                    [ ToleratedDivergence.IndexesUnreflected
+                    [ ToleratedDivergence.IndexOptionsUnreflected
                       ToleratedDivergence.StaticPopulationsUnreflected ])
           Qa   = Tolerance.ofSet (Set.ofList
                     [ ToleratedDivergence.StaticPopulationsUnreflected ])

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="MatrixLadderTests.fs" />
     <Compile Include="ForeignKeyReadbackTests.fs" />
     <Compile Include="IndexRoundtripTests.fs" />
+    <Compile Include="ReferenceConstraintStateTests.fs" />
     <Compile Include="StaticSeedsEmitterTests.fs" />
     <Compile Include="StaticSeedsRemapTests.fs" />
     <Compile Include="MigrationDependenciesEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -82,6 +82,7 @@
     <Compile Include="ScriptDomRoundTripTests.fs" />
     <Compile Include="TypesTests.fs" />
     <Compile Include="ToleranceTests.fs" />
+    <Compile Include="MatrixLadderTests.fs" />
     <Compile Include="StaticSeedsEmitterTests.fs" />
     <Compile Include="StaticSeedsRemapTests.fs" />
     <Compile Include="MigrationDependenciesEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="TypesTests.fs" />
     <Compile Include="ToleranceTests.fs" />
     <Compile Include="MatrixLadderTests.fs" />
+    <Compile Include="ForeignKeyReadbackTests.fs" />
     <Compile Include="StaticSeedsEmitterTests.fs" />
     <Compile Include="StaticSeedsRemapTests.fs" />
     <Compile Include="MigrationDependenciesEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="ToleranceTests.fs" />
     <Compile Include="MatrixLadderTests.fs" />
     <Compile Include="ForeignKeyReadbackTests.fs" />
+    <Compile Include="IndexRoundtripTests.fs" />
     <Compile Include="StaticSeedsEmitterTests.fs" />
     <Compile Include="StaticSeedsRemapTests.fs" />
     <Compile Include="MigrationDependenciesEmitterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReferenceConstraintStateTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReferenceConstraintStateTests.fs
@@ -1,0 +1,57 @@
+module Projection.Tests.ReferenceConstraintStateTests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open Projection.Core
+
+// ---------------------------------------------------------------------------
+// G14 — the Reference constraint-state guard. Trust is only meaningful when a
+// DB constraint exists: `¬IsConstraintTrusted ⟹ HasDbConstraint`. The illegal
+// quadrant `(HasDbConstraint=false ∧ IsConstraintTrusted=false)` — an untrusted
+// (WITH NOCHECK) reference with no constraint to NOCHECK — is normalized away by
+// `Reference.withConstraintState`, the sanctioned setter every external-evidence
+// producer (V1 rowset, ReadSide) routes through. These tests pin the guard +
+// prove the illegal quadrant is unreachable in practice.
+// ---------------------------------------------------------------------------
+
+let private baseRef : Reference =
+    let key s = SsKey.synthesized "OS_G14" s |> Result.value
+    Reference.create (key "ref") (Name.create "FK_X" |> Result.value) (key "src") (key "tgt")
+
+[<Fact>]
+let ``G14: Reference.create default is constraint-state consistent`` () =
+    Assert.True(Reference.isConstraintStateConsistent baseRef)
+
+[<Fact>]
+let ``G14: the illegal quadrant (no constraint, untrusted) normalizes to vacuous-trust`` () =
+    // The discriminating case: untrusted WITHOUT a DB constraint is illegal; the
+    // guard canonicalizes it to (no constraint, trusted) rather than leaving a
+    // NOCHECK marker on a non-existent constraint.
+    let r = baseRef |> Reference.withConstraintState false false
+    Assert.False(r.HasDbConstraint)
+    Assert.True(r.IsConstraintTrusted)
+    Assert.True(Reference.isConstraintStateConsistent r)
+
+[<Fact>]
+let ``G14: a real untrusted (NOCHECK) constraint is preserved`` () =
+    let r = baseRef |> Reference.withConstraintState true false
+    Assert.True(r.HasDbConstraint)
+    Assert.False(r.IsConstraintTrusted)
+    Assert.True(Reference.isConstraintStateConsistent r)
+
+[<Fact>]
+let ``G14: a real trusted constraint is preserved`` () =
+    let r = baseRef |> Reference.withConstraintState true true
+    Assert.True(r.HasDbConstraint && r.IsConstraintTrusted)
+    Assert.True(Reference.isConstraintStateConsistent r)
+
+[<Property>]
+let ``G14: withConstraintState always yields a consistent reference`` (hasDb: bool) (trusted: bool) =
+    baseRef |> Reference.withConstraintState hasDb trusted |> Reference.isConstraintStateConsistent
+
+[<Property>]
+let ``G14: withConstraintState is idempotent`` (hasDb: bool) (trusted: bool) =
+    let once = baseRef |> Reference.withConstraintState hasDb trusted
+    let twice = once |> Reference.withConstraintState once.HasDbConstraint once.IsConstraintTrusted
+    once = twice

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -181,7 +181,7 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
         match variant with
         | ToleratedDivergence.HeaderCommentsOmitted        -> ()
         | ToleratedDivergence.PostDeployForeignKeysSplit   -> ()
-        | ToleratedDivergence.IndexesUnreflected           -> ()
+        | ToleratedDivergence.IndexOptionsUnreflected           -> ()
         | ToleratedDivergence.StaticPopulationsUnreflected -> ()
         | ToleratedDivergence.EmptyTextNormalizedToNull    -> ()
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> ()

--- a/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
@@ -33,7 +33,7 @@ type ToleratedDivergenceGen =
             [
                 ToleratedDivergence.HeaderCommentsOmitted
                 ToleratedDivergence.PostDeployForeignKeysSplit
-                ToleratedDivergence.IndexesUnreflected
+                ToleratedDivergence.IndexOptionsUnreflected
                 ToleratedDivergence.StaticPopulationsUnreflected
                 ToleratedDivergence.EmptyTextNormalizedToNull
                 ToleratedDivergence.CharAnsiPaddingTolerated
@@ -77,7 +77,7 @@ let ``Closed-DU coverage: ToleratedDivergence.allKnown contains seven variants (
 
 [<Fact>]
 let ``Tolerance.ofSet round-trips through divergences`` () =
-    let s = Set.ofList [ ToleratedDivergence.HeaderCommentsOmitted; ToleratedDivergence.IndexesUnreflected ]
+    let s = Set.ofList [ ToleratedDivergence.HeaderCommentsOmitted; ToleratedDivergence.IndexOptionsUnreflected ]
     let t = Tolerance.ofSet s
     Assert.Equal<Set<ToleratedDivergence>> (s, Tolerance.divergences t)
 
@@ -85,7 +85,7 @@ let ``Tolerance.ofSet round-trips through divergences`` () =
 let ``Tolerance.withDivergence on strict yields a singleton tolerance`` () =
     let t = Tolerance.strict |> Tolerance.withDivergence ToleratedDivergence.HeaderCommentsOmitted
     Assert.True (Tolerance.tolerates ToleratedDivergence.HeaderCommentsOmitted t)
-    Assert.False (Tolerance.tolerates ToleratedDivergence.IndexesUnreflected t)
+    Assert.False (Tolerance.tolerates ToleratedDivergence.IndexOptionsUnreflected t)
     Assert.Equal (1, Set.count (Tolerance.divergences t))
 
 [<Fact>]
@@ -160,9 +160,9 @@ let ``3.4: empty config parses to strict (safe default); blank tokens are skippe
     match Tolerance.parse [] with
     | Ok t -> Assert.True(Tolerance.isStrict t)
     | Error e -> Assert.Fail(sprintf "%A" e)
-    match Tolerance.parse [ "  "; "IndexesUnreflected"; "" ] with
+    match Tolerance.parse [ "  "; "IndexOptionsUnreflected"; "" ] with
     | Ok t ->
-        Assert.True(Tolerance.tolerates ToleratedDivergence.IndexesUnreflected t)
+        Assert.True(Tolerance.tolerates ToleratedDivergence.IndexOptionsUnreflected t)
         Assert.Equal(1, Set.count (Tolerance.divergences t))
     | Error e -> Assert.Fail(sprintf "%A" e)
 


### PR DESCRIPTION
D1 — `scripts/matrix-status.sh` now derives the per-axis round-trip ladder and
writes it to `NORTH_STAR.matrix.generated.md`:
  - L1 from round-trip witness presence (as before),
  - L2 from `Tolerance.fs`'s new machine-readable `@ladder <Variant> <Axis>
    <Disposition>` tags — an `OpenGap` variant caps its axis at L2-partial and is
    named (Schema reports `IndexesUnreflected`); `AcceptedFaithful` variants do not,
  - L3 from `migrate A B` witness presence.
The generator cross-checks that every live `ToleratedDivergence` (per the `name`
single-source-of-truth) carries exactly one tag (exit 3 on drift) and is now
byte-deterministic (dropped the wall-clock stamp, per T1) so a `git diff` on the
artifact is a true coverage shift. Honesty mechanism: retiring an `OpenGap`
variant auto-flips its axis — L2 cannot be hand-marked.

D2 — wired the gates into CI (`.github/workflows/verifiability-projection.yml`):
verifiability-gate.sh (no phantom Bucket-A/B) + a matrix-currency diff gate
(stale/​untagged → red). Pure bash, no dotnet.

Witnesses: `tests/Projection.Tests/MatrixLadderTests.fs` (3, green) — Schema
L2-partial names IndexesUnreflected; Data reaches L3 (discriminating control);
open-gap count pinned to 1. Full fast pool green (2782 passed). Closes debrief
G13; EXECUTION_PLAN 6.E.1 LANDED. E1 retiring IndexesUnreflected will now flip
Schema to L3 automatically — the matrix measures the rest of the climb.

https://claude.ai/code/session_01WFudwkmeJA5U2p2AF3N24M