### PR TITLE
Add code-verified CONFIRMED_BACKLOG (2026-06-09)

### DIFF
--- a/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
+++ b/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
@@ -18,7 +18,7 @@ A two-wave parallel-agent execution slice landed on branch
 changes behavior-preserving / additive; full pure pool **2943 passed / 0
 failed**; each commit SSH-signed.
 
-**SHIPPED (10 items):**
+**SHIPPED (16 items):**
 - **B5** `ChannelDiff<'change>` unifies the 4 channel-diff records (alias-contained) — `1a4ad1b`.
 - **B2** `LineageDiagnostics.touchedEpilogue` combinator, 5 analytics passes — `c1dc7ad`. *(3 passes intentionally excluded: different return shape / conditional emission.)*
 - **B7** `Deploy.fs` decomposed into `DockerDaemon.fs` / `DatabaseNameGenerator.fs` / `DeployConnectionString.fs` + facade (1531→1315 LOC) — `90d9bee`.
@@ -33,15 +33,17 @@ failed**; each commit SSH-signed.
 - **A7** `ModuleFilter` gets its first production caller (`ModuleFilterBinding.fromConfig` applied in `Pipeline.readConfigModel`) — `a317c07`.
 - **D3** setup probe surfaces full grant set (INSERT/CREATE/DELETE/ALTER), not just `alterGranted` — `a317c07`.
 - **D4** `--from empty` genesis-force (`MigrationRun.previewFromStoreForcing`) — `a317c07`.
+- **A1** transfer refusal exit single-sourced through `Preflight.refusalOf` — `24c956b`. *Decision: exit 3 was the latent bug (`classify` already maps `cdcTrackedSink → 9`, the integrity-refusal class); routing the refusal arm through the seam makes it 9, all other codes byte-identical. The successful-with-drops branch untouched.*
+- **A5** rename-aware migrate-with-data — `38be8f5`. *Decision: data source is at schema A; `executeWithData`/`executeWithDataAndRecord` now route the data leg through `Transfer.runWithRenames`/`runReconcilingWithRenames` (`sourceContract = A`, `sinkContract = B`, renameMap from `CatalogDiff.between A B`). Empty rename map ⇒ identity repoint ⇒ byte-identical straight load. One pre-existing `executeWithData` canary was re-staged from B→A to match the settled premise; MigrationCanary 20/20 green on the integrated tree.*
 
 **RESOLVED-as-decision (operator, this session):**
 - **B4** retry → **DEFERRED**. The "exception leak" premise was stale (already caught by `ReadSide.read`'s outer try/with); only the retry gap remains. Adding retry needs a structural home for the primitive (`Retry.fs` is in `Adapters.OssysSql`; `Adapters.Sql` refs only `Core`). Re-open under a real transient-failure incident.
 - **A4** cross-schema FK diagnostic → **CLOSED on substance**. The `Unreadable` reason is named, classified, unit-tested (not silent); the stderr-vs-structured-channel detail isn't worth rippling `read`'s return shape into 4 consumers.
 
-**STILL OPEN — surfaced as semantic forks the CLI agent refused to guess (need an operator decision):**
-- **A1** single-source the transfer exit map via `Preflight.classify`. **Divergence found:** `runTransfer` hand-derives `transfer.cdcTrackedSink → exit 3`, but `classify` returns **exit 9** (`CdcTrackedSink`). Reverted to preserve current behavior. *Decide:* is exit 3 a latent bug (then route through `classify`, exit→9) or intended (leave the hand-derivation)?
-- **A5** rename-aware migrate-with-data. **Fork:** `executeWithData` assumes the data source is already at contract **B**; `runWithRenames` re-points an A→B map and is correct only if the source is at **A**. Unconditional wiring would double-apply renames. *Decide:* in Dev→UAT migrate-with-data, is the data source at old schema A or already at B (or either → needs a flag)?
-- **A7 polarity (flagged, not blocking):** `model.includeSystemModules/includeInactiveModules` default `false` while `ModuleFilter.empty` identity is `true`. The agent made filtering opt-in (effective only alongside a non-empty `model.modules`) to keep defaults byte-identical. *Decide later* if you want the flags to act globally with no `modules` named (a deliberate default-behavior change).
+**STILL OPEN — flagged for a later operator decision (not blocking):**
+- **A7 polarity:** `model.includeSystemModules/includeInactiveModules` default `false` while `ModuleFilter.empty` identity is `true`. The agent made filtering opt-in (effective only alongside a non-empty `model.modules`) to keep defaults byte-identical. *Decide later* if you want the flags to act globally with no `modules` named (a deliberate default-behavior change).
+
+*(A1 and A5 — previously the two open semantic forks — were decided and shipped this session; see the SHIPPED list above.)*
 
 Remaining backlog after this slice: the un-shipped Cluster-B/§E/§F items below (e.g. `Emitter.perKind` is done; **B8** binding-resolution dedup, **B9** IRBuilders α′ tail, the speculative §E/§F, the §C modeling decisions) plus A1/A5 above.
 

--- a/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
+++ b/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
@@ -1,0 +1,239 @@
+# CONFIRMED BACKLOG — V2 Projection Sidecar (2026-06-09)
+
+**Purpose.** A single, code-verified ledger of what is *actually still open* in
+`/sidecar/projection`, distilled from a full sweep of the documentation corpus
+(~125 markdown files) and then **confirmed against the live `src/` + `tests/`
+code**. It exists because the planning/audit/ontology docs are substantially
+**stale**: the large majority of items they describe as open/missing/partial
+have since shipped, often under different names than the docs use. Future
+sessions should treat *this* file as the starting point for "what's left," and
+treat the older docs as framing/provenance, not status.
+
+**Method.** Two passes. Pass 1 fanned out across the doc corpus and compiled a
+~185-item candidate superset. Pass 2 dispatched per-cluster confirmation agents
+that read the actual code under an explicit anti-false-positive discipline
+(treat "couldn't find it" as inconclusive; a dedicated `FooTests.fs` is strong
+evidence `Foo` ships; distinguish "exists but not wired" from "absent"; cite
+`file:line`). Verdict vocabulary below: **OPEN** (absent), **PARTIAL** (built,
+not fully wired/adopted), **CLOSED-stale** (doc said open; code says shipped),
+**DEFERRED** (absent by design, with a codified trigger), **OUT-OF-CORPUS**
+(belongs to the V1 C# trunk at `/home/user/outsystems-ddl-exporter/src/`, not
+this V2 subtree).
+
+**Headline.** Of ~185 candidates, the confirmed real backlog is ~30 items,
+dominated by (B) refactor/duplication debt and (A/D) small wiring + terminal-UX
+gaps. Every audit "CRITICAL"/"HIGH" data-plane and lifecycle finding (silent
+row-drop, no migrate-orchestrator, no pre-flight, transactional/resumable,
+SsKey-rename, CDC, eject/drift/wipe-and-load, episode-record, CatalogDiff
+widening, ReadSide un-hollow) verified **CLOSED**.
+
+Line numbers below were re-read at HEAD `105d8ec`; doc-cited line numbers from
+older revisions are unreliable and were discarded.
+
+---
+
+## A. Wiring gaps — capability built & tested, not reachable from a production path
+*Highest value-per-effort: the hard work is done; only the last connection is missing.*
+
+| # | Item | Verdict | Evidence |
+|---|------|---------|----------|
+| A1 | **`Preflight.all` / `allReporting` unwired** | OPEN | Aggregate gate + total `classify` `code→(exit,label)` map exist (`Preflight.fs:364,494`, map `:439`) with **zero production callers** (only `PreflightAllTests.fs:90,94`). Every verb hand-chains gates (`TransferRun.spanningPreflight:416`, `Program.migratePreflights:1382`) and the CLI re-derives exit codes by hand (`Program.fs:781-789`), duplicating what `classify` already supplies. |
+| A2 | **Resumable transfer not CLI-exposed** | PARTIAL | `Transfer.runResumable` (`TransferRun.fs:656`) + `writePlanResumable` (`:283`) with durable phase-marker table `__projection_transfer_progress` is built and Docker-canary-witnessed (`MigrationCanaryTests.fs:630` "AC-G10 … resumable transfer recovers a partial prior attempt with no duplicate rows"). Gap: production `transfer` routes through `runThroughConnectionsWithEmission` (`Program.fs:751`) with `WriteOptions.Resumable=false`; no `--resumable` flag selects `runResumable`. (By design it is phase-tracked, not single-transaction — `Preflight.fs:344-356`.) |
+| A3 | **Scoped delete arm not emitted (AC-D7/G4)** | PARTIAL | `WHEN NOT MATCHED BY SOURCE … THEN DELETE` + `DeleteScope` gate fully built and tested (`ScriptDomBuild.fs:694-922`, `WithDiagnosticsBuildersTests.fs:116-149`), but every production emitter hardcodes `DeleteScope = None` (`StaticSeedsEmitter.fs:188`, `MigrationDependenciesEmitter.fs:225`). Capability exists; no live emission path passes a scope. |
+| A4 | **Cross-schema FK diagnostic via stderr, not structured channel (E2/G4)** | minor / PARTIAL | No longer the doc's "CRITICAL silent gap": `ReadSide.ForeignKeyReadback.classify` returns `Unreadable of reason` for a NULL `SCHEMA_NAME()` (dropped schema / missing VIEW DEFINITION grant), named & unit-tested (`ForeignKeyReadbackTests.fs`). Both readback paths invoke it (`ReadSide.fs:~648,~1495`). Residual: surfaced via `eprintfn` to **stderr** (`:661,:1508`), not threaded into the structured `Diagnostics`/`Result` channel. CLOSED on the no-silent-drop axiom; PARTIAL only if "named diagnostic" must mean a structured entry. |
+| A5 | **Rename-aware migrate-with-data not wired** | PARTIAL | `TransferRun.runWithRenames` (`:782`) builds a `renameMap` from the A→B `CatalogDiff` and repoints rows (`RenameProjection.repointRows`), but is **not called** from the migrate-with-data CLI path (`runMigrateWithData`, `Program.fs:1544`, which wires `--reconcile`/`--user-map` only). Rename flow exists in the pipeline; the CLI combination is the gap. |
+| A6 | **`diff <runA> <runB>` only as `explain diff`, not a top-level verb** | PARTIAL | Run-vs-run diff fully built: `runDiff` (`Program.fs:1034`) resolves both operands via `Ref` incl. `@runId` (`Ref.fs:53-62`), renders via `Comparison.renderCatalogChange`. Wired as `explain diff <a> <b>` (`MovementSurface.fs:419`), not a top-level `diff` verb (absent from `parse`, `MovementSurface.fs:596-619`). |
+| A7 | **Entity/module filter not wired (`ModuleFilter`)** | PARTIAL | `ModuleFilter.apply` — module include-list + system/inactive filtering + **per-module entity filtering** (`EntityFilters : Map<string, ModuleEntityFilter>`, `ModuleEntityFilter.matches`/`missingNames`, structured `moduleFilter.entities.missing` error) — is fully built (`ModuleFilter.fs`, 437 LOC) and unit-tested (`ModuleFilterTests.fs`, incl. entity-filter cases). **Zero production callers**: only refs in `src/` outside its own file are comment citations in `MetadataContractOverrides.fs`. `Config.fs` carries `IncludeSystemModules` (`:63`) but never constructs/applies `ModuleFilterOptions`; no config field for module-selection or entity filters. Capability exists, unreachable from CLI/config. |
+
+---
+
+## B. Refactor / duplication debt — largest genuinely-open cluster
+*Survived the 2026-06-04 audit cleanup. Counts are the confirmation agent's own re-count at HEAD, which sometimes exceeds the audit's figures.*
+
+| # | Item | Verdict | Evidence (own count) |
+|---|------|---------|----------------------|
+| B1 | **`Emitter.perKind` combinator absent** | OPEN | No `perKind`/`ofKinds` in `ArtifactByKind.fs` (only `create`/`toMap`/`tryFind`/`keys`). The `allKinds |> List.map (k -> k.SsKey, render k) |> Map.ofList |> ArtifactByKind.create` shape is hand-rolled in **7** emitters: `JsonEmitter.fs:184`, `DistributionsEmitter.fs:215`, `RefactorLogEmitter.fs:333`, `SsdtDdlEmitter.fs:713`, `DecisionLogEmitter.fs:127`, `StaticPopulationEmitter.fs:129`, `ManifestEmitter.fs:378`. |
+| B2 | **Analytics-pass epilogue hand-rolled** | OPEN | The `Touched`-event map + `lineageDiagnostics { writeLineages; writeDiagnostic; return }` tail repeats identically in **8** passes (`grep "TransformKind = Touched"` in `Passes/`): Centrality `:156`, SchemaComplexity `:148`, BoundedContext `:184`, ProfileAnomaly `:135`, QueryHint `:93`, CanonicalizeIdentity, NormalizeStaticPopulations, TopologicalOrderPass `:411`. No shared epilogue combinator. |
+| B3 | **ReadSide materialize/drain loop** | OPEN | **17** identical `let! more = reader.ReadAsync()` drain loops in `ReadSide.fs` (e.g. `:254,306,345,382,416,444,475,517,554…`), each a hand-rolled `while hasMore` block. No `readAll`/`foldReader`/`drainReader`. (ReadSide-only; `LiveProfiler.fs` has 0 — it uses the EvidenceCache discovery path.) |
+| B4 | **ReadSide/LiveProfiler retry gap + exception leak** | OPEN | `Retry.fs` (Polly) is consumed **only** by `MetadataSnapshotRunner.fs`; `ReadSide.fs`/`LiveProfiler.fs` have zero `Retry`/`Polly`/`ResiliencePipeline` refs. ReadSide's `readXxx` return raw `Task<list/Map>` (e.g. `:239,292,365`), not `Task<Result<_>>` → exceptions propagate unwrapped. Both the retry gap and the leak are real. |
+| B5 | **`CatalogDiff` C1 channel records** | OPEN | 4 structurally-identical records in `CatalogDiff.fs` — `AttributeDiff` (`:60`), `ReferenceDiff` (`:104`), `IndexDiff` (`:135`), `SequenceDiff` (`:166`): each `{ Added; Removed; Renamed; Changed: XChange list }`, identical but for the `Changed` element type. Candidate for a `ChannelDiff<'facet>` (see also AR2). |
+| B6 | **Test-fixture dedup** | OPEN | Central `Fixtures.fs` defines `mustOk` as `let private` (`:25`) — unshareable. Across `tests/`: **64** local `mustOk`, **31** `mkKey`, ~44 `mkName` redefinitions. Helpers exist centrally but private and unadopted. |
+| B7 | **`Deploy.fs` decomposition (ACTIONABLES R2)** | OPEN | `Deploy.fs` is **1530 LOC** today (grew from the doc's 1470); only 3 small nested submodules (`Docker:76`, `DatabaseNameGenerator:278`, `ConnectionString:343`). The 5-module split never shipped. |
+| B8 | **`*Binding` catalog resolution** | PARTIAL | `CatalogResolution.fs` holds only `tryKindByLogical` (2 consumers: `EmissionFoldersBinding:150`, `SpecialCircumstancesBinding:63`), each still wrapping it per-file. The physical-table lookup (`SpecialCircumstancesBinding.resolveKindByPhysicalTable:81`) and attribute-ref lookup (`TighteningBinding.resolveAttributeRef:36`) are not centralized. ~2 lookup shapes remain. |
+| B9 | **IRBuilders Kind/Module/Catalog sweep tail (ch 4.8/4.9 slice α′)** | PARTIAL | 13 files / ~70 sites migrated at slice α; **19 files deferred** (slice α′) on an F# offside-rule tooling blocker. `IRBuilders.fs` now holds only `mkModule`+`mkCatalog`; ~30 test files still hand-build raw `Kind` record literals. Trigger codified at `CHAPTER_4_8_CLOSE.md:125` (indentation-preserving Python pass). Quantified tooling deferral, not a functional gap. |
+
+**Verified NOT debt (false-symmetry traps / already done — do not re-open):**
+`*Diagnostics`→`DiagnosticRule` registry merge (N3: FK/Joint diverge on ratio &
+threshold direction — merging miscompiles one); `MigrationRun` "2^N execute*
+explosion" (actually one `execute` core + decorators — `:498,526,556,579,627`);
+dead-algebra deletion (`LineageTree`/`Prism`/`PassContext`/`Pass.product` all
+gone — remaining grep hits are TLS/bitwise/comments); FSHARP-LOW point-free /
+`Static.fs` bind-ladder (Policy `>>` replaced by `matchById` `Policy.fs:691`;
+`Static.fs`→`NormalizeStaticPopulations.fs` is a clean exhaustive `match`);
+`CatalogReader` God-file (decomposed to 168-LOC facade); `optInt` +
+`CatalogResolution.tryKindByLogical` (extracted). The 8 periphery-adversarial
+traps N1–N8 remain DO-NOT-ATTEMPT.
+
+---
+
+## C. Identity / data-fidelity residuals — all minor, none silent bugs
+
+| # | Item | Verdict | Evidence |
+|---|------|---------|----------|
+| C1 | **IDENTITY seed/increment hardcoded `(1,1)`** | OPEN (by design) | `Attribute.IsIdentity : bool` carries only the boolean (`Catalog.fs:468`, docstring: seed/increment deferred — always emit `IDENTITY(1,1)`); emitter hardcodes (1,1) (`ScriptDomBuild.fs:371-379`). Matches OutSystems convention; accepted low-severity limitation. ("Composite IDENTITY one leg" is moot — IDENTITY is a single per-column bool.) |
+| C2 | **Empty-string ↔ NULL conflation** | OPEN (named tolerance) | Real & live: `ReadSide.formatRawValue` maps `DBNull`→`""` (`:790`) and `SqlLiteral.ofRaw` maps `""`→`NullLit` (`SqlLiteral.fs:75`). Captured as `ToleratedDivergence.EmptyTextNormalizedToNull` (`Tolerance.fs:85`) with retirement trigger ("needs a read-side sentinel; no fixture forces faithful preservation"). Documented + witnessed, not silent. |
+| C3 | **`TighteningIntervention.id : string`** | OPEN | Every variant carries a raw `id: string` (`Policy.fs:244,249,254,262`); accessor returns `string` (`:628`). Not lifted to a typed VO (the `SchemaName`/`TableName`/`ColumnName` VOs *are* now cashed across 15–20 files each / 136 unwrap sites — that half of the FSHARP claim is stale). |
+| C4 | **`Reference` boolean-tuple collapse** | OPEN (deliberate deferral) | `Index.Uniqueness` collapsed to a 3-state DU (`Catalog.fs:789`) and `ApprovalState` collapsed; `Reference` still carries raw bools `IsUserFk`/`HasDbConstraint`/`IsConstraintTrusted` (`Catalog.fs:587,600,620`). FSHARP audit explicitly deferred Reference to "its own modeling slice." |
+
+---
+
+## D. Terminal-UX / instrument polish
+*Voice "6 waves unwired" was a false alarm — the 2026-06-09 close doc matches the code (gates routed via `renderGate`→`classify`→`gateSurface`; no `%A`/shout-leads on live paths; catalog-diff/lifecycle/move surfaces all called). Open items are exactly the residuals that close doc honestly names, plus a few CLI affordances.*
+
+| # | Item | Verdict | Evidence |
+|---|------|---------|----------|
+| D1 | **Watch board footer + done-frame** | OPEN | `Watch.toRenderable` (`Watch.fs:231`) renders stage `Rows` only — no run-title header, no "→ verification follows" / "recorded as run N" footer (grep: zero hits). |
+| D2 | **Ladder "one lever" honest blocking-item display** (instrument slice 7) | OPEN | `buildReadinessView` (`TtyRenderer.fs:88`) shows "X green run(s) to go" but no single blocking-item source; no in-terminal ladder Surface with the lever. (`MatrixLadderTests` covers the `matrix-status.sh` generator, a different artifact.) |
+| D3 | **Setup live-probe breadth** | OPEN | `buildSetupView` (`TtyRenderer.fs:139`) probes reachability + ALTER only; INSERT/CREATE-TABLE grants not surfaced (they exist in `GrantEvidence` if a consumer wants them). |
+| D4 | **`--from empty` genesis-force flag** | OPEN | No `--from empty`. `--fresh` sets `Baseline.Empty` (`MovementSurface.fs:502`) but `planMovement` emits a no-silent-drop note that baseline is auto-derived, not honored (`:287`). Genesis in `MigrationRun.previewFromStore` is automatic only when the store is absent (`:182`); no flag forces genesis when a store exists. |
+| D5 | **`inspect <runId>` TUI / Explore navigator** (instrument slice 6; Dynamic-display Explore leg) | OPEN | No `inspect` verb / `Intent.Inspect` (`MovementSurface.fs:590` `secondaryVerbs` lacks it). `DYNAMIC_DISPLAY.md §2` itself names Explore/`inspect` as the unbuilt TUI leg. (Glance + Watch live legs *are* shipped — `renderWatch` wired at 6 sites.) |
+| D6 | **Instrument Timeline (slice 5)** | PARTIAL | No `Timeline`/`Lattice` node in the `View` DU (`View.fs:26-60`). §8 timeline-in-words exists (`View.Dots`+Note, `TtyRenderer.fs:95`) but not the dedicated Timeline/lattice slice. |
+| D7 | **Instrument User-map walkable Surface (slice 9)** | PARTIAL | Re-key flow + validate-user-map gate are wired into migrate/transfer (`Program.fs:677-784,1544+`); no walkable `Surface` specialization for the user map. |
+| D8 | **`--data synthetic --rows N` knob** | minor | Synthetic-data generation is wired (`parseFlowSource "synthetic"`→`SynthesizeAndLoad`→`SyntheticLoadRun.run`→`Transfer.runSynthetic`); the config-driven form is CLOSED. Missing only the `--rows N` knob (seed is a fixed literal, `SyntheticLoadRun.fs:24`). |
+
+---
+
+## E. HORIZON — genuinely not implemented (mostly speculative-by-design)
+*HORIZON.md's own `PROPOSED`/`SHIPPED` markers are unreliable; verified against code. Confirmed CLOSED despite "PROPOSED" markers: H-030 Faker, H-043 first-class diff, H-047 v1↔v2 registry audit (`RegisteredAllTransformsBidirectionalTests`), H-049 digest stability (`RegistryDigestRoundTripTests`), H-058 ReadSide reconstruction, H-059 `report` verb.*
+
+**Confirmed OPEN (absent in code):**
+- **Schema algebra / lifecycle:** H-007 SchemaDelta type, H-042 Catalog union/intersect/subtract, H-044 schema versioning/history, H-045 pass dependency graph (order is implicit in `chainSteps`), H-046 pass idempotence verification, H-023 coverage-gap tracking (`EmissionGap`), H-048 manifest external verifiability / `verify` verb (`RegistryDigest` exists in the manifest but no standalone re-derivation tool).
+- **Deferred-stub (trigger unfired, by design):** H-012 active patterns for SsKey (accessor surface is the abstraction), H-013 units-of-measure on Profile, H-014 phantom pipeline-stage types, H-017 profile inference passes.
+- **Speculative deep-categorical (all Skip stubs in `AxiomTests.fs:1184-1245`):** H-061 profunctor, H-063 free monad, H-064 colimits, H-065 Yoneda, H-066 parser CE, H-067 SRTP, H-068 measure-poly, H-069 SqlIdentifier VO, H-070 refinement-types, H-074 functional-dependency detection, H-077 time-series profiling.
+- **External-target emitters (none exist under `Targets.*`):** H-078 EF, H-079 dbt, H-080 Liquibase, H-081 OpenAPI/JSON-Schema, H-082 GraphQL, H-083 Data Vault, H-084 Flyway.
+
+---
+
+## F. PERF — optimizations not yet applied (low-leverage, non-blocking by design)
+*"CONFIRMED-OPEN" here just means "optimization not yet applied"; all are explicitly low-leverage. The 51-label perf canary is CLOSED — `ComprehensiveCanaryTests.fs` enumerates all 51 labels and asserts ≥45 fire (doc's "~6 labels" is stale; PERF doc confirms 65/65).*
+
+| Item | Verdict | Evidence |
+|------|---------|----------|
+| `SsdtDdlEmitter` schema-side topological-level grouping | OPEN | `statementsWith` emits a flat topo stream (`order : SsKey list`, `:778`); no per-level grouping (data-side got `composeRenderedLeveled`, schema-side did not). |
+| A4 `parseRowsetBundle` sequential `Map.ofList` | OPEN | Relocated to `OssysRowsetReader.fs:665`; ~13 sequential `List.groupBy >> Map.ofList`, not `Array.Parallel`. |
+| C8 `schemaObjectFromTableId` allocation | OPEN (structural floor) | `ScriptDomBuild.fs:95-98` allocates a fresh `SchemaObjectName` per call; documented as irreducible (typed-AST per-fragment isolation). |
+| D5 `Catalog.create` triple-walk | PARTIAL | D4's dup-Set + ref/index double-walk folded (Wave-0 slice 0.4, `Catalog.fs:1521-1536`); D5's top-level triple-walk over `allKindList` (`:1508,1510,1518`) remains 3 passes. |
+| E3 `TopologicalOrderPass` O(\|scc\|²) | OPEN | `internalEdgesOf` still nested `for a … for b …` (`TopologicalOrderPass.fs:328`); conditional on real SCC sizes. |
+
+---
+
+## G. Deferred-by-design (codified triggers — not bugs, not scheduled)
+- **DACPAC byte-determinism cash-out** (post-hoc `Origin.xml` canonicalization). `DacpacEmitter` returns raw DacFx bytes; header + tests assert content-equality only, byte-equality explicitly does NOT hold (`DacpacEmitterTests.fs:30,130`). Slice ζ deferred per `CHAPTER_3_X_CLOSE.md:5,74`; trigger = a snapshot consumer requiring byte-stable artifacts.
+- **Modality marks → extended properties / comments** (slice ε). `ModalityMark` emits only as diagnostics + JSON-manifest flags; `TenantScoped`/`SoftDeletable`/`SystemOwned` not projected into SQL. Deferred per `CHAPTER_3_X_CLOSE.md:152`; trigger = downstream consumer demanding structured modality access. (`Temporal`→PERIOD FOR SYSTEM_TIME *is* emitted.)
+- **Hex ports `IArtifactSink` / `IDeployHost`.** Neither interface exists; absent-until-consumer-demand, consistent with the codebase's "object expressions land when the abstraction lands" posture.
+- **`osm_model.json` retirement.** As of 2026-06-08 live OSSYS is primary and `osm_model.json` is demoted to optional fallback — explicitly NOT retired (`V1_INPUT_DEPRECATION.md`); 10 V2 src files still read it; retirement gated on N consecutive green differential runs + operator sign-off (R6 ladder).
+- **`UserRemapContext` → `SurrogateRemapContext` subsumption.** Both exist; bridged via one-directional `UserRemapContext.toSurrogate` (`UserRemap.fs:169`, consumed by `MigrationDependenciesEmitter.fs:403`) — a consumption-layer bridge, not a planned full type-merge. The typed User surface (email/SsKey diagnostics) intentionally stays distinct.
+
+---
+
+## H. OUT-OF-CORPUS (V1 C# trunk at `/home/user/outsystems-ddl-exporter/src/`)
+*Not assessable from this V2 subtree; V2 is self-contained with zero runtime dependency on V1.*
+- V1-soak debt: V1.1 EntityFilters wiring, V1.2 global topological sort for StaticSeeds, V1.3 DatabaseSnapshot dedup. **Note:** the V2 equivalents of V1.1 and V1.2 are *present* in V2 — entity filtering as `ModuleFilter` (built but unwired → see **A7**); topological sort as `TopologicalOrderPass`, applied **catalog-wide** across schema DDL + all data emission + transfer + parallel `levels` (CLOSED, not a backlog item). These V1.x rows pertain only to fixing the V1 C# trunk.
+- `DmmCompare` pipeline + DMM lens machinery; `LoadHarness` DMV instrumentation; V1 JSON-aggregation rowsets / `osm_model.json` emission path — all V1-trunk C#, sunset post-cutover+30.
+
+---
+
+## I. Confirmed CLOSED-stale (do not re-chase)
+*The bulk of the original candidate list. Recorded so future sessions don't re-investigate.*
+
+**Pre-flight / transfer integrity (all CLOSED-stale unless noted):** connection
+pre-flight (`Preflight.connectionPreflight:200`, wired `TransferRun:422`,
+`Program:1392/1607`); permission/grant pre-flight (`permissionPreflight:307`,
+`captureGrantEvidence:331`, `GrantEvidence:252`, wired `spanningPreflight:428`)
+— object-scope refinement survey-gated only; `transfer` silent row-drop → now
+exit-9 via `exitCodeForReport:962` (`TransferCanaryTests:428`); write-denied
+sink (= connection+permission pre-flight); validate-user-map **pre-write** halt
+(`validateUserMap:374`, wired `runCore:597`, `TransferRefusalTests:130`);
+NOT-NULL data-compat gate on execute (`tighteningPreflight`, wired
+`Program:1474`, `MigrationRun:435`); on-disk-bytes pre-flight (spec-equivalent —
+real `COUNT_BIG(... IS NULL)` probe `LiveProfiler.fs:169`).
+
+**CatalogDiff / ReadSide surface (all CLOSED):** C1 four-channel diff
+(kinds/attributes/references/indexes/sequences, `applyDiff` patches all);
+attribute-level changes + diff→ALTER (`SchemaMigrationEmitter.emitWith`, wired
+`MigrationRun.fs:127`); `CatalogDiff.compose` (consumers `Lifecycle.netDiff:194`,
+`Episode.netSchemaDiff:239`); refactorlog accumulate + real episode clock
+(`RefactorLogEmitter.accumulate:375`, `toRefactorLogXmlAt:165`,
+`RefactorLogAccumulateTests`); change-manifest full displacement
+(`ChangeManifest` `ToleranceResidual`+`AppliedTransforms` `:36,43`, consumers
+`ReportRun:28`, `Pipeline:1256`); `Kind.Indexes` via ReadSide
+(`readIndexes:496`, `attachIndexes:1282`; `Tolerance.IndexesUnreflected` **no
+longer exists** — narrowed to `IndexOptionsUnreflected`); FK-trust on readback
+(`is_not_trusted` read+set via `withConstraintState`, `ForeignKeyReadbackTests`);
+no-cheat round-trip across reference/index/sequence (`CatalogDiffTests` P1.4–P1.6).
+
+**Migrate / CDC / lifecycle (all CLOSED-stale):** migrate orchestrator threads
+rename→Transfer (`executeWithData`+`runWithRenames`+`repointRows`); wipe-and-load
+`EmissionMode` DU + live FK-ordered delete leg (`EmissionMode.fs`,
+`wipeFkOrdered` in `runCore:611`, CLI `--fresh`/`--replace`); CDC exact-count
+(`CdcMeasureTests` asserts `+1`/`+2`/`0`, not `>`); CDC-silence on redeploy
+(AC-X4/X8 assert zero ALTERs AND zero captures, meter proven live); episode
+record (`executeAndRecord`→`record`, wired `Program:1493/1654`); **eject** verb
+(`EjectRun.fs` complete + FTC self-verify, wired `projection seal --store`);
+**drift** (`DriftRun.detect` deployed-vs-model, wired `check drift`); full-export
+publish-with-changelog (`Pipeline.runWithConfigAndStore` accumulates refactorlog
++ ChangeManifest + episode).
+
+**Identity / data fidelity (CLOSED-stale):** SsKey synthesized-rename no longer
+silent (`synthesizedRenameWarnings` + `identity.synthesizedRenameUnstable` +
+V2.SsKey serialize/deserialize persisted as extended property & recovered on
+readback); extended-property round-trip (emit at SCHEMA/TABLE/COLUMN/INDEX +
+`ReadSide.readExtendedProperties:576`; `CommentMetadataUnreflected` retired);
+CHECK/NOCHECK trust (`untrustedFkAlters:349` two-step ALTER, readback of
+`is_not_trusted`); null-safe predicate across 8 SqlLiteral types
+(`CdcSilenceTests` Track D); computed-column exclusion from MERGE (`Computed =
+None` filter in both data emitters); representation tolerances
+(`CharAnsiPaddingTolerated`, `DecimalScaleTolerated`); Coordinate VOs now cashed
+across the IR.
+
+**Prescope / chapter / analyzer (CLOSED):** `AssignedBySink` realization wiring
+(`insertCaptureRow:106` per-row INSERT + `OUTPUT inserted.*`, wired into
+`writePlan` with topo-ordered remap; `TransferCanaryTests:736`); SnapshotRowsets
+members (isSystemEntity→SystemOwned, ColumnChecks, ColumnReality all parsed —
+only the OSSYS-*source* MetadataSnapshot reflection stays trigger-deferred);
+chapter A.4.7 slice η (`emit --skeleton-only` + `RegistryDigest` SHA256 +
+`RegistryDigestRoundTripTests`); Phase-8 custom analyzer
+(`NoUnsafeTimeInCoreAnalyzer.fs` — real CLI+Editor analyzer, 7 forbidden
+primitives, `Severity.Error`); Stage-2 typed VOs (defined + adopted across 28
+src files). **Voice waves 0–6** (gates/diff/lifecycle/move all wired per the
+2026-06-09 close doc). **Synthetic data** + **live Watch** + instrument slices
+1–4/8.
+
+**All `CHAPTER_*_OPEN.md` slices CLOSED by their `_CLOSE.md`:** 3.2, 3.5, 3.X
+(slices ε/ζ deferred-by-design), 4.1.A, 4.1.B, 4.2, 4.3 (δ/ε deferred), 4.4,
+4.5, 4.6, 4.7, 4.8 (α partial → B9), 4.9 (α′ partial → B9), 5.0, A.0′, A.4.7
+(η→A.4.7′), A.4.7′, B.3, B.4. **STAGING** S0.A–S0.L all shipped. **SLICE_D_***
+all shipped 2026-05-23 (only D.2.e ALTER-NOCHECK textual rework + formatter
+lineage-events deferred). **No-CLOSE-file ambiguous (unverified):** CHAPTER_3_6
+slices β–ε; CHAPTER_5 slices ν/θ (ν analyzer + θ Stage-2 VOs both verified
+shipped above).
+
+---
+
+## Suggested execution order
+1. **A (wiring gaps)** — highest value/effort. A1 (`Preflight.all`), A7
+   (`ModuleFilter`), A2 (`--resumable`), A3 (scoped delete), A5 (rename
+   migrate-with-data), A6 (`diff` verb), A4 (stderr→structured). Each is a
+   small connect-the-wire, mostly with the capability + tests already present.
+2. **B (refactor debt)** — B1/B2/B3 (combinator extractions, high duplication
+   payoff), then B6 (fixture dedup), B7 (`Deploy.fs` split), B5/B8/B9.
+3. **D (terminal UX)** — D1/D2/D3 are clean small slices the voice-close doc
+   already scoped.
+4. **C** — accept-or-model decisions (C1/C2 are documented tolerances; C3/C4
+   are typed-VO modeling slices when a consumer pushes).
+5. **E/F** — speculative/by-design; pull under a concrete consumer only.
+
+*Verification provenance: 8 parallel code-confirmation agents over `src/` +
+`tests/` at HEAD `105d8ec`, under an explicit anti-false-positive discipline,
+following a doc-corpus compilation pass. Re-confirm `file:line` anchors before
+acting — the tree moves.*

--- a/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
+++ b/sidecar/projection/CONFIRMED_BACKLOG_2026_06_09.md
@@ -9,6 +9,44 @@ have since shipped, often under different names than the docs use. Future
 sessions should treat *this* file as the starting point for "what's left," and
 treat the older docs as framing/provenance, not status.
 
+---
+
+## ⓪ Execution status — 2026-06-09 session (read this first)
+
+A two-wave parallel-agent execution slice landed on branch
+`claude/sidecar-projection-backlog-r1622k` (atop the backlog doc commit). All
+changes behavior-preserving / additive; full pure pool **2943 passed / 0
+failed**; each commit SSH-signed.
+
+**SHIPPED (10 items):**
+- **B5** `ChannelDiff<'change>` unifies the 4 channel-diff records (alias-contained) — `1a4ad1b`.
+- **B2** `LineageDiagnostics.touchedEpilogue` combinator, 5 analytics passes — `c1dc7ad`. *(3 passes intentionally excluded: different return shape / conditional emission.)*
+- **B7** `Deploy.fs` decomposed into `DockerDaemon.fs` / `DatabaseNameGenerator.fs` / `DeployConnectionString.fs` + facade (1531→1315 LOC) — `90d9bee`.
+- **B1** `ArtifactByKind.perKind`/`perKindBenched`, 9 emitter sites — `ac594ba`. *(Estimate was 7; `StaticPopulationEmitter`/`ManifestEmitter` were not actually `ArtifactByKind` sites.)*
+- **A3** delete-scope-ready data emitters (`DeleteScope option` threaded, default `None`, byte-identical) — `ac594ba`. *(Emitter side only; CLI exposure not yet wired.)*
+- **B3** `ReadSide.drainRows` combinator replaces 13 reader-drain loops — `0be4005`.
+- **D1** Watch done-frame + run-title header — `88e4dd0`.
+- **D2** Ladder "one lever" honest blocking-item — `88e4dd0`.
+- **B6** canonical `mkName` promoted to shared `Fixtures`, 24 local copies removed — `2a6f157`. *(`mustOk` ×64 / `mkKey` ×31 correctly LEFT — divergent error types / SsKey prefixes.)*
+- **A6** top-level `diff <a> <b>` verb (aliases `explain diff`) — `a317c07`.
+- **A2** `--resumable` flag → `Transfer.runResumable` (default off) — `a317c07`.
+- **A7** `ModuleFilter` gets its first production caller (`ModuleFilterBinding.fromConfig` applied in `Pipeline.readConfigModel`) — `a317c07`.
+- **D3** setup probe surfaces full grant set (INSERT/CREATE/DELETE/ALTER), not just `alterGranted` — `a317c07`.
+- **D4** `--from empty` genesis-force (`MigrationRun.previewFromStoreForcing`) — `a317c07`.
+
+**RESOLVED-as-decision (operator, this session):**
+- **B4** retry → **DEFERRED**. The "exception leak" premise was stale (already caught by `ReadSide.read`'s outer try/with); only the retry gap remains. Adding retry needs a structural home for the primitive (`Retry.fs` is in `Adapters.OssysSql`; `Adapters.Sql` refs only `Core`). Re-open under a real transient-failure incident.
+- **A4** cross-schema FK diagnostic → **CLOSED on substance**. The `Unreadable` reason is named, classified, unit-tested (not silent); the stderr-vs-structured-channel detail isn't worth rippling `read`'s return shape into 4 consumers.
+
+**STILL OPEN — surfaced as semantic forks the CLI agent refused to guess (need an operator decision):**
+- **A1** single-source the transfer exit map via `Preflight.classify`. **Divergence found:** `runTransfer` hand-derives `transfer.cdcTrackedSink → exit 3`, but `classify` returns **exit 9** (`CdcTrackedSink`). Reverted to preserve current behavior. *Decide:* is exit 3 a latent bug (then route through `classify`, exit→9) or intended (leave the hand-derivation)?
+- **A5** rename-aware migrate-with-data. **Fork:** `executeWithData` assumes the data source is already at contract **B**; `runWithRenames` re-points an A→B map and is correct only if the source is at **A**. Unconditional wiring would double-apply renames. *Decide:* in Dev→UAT migrate-with-data, is the data source at old schema A or already at B (or either → needs a flag)?
+- **A7 polarity (flagged, not blocking):** `model.includeSystemModules/includeInactiveModules` default `false` while `ModuleFilter.empty` identity is `true`. The agent made filtering opt-in (effective only alongside a non-empty `model.modules`) to keep defaults byte-identical. *Decide later* if you want the flags to act globally with no `modules` named (a deliberate default-behavior change).
+
+Remaining backlog after this slice: the un-shipped Cluster-B/§E/§F items below (e.g. `Emitter.perKind` is done; **B8** binding-resolution dedup, **B9** IRBuilders α′ tail, the speculative §E/§F, the §C modeling decisions) plus A1/A5 above.
+
+---
+
 **Method.** Two passes. Pass 1 fanned out across the doc corpus and compiled a
 ~185-item candidate superset. Pass 2 dispatched per-cluster confirmation agents
 that read the actual code under an explicit anti-false-positive discipline

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -235,6 +235,29 @@ module ReadSide =
             | :? byte as b -> Some (int b)
             | _ -> None
 
+    /// Drain a `SqlDataReader` cursor to EOF, invoking `onRow reader` for
+    /// every row the cursor advances over. The single concept the
+    /// ~17 hand-rolled `while hasMore do let! more = reader.ReadAsync() ...`
+    /// loops were each re-expressing: a row-by-row walk of one result set,
+    /// with the per-row projection / accumulation supplied by the caller.
+    /// `onRow` reads the columns it needs off the still-positioned cursor and
+    /// accumulates into the caller's own sink (ResizeArray / HashSet /
+    /// Dictionary / classify-and-skip), so the drain order and per-row
+    /// effects are byte-identical to the loops it replaces. Scoped to ONE
+    /// result set — callers walking a multi-batch reader call it once per
+    /// `NextResultAsync` step (see `readSchemaCombined`).
+    let private drainRows
+        (reader: SqlDataReader)
+        (onRow: SqlDataReader -> unit)
+        : Task<unit> =
+        task {
+            let mutable hasMore = true
+            while hasMore do
+                let! more = reader.ReadAsync()
+                if more then onRow reader
+                else hasMore <- false
+        }
+
     let private readColumnRows (cnn: SqlConnection)
         : Task<list<ColumnRow>> =
         task {
@@ -249,10 +272,7 @@ module ReadSide =
             use! reader = cmd.ExecuteReaderAsync()
             let rows = ResizeArray<ColumnRow>()
             let optInt = optIntOf reader
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let lengthRaw = optInt 5
                     let length =
                         match lengthRaw with
@@ -268,9 +288,7 @@ module ReadSide =
                             Length = length
                             Precision = optInt 6
                             Scale = optInt 7
-                        })
-                else
-                    hasMore <- false
+                        }))
             // Defensive diagnostic (slice A.4.7'-prelude.defensive-
             // hardening): zero column rows from INFORMATION_SCHEMA.COLUMNS
             // is a SIGNAL not silence. Either (a) the user-schema is
@@ -301,16 +319,11 @@ module ReadSide =
                    AND t.is_ms_shipped = 0"
             use! reader = cmd.ExecuteReaderAsync()
             let result = System.Collections.Generic.HashSet<string * string * string>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     result.Add(
                         reader.GetString 0,
                         reader.GetString 1,
-                        reader.GetString 2) |> ignore
-                else
-                    hasMore <- false
+                        reader.GetString 2) |> ignore)
             return Set.ofSeq result
         }
 
@@ -340,16 +353,11 @@ module ReadSide =
                    AND tc.TABLE_SCHEMA NOT IN ('sys','INFORMATION_SCHEMA')"
             use! reader = cmd.ExecuteReaderAsync()
             let result = System.Collections.Generic.HashSet<string * string * string>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let schema = reader.GetString 0
                     let table = reader.GetString 1
                     let column = reader.GetString 2
-                    result.Add(schema, table, column) |> ignore
-                else
-                    hasMore <- false
+                    result.Add(schema, table, column) |> ignore)
             return Set.ofSeq result
         }
 
@@ -377,14 +385,9 @@ module ReadSide =
             use! reader = cmd.ExecuteReaderAsync()
             let result =
                 System.Collections.Generic.Dictionary<string * string * string, string>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let key = (reader.GetString 0, reader.GetString 1, reader.GetString 2)
-                    result.[key] <- reader.GetString 3
-                else
-                    hasMore <- false
+                    result.[key] <- reader.GetString 3)
             return result |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
         }
 
@@ -411,14 +414,9 @@ module ReadSide =
             use! reader = cmd.ExecuteReaderAsync()
             let result =
                 System.Collections.Generic.Dictionary<string * string * string, string * bool>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let key = (reader.GetString 0, reader.GetString 1, reader.GetString 2)
-                    result.[key] <- (reader.GetString 3, reader.GetBoolean 4)
-                else
-                    hasMore <- false
+                    result.[key] <- (reader.GetString 3, reader.GetBoolean 4))
             return result |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
         }
 
@@ -439,18 +437,14 @@ module ReadSide =
                  WHERE tr.is_ms_shipped = 0 AND t.is_ms_shipped = 0"
             use! reader = cmd.ExecuteReaderAsync()
             let acc = System.Collections.Generic.Dictionary<string * string, ResizeArray<string * bool * string>>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let key = (reader.GetString 0, reader.GetString 1)
                     let body = if reader.IsDBNull 4 then "" else reader.GetString 4
                     let entry = (reader.GetString 2, reader.GetBoolean 3, body)
                     match acc.TryGetValue key with
                     | true, lst -> lst.Add entry
                     | false, _ ->
-                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst
-                else hasMore <- false
+                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst)
             return acc |> Seq.map (fun kv -> kv.Key, List.ofSeq kv.Value) |> Map.ofSeq
         }
 
@@ -470,17 +464,13 @@ module ReadSide =
                  WHERE t.is_ms_shipped = 0"
             use! reader = cmd.ExecuteReaderAsync()
             let acc = System.Collections.Generic.Dictionary<string * string, ResizeArray<string * string * bool>>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let key = (reader.GetString 0, reader.GetString 1)
                     let entry = (reader.GetString 2, reader.GetString 3, reader.GetBoolean 4)
                     match acc.TryGetValue key with
                     | true, lst -> lst.Add entry
                     | false, _ ->
-                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst
-                else hasMore <- false
+                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst)
             return acc |> Seq.map (fun kv -> kv.Key, List.ofSeq kv.Value) |> Map.ofSeq
         }
 
@@ -512,10 +502,7 @@ module ReadSide =
                  ORDER BY SCHEMA_NAME(t.schema_id), t.name, i.name, ic.key_ordinal"
             use! reader = cmd.ExecuteReaderAsync()
             let acc = System.Collections.Generic.Dictionary<string * string, ResizeArray<IndexColumnRow>>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let key = (reader.GetString 0, reader.GetString 1)
                     let entry =
                         { IndexName    = reader.GetString 2
@@ -526,8 +513,7 @@ module ReadSide =
                     match acc.TryGetValue key with
                     | true, lst -> lst.Add entry
                     | false, _ ->
-                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst
-                else hasMore <- false
+                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst)
             return acc |> Seq.map (fun kv -> kv.Key, List.ofSeq kv.Value) |> Map.ofSeq
         }
 
@@ -549,10 +535,7 @@ module ReadSide =
             let optInt (i: int) : int option =
                 if reader.IsDBNull i then None else Some (System.Convert.ToInt32(reader.GetValue i))
             let rows = ResizeArray<SequenceRow>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     rows.Add(
                         { Schema       = reader.GetString 0
                           Name         = reader.GetString 1
@@ -563,8 +546,7 @@ module ReadSide =
                           MaximumValue = optDec 6
                           IsCycling    = reader.GetBoolean 7
                           IsCached     = reader.GetBoolean 8
-                          CacheSize    = optInt 9 })
-                else hasMore <- false
+                          CacheSize    = optInt 9 }))
             return List.ofSeq rows
         }
 
@@ -590,10 +572,7 @@ module ReadSide =
                    AND ep.name <> N'V2.SsKey'"
             use! reader = cmd.ExecuteReaderAsync()
             let acc = System.Collections.Generic.Dictionary<string * string * string option, ResizeArray<string * string>>()
-            let mutable hasMore = true
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let col = if reader.IsDBNull 2 then None else Some (reader.GetString 2)
                     let key = (reader.GetString 0, reader.GetString 1, col)
                     let value = if reader.IsDBNull 4 then "" else reader.GetString 4
@@ -601,8 +580,7 @@ module ReadSide =
                     match acc.TryGetValue key with
                     | true, lst -> lst.Add entry
                     | false, _ ->
-                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst
-                else hasMore <- false
+                        let lst = ResizeArray<_>() in lst.Add entry; acc.[key] <- lst)
             return acc |> Seq.map (fun kv -> kv.Key, List.ofSeq kv.Value) |> Map.ofSeq
         }
 
@@ -635,15 +613,12 @@ module ReadSide =
                  ORDER BY SCHEMA_NAME(t.schema_id), t.name, c.column_id"
             use! reader = cmd.ExecuteReaderAsync()
             let rows = ResizeArray<FkRow>()
-            let mutable hasMore = true
             // E2 (debrief G4): a NULL SCHEMA_NAME() (dropped schema /
             // missing VIEW DEFINITION grant) is classified Unreadable and
             // surfaces a NAMED diagnostic + skip — never a silent drop nor
             // an opaque GetString cast failure.
             let rawOpt i = if reader.IsDBNull i then None else Some (reader.GetString i)
-            while hasMore do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let isNotTrusted = (not (reader.IsDBNull 6)) && reader.GetBoolean 6
                     match
                         ForeignKeyReadback.classify
@@ -658,9 +633,7 @@ module ReadSide =
                               TargetTable  = c.TargetTable
                               TargetColumn = c.TargetColumn
                               IsNotTrusted = c.IsNotTrusted })
-                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason
-                else
-                    hasMore <- false
+                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason)
             return List.ofSeq rows
         }
 
@@ -1432,10 +1405,7 @@ module ReadSide =
             // Result set 1: column rows (matches readColumnRows shape).
             let columnRows = ResizeArray<ColumnRow>()
             let optInt = optIntOf reader
-            let mutable hasMore1 = true
-            while hasMore1 do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let lengthRaw = optInt 5
                     let length =
                         match lengthRaw with
@@ -1451,46 +1421,34 @@ module ReadSide =
                             Length = length
                             Precision = optInt 6
                             Scale = optInt 7
-                        })
-                else hasMore1 <- false
+                        }))
 
             // Result set 2: primary-key triples.
             let! _ = reader.NextResultAsync()
             let primaryKeySet = System.Collections.Generic.HashSet<string * string * string>()
-            let mutable hasMore2 = true
-            while hasMore2 do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     primaryKeySet.Add(
                         reader.GetString 0,
                         reader.GetString 1,
-                        reader.GetString 2) |> ignore
-                else hasMore2 <- false
+                        reader.GetString 2) |> ignore)
 
             // Result set 3: identity-column triples.
             let! _ = reader.NextResultAsync()
             let identitySet = System.Collections.Generic.HashSet<string * string * string>()
-            let mutable hasMore3 = true
-            while hasMore3 do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     identitySet.Add(
                         reader.GetString 0,
                         reader.GetString 1,
-                        reader.GetString 2) |> ignore
-                else hasMore3 <- false
+                        reader.GetString 2) |> ignore)
 
             // Result set 4: foreign-key tuples.
             let! _ = reader.NextResultAsync()
             let fkRows = ResizeArray<FkRow>()
-            let mutable hasMore4 = true
             // E2 (debrief G4): classify each FK row's coordinates; a NULL
             // SCHEMA_NAME() yields a NAMED diagnostic + skip instead of an
             // opaque `GetString` cast failure that would abort the readback.
             let rawOpt4 i = if reader.IsDBNull i then None else Some (reader.GetString i)
-            while hasMore4 do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let isNotTrusted = (not (reader.IsDBNull 6)) && reader.GetBoolean 6
                     match
                         ForeignKeyReadback.classify
@@ -1505,8 +1463,7 @@ module ReadSide =
                               TargetTable  = c.TargetTable
                               TargetColumn = c.TargetColumn
                               IsNotTrusted = c.IsNotTrusted })
-                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason
-                else hasMore4 <- false
+                    | ForeignKeyReadback.Unreadable reason -> eprintfn "%s" reason)
 
             // Result set 5: V2.LogicalName extended properties
             // (slice D.1.b). Column 2 (sys.columns.name) is NULL for
@@ -1515,10 +1472,7 @@ module ReadSide =
             let! _ = reader.NextResultAsync()
             let tableLogical = System.Collections.Generic.Dictionary<string * string, string>()
             let columnLogical = System.Collections.Generic.Dictionary<string * string * string, string>()
-            let mutable hasMore5 = true
-            while hasMore5 do
-                let! more = reader.ReadAsync()
-                if more then
+            do! drainRows reader (fun reader ->
                     let schema = reader.GetString 0
                     let table = reader.GetString 1
                     let value = reader.GetString 3
@@ -1526,8 +1480,7 @@ module ReadSide =
                         tableLogical[(schema, table)] <- value
                     else
                         let column = reader.GetString 2
-                        columnLogical[(schema, table, column)] <- value
-                else hasMore5 <- false
+                        columnLogical[(schema, table, column)] <- value)
 
             // Result set 6: V2.SsKey extended properties (Wave 4.1).
             // Table-level only (minor_id = 0); the serialized identity
@@ -1536,12 +1489,8 @@ module ReadSide =
             // rename).
             let! _ = reader.NextResultAsync()
             let tableSsKeys = System.Collections.Generic.Dictionary<string * string, string>()
-            let mutable hasMore6 = true
-            while hasMore6 do
-                let! more = reader.ReadAsync()
-                if more then
-                    tableSsKeys[(reader.GetString 0, reader.GetString 1)] <- reader.GetString 2
-                else hasMore6 <- false
+            do! drainRows reader (fun reader ->
+                    tableSsKeys[(reader.GetString 0, reader.GetString 1)] <- reader.GetString 2)
 
             return
                 List.ofSeq columnRows,
@@ -1569,10 +1518,7 @@ module ReadSide =
                  ORDER BY 1"
             use! reader = cmd.ExecuteReaderAsync()
             let names = ResizeArray<string>()
-            let mutable more = true
-            while more do
-                let! has = reader.ReadAsync()
-                if has then names.Add(reader.GetString 0) else more <- false
+            do! drainRows reader (fun reader -> names.Add(reader.GetString 0))
             return List.ofSeq names
         }
 

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -776,20 +776,17 @@ let private runTransfer
             dropCode
         | Error errors ->
             printErrors Console.Error errors
-            let anyCode (prefix: string) =
-                errors |> List.exists (fun (e: ValidationError) -> e.Code.StartsWith prefix)
-            // G1 — a dead/unreachable endpoint refuses with exit 6 (connection).
-            // G2 — an insufficient sink grant (or a failed grant probe) refuses
-            // with exit 7 (permission), mirroring the migrate verb's mapping.
-            if anyCode "transfer.connection" then 6
-            elif anyCode "transfer.insufficientGrant" || anyCode "transfer.grantProbeFailed" then 7
-            elif anyCode "transfer.reconcile." || anyCode "transfer.userMap." then 2
-            // AC-I5 — a pre-write validate-user-map halt maps to the SAME exit
-            // as a post-write drop (9), so an orphan returns the same code
-            // whether refused before the write or reported after it; only the
-            // timing (and the untouched Sink) changes.
-            elif anyCode "transfer.unmappedIdentities" then Transfer.DroppedReferencesExit
-            else 3
+            // A1 — single-source the refusal exit through `Preflight.refusalOf`
+            // (the canonical `classify` seam over the primary error code) rather
+            // than a hand-derived if/elif. The prior chain lacked an arm for
+            // `transfer.cdcTrackedSink` and silently dropped it to the generic
+            // `else 3`; `classify` maps it to 9 (`CdcTrackedSink`). Connection(6) /
+            // grant(7) / reconcile+userMap(2) / unmappedIdentities(9) classify
+            // byte-identically; a genuinely unclassified code stays at the named
+            // `(3, UnclassifiedRefusal)` default. The AC-I5 pre-write halt
+            // (`transfer.unmappedIdentities → 9`) and the post-write drop
+            // (`Transfer.DroppedReferencesExit`) still coincide at 9 via classify.
+            (Preflight.refusalOf errors).ExitCode
     // --watch + a real TTY → the live data-load board (§13); the transfer leg
     // streams the "load" stage with per-table progress. Only on a real --execute
     // (a dry-run writes no rows, so the load stage would never advance).

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -26,13 +26,14 @@ let private usageLines : string list =
         "  write (and needs PROJECTION_ALLOW_EXECUTE=1). Conn refs are env:/file: only (D9)."
         ""
         "USAGE:"
-        "    projection <flow> [--go] [--fresh] [--allow-drops] [--allow-cdc]   the daily surface"
+        "    projection <flow> [--go] [--fresh] [--allow-drops] [--allow-cdc] [--resumable]   the daily surface"
         "    projection                                           list flows (name: from → to)"
         "    projection check  ( <source.sql> [--cdc-silence] | drift --model <m> --to <t>"
         "                      | data --before <t> --after <t> | ready )"
+        "    projection diff <a> <b> [--format json] [--depth N]   change between two refs"
         "    projection explain ( diff <a> <b> [--format json] [--depth N] | policy <a> <b>"
         "                       | node <config> <ssKey> | suggest <config> [--apply <out>] | registry"
-        "                       | migrate --to <b> ( --from <a> | --store <s> ) [--allow-drops] )"
+        "                       | migrate --to <b> ( --from <a> | --from empty | --store <s> ) [--allow-drops] )"
         "    projection seal ( --store <path> | approve <version> --approver <name> ... )"
         "    projection report <flow>        the on-prem migration-team change bundle"
         "    projection init                 scaffold a projection.json"
@@ -46,7 +47,8 @@ let private usageLines : string list =
         "  safe); a direct target previews until --go (which also needs"
         "  PROJECTION_ALLOW_EXECUTE=1, R6). --fresh wipes-and-loads (the rare from-scratch);"
         "  --allow-drops accepts declared loss; --allow-cdc overrides the CDC-tracked-sink"
-        "  pre-flight gate; a schema-from-model flow against a data-only target is refused."
+        "  pre-flight gate; --resumable routes the data leg through the resumable upsert"
+        "  envelope; a schema-from-model flow against a data-only target is refused."
         ""
         "CHECK — assert fidelity.  fidelity canary (default; --cdc-silence adds the redeploy"
         "  silence assertion) · drift (deployed vs model) · data (row/null counts) · ready"
@@ -680,6 +682,7 @@ let private runTransfer
     (allowCdc: bool)
     (allowDrops: bool)
     (emission: EmissionMode)
+    (resumable: bool)
     (tables: string list)
     : int =
     let collect = function Ok _ -> [] | Error es -> es
@@ -748,7 +751,7 @@ let private runTransfer
         TransferSpec.resolveAllReconciliation contract entries userMapEntries
     let runBody () =
         let result =
-            (Transfer.runThroughConnectionsWithEmission mode emission allowCdc allowDrops tables connections resolveReconciliation)
+            (Transfer.runThroughConnectionsResumable mode emission resumable allowCdc allowDrops tables connections resolveReconciliation)
                 .GetAwaiter().GetResult()
         match result with
         | Ok report ->
@@ -983,13 +986,17 @@ let private runReadiness () : int =
                 Phase = LogSink.End }
         0
 
-/// Live-probe a target for the setup readback: `(ref, reachable, alterGranted)`.
-/// Reuses the same machinery the migrate pre-flights use — resolve the ref,
-/// open the connection (reachability), capture the grant evidence (the §14 / A.6
-/// "ALTER granted on dbo"). A failed resolve / open is `unreachable`, never a
-/// stack trace; the grant is left false when the target is unreachable.
-let private probeTarget (connRef: string) : string * bool * bool =
-    let unreachable = (connRef, false, false)
+/// Live-probe a target for the setup readback:
+/// `(ref, reachable, grants)` where `grants` pairs each planned write action
+/// (ALTER / INSERT / DELETE / CREATE TABLE) with its database-scope grant
+/// status. Reuses the same machinery the migrate pre-flights use — resolve the
+/// ref, open the connection (reachability), capture the grant evidence (the §14
+/// / A.6 readback). D3 — the broader grants (INSERT / CREATE TABLE / DELETE) are
+/// surfaced, not collapsed to ALTER alone, so the setup view names exactly which
+/// writes a target permits. A failed resolve / open is `unreachable`, never a
+/// stack trace; every grant reads false when the target is unreachable.
+let private probeTarget (connRef: string) : string * bool * (Preflight.WriteAction * bool) list =
+    let unreachable = (connRef, false, [])
     match TransferSpec.parseConnectionSpec connRef with
     | Error _ -> unreachable
     | Ok ref ->
@@ -999,11 +1006,11 @@ let private probeTarget (connRef: string) : string * bool * bool =
             try
                 use cnn = new Microsoft.Data.SqlClient.SqlConnection(connStr)
                 cnn.OpenAsync().GetAwaiter().GetResult()
-                let alterGranted =
+                let grants =
                     match (Preflight.captureGrantEvidence cnn).GetAwaiter().GetResult() with
-                    | Ok g    -> Set.contains ("", "ALTER") g.Granted
-                    | Error _ -> false
-                (connRef, true, alterGranted)
+                    | Ok g    -> Preflight.allWriteActions |> List.map (fun a -> a, Preflight.coversAtDatabaseScope a g)
+                    | Error _ -> Preflight.allWriteActions |> List.map (fun a -> a, false)
+                (connRef, true, grants)
             with _ -> unreachable
 
 /// `projection setup [--conn <ref>]` — the arrival/setup readback (§14 /
@@ -1314,7 +1321,7 @@ let private runMigratePreview (fromPath: string) (toPath: string) (declaration: 
 /// `LifecycleStore`; B is the new authored model. Closes the emission→snapshot→
 /// diff loop: the diff basis is provenance, not a second hand-authored model. A
 /// missing store is genesis (A = ∅).
-let private runMigrateFromStore (storePath: string) (toPath: string) (declaration: LossDeclaration) : int =
+let private runMigrateFromStore (storePath: string) (toPath: string) (declaration: LossDeclaration) (forceGenesis: bool) : int =
     let bRead = (Compose.read toPath).GetAwaiter().GetResult()
     match bRead with
     | Error errors ->
@@ -1322,9 +1329,15 @@ let private runMigrateFromStore (storePath: string) (toPath: string) (declaratio
         printErrors Console.Error errors
         6
     | Ok target ->
+        // `--from empty` forces A = ∅ (genesis) against a populated store — the
+        // banner names the forced from-scratch basis so the displacement is not
+        // mistaken for a store-derived diff.
+        let banner =
+            if forceGenesis then sprintf "projection migrate (from empty) -> %s  (dry-run, genesis)" toPath
+            else sprintf "projection migrate (store:%s) -> %s  (dry-run, snapshot⊖snapshot)" storePath toPath
         reportPreviewOutcome
-            (sprintf "projection migrate (store:%s) -> %s  (dry-run, snapshot⊖snapshot)" storePath toPath)
-            (MigrationRun.previewFromStore storePath declaration target)
+            banner
+            (MigrationRun.previewFromStoreForcing forceGenesis storePath declaration target)
 
 /// Derive the A2 pre-flight's planned-writes from a migration's schema
 /// statements: every DDL statement maps to the write it performs at the sink
@@ -1827,7 +1840,7 @@ let private runPlan (plan: ExecutionPlan) : int =
     | PlanAction.PreviewSchema (model, modelOssys, conn, decl) ->
         needCatalog modelOssys model (fun cat -> runProjectLivePreview cat conn decl)
     | PlanAction.Transfer (src, sink, opts, execute) ->
-        runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Tables
+        runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables
     | PlanAction.MigrateWithData (model, modelOssys, sink, src, opts) ->
         needCatalog modelOssys model (fun cat -> runMigrateWithData cat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Store opts.Env)
     | PlanAction.SynthesizeAndLoad (model, modelOssys, profile, conn, opts, execute) ->
@@ -1868,7 +1881,7 @@ let private runPlan (plan: ExecutionPlan) : int =
             printfn "  %-12s %s" (stageBindingText rt.StageBinding) rt.Name
         0
     | PlanAction.ExplainMigratePreview (fromP, toP, decl)   -> runMigratePreview fromP toP decl
-    | PlanAction.ExplainMigrateFromStore (store, toP, decl) -> runMigrateFromStore store toP decl
+    | PlanAction.ExplainMigrateFromStore (store, toP, decl, forceGenesis) -> runMigrateFromStore store toP decl forceGenesis
     // seal ---------------------------------------------------------------
     | PlanAction.SealEject store -> runEject store
     | PlanAction.SealApprove (version, approver, rationale, store) -> runApprove version approver rationale store

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -152,13 +152,15 @@ let renderReadinessBoardTo
 /// configured is a choice to make, not a failure"). Pure over the resolved
 /// state so the env reads + the live probe stay at the boundary (`runSetup`); an
 /// unset optional (the run ledger) earns a recommendation, never a scold.
-/// `connection` is `(ref, reachable, alterGranted)` when a target was probed.
+/// `connection` is `(ref, reachable, grants)` when a target was probed, where
+/// `grants` pairs each planned write action with its database-scope grant status
+/// (D3 — the broader INSERT / CREATE TABLE / DELETE grants, not ALTER alone).
 let buildSetupView
     (ledger: string option)
     (executeArmed: bool)
     (dwellMs: int64)
     (benchDir: string option)
-    (connection: (string * bool * bool) option)
+    (connection: (string * bool * (Preflight.WriteAction * bool) list) option)
     : View.View =
     let history =
         match ledger with
@@ -177,15 +179,37 @@ let buildSetupView
     let connectionBlock =
         match connection with
         | None -> []
-        | Some (ref, reachable, alterGranted) ->
+        | Some (ref, reachable, grants) ->
             let connField =
                 if reachable then View.Field("connection", sprintf "%s %s reachable" ref Theme.dot, View.Ok)
                 else View.Field("connection", sprintf "%s %s unreachable" ref Theme.dot, View.Bad)
+            // The ALTER line is preserved (the §14 / A.6 readback that already
+            // shipped); the broader write grants (INSERT / CREATE TABLE / DELETE)
+            // read on their own line — the granted set, or the missing set named
+            // exactly (mirroring `buildSurveyView`'s "missing X, Y" phrasing).
+            let alterGranted = grants |> List.exists (fun (a, g) -> a = Preflight.WriteAction.Alter && g)
             let grantField =
                 if not reachable then []
                 elif alterGranted then [ View.Field("grant", "ALTER granted", View.Ok) ]
                 else [ View.Field("grant", "ALTER not granted", View.Warn) ]
-            connField :: grantField
+            let dataActions =
+                grants |> List.filter (fun (a, _) -> a <> Preflight.WriteAction.Alter)
+            let writesField =
+                if not reachable || List.isEmpty dataActions then []
+                else
+                    let missing = dataActions |> List.filter (fun (_, g) -> not g) |> List.map (fun (a, _) -> Preflight.permissionName a)
+                    match missing with
+                    | [] -> [ View.Field("writes", "INSERT, CREATE TABLE, DELETE granted", View.Ok) ]
+                    | _  ->
+                        // Terminal View-field operator copy at the setup-readback boundary:
+                        // join the (≤3) missing permission-name strings into the "missing
+                        // X, Y" phrasing, the same primitive the sibling `buildSurveyView`
+                        // "missing" line uses at the same boundary. (1) lib: String.concat;
+                        // (2) already in codebase; (3) cost: none (typed string list → one
+                        // terminal string); (4) no typed-AST builder applies (leaf copy).
+                        let missingList = missing |> String.concat ", "  // LINT-ALLOW: see four-question rationale above
+                        [ View.Field("writes", sprintf "missing %s" missingList, View.Warn) ]
+            (connField :: grantField) @ writesField
     let recommendation =
         match ledger with
         | Some _ -> []

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -92,6 +92,22 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (ledgerPat
             View.Hero(View.Ok, sprintf "ELIGIBLE %s %d consecutive green canaries" Theme.dot r.ConsecutiveGreen)
         else
             View.Hero(View.Pending, sprintf "NOT YET %s %d green run(s) to cutover-ready" Theme.dot toGo)
+    // The one lever (§8 / Appendix A.5: "One lever, named, with the next move" —
+    // never a list of problems). Derived from the data already in the readiness
+    // model: when the streak is broken (the most recent round-trip verification
+    // diverged), THAT is the single blocking item — restoring a green check is the
+    // honest next step; otherwise the lever is the remaining distance, the streak
+    // read as distance to cutover. Rendered only while not yet eligible.
+    let lever =
+        if r.Eligible then []
+        else
+            match r.LastCanary with
+            | Some "green" ->
+                [ View.Note(sprintf "The lever %s %d more green round-trip verification(s) before cutover." Theme.dot toGo) ]
+            | Some _ ->
+                [ View.Note(sprintf "The lever %s the most recent round-trip verification diverged; a green check restores the streak." Theme.dot) ]
+            | None ->
+                [ View.Note(sprintf "The lever %s a round-trip verification has not yet run; the first green check opens the streak." Theme.dot) ]
     let history = if List.isEmpty recent then [] else [ View.Dots("history", recent) ]
     // The timeline read in words — the dots' shape said plainly (§8 / Appendix
     // A.5): how the recent checks landed, and which run is the present one.
@@ -111,6 +127,7 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (ledgerPat
           hero
           View.Blank
           View.Meter("cutover", r.ConsecutiveGreen, r.Threshold, sprintf "%d / %d green" r.ConsecutiveGreen r.Threshold) ]
+        @ lever
         @ history
         @ timeline
         @ [ View.Field(

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -107,6 +107,22 @@ module Voice =
         | "load"     -> "Data load"
         | other      -> other
 
+    /// The §13 follow-on for a run whose terminal stage is `terminalStage` — "the
+    /// rhythm names the next move" (a finished change build offers the verify; a
+    /// finished verify offers the record). Stative + agentless: the next phase is
+    /// named as a state that follows, never an instruction to the reader. Public so
+    /// the Watch board's done-frame reads the one mapping and the totality test can
+    /// assert it is total over the terminal stages the board can reach.
+    let followOnAfter (terminalStage: string) : string =
+        match terminalStage with
+        | "extract"  -> "The data check follows."
+        | "profile"  -> "The change build follows."
+        | "emit"     -> "Verification follows."
+        | "deploy"   -> "Verification follows."
+        | "canary"   -> "The record follows."
+        | "load"     -> "Verification follows."
+        | _          -> "The run is complete."
+
     // ------------------------------------------------------------------
     // The catalog — grouped by `THE_VOICE.md` section (decision 5: the
     // harvested catalog mirrors the doc). Each entry is a separable
@@ -289,6 +305,41 @@ module Voice =
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
+    /// `watch.runTitle` — the live board's run-title header (`THE_VOICE.md` §13 —
+    /// "the instrument speaks about its own running"). A neutral, agentless naming
+    /// of the run in flight (the command is the subject, never "you"); the board
+    /// reuses it as the frame the stage lines fill beneath. A render-synthesized
+    /// frame, not a LogSink envelope — the board is a rendering of the run, so the
+    /// title is voiced here (one register) rather than authored in the renderer.
+    let private watchRunTitle : Copy =
+        { Code           = "watch.runTitle"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "command" p with
+                | Some cmd -> View.Note(sprintf "%s — the run in flight." cmd)
+                | None     -> View.Note "The run in flight."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
+    /// `watch.runDone` — the live board's done-frame (`THE_VOICE.md` §13 — "the
+    /// rhythm names the next move … Nothing terminates at 'done'"). When the run
+    /// reaches its terminal stage, the board names what follows (`followOn`,
+    /// derived from the terminal stage — e.g. "Verification follows" after the
+    /// change build) and, when a run identity is present, states the record plainly
+    /// ("Recorded as run N"). Stative + agentless; the follow-on is the §13 move.
+    let private watchRunDone : Copy =
+        { Code           = "watch.runDone"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                let followOn = textOr "followOn" "The run is complete." p
+                match text "runIdentity" p with
+                | Some n -> View.Note(sprintf "%s Recorded as run %s." followOn (humane n))
+                | None   -> View.Note followOn
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `summary.stageCompleted` — a stage of the run completed (`THE_VOICE.md`
     /// §13). Resultative; the stage name is operator-shaped via `stageName`,
     /// never the internal engine verb.
@@ -347,6 +398,8 @@ module Voice =
           deployStarted
           canaryStarted
           loadStarted
+          watchRunTitle
+          watchRunDone
           summaryStageCompleted
           // §14 / §10 — config & errors
           configValidationFailed ]

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -50,9 +50,17 @@ module Watch =
     /// current visible state. Ordered by first appearance.
     type StageLine = { Key: string; State: StageState }
 
-    type Board = { Stages: StageLine list }
+    /// The board — the stage lines, plus the optional run frame (`THE_VOICE.md`
+    /// §13: "the instrument speaks about its own running"). `Title` is the
+    /// run-in-flight header voiced above the arc; `RunIdentity` is the run's
+    /// ordinal, voiced in the done-frame as "Recorded as run N" when present. Both
+    /// default to absent — the board renders the bare arc when no frame is given.
+    type Board =
+        { Stages: StageLine list
+          Title: string option
+          RunIdentity: string option }
 
-    let empty : Board = { Stages = [] }
+    let empty : Board = { Stages = []; Title = None; RunIdentity = None }
 
     /// A board pre-seeded with the run's planned stages, each `Pending` — so the
     /// operator sees the whole arc before the first stage starts, the stages
@@ -62,7 +70,17 @@ module Watch =
         { Stages =
             stageKeys
             |> List.filter (fun k -> not (k = "pipeline"))
-            |> List.map (fun k -> { Key = k; State = Pending }) }
+            |> List.map (fun k -> { Key = k; State = Pending })
+          Title = None
+          RunIdentity = None }
+
+    /// A seeded board carrying the run frame — the run-title header voiced above
+    /// the arc (`THE_VOICE.md` §13) and, when known up front, the run's ordinal for
+    /// the done-frame's "Recorded as run N". The boundary (`renderWatch`) supplies
+    /// the command + any run identity it holds; the board renders the bare arc when
+    /// neither is given (the `seeded` shape stays the unframed default).
+    let seededWith (command: string option) (runIdentity: string option) (stageKeys: string list) : Board =
+        { seeded stageKeys with Title = command; RunIdentity = runIdentity }
 
     /// The umbrella "pipeline" stage (`FullExportRun.recordStage "pipeline"`) wraps
     /// the whole run; it is not a sub-stage the operator watches, so the board
@@ -219,6 +237,42 @@ module Watch =
             | Some ms -> sprintf "%s · %s" baseText (secondsText ms)
             | None    -> baseText
 
+    /// The run's terminal stage — the last line on the board (the arc's final
+    /// stage). `None` for an empty board. The done-frame's follow-on is keyed off
+    /// it (§13 — "a finished change build offers the verify").
+    let terminalStageKey (board: Board) : string option =
+        board.Stages |> List.tryLast |> Option.map (fun s -> s.Key)
+
+    /// Whether the run has reached its terminal stage — every seeded stage is
+    /// `Done`. The done-frame renders only then (the §13 rhythm names the next move
+    /// once the visible arc has landed, never mid-run).
+    let isTerminal (board: Board) : bool =
+        not (List.isEmpty board.Stages)
+        && board.Stages |> List.forall (fun s -> match s.State with Done _ -> true | _ -> false)
+
+    /// The done-frame line — the §13 follow-on for the terminal stage, with the
+    /// recorded-run identity beneath when the board carries one. Voiced through
+    /// `watch.runDone` (the catalog holds the copy; the board never authors prose).
+    /// `None` until the run is terminal.
+    let doneFrameText (board: Board) : string option =
+        if not (isTerminal board) then None
+        else
+            let followOn =
+                match terminalStageKey board with
+                | Some key -> Voice.followOnAfter key
+                | None     -> "The run is complete."
+            let payload =
+                [ "followOn", box followOn ]
+                @ (match board.RunIdentity with Some n -> [ "runIdentity", box n ] | None -> [])
+                |> Map.ofList
+            Some(statementText "watch.runDone" payload)
+
+    /// The run-title header line — voiced through `watch.runTitle` when the board
+    /// carries a title. `None` for an unframed board.
+    let titleText (board: Board) : string option =
+        board.Title
+        |> Option.map (fun cmd -> statementText "watch.runTitle" (Map.ofList [ "command", box cmd ]))
+
     let private rowMarkup (line: StageLine) : string =
         let text = Markup.Escape(lineText line)
         match line.State with
@@ -227,10 +281,20 @@ module Watch =
         | Done _   -> sprintf "%s  %s" Theme.ok                       (Theme.green text)
 
     /// Project the board onto a Spectre renderable — the live target the
-    /// `LiveDisplayContext` updates in place.
+    /// `LiveDisplayContext` updates in place. The optional run-title header frames
+    /// the arc above; the done-frame (the §13 follow-on + the recorded-run
+    /// identity) closes it below once the run reaches its terminal stage.
     let toRenderable (board: Board) : IRenderable =
-        let rows = board.Stages |> List.map (fun s -> Markup(rowMarkup s) :> IRenderable)
-        Rows(rows) :> IRenderable
+        let titleRow =
+            match titleText board with
+            | Some t -> [ Markup(Theme.muted (Markup.Escape t)) :> IRenderable ]
+            | None   -> []
+        let stageRows = board.Stages |> List.map (fun s -> Markup(rowMarkup s) :> IRenderable)
+        let doneRow =
+            match doneFrameText board with
+            | Some t -> [ Markup(sprintf "%s  %s" Theme.ok (Theme.green (Markup.Escape t))) :> IRenderable ]
+            | None   -> []
+        Rows(titleRow @ stageRows @ doneRow) :> IRenderable
 
     // -- the live shell --------------------------------------------------------
 

--- a/sidecar/projection/src/Projection.Core/ArtifactByKind.fs
+++ b/sidecar/projection/src/Projection.Core/ArtifactByKind.fs
@@ -81,6 +81,37 @@ module ArtifactByKind =
         | k :: _, _ -> Error (KindNotProduced k)
         | [], k :: _ -> Error (UnexpectedKind k)
 
+    /// Build the artifact by rendering every catalog kind. Captures the
+    /// recurring fold every sibling Π hand-rolled: walk `Catalog.allKinds`,
+    /// key each kind's rendered element by its `SsKey`, and pass the
+    /// resulting `Map` through the `create` smart constructor. The total
+    /// keyset is `Catalog.allKinds`'s SsKey set by construction, so the
+    /// strict-equality contract holds with no missing/extra keys; the
+    /// `Result` therefore only ever surfaces a `RenderFailed`-class error
+    /// if `render` itself fails (it does not here — `render` is total).
+    ///
+    /// Concept-shaped: this IS the per-kind projection of a Catalog into
+    /// an `ArtifactByKind`, the artifact's defining construction. Use it
+    /// wherever a sibling emitter produces exactly one element per kind.
+    let perKind (catalog: Catalog) (render: Kind -> 'element)
+        : Result<ArtifactByKind<'element>, EmitError> =
+        Catalog.allKinds catalog
+        |> List.map (fun k -> k.SsKey, render k)
+        |> Map.ofList
+        |> create catalog
+
+    /// `perKind` with per-kind bench instrumentation. The `label` scopes
+    /// each kind's render (drop-in for `Bench.iterMap`) so emitters that
+    /// time per-kind work keep their existing observability while sharing
+    /// the projection. Output is identical to `perKind`; only the bench
+    /// table differs (each kind's render is timed under `label`).
+    let perKindBenched (label: string) (catalog: Catalog) (render: Kind -> 'element)
+        : Result<ArtifactByKind<'element>, EmitError> =
+        Catalog.allKinds catalog
+        |> Bench.iterMap label (fun k -> k.SsKey, render k)
+        |> Map.ofList
+        |> create catalog
+
     /// Project the underlying `Map<SsKey, 'a>`. Read-only; callers
     /// must not reconstruct an `ArtifactByKind` from this — the smart
     /// constructor is the only path that re-validates.

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -50,6 +50,23 @@ type AttributeChange =
         Facets       : Set<AttributeFacet>
     }
 
+/// The structurally-identical carrier behind every per-channel diff
+/// (attributes / references / indexes / sequences). `Added` / `Removed`
+/// are entity `SsKey`s present in only the target / source; `Renamed`
+/// carries a same-`SsKey` `Name` change; `Changed` names survivors whose
+/// emitted shape differs, the channel's own change-evidence type filling
+/// `'change`. The four channels were four byte-identical records before;
+/// they are now one generic with four named instantiations (the aliases
+/// below), so field access and the public type names are unchanged for
+/// every consumer.
+type ChannelDiff<'change> =
+    {
+        Added   : Set<SsKey>
+        Removed : Set<SsKey>
+        Renamed : Map<SsKey, RenameRecord>
+        Changed : 'change list
+    }
+
 /// Per-kind attribute-level diff for a kind present in BOTH catalogs.
 /// `Added` / `Removed` are attribute `SsKey`s present in only the target /
 /// source; `Renamed` carries a same-`SsKey` `Name` change (edge-case-2 of
@@ -57,13 +74,7 @@ type AttributeChange =
 /// `Changed` names attributes whose emitted column shape differs facet by
 /// facet. An empty `AttributeDiff` (all four empty) means the kind's
 /// attributes are identical; `between` stores only non-empty diffs.
-type AttributeDiff =
-    {
-        Added   : Set<SsKey>
-        Removed : Set<SsKey>
-        Renamed : Map<SsKey, RenameRecord>
-        Changed : AttributeChange list
-    }
+type AttributeDiff = ChannelDiff<AttributeChange>
 
 // -- C1 (2026-06-02): widen the captured surface beyond column shape --------
 //
@@ -101,13 +112,7 @@ type ReferenceChange =
 
 /// Per-kind reference-level diff (kind present in both catalogs). Mirrors
 /// `AttributeDiff`; references match by `SsKey`.
-type ReferenceDiff =
-    {
-        Added   : Set<SsKey>
-        Removed : Set<SsKey>
-        Renamed : Map<SsKey, RenameRecord>
-        Changed : ReferenceChange list
-    }
+type ReferenceDiff = ChannelDiff<ReferenceChange>
 
 /// C1 — a single facet of an index's emitted shape. `Options` groups the
 /// `WITH (…)` knobs + the platform-auto / disabled flags so the facet set
@@ -132,13 +137,7 @@ type IndexChange =
 
 /// Per-kind index-level diff (kind present in both catalogs). Mirrors
 /// `AttributeDiff`; indexes match by `SsKey`.
-type IndexDiff =
-    {
-        Added   : Set<SsKey>
-        Removed : Set<SsKey>
-        Renamed : Map<SsKey, RenameRecord>
-        Changed : IndexChange list
-    }
+type IndexDiff = ChannelDiff<IndexChange>
 
 /// C1 — a single facet of a sequence's shape. `Cache` groups `CacheMode` +
 /// `CacheSize`.
@@ -163,13 +162,7 @@ type SequenceChange =
 
 /// Catalog-level sequence diff (sequences are `Catalog.Sequences`, not
 /// kind-scoped). Mirrors `AttributeDiff`; sequences match by `SsKey`.
-type SequenceDiff =
-    {
-        Added   : Set<SsKey>
-        Removed : Set<SsKey>
-        Renamed : Map<SsKey, RenameRecord>
-        Changed : SequenceChange list
-    }
+type SequenceDiff = ChannelDiff<SequenceChange>
 
 /// Total decomposition of `source ∪ target` SsKeys into four pairwise-
 /// disjoint partitions. The smart constructor `CatalogDiff.between`
@@ -278,10 +271,13 @@ module CatalogDiff =
           if s.Computed <> t.Computed then AttributeFacet.Computed ]
         |> Set.ofList
 
-    let private emptyAttributeDiff : AttributeDiff =
+    /// The empty channel diff — all four fields empty — over any change type.
+    let private emptyChannelDiff<'change> : ChannelDiff<'change> =
         { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Changed = [] }
 
-    let private attributeDiffIsEmpty (d: AttributeDiff) : bool =
+    /// A channel diff is empty iff all four fields are empty. One predicate
+    /// for every channel (the four byte-identical `*DiffIsEmpty` collapsed).
+    let private channelDiffIsEmpty (d: ChannelDiff<'change>) : bool =
         Set.isEmpty d.Added
         && Set.isEmpty d.Removed
         && Map.isEmpty d.Renamed
@@ -330,12 +326,6 @@ module CatalogDiff =
     // changed facets for survivors whose shape differs. `Changed` is computed
     // in source-list order for T1 determinism (not Set hash order).
 
-    let private emptyReferenceDiff : ReferenceDiff =
-        { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Changed = [] }
-
-    let private referenceDiffIsEmpty (d: ReferenceDiff) : bool =
-        Set.isEmpty d.Added && Set.isEmpty d.Removed && Map.isEmpty d.Renamed && List.isEmpty d.Changed
-
     let private changedReferenceFacets (s: Reference) (t: Reference) : Set<ReferenceFacet> =
         [ if s.TargetKind <> t.TargetKind then ReferenceFacet.Target
           if s.SourceAttribute <> t.SourceAttribute then ReferenceFacet.SourceAttribute
@@ -372,12 +362,6 @@ module CatalogDiff =
           Removed = Set.difference srcKeys tgtKeys
           Renamed = renamed
           Changed = changed }
-
-    let private emptyIndexDiff : IndexDiff =
-        { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Changed = [] }
-
-    let private indexDiffIsEmpty (d: IndexDiff) : bool =
-        Set.isEmpty d.Added && Set.isEmpty d.Removed && Map.isEmpty d.Renamed && List.isEmpty d.Changed
 
     let private changedIndexFacets (s: Index) (t: Index) : Set<IndexFacet> =
         [ if s.Columns <> t.Columns then IndexFacet.Columns
@@ -418,12 +402,6 @@ module CatalogDiff =
           Removed = Set.difference srcKeys tgtKeys
           Renamed = renamed
           Changed = changed }
-
-    let private emptySequenceDiff : SequenceDiff =
-        { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Changed = [] }
-
-    let private sequenceDiffIsEmpty (d: SequenceDiff) : bool =
-        Set.isEmpty d.Added && Set.isEmpty d.Removed && Map.isEmpty d.Renamed && List.isEmpty d.Changed
 
     let private changedSequenceFacets (s: Sequence) (t: Sequence) : Set<SequenceFacet> =
         [ if s.Schema <> t.Schema then SequenceFacet.Schema
@@ -520,7 +498,7 @@ module CatalogDiff =
                     match Catalog.tryFindKind key source, Catalog.tryFindKind key target with
                     | Some sk, Some tk ->
                         let d = attributeDiff sk tk
-                        if attributeDiffIsEmpty d then acc else Map.add key d acc
+                        if channelDiffIsEmpty d then acc else Map.add key d acc
                     | _ -> acc)
                 Map.empty
         // C1 — descend into references + indexes for every kind in BOTH catalogs;
@@ -533,7 +511,7 @@ module CatalogDiff =
                     match Catalog.tryFindKind key source, Catalog.tryFindKind key target with
                     | Some sk, Some tk ->
                         let d = referenceDiff sk tk
-                        if referenceDiffIsEmpty d then acc else Map.add key d acc
+                        if channelDiffIsEmpty d then acc else Map.add key d acc
                     | _ -> acc)
                 Map.empty
         let indexDiffs =
@@ -543,7 +521,7 @@ module CatalogDiff =
                     match Catalog.tryFindKind key source, Catalog.tryFindKind key target with
                     | Some sk, Some tk ->
                         let d = indexDiff sk tk
-                        if indexDiffIsEmpty d then acc else Map.add key d acc
+                        if channelDiffIsEmpty d then acc else Map.add key d acc
                     | _ -> acc)
                 Map.empty
         // C1 — sequences are catalog-level, not kind-scoped.
@@ -671,7 +649,7 @@ module CatalogDiff =
         && Map.isEmpty data.AttributeDiffs
         && Map.isEmpty data.ReferenceDiffs
         && Map.isEmpty data.IndexDiffs
-        && sequenceDiffIsEmpty data.SequenceDiff
+        && channelDiffIsEmpty data.SequenceDiff
 
     // -- 6.A.11: applyDiff — the `between` peer (H-007) -----------------------
     //

--- a/sidecar/projection/src/Projection.Core/Diagnostics.fs
+++ b/sidecar/projection/src/Projection.Core/Diagnostics.fs
@@ -407,6 +407,57 @@ module LineageDiagnostics =
     let writeLineages (events: LineageEvent list) : Lineage<Diagnostics<unit>> =
         Lineage.ofValueAndEvents events (Diagnostics.ofValue ())
 
+    /// The **"every kind was visited" lineage epilogue** — the
+    /// `DataIntent` writer tail shared by the analytics passes
+    /// (Centrality / BoundedContext / SchemaComplexity / ProfileAnomaly /
+    /// QueryHint). Each scans the catalog, computes a derived result, and
+    /// witnesses its scan by emitting one `Touched` / `DataIntent`
+    /// `LineageEvent` per node touched (per A25) alongside any findings it
+    /// surfaced.
+    ///
+    /// `touched` is the ordered list of `SsKey`s the pass observed — the
+    /// caller projects it from the source it scanned (graph `nodes`
+    /// directly, or `allKinds |> List.map (fun k -> k.SsKey)`). One event
+    /// is emitted per key, in order; all are `Touched` / `DataIntent`
+    /// because the scan carries no operator opinion (the result is the
+    /// pass's opinion, not the per-node witness). `findings` are the
+    /// diagnostics the pass surfaced (empty when the pass emits none).
+    ///
+    /// Behaviourally identical to the hand-rolled
+    /// `lineageDiagnostics { do! writeLineages events
+    ///                       do! writeDiagnostics findings
+    ///                       return result }`
+    /// tail it replaces — the events are built here from `passName` /
+    /// `passVersion` so the per-pass driver no longer constructs the
+    /// `LineageEvent` record by hand (writer-fidelity discipline,
+    /// `DECISIONS 2026-05-30`).
+    let touchedEpilogue
+        (passName: string)
+        (passVersion: int)
+        (touched: SsKey list)
+        (findings: DiagnosticEntry list)
+        (result: 'a)
+        : Lineage<Diagnostics<'a>> =
+        let events =
+            touched
+            |> List.map (fun key ->
+                { PassName       = passName
+                  PassVersion    = passVersion
+                  SsKey          = key
+                  TransformKind  = Touched
+                  Classification = DataIntent })
+        // Explicit desugaring of
+        //   lineageDiagnostics { do! writeLineages events
+        //                        do! writeDiagnostics findings
+        //                        return result }
+        // — the `lineageDiagnostics` CE is declared below this module, so
+        // the dual-writer tail is threaded directly through `bind` here
+        // (the worked equivalence is documented on the CE type).
+        writeLineages events
+        |> bind (fun () ->
+            writeDiagnostics findings
+            |> bind (fun () -> ofValue result))
+
 
 /// `lineageDiagnostics { ... }` CE for the dual writer. Same algebraic
 /// shape as `lineage { ... }`, over `Lineage<Diagnostics<'a>>`. The

--- a/sidecar/projection/src/Projection.Core/Passes/BoundedContextPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/BoundedContextPass.fs
@@ -175,20 +175,7 @@ module BoundedContextPass =
                 (sprintf "boundedContext v%d: %d community candidates from %d nodes"
                     version (List.length candidates) (List.length nodes))
 
-        let events =
-            nodes
-            |> List.map (fun key ->
-                { PassName       = passName
-                  PassVersion    = version
-                  SsKey          = key
-                  TransformKind  = Touched
-                  Classification = DataIntent })
-
-        lineageDiagnostics {
-            do! LineageDiagnostics.writeLineages events
-            do! LineageDiagnostics.writeDiagnostic entry
-            return result
-        }
+        LineageDiagnostics.touchedEpilogue passName version nodes [ entry ] result
 
     let registered : RegisteredTransform<TopologicalOrder, BoundedContextDiscovery> =
         { Name         = passName

--- a/sidecar/projection/src/Projection.Core/Passes/CentralityPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/CentralityPass.fs
@@ -153,20 +153,7 @@ module CentralityPass =
                     (sprintf "centrality v%d: PageRank over %d nodes, %d edges; converged in %d iterations"
                         version n (List.length t.Edges) iterations)
 
-            let events =
-                nodes
-                |> List.map (fun key ->
-                    { PassName       = passName
-                      PassVersion    = version
-                      SsKey          = key
-                      TransformKind  = Touched
-                      Classification = DataIntent })
-
-            lineageDiagnostics {
-                do! LineageDiagnostics.writeLineages events
-                do! LineageDiagnostics.writeDiagnostic entry
-                return result
-            }
+            LineageDiagnostics.touchedEpilogue passName version nodes [ entry ] result
 
     /// Registered transform metadata. Input type is `TopologicalOrder`.
     let registered : RegisteredTransform<TopologicalOrder, CentralityRanking> =

--- a/sidecar/projection/src/Projection.Core/Passes/ProfileAnomalyPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/ProfileAnomalyPass.fs
@@ -126,20 +126,8 @@ module ProfileAnomalyPass =
 
         let allDiagnostics = nullDiagnostics @ cvDiagnostics
 
-        let events =
-            allKinds
-            |> List.map (fun k ->
-                { PassName       = passName
-                  PassVersion    = version
-                  SsKey          = k.SsKey
-                  TransformKind  = Touched
-                  Classification = DataIntent })
-
-        lineageDiagnostics {
-            do! LineageDiagnostics.writeLineages events
-            do! LineageDiagnostics.writeDiagnostics allDiagnostics
-            return report
-        }
+        let touched = allKinds |> List.map (fun k -> k.SsKey)
+        LineageDiagnostics.touchedEpilogue passName version touched allDiagnostics report
 
     let registered (profile: Profile) : RegisteredTransform<Catalog, ProfileAnomalyReport> =
         { Name         = passName

--- a/sidecar/projection/src/Projection.Core/Passes/QueryHintPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/QueryHintPass.fs
@@ -90,20 +90,8 @@ module QueryHintPass =
                         (SsKey.rootOriginal idxKey) sel.DistinctCount suggestedFillFactor)
                   with SsKey = Some idxKey; SuggestedConfig = Some suggestedConfig })
 
-        let events =
-            allKinds
-            |> List.map (fun k ->
-                { PassName       = passName
-                  PassVersion    = version
-                  SsKey          = k.SsKey
-                  TransformKind  = Touched
-                  Classification = DataIntent })
-
-        lineageDiagnostics {
-            do! LineageDiagnostics.writeLineages events
-            do! LineageDiagnostics.writeDiagnostics diagnostics
-            return report
-        }
+        let touched = allKinds |> List.map (fun k -> k.SsKey)
+        LineageDiagnostics.touchedEpilogue passName version touched diagnostics report
 
     let registered (profile: Profile) : RegisteredTransform<Catalog, QueryHintReport> =
         { Name         = passName

--- a/sidecar/projection/src/Projection.Core/Passes/SchemaComplexityPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/SchemaComplexityPass.fs
@@ -139,20 +139,8 @@ module SchemaComplexityPass =
                 (sprintf "schemaComplexity v%d: cyclomatic=%d coupling=%.3f cohesion=%.3f depth=%d nullability=%.3f overall=%.3f"
                     version cyclomatic coupling cohesion depth nullabilityRatio overallScore)
 
-        let events =
-            allKinds
-            |> List.map (fun k ->
-                { PassName       = passName
-                  PassVersion    = version
-                  SsKey          = k.SsKey
-                  TransformKind  = Touched
-                  Classification = DataIntent })
-
-        lineageDiagnostics {
-            do! LineageDiagnostics.writeLineages events
-            do! LineageDiagnostics.writeDiagnostic entry
-            return result
-        }
+        let touched = allKinds |> List.map (fun k -> k.SsKey)
+        LineageDiagnostics.touchedEpilogue passName version touched [ entry ] result
 
     let registered (topology: TopologicalOrder option) : RegisteredTransform<Catalog, SchemaComplexity> =
         let topoDefault = topology |> Option.defaultValue TopologicalOrder.empty

--- a/sidecar/projection/src/Projection.Pipeline/DatabaseNameGenerator.fs
+++ b/sidecar/projection/src/Projection.Pipeline/DatabaseNameGenerator.fs
@@ -1,0 +1,47 @@
+namespace Projection.Pipeline
+
+open System
+
+/// **First-class non-determinism boundary.** `DatabaseNameGenerator
+/// = unit -> string` is the typed seam through which `Guid.NewGuid`
+/// (or any test-pinned counter) enters Pipeline. Per
+/// `DECISIONS 2026-05-09 — No-string-concatenation / no-regex
+/// discipline` audit Tier 2: the leak from non-determinism into
+/// the deploy boundary is reified as a parameter, not hidden in
+/// a closure. Callers that need byte-determinism on database
+/// names inject a counter-based generator; the default uses
+/// `Guid.NewGuid` for unique-per-run isolation in shared
+/// containers (the canary's de-facto requirement).
+///
+/// Re-exposed (type + module) under `Deploy.DatabaseNameGenerator`
+/// via nested abbreviation so existing call sites are untouched.
+type DatabaseNameGenerator = unit -> string
+
+[<RequireQualifiedAccess>]
+module DatabaseNameGenerator =
+
+    /// Default `DatabaseNameGenerator` — uses `Guid.NewGuid`. The
+    /// observable non-determinism is scoped to per-database
+    /// names; T1 byte-determinism at the SQL emission layer is
+    /// unaffected (V2's Π output is pure; only the deploy-host's
+    /// per-database scoping is non-deterministic, and that's a
+    /// Pipeline concern). Per-segment formatting goes through
+    /// `String.Concat` rather than `sprintf`.
+    /// Length of the GUID suffix used in ephemeral database
+    /// names. 12 chars of N-format GUID is ~48 bits of entropy
+    /// — sufficient for per-run uniqueness across concurrent
+    /// canary processes; short enough to fit `Source_<suffix>`
+    /// under SQL Server's 128-char identifier limit with
+    /// generous prefix headroom.
+    [<Literal>]
+    let private GuidSuffixLength : int = 12
+
+    let guidBased : DatabaseNameGenerator =
+        // The `guidBased` binding IS the sanctioned `Guid.NewGuid`
+        // site — the reified non-determinism boundary. Audit
+        // Lens-2 Tier-1 discharged: Guid.NewGuid is now type-
+        // visible through the seam, not hidden inside a private
+        // function.
+        fun () ->
+            let suffix = Guid.NewGuid().ToString("N").Substring(0, GuidSuffixLength)  // LINT-ALLOW: reified non-determinism boundary
+            suffix

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -65,198 +65,29 @@ module Deploy =
             TargetReport : Report
         }
 
-    /// Docker availability + lazy JIT bring-up. Per session-36 — the
-    /// session-start hook starts dockerd at session boot, but the
-    /// daemon can drop mid-session (OOM, signal, environment shift);
-    /// `ensureRunning` probes responsiveness and re-starts the daemon
-    /// best-effort so canary tests don't fail spuriously. `isAvailable`
-    /// stays as the static yes/no for callers that just want a probe;
-    /// tests that actually need Docker should call `ensureRunning`.
+    /// Docker availability + lazy JIT bring-up. The implementation
+    /// lives in the concept-named `DockerDaemon` module (container-
+    /// daemon lifecycle); this nested `Deploy.Docker` facade forwards
+    /// to it so every existing `Deploy.Docker.*` call site
+    /// (`isAvailable`, `ensureRunning`, `resetMemo`) is untouched.
+    /// Per session-36 — the session-start hook starts dockerd at
+    /// session boot, but the daemon can drop mid-session (OOM, signal,
+    /// environment shift); `ensureRunning` probes responsiveness and
+    /// re-starts the daemon best-effort so canary tests don't fail
+    /// spuriously.
     [<RequireQualifiedAccess>]
     module Docker =
-        // Canonical Docker Unix socket locations. Two candidates:
-        //   1. system-wide socket at /var/run/docker.sock (Linux default)
-        //   2. user-scoped rootless socket under ~/.docker/run/docker.sock
-        // Path composition flows through `Path.Combine` (audit Top-10
-        // #6: filesystem boundary uses BCL primitive, not `sprintf`).
-        [<Literal>]
-        let private SystemSocketPath : string = "/var/run/docker.sock"
-
-        let private socketCandidates : string list =
-            // Defensive against empty home directory (distroless
-            // containers; `USER nobody`; k8s pods without `$HOME`):
-            // `GetFolderPath SpecialFolder.UserProfile` returns "" on
-            // those hosts; `Path.Combine("", ...)` yields a relative
-            // path that resolves against `CurrentDirectory`, which
-            // is misleading at probe time. Guard the rootless
-            // candidate behind a non-empty home.
-            let home = Environment.GetFolderPath Environment.SpecialFolder.UserProfile
-            if String.IsNullOrEmpty home then
-                [ SystemSocketPath ]
-            else
-                [ SystemSocketPath
-                  Path.Combine(home, ".docker", "run", "docker.sock") ]
-
-        // Why these specific values (not arbitrary):
-        // - `ProbeTimeoutMs = 2000`: `docker version` against a healthy
-        //   daemon returns in tens of ms; 2 s is the slack for a
-        //   loaded host. Larger timeouts hide a wedged daemon
-        //   (downstream canary work fails anyway). 2 s is the smallest
-        //   value that doesn't false-negative under host load.
-        // - `BringupBudgetMs = 5000`: dockerd cold-start measured at
-        //   1-3 s on hosts where bring-up is permitted; 5 s is the
-        //   smallest budget that survives a sandbox-loaded p99 cold
-        //   boot. Per `DECISIONS 2026-05-10 — Docker probe efficiency`,
-        //   higher budgets ARE NOT a help on a host where the daemon
-        //   genuinely cannot start (web sandbox without dockerd
-        //   privileges) — the budget is paid once per call (×N tests
-        //   absent memoization), and then the daemon still won't be
-        //   up. Memoization (below) collapses the test-suite-level
-        //   cost; the lower per-call ceiling makes even un-memoized
-        //   first-call paths reasonable.
-        // - `BringupPollMs = 200`: below the perceptual instant-response
-        //   threshold (~250 ms) so a successful bring-up returns
-        //   without feeling laggy; small enough to detect a fast
-        //   bring-up promptly without hammering the probe.
-        // The shape is a poll-until-ready loop, not a fixed wait —
-        // we exit as soon as the daemon is responsive; the budget
-        // is only consumed in the failure case.
-        [<Literal>]
-        let private ProbeTimeoutMs : int = 2_000
-
-        [<Literal>]
-        let private BringupBudgetMs : int = 5_000
-
-        [<Literal>]
-        let private BringupPollMs : int = 200
-
         /// Static probe: env var or socket file present. Cheap; doesn't
-        /// contact the daemon. Used as the gate for "this environment
-        /// could plausibly run Docker."
-        let isAvailable () : bool =
-            let hasEnvHost =
-                let v = Environment.GetEnvironmentVariable "DOCKER_HOST"
-                not (String.IsNullOrWhiteSpace v)
-            let socketExists =
-                socketCandidates |> List.exists File.Exists
-            hasEnvHost || socketExists
+        /// contact the daemon. Forwards to `DockerDaemon.isAvailable`.
+        let isAvailable () : bool = DockerDaemon.isAvailable ()
 
-        /// Active probe: shell out to `docker version` with a 2 s
-        /// ceiling. Captures the daemon-not-listening case that
-        /// `isAvailable` (socket-file probe only) misses.
-        let private isResponding () : bool =
-            try
-                let psi =
-                    System.Diagnostics.ProcessStartInfo(
-                        FileName = "docker",
-                        Arguments = "version --format \"{{.Server.Version}}\"",
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        UseShellExecute = false)
-                match System.Diagnostics.Process.Start psi with
-                | null -> false
-                | p ->
-                    use _ = p
-                    if p.WaitForExit ProbeTimeoutMs then p.ExitCode = 0
-                    else
-                        try p.Kill() with _ -> ()
-                        false
-            with _ -> false
+        /// JIT bring-up (memoized). Forwards to
+        /// `DockerDaemon.ensureRunning`.
+        let ensureRunning () : bool = DockerDaemon.ensureRunning ()
 
-        /// Best-effort daemon spawn followed by poll-until-ready. The
-        /// budget is a *ceiling* — we exit as soon as the daemon
-        /// answers `isResponding`, so a healthy bring-up returns
-        /// within a few hundred ms. The full budget consumes only
-        /// when dockerd genuinely failed to start.
-        let private startDaemon () : bool =
-            try
-                let psi =
-                    System.Diagnostics.ProcessStartInfo(
-                        FileName = "sudo",
-                        Arguments = "dockerd",
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        UseShellExecute = false)
-                System.Diagnostics.Process.Start psi |> ignore
-            with _ -> ()
-            let sw = System.Diagnostics.Stopwatch.StartNew()
-            let mutable up = isResponding ()
-            while not up && sw.ElapsedMilliseconds < int64 BringupBudgetMs do
-                System.Threading.Thread.Sleep BringupPollMs
-                up <- isResponding ()
-            up
-
-        // Memoization for `ensureRunning`. Per `DECISIONS 2026-05-10 —
-        // Docker probe efficiency`: a test suite invokes `ensureRunning`
-        // per-test through `skipIfNoDocker`; absent memoization, every
-        // canary test pays the full bring-up budget when Docker is
-        // unavailable (~14 minutes for a 15-test suite at the prior
-        // 30 s budget). Memoization collapses the suite-level cost to
-        // a single probe-and-bring-up cycle; the result is cached for
-        // the life of the process.
-        //
-        // Thread-safety: the lock guards both read and write. Re-entry
-        // is impossible (the inner work is `isAvailable` /
-        // `isResponding` / `startDaemon`, none of which call
-        // `ensureRunning`).
-        //
-        // Reset semantics: `resetMemo ()` clears the cache for callers
-        // that need to re-probe (e.g., a long-running CLI that wants
-        // to retry after a daemon recovery). Tests do not use it; the
-        // canary-test pattern is one probe per process.
-        let private memoLock : obj = obj ()
-        let mutable private memoResult : bool option = None
-
-        // A warm external SQL Server (`PROJECTION_MSSQL_CONN_STR` — the
-        // dev-loop warm container or any reachable instance) needs no
-        // *local* Docker daemon: the tests connect over TCP and create
-        // per-test databases on it. Short-circuit the daemon probe in
-        // that case so the warm-reuse loop runs even where `dockerd`
-        // can't be brought up. The literal is inlined (the canonical
-        // `WarmConnStringEnvVar` is defined after this nested module in
-        // the compile order); kept in sync by the single call site.
-        let private warmConfigured () : bool =
-            not (String.IsNullOrWhiteSpace
-                    (Environment.GetEnvironmentVariable "PROJECTION_MSSQL_CONN_STR"))
-
-        let private probeOnce () : bool =
-            // Per the chapter-3.1 sandbox finding (codified
-            // 2026-05-10 — Docker probe efficiency): the dominant
-            // worst case in the web sandbox is `isAvailable` true
-            // (socket file present from a prior bring-up attempt)
-            // but the daemon not responding AND `sudo dockerd`
-            // unavailable to us. `BringupBudgetMs` is the ceiling
-            // for that loop; memoization (above) keeps the cost
-            // suite-wide constant.
-            if warmConfigured () then true
-            elif not (isAvailable ()) then false
-            elif isResponding () then true
-            else startDaemon ()
-
-        /// JIT bring-up. Returns true iff Docker is usable for canary
-        /// work. Tests gate on this for clean skip-if-unavailable
-        /// semantics that survive a mid-session daemon drop.
-        ///
-        /// **Memoized** per `DECISIONS 2026-05-10 — Docker probe
-        /// efficiency`. The bring-up budget is paid at most once per
-        /// process. Use `resetMemo ()` if you need to retry after a
-        /// known recovery event (rare; tests don't).
-        let ensureRunning () : bool =
-            lock memoLock (fun () ->
-                match memoResult with
-                | Some cached -> cached
-                | None ->
-                    let result = probeOnce ()
-                    memoResult <- Some result
-                    result)
-
-        /// Clear the memoized `ensureRunning` result. The next call
-        /// re-probes from scratch. Per the discipline above: only
-        /// callers that have *evidence* of daemon recovery should
-        /// invoke this (e.g., a test runner with a between-suite
-        /// hook that re-armed Docker).
-        let resetMemo () : unit =
-            lock memoLock (fun () -> memoResult <- None)
+        /// Clear the memoized `ensureRunning` result. Forwards to
+        /// `DockerDaemon.resetMemo`.
+        let resetMemo () : unit = DockerDaemon.resetMemo ()
 
     [<Literal>]
     let private DefaultImage : string =
@@ -264,44 +95,19 @@ module Deploy =
 
     /// **First-class non-determinism boundary.** `DatabaseNameGenerator
     /// = unit -> string` is the typed seam through which `Guid.NewGuid`
-    /// (or any test-pinned counter) enters Pipeline. Per
-    /// `DECISIONS 2026-05-09 — No-string-concatenation / no-regex
-    /// discipline` audit Tier 2: the leak from non-determinism into
-    /// the deploy boundary is reified as a parameter, not hidden in
-    /// a closure. Callers that need byte-determinism on database
-    /// names inject a counter-based generator; the default uses
-    /// `Guid.NewGuid` for unique-per-run isolation in shared
-    /// containers (the canary's de-facto requirement).
-    type DatabaseNameGenerator = unit -> string
+    /// (or any test-pinned counter) enters Pipeline. The type + the
+    /// default generator live in the concept-named
+    /// `DatabaseNameGenerator` module; re-exposed here as
+    /// `Deploy.DatabaseNameGenerator` (the type abbreviation plus a
+    /// nested facade) so existing references are untouched.
+    type DatabaseNameGenerator = Projection.Pipeline.DatabaseNameGenerator
 
     [<RequireQualifiedAccess>]
     module DatabaseNameGenerator =
-
-        /// Default `DatabaseNameGenerator` — uses `Guid.NewGuid`. The
-        /// observable non-determinism is scoped to per-database
-        /// names; T1 byte-determinism at the SQL emission layer is
-        /// unaffected (V2's Π output is pure; only the deploy-host's
-        /// per-database scoping is non-deterministic, and that's a
-        /// Pipeline concern). Per-segment formatting goes through
-        /// `String.Concat` rather than `sprintf`.
-        /// Length of the GUID suffix used in ephemeral database
-        /// names. 12 chars of N-format GUID is ~48 bits of entropy
-        /// — sufficient for per-run uniqueness across concurrent
-        /// canary processes; short enough to fit `Source_<suffix>`
-        /// under SQL Server's 128-char identifier limit with
-        /// generous prefix headroom.
-        [<Literal>]
-        let private GuidSuffixLength : int = 12
-
+        /// Default `DatabaseNameGenerator` — uses `Guid.NewGuid`.
+        /// Forwards to `DatabaseNameGenerator.guidBased`.
         let guidBased : DatabaseNameGenerator =
-            // The `guidBased` binding IS the sanctioned `Guid.NewGuid`
-            // site — the reified non-determinism boundary. Audit
-            // Lens-2 Tier-1 discharged: Guid.NewGuid is now type-
-            // visible through the seam, not hidden inside a private
-            // function.
-            fun () ->
-                let suffix = Guid.NewGuid().ToString("N").Substring(0, GuidSuffixLength)  // LINT-ALLOW: reified non-determinism boundary
-                suffix
+            Projection.Pipeline.DatabaseNameGenerator.guidBased
 
     let private uniqueDatabaseName
         (gen: DatabaseNameGenerator)
@@ -335,44 +141,23 @@ module Deploy =
 
     /// Typed connection-string handling — chapter-3.6 cash-out of
     /// audit Top-10 #1 (centralize connection-string validation
-    /// behind `SqlConnectionStringBuilder`). Wraps the BCL builder
-    /// in a `Result<_>` so malformed strings surface as
-    /// `ValidationError` at the validation boundary, not as an
-    /// opaque `SqlException` at connect time.
+    /// behind `SqlConnectionStringBuilder`). The implementation lives
+    /// in the concept-named `DeployConnectionString` module; this
+    /// nested `Deploy.ConnectionString` facade forwards to it so every
+    /// existing `Deploy.ConnectionString.*` call site (`parse`,
+    /// `buildPerDb`) is untouched.
     [<RequireQualifiedAccess>]
     module ConnectionString =
-
-        let private invalidConnectionString (message: string) : ValidationError =
-            ValidationError.create "deploy.connectionString.invalid" message
-
         /// Parse a connection string into a validated typed builder.
-        /// `SqlConnectionStringBuilder` throws on malformed input;
-        /// we catch and lift to `ValidationError` so the boundary
-        /// surfaces structured errors.
+        /// Forwards to `DeployConnectionString.parse`.
         let parse (connStr: string) : Result<SqlConnectionStringBuilder> =
-            if System.String.IsNullOrWhiteSpace connStr then
-                Result.failureOf
-                    (invalidConnectionString
-                        "Connection string is null, empty, or whitespace.")
-            else
-                try
-                    Result.success (SqlConnectionStringBuilder(connStr))
-                with
-                | :? System.ArgumentException as ex ->
-                    Result.failureOf (invalidConnectionString ex.Message)
-                | :? System.FormatException as ex ->
-                    Result.failureOf (invalidConnectionString ex.Message)
+            DeployConnectionString.parse connStr
 
         /// Build a per-database connection string from a master
-        /// connection string. Trusts the `master` argument (callers
-        /// flow through `parse` first if validation is needed); the
-        /// `dbName` is set as `InitialCatalog`. Identifier escaping
-        /// (handling `]` inside dbName) is `SqlConnectionStringBuilder`'s
-        /// responsibility — its setter handles SQL-quoting per spec.
+        /// connection string. Forwards to
+        /// `DeployConnectionString.buildPerDb`.
         let buildPerDb (master: string) (dbName: string) : string =
-            let b = SqlConnectionStringBuilder(master)
-            b.InitialCatalog <- dbName
-            b.ConnectionString
+            DeployConnectionString.buildPerDb master dbName
 
     let private buildPerDbConnectionString (master: string) (dbName: string) : string =
         ConnectionString.buildPerDb master dbName

--- a/sidecar/projection/src/Projection.Pipeline/DeployConnectionString.fs
+++ b/sidecar/projection/src/Projection.Pipeline/DeployConnectionString.fs
@@ -1,0 +1,50 @@
+namespace Projection.Pipeline
+
+open Microsoft.Data.SqlClient
+open Projection.Core
+
+/// Typed connection-string handling — chapter-3.6 cash-out of
+/// audit Top-10 #1 (centralize connection-string validation
+/// behind `SqlConnectionStringBuilder`). Wraps the BCL builder
+/// in a `Result<_>` so malformed strings surface as
+/// `ValidationError` at the validation boundary, not as an
+/// opaque `SqlException` at connect time.
+///
+/// Re-exposed under `Deploy.ConnectionString` via a nested module
+/// abbreviation so every existing `Deploy.ConnectionString.*`
+/// call site (`buildPerDb`, `parse`) keeps working; this is the
+/// concept-named home (deploy connection-string building).
+[<RequireQualifiedAccess>]
+module DeployConnectionString =
+
+    let private invalidConnectionString (message: string) : ValidationError =
+        ValidationError.create "deploy.connectionString.invalid" message
+
+    /// Parse a connection string into a validated typed builder.
+    /// `SqlConnectionStringBuilder` throws on malformed input;
+    /// we catch and lift to `ValidationError` so the boundary
+    /// surfaces structured errors.
+    let parse (connStr: string) : Result<SqlConnectionStringBuilder> =
+        if System.String.IsNullOrWhiteSpace connStr then
+            Result.failureOf
+                (invalidConnectionString
+                    "Connection string is null, empty, or whitespace.")
+        else
+            try
+                Result.success (SqlConnectionStringBuilder(connStr))
+            with
+            | :? System.ArgumentException as ex ->
+                Result.failureOf (invalidConnectionString ex.Message)
+            | :? System.FormatException as ex ->
+                Result.failureOf (invalidConnectionString ex.Message)
+
+    /// Build a per-database connection string from a master
+    /// connection string. Trusts the `master` argument (callers
+    /// flow through `parse` first if validation is needed); the
+    /// `dbName` is set as `InitialCatalog`. Identifier escaping
+    /// (handling `]` inside dbName) is `SqlConnectionStringBuilder`'s
+    /// responsibility — its setter handles SQL-quoting per spec.
+    let buildPerDb (master: string) (dbName: string) : string =
+        let b = SqlConnectionStringBuilder(master)
+        b.InitialCatalog <- dbName
+        b.ConnectionString

--- a/sidecar/projection/src/Projection.Pipeline/DockerDaemon.fs
+++ b/sidecar/projection/src/Projection.Pipeline/DockerDaemon.fs
@@ -1,0 +1,205 @@
+namespace Projection.Pipeline
+
+// LINT-ALLOW-FILE-MUTATION: Docker JIT bring-up poll loop mutable (`memoResult` +
+//   the `up` poll accumulator). Per audit Lens-2 Tier-1+2; the daemon-readiness
+//   poll is the sanctioned mutation boundary for the bring-up budget loop.
+
+open System
+open System.IO
+
+/// Docker availability + lazy JIT bring-up. Per session-36 — the
+/// session-start hook starts dockerd at session boot, but the
+/// daemon can drop mid-session (OOM, signal, environment shift);
+/// `ensureRunning` probes responsiveness and re-starts the daemon
+/// best-effort so canary tests don't fail spuriously. `isAvailable`
+/// stays as the static yes/no for callers that just want a probe;
+/// tests that actually need Docker should call `ensureRunning`.
+///
+/// Re-exposed under `Deploy.Docker` via a nested module abbreviation
+/// so every existing `Deploy.Docker.*` call site keeps working;
+/// this is the concept-named home (container-daemon lifecycle).
+[<RequireQualifiedAccess>]
+module DockerDaemon =
+    // Canonical Docker Unix socket locations. Two candidates:
+    //   1. system-wide socket at /var/run/docker.sock (Linux default)
+    //   2. user-scoped rootless socket under ~/.docker/run/docker.sock
+    // Path composition flows through `Path.Combine` (audit Top-10
+    // #6: filesystem boundary uses BCL primitive, not `sprintf`).
+    [<Literal>]
+    let private SystemSocketPath : string = "/var/run/docker.sock"
+
+    let private socketCandidates : string list =
+        // Defensive against empty home directory (distroless
+        // containers; `USER nobody`; k8s pods without `$HOME`):
+        // `GetFolderPath SpecialFolder.UserProfile` returns "" on
+        // those hosts; `Path.Combine("", ...)` yields a relative
+        // path that resolves against `CurrentDirectory`, which
+        // is misleading at probe time. Guard the rootless
+        // candidate behind a non-empty home.
+        let home = Environment.GetFolderPath Environment.SpecialFolder.UserProfile
+        if String.IsNullOrEmpty home then
+            [ SystemSocketPath ]
+        else
+            [ SystemSocketPath
+              Path.Combine(home, ".docker", "run", "docker.sock") ]
+
+    // Why these specific values (not arbitrary):
+    // - `ProbeTimeoutMs = 2000`: `docker version` against a healthy
+    //   daemon returns in tens of ms; 2 s is the slack for a
+    //   loaded host. Larger timeouts hide a wedged daemon
+    //   (downstream canary work fails anyway). 2 s is the smallest
+    //   value that doesn't false-negative under host load.
+    // - `BringupBudgetMs = 5000`: dockerd cold-start measured at
+    //   1-3 s on hosts where bring-up is permitted; 5 s is the
+    //   smallest budget that survives a sandbox-loaded p99 cold
+    //   boot. Per `DECISIONS 2026-05-10 — Docker probe efficiency`,
+    //   higher budgets ARE NOT a help on a host where the daemon
+    //   genuinely cannot start (web sandbox without dockerd
+    //   privileges) — the budget is paid once per call (×N tests
+    //   absent memoization), and then the daemon still won't be
+    //   up. Memoization (below) collapses the test-suite-level
+    //   cost; the lower per-call ceiling makes even un-memoized
+    //   first-call paths reasonable.
+    // - `BringupPollMs = 200`: below the perceptual instant-response
+    //   threshold (~250 ms) so a successful bring-up returns
+    //   without feeling laggy; small enough to detect a fast
+    //   bring-up promptly without hammering the probe.
+    // The shape is a poll-until-ready loop, not a fixed wait —
+    // we exit as soon as the daemon is responsive; the budget
+    // is only consumed in the failure case.
+    [<Literal>]
+    let private ProbeTimeoutMs : int = 2_000
+
+    [<Literal>]
+    let private BringupBudgetMs : int = 5_000
+
+    [<Literal>]
+    let private BringupPollMs : int = 200
+
+    /// Static probe: env var or socket file present. Cheap; doesn't
+    /// contact the daemon. Used as the gate for "this environment
+    /// could plausibly run Docker."
+    let isAvailable () : bool =
+        let hasEnvHost =
+            let v = Environment.GetEnvironmentVariable "DOCKER_HOST"
+            not (String.IsNullOrWhiteSpace v)
+        let socketExists =
+            socketCandidates |> List.exists File.Exists
+        hasEnvHost || socketExists
+
+    /// Active probe: shell out to `docker version` with a 2 s
+    /// ceiling. Captures the daemon-not-listening case that
+    /// `isAvailable` (socket-file probe only) misses.
+    let private isResponding () : bool =
+        try
+            let psi =
+                System.Diagnostics.ProcessStartInfo(
+                    FileName = "docker",
+                    Arguments = "version --format \"{{.Server.Version}}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false)
+            match System.Diagnostics.Process.Start psi with
+            | null -> false
+            | p ->
+                use _ = p
+                if p.WaitForExit ProbeTimeoutMs then p.ExitCode = 0
+                else
+                    try p.Kill() with _ -> ()
+                    false
+        with _ -> false
+
+    /// Best-effort daemon spawn followed by poll-until-ready. The
+    /// budget is a *ceiling* — we exit as soon as the daemon
+    /// answers `isResponding`, so a healthy bring-up returns
+    /// within a few hundred ms. The full budget consumes only
+    /// when dockerd genuinely failed to start.
+    let private startDaemon () : bool =
+        try
+            let psi =
+                System.Diagnostics.ProcessStartInfo(
+                    FileName = "sudo",
+                    Arguments = "dockerd",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false)
+            System.Diagnostics.Process.Start psi |> ignore
+        with _ -> ()
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let mutable up = isResponding ()
+        while not up && sw.ElapsedMilliseconds < int64 BringupBudgetMs do
+            System.Threading.Thread.Sleep BringupPollMs
+            up <- isResponding ()
+        up
+
+    // Memoization for `ensureRunning`. Per `DECISIONS 2026-05-10 —
+    // Docker probe efficiency`: a test suite invokes `ensureRunning`
+    // per-test through `skipIfNoDocker`; absent memoization, every
+    // canary test pays the full bring-up budget when Docker is
+    // unavailable (~14 minutes for a 15-test suite at the prior
+    // 30 s budget). Memoization collapses the suite-level cost to
+    // a single probe-and-bring-up cycle; the result is cached for
+    // the life of the process.
+    //
+    // Thread-safety: the lock guards both read and write. Re-entry
+    // is impossible (the inner work is `isAvailable` /
+    // `isResponding` / `startDaemon`, none of which call
+    // `ensureRunning`).
+    //
+    // Reset semantics: `resetMemo ()` clears the cache for callers
+    // that need to re-probe (e.g., a long-running CLI that wants
+    // to retry after a daemon recovery). Tests do not use it; the
+    // canary-test pattern is one probe per process.
+    let private memoLock : obj = obj ()
+    let mutable private memoResult : bool option = None
+
+    // A warm external SQL Server (`PROJECTION_MSSQL_CONN_STR` — the
+    // dev-loop warm container or any reachable instance) needs no
+    // *local* Docker daemon: the tests connect over TCP and create
+    // per-test databases on it. Short-circuit the daemon probe in
+    // that case so the warm-reuse loop runs even where `dockerd`
+    // can't be brought up. The literal is inlined (the canonical
+    // `Deploy.WarmConnStringEnvVar` lives on the `Deploy` module in
+    // the compile order); kept in sync by the single call site.
+    let private warmConfigured () : bool =
+        not (String.IsNullOrWhiteSpace
+                (Environment.GetEnvironmentVariable "PROJECTION_MSSQL_CONN_STR"))
+
+    let private probeOnce () : bool =
+        // Per the chapter-3.1 sandbox finding (codified
+        // 2026-05-10 — Docker probe efficiency): the dominant
+        // worst case in the web sandbox is `isAvailable` true
+        // (socket file present from a prior bring-up attempt)
+        // but the daemon not responding AND `sudo dockerd`
+        // unavailable to us. `BringupBudgetMs` is the ceiling
+        // for that loop; memoization (above) keeps the cost
+        // suite-wide constant.
+        if warmConfigured () then true
+        elif not (isAvailable ()) then false
+        elif isResponding () then true
+        else startDaemon ()
+
+    /// JIT bring-up. Returns true iff Docker is usable for canary
+    /// work. Tests gate on this for clean skip-if-unavailable
+    /// semantics that survive a mid-session daemon drop.
+    ///
+    /// **Memoized** per `DECISIONS 2026-05-10 — Docker probe
+    /// efficiency`. The bring-up budget is paid at most once per
+    /// process. Use `resetMemo ()` if you need to retry after a
+    /// known recovery event (rare; tests don't).
+    let ensureRunning () : bool =
+        lock memoLock (fun () ->
+            match memoResult with
+            | Some cached -> cached
+            | None ->
+                let result = probeOnce ()
+                memoResult <- Some result
+                result)
+
+    /// Clear the memoized `ensureRunning` result. The next call
+    /// re-probes from scratch. Per the discipline above: only
+    /// callers that have *evidence* of daemon recovery should
+    /// invoke this (e.g., a test runner with a between-suite
+    /// hook that re-armed Docker).
+    let resetMemo () : unit =
+        lock memoLock (fun () -> memoResult <- None)

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -166,13 +166,14 @@ module MigrationRun =
     /// and the next reads it back here as the comparison basis. A **missing store
     /// is genesis** — A = ∅, so every kind is `Add` and there are no losses (the
     /// first emission of a timeline). Fail-closed on a malformed store.
-    let previewFromStore
+    let previewFromStoreForcing
+        (forceGenesis: bool)
         (path: string)
         (declaration: LossDeclaration)
         (target: Catalog)
         : Result<MigrationArtifacts, MigrationError> =
         let priorSchema : Result<Catalog, MigrationError> =
-            if System.IO.File.Exists path then
+            if (not forceGenesis) && System.IO.File.Exists path then
                 match LifecycleStore.load path with
                 | Error e -> Error (StoreReadFailed (string e))
                 | Ok chain ->
@@ -187,6 +188,16 @@ module MigrationRun =
         match priorSchema with
         | Error e -> Error e
         | Ok source -> preview declaration source target
+
+    /// The store-derived preview with genesis only on an absent store (the
+    /// default — every prior caller's behavior). `previewFromStoreForcing false`
+    /// is identical; this is the named no-force form.
+    let previewFromStore
+        (path: string)
+        (declaration: LossDeclaration)
+        (target: Catalog)
+        : Result<MigrationArtifacts, MigrationError> =
+        previewFromStoreForcing false path declaration target
 
     /// Record a completed migration's episode onto the timeline persisted at
     /// `path` (the durable substrate, 6.H.2). On the first migration of a

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -585,8 +585,17 @@ module MigrationRun =
     /// reconciling per `reconciliation` (the User re-key; empty = a straight
     /// load). Schema is minimum-viable + fail-loud; data is the existing
     /// `Transfer` engine. The data leg runs **only if** the schema leg verified
-    /// (never load into an unverified target). Both substrates end at B; the data
-    /// source's rows must match the contract B.
+    /// (never load into an unverified target).
+    ///
+    /// **A5 — the data source is at schema A.** In the established Dev→UAT
+    /// migrate-with-data flow the `dataSource` holds rows at the OLD schema A
+    /// (`sinkSource`), not already at B. The data leg therefore routes through
+    /// the rename-aware Transfer (`runWithRenames` / `runReconcilingWithRenames`)
+    /// with `sourceContract = sinkSource` (A) and `sinkContract = target` (B), so
+    /// rows are re-pointed onto the B names via the A→B `CatalogDiff` renames
+    /// (identity-matched, never ordinal) before the write. A no-renames diff
+    /// yields an empty rename map ⇒ identity repoint ⇒ byte-identical to the
+    /// straight load.
     let executeWithData
         (declaration: LossDeclaration)
         (mode: Transfer.Mode)
@@ -606,13 +615,17 @@ module MigrationRun =
                     return Error (VerificationFailed schema.SchemaDiff)
                 else
                     let! transferResult =
+                        // A5 — the data source is at A (`sinkSource`); re-point
+                        // rows A→B through the rename-aware Transfer. The renameMap
+                        // derives from `CatalogDiff.between sinkSource target`; a
+                        // no-renames diff repoints by identity (== the straight load).
                         if Map.isEmpty reconciliation then
-                            Transfer.run mode allowCdc dataSource sink target
+                            Transfer.runWithRenames mode allowCdc dataSource sink sinkSource target
                         else
                             // allowDrops = false: enforce the AC-I5 pre-write validate-user-map
                             // halt on the reconciling migrate-with-data path (the reconcile+migrate
                             // composition, AC-I7, is the follow-on; --allow-drops flows here then).
-                            Transfer.runReconciling mode allowCdc false dataSource sink target reconciliation
+                            Transfer.runReconcilingWithRenames mode allowCdc dataSource sink sinkSource target reconciliation
                     match transferResult with
                     | Ok report -> return Ok { Schema = schema; Transfer = report }
                     | Error es -> return Error (DataTransferFailed es)
@@ -659,10 +672,12 @@ module MigrationRun =
                 // after; the delta is the CDC capture count of the transfer.
                 let! baseline = Deploy.cdcCaptureTotal sink
                 let! transferResult =
+                    // A5 — the data source is at A (`sinkSource`); re-point rows
+                    // A→B through the rename-aware Transfer (see `executeWithData`).
                     if Map.isEmpty reconciliation then
-                        Transfer.run mode allowCdc dataSource sink target
+                        Transfer.runWithRenames mode allowCdc dataSource sink sinkSource target
                     else
-                        Transfer.runReconciling mode allowCdc false dataSource sink target reconciliation
+                        Transfer.runReconcilingWithRenames mode allowCdc dataSource sink sinkSource target reconciliation
                 match transferResult with
                 | Error es -> return Error (DataTransferFailed es)
                 | Ok report ->

--- a/sidecar/projection/src/Projection.Pipeline/ModuleFilterBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/ModuleFilterBinding.fs
@@ -1,0 +1,70 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// Boundary translation from the `Config.ModelSection` module-selection axis
+/// (JSON-shape: a `model.modules` selector list + the system / inactive
+/// include flags) to the Core-shape `ModuleFilterOptions` the
+/// `ModuleFilter.apply` Selection seam consumes.
+///
+/// Per V2_PRODUCTION_CUTOVER.md §3.4 / §5.6: Config types live at the Pipeline
+/// boundary and carry JSON-shape primitives; Core types carry the
+/// ubiquitous-language value objects. This module is the binding step between
+/// the two (the sibling of `RenameBinding` / `TighteningBinding`), so it lives
+/// in Pipeline (it depends on `Config.ModelSection`, a Pipeline type, and
+/// produces `ModuleFilterOptions`, a Core type).
+///
+/// **Pillar 9 — `OperatorIntent of Selection`.** The mapping is a faithful
+/// translation: each `ModuleSelector` becomes one module name (and, for the
+/// `WithEntities` form, one per-module entity filter); `IncludeSystemModules`
+/// / `IncludeInactiveModules` carry the operator's include flags through.
+///
+/// **The opt-in gate (byte-identical default).** Module selection is opt-in
+/// through a non-empty `model.modules`. When `modules` is empty, the binding
+/// returns `ModuleFilter.empty` — the all-permissive identity — so the
+/// full-export path that ships today (no module selection; system + inactive
+/// modules carried, never filtered at the adapter boundary per
+/// `CatalogReader.fs:166`) is preserved EXACTLY. The system / inactive include
+/// flags take effect only alongside a declared module selection; their config
+/// defaults (`includeSystemModules: false` / `includeInactiveModules: false`)
+/// thus do NOT silently activate a system/inactive drop on a config that names
+/// no modules. (See the binding's `DECISIONS` cash-out: the config-default
+/// polarity is the opposite of `ModuleFilter.empty`'s identity polarity, so
+/// straight-through wiring would change the default; the opt-in gate resolves
+/// the conflict in favor of byte-identical-by-default.)
+[<RequireQualifiedAccess>]
+module ModuleFilterBinding =
+
+    /// Split a `ModuleSelector` list into the module-name include list and the
+    /// per-module entity-filter pairs (`WithEntities` only). The module name is
+    /// carried for every selector; the entity filter is attached for the
+    /// `WithEntities` form.
+    let private split (selectors: Config.ModuleSelector list) : string list * (string * string seq) list =
+        let names =
+            selectors
+            |> List.map (function
+                | Config.ModuleSelector.Whole name             -> name
+                | Config.ModuleSelector.WithEntities (name, _) -> name)
+        let entityFilters =
+            selectors
+            |> List.choose (function
+                | Config.ModuleSelector.WithEntities (name, entities) -> Some (name, Seq.ofList entities)
+                | Config.ModuleSelector.Whole _                       -> None)
+        names, entityFilters
+
+    /// Construct the Core-shape `ModuleFilterOptions` from the `model` section.
+    /// An empty `model.modules` is the all-permissive identity (`ModuleFilter.
+    /// empty`) — module selection is opt-in, so the default config is
+    /// byte-identical. A non-empty selection routes the include flags + the
+    /// per-module entity filters through `ModuleFilter.createOptions` (which
+    /// validates + normalizes the operator-supplied names).
+    let fromConfig (model: Config.ModelSection) : Result<ModuleFilterOptions> =
+        match model.Modules with
+        | [] -> Result.success ModuleFilter.empty
+        | selectors ->
+            let names, entityFilters = split selectors
+            ModuleFilter.createOptions
+                names
+                model.IncludeSystemModules
+                model.IncludeInactiveModules
+                entityFilters

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -99,6 +99,10 @@ type MovementSpec =
         AllowDrops  : bool
         /// Permit schema DDL against a CDC-tracked sink.
         AllowCdc    : bool
+        /// G10 — route the incremental data load through the resumable /
+        /// idempotent-upsert envelope (`Transfer.runResumable`). Honored on the
+        /// pure-transfer data leg; inert elsewhere. Default false (byte-identical).
+        Resumable   : bool
         /// Durable provenance store; fills from the target's config or `--store`.
         Store       : string option
         /// Environment label for the timeline / episode.
@@ -125,6 +129,7 @@ module MovementSpec =
             Tables      = []
             AllowDrops  = false
             AllowCdc    = false
+            Resumable   = false
             Store       = None
             Env         = None
             Commit      = false
@@ -171,6 +176,9 @@ type FlowRunOpts =
         /// Override the CDC-tracked-sink pre-flight gate (the gate refuses a
         /// live write into a CDC-tracked sink unless this is set — item 3).
         AllowCdc   : bool
+        /// `--resumable` — route the incremental data load through the resumable
+        /// / idempotent-upsert envelope (G10). Default false (byte-identical).
+        Resumable  : bool
     }
 
 /// The operator intents (THE_CLI.md §2). `Flow` is the hero — the daily
@@ -199,6 +207,8 @@ type LoadOpts =
         Reconcile   : string list
         Rekey       : string option
         AllowCdc    : bool
+        /// G10 — resumable/idempotent data load on the pure-transfer leg.
+        Resumable   : bool
         Store       : string option
         Env         : string option
         /// Declared table subset for the data leg (item 5); empty = all.
@@ -256,7 +266,11 @@ type PlanAction =
     | ExplainSuggest of config: string * applyTo: string option
     | ExplainRegistry
     | ExplainMigratePreview of fromPath: string * toPath: string * declaration: LossDeclaration
-    | ExplainMigrateFromStore of store: string * toPath: string * declaration: LossDeclaration
+    /// `forceGenesis` (the `--from empty` flag): when true, the prior state A is
+    /// forced to ∅ (every kind `Add`, no losses) EVEN when the store file exists —
+    /// the "first emission" framing on demand. Default false preserves the
+    /// store-derived A (genesis only when the store is absent).
+    | ExplainMigrateFromStore of store: string * toPath: string * declaration: LossDeclaration * forceGenesis: bool
     // seal ---------------------------------------------------------------
     | SealEject of store: string
     | SealApprove of version: string * approver: string * rationale: string option * store: string option

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -308,6 +308,7 @@ module Command =
           Reconcile   = spec.Reconcile
           Rekey       = spec.Rekey
           AllowCdc    = spec.AllowCdc
+          Resumable   = spec.Resumable
           Store       = spec.Store
           Env         = spec.Env
           Tables      = spec.Tables }
@@ -380,7 +381,15 @@ module Command =
             | _, PlanAction.Transfer _ -> []
             | _, PlanAction.SynthesizeAndLoad _ -> []
             | _ -> [ "--fresh accepted; this action has no selectable data-load strategy (incremental applied)." ]
-        { Notes = unhonoredNotes spec @ freshNote; Action = action }
+        // The resumable/idempotent envelope (G10) is honored on the pure-transfer
+        // data leg only; any other action carries no resumable write seam, so the
+        // flag is noted, never silently dropped (THE_VOICE no-silent-drop).
+        let resumableNote =
+            match spec.Resumable, action with
+            | false, _ -> []
+            | true, PlanAction.Transfer _ -> []
+            | true, _ -> [ "--resumable accepted; this action has no resumable data-load seam (standard write applied)." ]
+        { Notes = unhonoredNotes spec @ freshNote @ resumableNote; Action = action }
 
     /// Route a `check` verb tail to its proof-plane action — purely.
     let planCheck (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
@@ -424,15 +433,23 @@ module Command =
             | "migrate" :: _ ->
                 let decl = parseLossDeclaration args
                 match valueOf "--to", valueOf "--from", valueOf "--store" with
+                // `--from empty` is the genesis-force keyword: A = ∅ against the
+                // named `--store` (or, with no store, an empty-string store the
+                // forced genesis never reads). It is NOT a model path, so it does
+                // not route to the two-model `ExplainMigratePreview`.
+                | Some toP, Some "empty", store ->
+                    PlanAction.ExplainMigrateFromStore (defaultArg store "", toP, decl, true)
                 | Some toP, Some fromP, _    -> PlanAction.ExplainMigratePreview (fromP, toP, decl)
-                | Some toP, None, Some store -> PlanAction.ExplainMigrateFromStore (store, toP, decl)
+                | Some toP, None, Some store -> PlanAction.ExplainMigrateFromStore (store, toP, decl, false)
                 | _ -> PlanAction.Refused (2, err "cli.explain.migrateArgs" "projection explain migrate: needs --to <modelB> with --from <modelA> or --store <lifecycle>.")
             | sub :: _ when Map.containsKey sub cfg.Flows ->
                 // explain <flow>: B = the flow's model, A_prior = the target store.
                 let flow = Map.find sub cfg.Flows
                 let decl = parseLossDeclaration args
+                // `--from empty` forces genesis (A = ∅) for the flow preview too.
+                let forceGenesis = (valueOf "--from" = Some "empty")
                 match cfg.Model, (Map.tryFind flow.To cfg.Environments |> Option.bind (fun e -> e.Store)) with
-                | Some model, Some store -> PlanAction.ExplainMigrateFromStore (store, model, decl)
+                | Some model, Some store -> PlanAction.ExplainMigrateFromStore (store, model, decl, forceGenesis)
                 | None, _ -> PlanAction.Refused (1, err "cli.explain.flowNoModel" (sprintf "explain '%s': no model — set \"model\" in projection.json." sub))
                 | _, None -> PlanAction.Refused (6, err "cli.explain.flowNoStore" (sprintf "explain '%s': target environment '%s' has no `store` to diff against (publish + seal once first)." sub flow.To))
             | _ -> PlanAction.Refused (2, err "cli.explain.unknown" "projection explain: expected <flow> | diff | policy | node | suggest | registry | migrate.")
@@ -504,6 +521,7 @@ module Command =
                         Tables   = flow.Tables
                         AllowDrops = opts.AllowDrops
                         AllowCdc = opts.AllowCdc
+                        Resumable = opts.Resumable
                         // The target's durable timeline: a live --go records an
                         // episode into it (which `report` later diffs). F4.
                         Store    = toEnv.Store
@@ -587,7 +605,7 @@ module Command =
 
     /// The closed secondary-verb set (THE_CLI.md §3). A first token outside
     /// this set is read as a flow name; an unknown one is refused, naming both.
-    let private secondaryVerbs = set [ "check"; "explain"; "seal"; "report"; "profile"; "init" ]
+    let private secondaryVerbs = set [ "check"; "explain"; "seal"; "report"; "profile"; "init"; "diff" ]
 
     /// Map an argv to an `Intent` (THE_CLI.md §3): the daily surface
     /// `projection <flow> [--go] [--fresh] [--allow-drops]` (the verb is
@@ -597,6 +615,11 @@ module Command =
         match argv with
         | "check" :: rest   -> Result.success (Intent.Check rest)
         | "explain" :: rest -> Result.success (Intent.Explain rest)
+        // `diff <a> <b>` — the top-level alias for `explain diff <a> <b>`: the
+        // run-vs-run change surface promoted to a first-class verb. The tail
+        // rides the SAME `planExplain` "diff" routing (→ `runDiff`), so the
+        // alias is behavior-identical to the `explain diff` form.
+        | "diff" :: rest    -> Result.success (Intent.Explain ("diff" :: rest))
         | "seal" :: rest    -> Result.success (Intent.Seal rest)
         | "report" :: rest  -> Result.success (Intent.Report rest)
         | "profile" :: rest -> Result.success (Intent.Profile rest)
@@ -605,7 +628,8 @@ module Command =
                 { Go         = List.contains "--go" rest
                   Fresh      = List.contains "--fresh" rest
                   AllowDrops = List.contains "--allow-drops" rest
-                  AllowCdc   = List.contains "--allow-cdc" rest }
+                  AllowCdc   = List.contains "--allow-cdc" rest
+                  Resumable  = List.contains "--resumable" rest }
             Result.success (Intent.Flow (Map.find first cfg.Flows, opts))
         | first :: _ when secondaryVerbs.Contains first ->
             // a known verb with a malformed tail falls through its own branch;

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -1013,21 +1013,43 @@ module Compose =
         : unit =
         LogSink.emit { LogSink.envelope LogSink.Info category code payload with Phase = phase }
 
+    /// Apply the config-driven module-selection filter (`model.modules` +
+    /// the system / inactive include flags) to the read catalog — the
+    /// `ModuleFilter.apply` Selection seam (pillar 9). An empty `model.modules`
+    /// is the all-permissive identity (`ModuleFilterBinding.fromConfig` returns
+    /// `ModuleFilter.empty`, and `ModuleFilter.apply` short-circuits to the
+    /// input), so the default config is byte-identical. A non-empty selection
+    /// narrows the catalog to the named modules + their per-module entity
+    /// subsets; operator-supplied-name mismatches surface as structured
+    /// `moduleFilter.*` errors (fail-loud, never a silent empty catalog).
+    let private applyModuleFilter
+        (cfg: Config.Config)
+        (catalog: Catalog)
+        : Result<Catalog> =
+        ModuleFilterBinding.fromConfig cfg.Model
+        |> Result.bind (fun opts -> ModuleFilter.apply opts catalog)
+
     /// The full-export model read under the live-OSSYS-primary / file-fallback
     /// policy (V1_INPUT_DEPRECATION.md §3). `cfg.Model.Ossys` set ⇒ read live
     /// from OSSYS (`LiveModelRead`, V1-free); else read `cfg.Model.Path` (the
-    /// `osm_model.json` fallback). Byte-identical to the prior `read
-    /// cfg.Model.Path` when `Ossys = None`.
+    /// `osm_model.json` fallback). The read catalog passes through the
+    /// config-driven module-selection filter (identity on the default config).
+    /// Byte-identical to the prior `read cfg.Model.Path` when `Ossys = None` and
+    /// no `model.modules` selection is declared.
     let readConfigModel (cfg: Config.Config) : Task<Result<Catalog>> =
-        match cfg.Model.Ossys, cfg.Model.Path with
-        | Some connSpec, _ -> LiveModelRead.fromConnSpec connSpec
-        | None, Some path -> read path
-        | None, None ->
-            Task.FromResult
-                (Result.failureOf
-                    (ValidationError.create
-                        "pipeline.config.modelNoSource"
-                        "model needs `path` (osm_model.json) or `ossys` (live OSSYS connection)."))
+        task {
+            let! read =
+                match cfg.Model.Ossys, cfg.Model.Path with
+                | Some connSpec, _ -> LiveModelRead.fromConnSpec connSpec
+                | None, Some path -> read path
+                | None, None ->
+                    Task.FromResult
+                        (Result.failureOf
+                            (ValidationError.create
+                                "pipeline.config.modelNoSource"
+                                "model needs `path` (osm_model.json) or `ossys` (live OSSYS connection)."))
+            return read |> Result.bind (applyModuleFilter cfg)
+        }
 
     let runWithConfig (cfg: Config.Config) : Task<Result<RunReport>> =
         task {

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="ApprovalStore.fs" />
     <Compile Include="LifecycleStore.fs" />
     <Compile Include="RenameBinding.fs" />
+    <Compile Include="ModuleFilterBinding.fs" />
     <Compile Include="TighteningBinding.fs" />
     <Compile Include="SpecialCircumstancesBinding.fs" />
     <Compile Include="SpecialCircumstancesDiagnostics.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -35,6 +35,9 @@
     <Compile Include="Pipeline.fs" />
     <Compile Include="PolicyDiff.fs" />
     <Compile Include="Bulk.fs" />
+    <Compile Include="DockerDaemon.fs" />
+    <Compile Include="DatabaseNameGenerator.fs" />
+    <Compile Include="DeployConnectionString.fs" />
     <Compile Include="Deploy.fs" />
     <Compile Include="BenchSink.fs" />
     <Compile Include="Preflight.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -882,9 +882,15 @@ module Transfer =
                     (ValidationError.create "transfer.tablesUnknown"
                         (sprintf "table subset names not found in the source schema: %s" (String.concat ", " missing)))
 
-    let runThroughConnectionsWithEmission
+    /// The full apparatus-driven entry: the emission mode, the G10 resumable
+    /// flag, and the declared table subset, threaded onto the `WriteOptions` the
+    /// write seam consumes. `resumable = true` routes the incremental load
+    /// through `writePlanResumable` (the idempotent upsert envelope); it is inert
+    /// under `WipeAndLoad` (the wipe leg owns the refresh).
+    let runThroughConnectionsResumable
         (mode: Mode)
         (emission: EmissionMode)
+        (resumable: bool)
         (allowCdc: bool)
         (allowDrops: bool)
         (tables: string list)
@@ -909,8 +915,21 @@ module Transfer =
                             match resolveReconciliation contract with
                             | Error es -> return Result.failure es
                             | Ok reconciliation ->
-                                return! runCore mode allowCdc allowDrops source sink contract reconciliation None { WriteOptions.ofEmission emission with LoadSet = loadSet }
+                                return! runCore mode allowCdc allowDrops source sink contract reconciliation None { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet }
         }
+
+    /// The non-resumable form (every existing caller's behavior — byte-identical
+    /// to the pre-resumable write path).
+    let runThroughConnectionsWithEmission
+        (mode: Mode)
+        (emission: EmissionMode)
+        (allowCdc: bool)
+        (allowDrops: bool)
+        (tables: string list)
+        (connections: TransferConnections)
+        (resolveReconciliation: Catalog -> Result<Map<SsKey, ReconciliationStrategy>>)
+        : Task<Result<TransferReport>> =
+        runThroughConnectionsResumable mode emission false allowCdc allowDrops tables connections resolveReconciliation
 
     /// The incremental-MERGE default (the existing callers' behavior); the
     /// `--how` CLI surface selects `WipeAndLoad` via the `WithEmission` form.

--- a/sidecar/projection/src/Projection.Targets.Data/BootstrapEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/BootstrapEmitter.fs
@@ -79,11 +79,7 @@ module BootstrapEmitter =
         (_plan: DataLoadPlan)
         : Result<ArtifactByKind<DataInsertScript>, EmitError> =
         use _ = Bench.scope "emit.bootstrap.emitFromPlan"
-        let slices =
-            Catalog.allKinds catalog
-            |> List.map (fun k -> k.SsKey, emptyScript)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKind catalog (fun _ -> emptyScript)
 
     /// Π_Bootstrap emit (composer-facing; hoisted-topo + UserRemap
     /// context). Builds the (currently empty) plan and delegates to

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -80,12 +80,7 @@ module DataEmissionComposer =
     /// branches. Per T11 strict-equality keyset: every kind is
     /// keyed; no kind is silently absent.
     let private emptyArtifact (catalog: Catalog) : Result<ArtifactByKind<DataInsertScript>, EmitError> =
-        let allKinds = Catalog.allKinds catalog
-        let slices =
-            allKinds
-            |> List.map (fun k -> k.SsKey, emptyScript)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKind catalog (fun _ -> emptyScript)
 
     /// Run the three sibling emitters per the policy's data-
     /// composition variant. Per pre-scope §3.4 + §3.2:

--- a/sidecar/projection/src/Projection.Targets.Data/MigrationDependenciesEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/MigrationDependenciesEmitter.fs
@@ -188,6 +188,7 @@ module MigrationDependenciesEmitter =
     /// CDC-aware predicate dispatch per `Profile.CdcAwareness` is
     /// preserved.
     let private renderMerge
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (cdcAware: bool)
         (deferred: Set<Name>)
         (k: Kind)
@@ -222,7 +223,7 @@ module MigrationDependenciesEmitter =
                 UpdColumns = updColumns
                 Rows        = typedRows |> List.map (typedValuesToSqlLiterals deferred (writableAttributes k))
                 CdcAware    = cdcAware
-                DeleteScope = None
+                DeleteScope = deleteScope
             }
         let mergeStmt = (ScriptDomBuild.buildMergeStatement args).Value
         System.String.Concat(  // LINT-ALLOW: terminal MERGE statement-terminator + GO-batch suffix on the rendered MERGE (chapter 4.1.B slice ε); segments are typed (output of `ScriptDomGenerate.generateOne` from typed AST + SQL Server's required MERGE statement-terminator + V1 batch-separator literal); same architectural shape as StaticSeedsEmitter's terminal-text boundary
@@ -311,6 +312,7 @@ module MigrationDependenciesEmitter =
     /// Mirrors `StaticSeedsEmitter.kindToScript` exactly — both
     /// emitters realize the same algebra over the same plan shape.
     let private kindToScript
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (cdc: CdcAwareness)
         (kind: Kind)
         (load: DataLoadKind)
@@ -331,7 +333,7 @@ module MigrationDependenciesEmitter =
                     row.Identifier,
                     rowToTypedValues typeLookup kind.Attributes row)
             let renderedPhase1 =
-                renderMerge cdcAware deferred kind (typedRows |> List.map snd)
+                renderMerge deleteScope cdcAware deferred kind (typedRows |> List.map snd)
             let renderedPhase2 =
                 if Set.isEmpty deferred then ""
                 else
@@ -355,12 +357,20 @@ module MigrationDependenciesEmitter =
               RenderedPhase2 = renderedPhase2
               Rendered       = rendered }
 
-    /// Π_MigrationDependencies emit (canonical; plan-consuming).
-    /// Realizes the supplied `DataLoadPlan` as per-kind MERGE/UPDATE
-    /// scripts; the plan carries post-substitution rows (the User-FK
-    /// remap was applied at `DataLoadPlan.build`). DataIntent
+    /// Π_MigrationDependencies emit (canonical; plan-consuming,
+    /// scope-bearing). Realizes the supplied `DataLoadPlan` as per-kind
+    /// MERGE/UPDATE scripts; the plan carries post-substitution rows (the
+    /// User-FK remap was applied at `DataLoadPlan.build`). DataIntent
     /// end-to-end — operator opinion landed once at plan-build.
-    let emitFromPlan
+    ///
+    /// `deleteScope` gates the `WHEN NOT MATCHED BY SOURCE … DELETE` arm
+    /// (per `ScriptDomBuild.DeleteScope`): `None` (the `emitFromPlan`
+    /// default) emits an upsert-only MERGE byte-identical to the
+    /// pre-scope form; `Some scope` activates the convergent-delete arm.
+    /// The parameter makes the emitter scope-ready; the policy that
+    /// selects a scope is CLI/EmissionPolicy plumbing, not the emitter's.
+    let emitFromPlanWith
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (catalog: Catalog)
         (profile: Profile)
         (plan: DataLoadPlan)
@@ -370,16 +380,20 @@ module MigrationDependenciesEmitter =
         let loadByKind = plan.Loads |> List.map (fun l -> l.Kind, l) |> Map.ofList
         let emptyScript : DataInsertScript =
             { Phase1Merges = []; Phase2Updates = []; RenderedPhase1 = ""; RenderedPhase2 = ""; Rendered = "" }
-        let slices =
-            Catalog.allKinds catalog
-            |> Bench.iterMap "emit.migrationDeps.kind" (fun k ->
-                let script =
-                    match Map.tryFind k.SsKey loadByKind with
-                    | Some load -> kindToScript cdc k load
-                    | None      -> emptyScript
-                k.SsKey, script)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKindBenched "emit.migrationDeps.kind" catalog (fun k ->
+            match Map.tryFind k.SsKey loadByKind with
+            | Some load -> kindToScript deleteScope cdc k load
+            | None      -> emptyScript)
+
+    /// Π_MigrationDependencies emit (canonical; plan-consuming). The
+    /// upsert-only default form — `emitFromPlanWith` with no delete
+    /// scope. Output is byte-identical to the pre-scope emitter.
+    let emitFromPlan
+        (catalog: Catalog)
+        (profile: Profile)
+        (plan: DataLoadPlan)
+        : Result<ArtifactByKind<DataInsertScript>, EmitError> =
+        emitFromPlanWith None catalog profile plan
 
     /// Build the `DataLoadPlan` from the supplied `MigrationDependency
     /// Context` (operator-supplied rows) and `UserRemapContext`

--- a/sidecar/projection/src/Projection.Targets.Data/StaticSeedsEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/StaticSeedsEmitter.fs
@@ -148,6 +148,7 @@ module StaticSeedsEmitter =
     /// VALUES so cycle-participating rows can INSERT before their
     /// same-SCC FK targets exist.
     let private renderMerge
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (cdcAware: bool)
         (deferred: Set<Name>)
         (k: Kind)
@@ -185,7 +186,7 @@ module StaticSeedsEmitter =
                 UpdColumns = updColumns
                 Rows        = typedRows |> List.map (typedValuesToSqlLiterals deferred (writableAttributes k))
                 CdcAware    = cdcAware
-                DeleteScope = None
+                DeleteScope = deleteScope
             }
         let mergeStmt = (ScriptDomBuild.buildMergeStatement args).Value
         // ScriptDomGenerate.generateOne emits the MERGE without a
@@ -270,6 +271,7 @@ module StaticSeedsEmitter =
     /// over the supplied rows (slice E will refine `AssignedBySink` to
     /// suppress the IDENTITY PK column).
     let private kindToScript
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (cdc: CdcAwareness)
         (kind: Kind)
         (load: DataLoadKind)
@@ -294,7 +296,7 @@ module StaticSeedsEmitter =
                     row.Identifier,
                     staticRowToTypedValues typeLookup kind.Attributes row)
             let renderedPhase1 =
-                renderMerge cdcAware deferred kind (typedRows |> List.map snd)
+                renderMerge deleteScope cdcAware deferred kind (typedRows |> List.map snd)
             let renderedPhase2 =
                 if Set.isEmpty deferred then ""
                 else
@@ -333,14 +335,22 @@ module StaticSeedsEmitter =
     /// MERGE variant. Slice δ (cycle-breaking): kinds in
     /// `topo.Cycles` defer their nullable same-SCC FK columns across
     /// the two-phase MERGE/UPDATE pattern.
-    /// Π_StaticSeeds emit (canonical; plan-consuming). Realizes the
-    /// supplied `DataLoadPlan` as per-kind MERGE/UPDATE scripts: the
-    /// plan carries POST-substitution rows + the deferred-FK set per
-    /// kind; this entry just renders. Realization is `DataIntent`
-    /// end-to-end — operator-supplied identity substitution landed once
-    /// at `DataLoadPlan.build`. Kinds absent from the plan (no load)
-    /// produce empty scripts per T11.
-    let emitFromPlan
+    /// Π_StaticSeeds emit (canonical; plan-consuming, scope-bearing).
+    /// Realizes the supplied `DataLoadPlan` as per-kind MERGE/UPDATE
+    /// scripts: the plan carries POST-substitution rows + the
+    /// deferred-FK set per kind; this entry just renders. Realization is
+    /// `DataIntent` end-to-end — operator-supplied identity substitution
+    /// landed once at `DataLoadPlan.build`. Kinds absent from the plan
+    /// (no load) produce empty scripts per T11.
+    ///
+    /// `deleteScope` gates the `WHEN NOT MATCHED BY SOURCE … DELETE` arm
+    /// (per `ScriptDomBuild.DeleteScope`): `None` (the `emitFromPlan`
+    /// default) emits an upsert-only MERGE byte-identical to the
+    /// pre-scope form; `Some scope` activates the convergent-delete arm.
+    /// The parameter makes the emitter scope-ready; the policy that
+    /// selects a scope is CLI/EmissionPolicy plumbing, not the emitter's.
+    let emitFromPlanWith
+        (deleteScope: ScriptDomBuild.DeleteScope option)
         (catalog: Catalog)
         (profile: Profile)
         (plan: DataLoadPlan)
@@ -350,16 +360,20 @@ module StaticSeedsEmitter =
         let loadByKind = plan.Loads |> List.map (fun l -> l.Kind, l) |> Map.ofList
         let emptyScript : DataInsertScript =
             { Phase1Merges = []; Phase2Updates = []; RenderedPhase1 = ""; RenderedPhase2 = ""; Rendered = "" }
-        let slices =
-            Catalog.allKinds catalog
-            |> Bench.iterMap "emit.staticSeeds.kind" (fun k ->
-                let script =
-                    match Map.tryFind k.SsKey loadByKind with
-                    | Some load -> kindToScript cdc k load
-                    | None      -> emptyScript
-                k.SsKey, script)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKindBenched "emit.staticSeeds.kind" catalog (fun k ->
+            match Map.tryFind k.SsKey loadByKind with
+            | Some load -> kindToScript deleteScope cdc k load
+            | None      -> emptyScript)
+
+    /// Π_StaticSeeds emit (canonical; plan-consuming). The upsert-only
+    /// default form — `emitFromPlanWith` with no delete scope. Output is
+    /// byte-identical to the pre-scope emitter.
+    let emitFromPlan
+        (catalog: Catalog)
+        (profile: Profile)
+        (plan: DataLoadPlan)
+        : Result<ArtifactByKind<DataInsertScript>, EmitError> =
+        emitFromPlanWith None catalog profile plan
 
     /// Π_StaticSeeds emit (composer-facing; hoisted topo). Builds the
     /// plan from `Kind.staticPopulations` per kind with the empty

--- a/sidecar/projection/src/Projection.Targets.Distributions/DistributionsEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Distributions/DistributionsEmitter.fs
@@ -212,12 +212,7 @@ module DistributionsEmitter =
     /// re-parsing.
     let emitSlices : EmitterWithProfile<JsonNode> = fun catalog profile ->
         use _ = Bench.scope "emit.distributions.emitSlices"
-        let allKinds = Catalog.allKinds catalog
-        let slices =
-            allKinds
-            |> List.map (fun k -> k.SsKey, kindJsonNode profile k)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKind catalog (kindJsonNode profile)
 
     /// Emit the distribution report as JSON text. Takes the enriched
     /// IR (`Catalog × Profile`) and produces a deterministic string —

--- a/sidecar/projection/src/Projection.Targets.Json/JsonEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/JsonEmitter.fs
@@ -181,12 +181,7 @@ module JsonEmitter =
     /// re-parsing.
     let emitSlices : Emitter<JsonNode> = fun catalog ->
         use _ = Bench.scope "emit.json.emitSlices"
-        let allKinds = Catalog.allKinds catalog
-        let slices =
-            allKinds
-            |> List.map (fun k -> k.SsKey, kindJsonNode k)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKind catalog kindJsonNode
 
     /// Slice 6 (2026-06-02 audit): typed catalog-envelope JsonNode
     /// description. Mirrors the SSDT `statements : Catalog ->

--- a/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/DecisionLogEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/DecisionLogEmitter.fs
@@ -124,15 +124,10 @@ module internal DiagnosticDocument =
         (entries: DiagnosticEntry list)
         : Result<ArtifactByKind<JsonNode>, EmitError> =
         let grouped = entriesByKind entries
-        let allKinds = Catalog.allKinds catalog
-        let slices =
-            allKinds
-            |> List.map (fun k ->
-                let kindEntries =
-                    Map.tryFind k.SsKey grouped |> Option.defaultValue []
-                k.SsKey, kindJsonNode k kindEntries)
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKind catalog (fun k ->
+            let kindEntries =
+                Map.tryFind k.SsKey grouped |> Option.defaultValue []
+            kindJsonNode k kindEntries)
 
 
 /// Π_DecisionLog — chapter 4.3 slice α emitter for the operator-

--- a/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
@@ -329,15 +329,10 @@ module RefactorLogEmitter =
         // foreign-key renames (logical Reference.Name, N1). All are
         // RenameRefactor operations on the same kind's slice; a kind with
         // none carries the empty list (T11 keyset = target's kinds).
-        let slices =
-            Catalog.allKinds target
-            |> List.map (fun k ->
-                k.SsKey,
-                kindRefactorEntries renames k
-                @ columnRefactorEntries diff k
-                @ referenceRefactorEntries diff k)
-            |> Map.ofList
-        ArtifactByKind.create target slices
+        ArtifactByKind.perKind target (fun k ->
+            kindRefactorEntries renames k
+            @ columnRefactorEntries diff k
+            @ referenceRefactorEntries diff k)
 
 
     /// Flatten an `ArtifactByKind<RefactorLogEntry list>` into a single

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
@@ -832,26 +832,22 @@ module SsdtDdlEmitter =
     let emitSlicesWith (overlay: DecisionOverlay) : Emitter<SsdtFile> = fun catalog ->
         use _ = Bench.scope "emit.ssdt.emitSlices"
         let modules = moduleByKindKey catalog
-        let allKinds, targetByKey, pkAttrByKey = buildLookups catalog
+        let _allKinds, targetByKey, pkAttrByKey = buildLookups catalog
         // Per-kind iterMap — surfaces P50/P95/P99 of per-kind emission
         // cost (the dominant emit.ssdt work at production scale is
         // proportional to the kind count). Slice A.4.7'-prelude
         // .perf-sweep-6 instrumentation gap-fill.
-        let slices =
-            allKinds
-            |> Bench.iterMap "emit.ssdt.emitSlices.kind" (fun k ->
-                match Map.tryFind k.SsKey modules with
-                | Some m ->
-                    k.SsKey, kindToSsdtFile overlay targetByKey pkAttrByKey m k
-                | None ->
-                    // Unreachable: `Catalog.allKinds` walks
-                    // `c.Modules |> List.collect (fun m -> m.Kinds)`;
-                    // every yielded Kind has an owning Module. The
-                    // defensive `invalidOp` makes the unreachability
-                    // structural.
-                    invalidOp (sprintf "SsdtDdlEmitter.emitSlices: kind %A has no owning module (unreachable; Catalog.allKinds invariant)" k.SsKey))
-            |> Map.ofList
-        ArtifactByKind.create catalog slices
+        ArtifactByKind.perKindBenched "emit.ssdt.emitSlices.kind" catalog (fun k ->
+            match Map.tryFind k.SsKey modules with
+            | Some m ->
+                kindToSsdtFile overlay targetByKey pkAttrByKey m k
+            | None ->
+                // Unreachable: `Catalog.allKinds` walks
+                // `c.Modules |> List.collect (fun m -> m.Kinds)`;
+                // every yielded Kind has an owning Module. The
+                // defensive `invalidOp` makes the unreachability
+                // structural.
+                invalidOp (sprintf "SsdtDdlEmitter.emitSlices: kind %A has no owning module (unreachable; Catalog.allKinds invariant)" k.SsKey))
 
     /// Π port realization (the `empty`-overlay default). Byte-identical to
     /// pre-Wave-2 emission. See `emitSlicesWith`.

--- a/sidecar/projection/tests/Projection.Tests/ClassificationCarryThroughTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ClassificationCarryThroughTests.fs
@@ -194,7 +194,6 @@ let ``A.4.7 slice α: Lineage.tellMany preserves Classification on appended even
 // tests (slice θ) close the structural loop.
 // ---------------------------------------------------------------------------
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 [<Fact>]
 let ``A.4.7 slice α: CanonicalizeIdentity events carry DataIntent`` () =

--- a/sidecar/projection/tests/Projection.Tests/DacpacEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DacpacEmitterTests.fs
@@ -42,13 +42,6 @@ let private mustOkBytes (r: Result<byte[]>) : byte[] =
         Assert.Fail (sprintf "expected Ok; got %A" errs)
         Unchecked.defaultof<byte[]>
 
-let private mkName (s: string) : Name =
-    match Name.create s with
-    | Ok n -> n
-    | Error es ->
-        let codes = es |> List.map (fun e -> e.Code) |> String.concat ", "
-        invalidOp (sprintf "DacpacEmitterTests.mkName failed: %s" codes)
-
 /// Single-Kind catalog mirroring the pre-scope §5 minimum slice: one
 /// Module, one Kind, two attributes including a PK, no FKs, no
 /// indexes, no modality marks. Built inline to keep this test

--- a/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
@@ -32,9 +32,6 @@ let private mustOk r =
 let private mkKey (parts: string list) : SsKey =
     SsKey.synthesizedComposite "OS_TEST" parts |> mustOk
 
-let private mkName (s: string) : Name =
-    Name.create s |> mustOk
-
 let private mustOkEmit (r: Result<'a, EmitError>) : 'a =
     match r with
     | Ok v -> v

--- a/sidecar/projection/tests/Projection.Tests/EndToEndDifferentialTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EndToEndDifferentialTests.fs
@@ -40,7 +40,6 @@ let private nullRun (catalog: Catalog) (policy: Policy) (profile: Profile) : Lin
 // ---------------------------------------------------------------------------
 
 let private mkKey s = testKey s
-let private mkName s = Name.create s |> Result.value
 
 // ---------------------------------------------------------------------------
 // V2 catalog matching V1's profile.micro-fk-protect fixture (Parent / Child

--- a/sidecar/projection/tests/Projection.Tests/Fixtures.fs
+++ b/sidecar/projection/tests/Projection.Tests/Fixtures.fs
@@ -31,6 +31,14 @@ let private mustOk r =
 
 let private name (s: string)  : Name  = Name.create s   |> mustOk
 
+/// Canonical fixture `Name` builder. Tests across the suite re-spell
+/// `Name.create s |> Result.value` (~44 local `mkName` copies, B6 audit);
+/// this is the one shared, accessible definition. Force-unwraps because
+/// fixture names are constants known to satisfy `Name.create`. The
+/// `private name` alias above is the in-file spelling; `mkName` is the
+/// exported one consuming test files open and reuse.
+let mkName (s: string) : Name = name s
+
 /// Typed SsKey builders mirroring the adapter conventions
 /// (`Projection.Adapters.Osm.CatalogReader`,
 /// `Projection.Adapters.Sql.Static`). Tests build expected catalogs

--- a/sidecar/projection/tests/Projection.Tests/FullExportDataBundleTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportDataBundleTests.fs
@@ -21,7 +21,6 @@ let private mustOk r =
     | Error es -> invalidOp (sprintf "fixture: %A" es)
 
 let private mkKey (parts: string list) : SsKey = SsKey.synthesizedComposite "OS_X1" parts |> mustOk
-let private mkName (s: string) : Name = Name.create s |> mustOk
 
 /// A static-entity kind with two explicit rows (Id/Code/Label).
 let private countryKind () : Kind =

--- a/sidecar/projection/tests/Projection.Tests/IndexDataSpaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/IndexDataSpaceTests.fs
@@ -29,7 +29,6 @@ let private mustOk (r: FsResult<'a, EmitError>) : 'a =
 let private enrich (c: Catalog) : Catalog =
     (CanonicalizeIdentity.registered.Run c |> Lineage.map (fun d -> d.Value)).Value
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 let private bodyOf (k: SsKey) (cat: Catalog) : string =
     let artifact = SsdtDdlEmitter.emitSlices (enrich cat) |> mustOk

--- a/sidecar/projection/tests/Projection.Tests/IndexFilterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/IndexFilterTests.fs
@@ -20,7 +20,6 @@ open Projection.Tests.Fixtures
 let private mkKey (v: string) : SsKey =
     SsKey.synthesized "test" v |> Result.value
 
-let private mkName (v: string) : Name = Name.create v |> Result.value
 
 let private mkTableId (schema: string) (table: string) : TableId =
     TableId.create schema table |> Result.value

--- a/sidecar/projection/tests/Projection.Tests/IndexIncludedColumnsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/IndexIncludedColumnsTests.fs
@@ -22,7 +22,6 @@ open Projection.Tests.IRBuilders
 let private mkKey (v: string) : SsKey =
     SsKey.synthesized "test" v |> Result.value
 
-let private mkName (v: string) : Name = Name.create v |> Result.value
 
 let private mkTableId (schema: string) (table: string) : TableId =
     TableId.create schema table |> Result.value

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -296,12 +296,15 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
     member _.``migrate canary: executeWithData migrates the sink schema then loads rows from the source`` () =
         if not (Deploy.Docker.ensureRunning ()) then () else
         TaskSync.run (fun () ->
-            // Source DB at state B with seeded rows; sink DB at state A (empty).
+            // A5 — the data source is at the OLD schema A (MIGAB_CUSTOMER), NOT
+            // already at B. The data leg re-points the A-named rows A→B (the table
+            // is renamed MIGAB_CUSTOMER→MIGAB_PATRON; EMAIL is widened, not renamed)
+            // and writes against the sink's B contract. Sink DB starts at A (empty).
             fixture.WithEphemeralDatabase "MigrateDataSrc" (fun source _ ->
                 task {
-                    do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogB |> Render.toText)
+                    do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogA |> Render.toText)
                     do! Deploy.executeBatch source
-                            "INSERT INTO [dbo].[MIGAB_PATRON] ([ID],[EMAIL],[LOYALTY]) VALUES (1, N'dave@example.com', 3), (2, N'erin@example.com', 9);"
+                            "INSERT INTO [dbo].[MIGAB_CUSTOMER] ([ID],[EMAIL]) VALUES (1, N'dave@example.com'), (2, N'erin@example.com');"
                     do! fixture.WithEphemeralDatabase "MigrateDataSink" (fun sink _ ->
                         task {
                             do! Deploy.executeBatch sink (SsdtDdlEmitter.statements catalogA |> Render.toText)
@@ -317,7 +320,7 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                             | Ok result ->
                                 // Schema leg: the sink is now at B.
                                 Assert.True(result.Schema.Verified, sprintf "sink schema not at B:\n%s" (PhysicalSchema.renderDiff result.Schema.SchemaDiff))
-                                // Data leg: both rows landed in the sink's migrated table.
+                                // Data leg: both rows landed in the sink's migrated (renamed) table.
                                 let! count = scalarString sink "SELECT COUNT(*) FROM [dbo].[MIGAB_PATRON];"
                                 Assert.Equal("2", count)
                                 let! email = scalarString sink "SELECT [EMAIL] FROM [dbo].[MIGAB_PATRON] WHERE [ID]=2;"
@@ -328,6 +331,47 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
                                 Assert.Contains("load.started", codes)
                                 Assert.Contains("summary.stageProgress", codes)
                                 Assert.Contains("summary.stageCompleted", codes)
+                        })
+                }))
+
+    // A5 — rename-aware migrate-with-data: the data source is at the OLD schema
+    // A. The sink (UAT) starts at A (EMAIL); the Dev data source ALSO holds rows
+    // at A (EMAIL); the target is B (the column renamed EMAIL→CONTACT). The data
+    // leg must re-point the A-named rows onto the sink's B name (CONTACT). Pre-A5
+    // the data leg loaded against contract B directly, so the source's EMAIL rows
+    // had no CONTACT value — CONTACT would land NULL. The re-pointed write is the
+    // discriminator: CONTACT carries the source data BY IDENTITY (the A→B rename
+    // map), never NULL.
+    [<Fact>]
+    member _.``A5: migrate-with-data re-points a renamed column when the data source is at schema A`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        TaskSync.run (fun () ->
+            // Data source (Dev) at schema A (EMAIL) with seeded rows; sink (UAT) at A.
+            fixture.WithEphemeralDatabase "MigrateRenameSrc" (fun source _ ->
+                task {
+                    do! Deploy.executeBatch source (SsdtDdlEmitter.statements catalogAcol |> Render.toText)
+                    do! Deploy.executeBatch source
+                            "INSERT INTO [dbo].[MIGAB_COL] ([ID],[EMAIL]) VALUES (1, N'alice@x'), (2, N'bob@x');"
+                    do! fixture.WithEphemeralDatabase "MigrateRenameSink" (fun sink _ ->
+                        task {
+                            do! Deploy.executeBatch sink (SsdtDdlEmitter.statements catalogAcol |> Render.toText)
+
+                            // One call: migrate the sink A→B (EMAIL→CONTACT), THEN
+                            // load the source's A-named rows re-pointed onto CONTACT.
+                            let! outcome =
+                                MigrationRun.executeWithData DeclareNone Transfer.Execute true catalogAcol catalogBcol Map.empty source sink
+                            match outcome with
+                            | Error e -> Assert.Fail(sprintf "A5 rename-aware migrate-with-data failed: %A" e)
+                            | Ok result ->
+                                Assert.True(result.Schema.Verified, sprintf "sink schema not at B:\n%s" (PhysicalSchema.renderDiff result.Schema.SchemaDiff))
+                                // THE DISCRIMINATOR: the renamed CONTACT column carries the
+                                // source's EMAIL values — re-pointed A→B by identity, not NULL.
+                                let! c1 = scalarString sink "SELECT [CONTACT] FROM [dbo].[MIGAB_COL] WHERE [ID]=1;"
+                                Assert.Equal("alice@x", c1)
+                                let! c2 = scalarString sink "SELECT [CONTACT] FROM [dbo].[MIGAB_COL] WHERE [ID]=2;"
+                                Assert.Equal("bob@x", c2)
+                                let! count = scalarString sink "SELECT COUNT(*) FROM [dbo].[MIGAB_COL];"
+                                Assert.Equal("2", count)
                         })
                 }))
 

--- a/sidecar/projection/tests/Projection.Tests/MigrationRunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationRunTests.fs
@@ -162,6 +162,24 @@ let ``6.H: previewFromStore diffs B against the reconstructed prior snapshot (sa
         Assert.Equal(direct.Plan.Preview.Norm, fromStore.Plan.Preview.Norm)
         Assert.Equal(1, fromStore.Plan.Preview.Channels.RenamedKinds))
 
+[<Fact>]
+let ``D4: previewFromStoreForcing true forces genesis even when the store exists`` () =
+    withTempFile (fun path ->
+        // A populated store whose reconstructed prior IS the target B: a
+        // non-forced preview against it is the identity (zero displacement).
+        let coord = EpisodeCoordinate.create (ver 0 "1.0.0") Environment.Dev (at "2026-06-01T09:00:00+00:00")
+        LifecycleStore.save path (EpisodicLifecycle.genesis (tl "dev") (Episode.ofSchema coord sampleCatalog))
+        |> (function FsResult.Ok () -> () | FsResult.Error e -> Assert.Fail(sprintf "%A" e))
+        // Non-forced: A reconstructs to sampleCatalog (= B), so nothing is Added.
+        let noForce = MigrationRun.previewFromStoreForcing false path DeclareNone sampleCatalog |> mustOk
+        Assert.Equal(0, noForce.Plan.Preview.Channels.AddedKinds)
+        // Forced (`--from empty`): A = ∅ regardless of the store, so EVERY kind is
+        // Added and nothing is dropped — the from-scratch shape on a live store.
+        let forced = MigrationRun.previewFromStoreForcing true path DeclareNone sampleCatalog |> mustOk
+        Assert.True(Migration.isSafe forced.Plan)
+        Assert.Equal(0, forced.Plan.Preview.Channels.RemovedKinds)
+        Assert.True(forced.Plan.Preview.Channels.AddedKinds > 0))
+
 // ===========================================================================
 // The live-execute rename channel — sp_rename for physical table renames
 // ===========================================================================

--- a/sidecar/projection/tests/Projection.Tests/ModuleFilterBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ModuleFilterBindingTests.fs
@@ -1,0 +1,111 @@
+module Projection.Tests.ModuleFilterBindingTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.IRBuilders
+
+/// A7 — `ModuleFilterBinding.fromConfig` coverage. Verifies the binder maps the
+/// `Config.ModelSection` module-selection axis (`model.modules` + the system /
+/// inactive include flags) onto the typed `ModuleFilterOptions` that
+/// `ModuleFilter.apply` consumes, and that an empty `model.modules` is the
+/// all-permissive identity (byte-identical full-export default).
+
+let private mustOk r =
+    match r with
+    | Ok v -> v
+    | Error es ->
+        let codes = es |> List.map (fun (e: ValidationError) -> e.Code) |> String.concat ", "
+        invalidOp (sprintf "fixture: %s" codes)
+
+let private mkSsKey label = SsKey.synthesized "OS_TEST" label |> mustOk
+let private mkName s = Name.create s |> mustOk
+let private mkTable s = TableId.create "dbo" s |> mustOk
+let private mkAttr label = Attribute.create (mkSsKey (sprintf "ATTR_%s" label)) (mkName label) PrimitiveType.Integer
+let private mkKind label = Kind.create (mkSsKey (sprintf "KIND_%s" label)) (mkName label) (mkTable label) [ mkAttr label ]
+let private mkActiveModule name kinds =
+    let m = mkModule (mkSsKey (sprintf "MOD_%s" name)) (mkName name) kinds
+    { m with IsActive = true }
+
+/// A `ModelSection` carrying a given module selection; the include flags follow
+/// the config defaults (`includeSystemModules` / `includeInactiveModules` =
+/// false, `onlyActiveAttributes` = true) so the binding's opt-in gate is the
+/// behavior under test.
+let private modelWith (modules: Config.ModuleSelector list) : Config.ModelSection =
+    { Path                   = Some "model.json"
+      Ossys                  = None
+      Modules                = modules
+      IncludeSystemModules   = false
+      IncludeInactiveModules = false
+      OnlyActiveAttributes   = true
+      ValidationOverrides    = { AllowMissingSchema = [] } }
+
+[<Fact>]
+let ``A7: an empty model.modules binds to ModuleFilter.empty (identity, byte-identical default)`` () =
+    let opts = ModuleFilterBinding.fromConfig (modelWith []) |> mustOk
+    Assert.False(ModuleFilter.hasFilter opts)
+    Assert.Equal<ModuleFilterOptions>(ModuleFilter.empty, opts)
+
+[<Fact>]
+let ``A7: an empty model.modules applies as the identity on any catalog`` () =
+    // Even with a system + inactive module present, the no-selection config
+    // leaves the catalog untouched (the opt-in gate preserves today's behavior).
+    let sysKind = { mkKind "S1" with Modality = [ ModalityMark.SystemOwned ] }
+    let cat =
+        mkCatalog
+            [ mkActiveModule "App" [ mkKind "E1" ]
+              { mkActiveModule "Sys" [ sysKind ] with IsActive = false } ]
+    let opts = ModuleFilterBinding.fromConfig (modelWith []) |> mustOk
+    let result = ModuleFilter.apply opts cat |> mustOk
+    Assert.Equal<Module list>(cat.Modules, result.Modules)
+
+[<Fact>]
+let ``A7: a Whole selector binds the module name with no entity filter`` () =
+    let opts =
+        ModuleFilterBinding.fromConfig (modelWith [ Config.ModuleSelector.Whole "App" ])
+        |> mustOk
+    Assert.Equal<Set<string>>(Set.ofList [ "app" ], opts.Modules)
+    Assert.True(Map.isEmpty opts.EntityFilters)
+
+[<Fact>]
+let ``A7: a WithEntities selector binds the module name + a per-module entity filter`` () =
+    let opts =
+        ModuleFilterBinding.fromConfig
+            (modelWith [ Config.ModuleSelector.WithEntities ("App", [ "E1"; "E2" ]) ])
+        |> mustOk
+    Assert.Equal<Set<string>>(Set.ofList [ "app" ], opts.Modules)
+    Assert.True(opts.EntityFilters.ContainsKey "app")
+    Assert.Equal<Set<string>>(Set.ofList [ "e1"; "e2" ], opts.EntityFilters.["app"].NormalizedNames)
+
+[<Fact>]
+let ``A7: a module selection narrows the catalog to the named modules (apply through the binding)`` () =
+    let cat =
+        mkCatalog
+            [ mkActiveModule "App" [ mkKind "E1" ]
+              mkActiveModule "Reporting" [ mkKind "E2" ] ]
+    let opts = ModuleFilterBinding.fromConfig (modelWith [ Config.ModuleSelector.Whole "App" ]) |> mustOk
+    let result = ModuleFilter.apply opts cat |> mustOk
+    let names = result.Modules |> List.map (fun m -> Name.value m.Name) |> Set.ofList
+    Assert.Equal<Set<string>>(Set.ofList [ "App" ], names)
+
+[<Fact>]
+let ``A7: a WithEntities selection keeps only the named entities in that module`` () =
+    let cat = mkCatalog [ mkActiveModule "App" [ mkKind "E1"; mkKind "E2"; mkKind "E3" ] ]
+    let opts =
+        ModuleFilterBinding.fromConfig
+            (modelWith [ Config.ModuleSelector.WithEntities ("App", [ "E1" ]) ])
+        |> mustOk
+    let result = ModuleFilter.apply opts cat |> mustOk
+    let kindNames =
+        result.Modules
+        |> List.collect (fun m -> m.Kinds |> List.map (fun k -> Name.value k.Name))
+        |> Set.ofList
+    Assert.Equal<Set<string>>(Set.ofList [ "E1" ], kindNames)
+
+[<Fact>]
+let ``A7: naming a module absent from the catalog is a fail-loud moduleFilter.modules.missing`` () =
+    let cat = mkCatalog [ mkActiveModule "App" [ mkKind "E1" ] ]
+    let opts = ModuleFilterBinding.fromConfig (modelWith [ Config.ModuleSelector.Whole "Nope" ]) |> mustOk
+    match ModuleFilter.apply opts cat with
+    | Ok _ -> Assert.Fail "expected a missing-module refusal"
+    | Error es -> Assert.Contains("moduleFilter.modules.missing", es |> List.map (fun e -> e.Code))

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -133,7 +133,7 @@ let private liveDev = Destination.Live (ConnectionRef.EnvVar "DEV_CONN")
 let private baseLive = MovementSpec.forDestination liveDev
 let private defaultOpts : LoadOpts =
     { Declaration = DeclareNone; Emission = EmissionMode.Incremental
-      Reconcile = []; Rekey = None; AllowCdc = false; Store = None; Env = None; Tables = [] }
+      Reconcile = []; Rekey = None; AllowCdc = false; Resumable = false; Store = None; Env = None; Tables = [] }
 
 [<Fact>]
 let ``planMovement: --fresh selects WipeAndLoad on the transfer path`` () =
@@ -145,6 +145,23 @@ let ``planMovement: --fresh selects WipeAndLoad on the transfer path`` () =
 let ``planMovement: --fresh on a non-transfer action is noted, never silently ignored`` () =
     let p = Command.planMovement routeCfg { baseLive with Commit = true; Model = ModelSource.ModelFile "m.json"; Strategy = Strategy.Replace }
     Assert.Contains(p.Notes, fun (n: string) -> n.Contains "--fresh")
+
+[<Fact>]
+let ``planMovement: --resumable threads onto the transfer LoadOpts (A2)`` () =
+    match planOf { baseLive with Commit = true; Scope = Scope.Data; Data = DataOrigin.FromTarget "qa"; Resumable = true } with
+    | PlanAction.Transfer (_, _, opts, true) -> Assert.True opts.Resumable
+    | other -> Assert.Fail(sprintf "expected Transfer, got %A" other)
+
+[<Fact>]
+let ``planMovement: --resumable default off on the transfer LoadOpts (A2 byte-identical)`` () =
+    match planOf { baseLive with Commit = true; Scope = Scope.Data; Data = DataOrigin.FromTarget "qa" } with
+    | PlanAction.Transfer (_, _, opts, true) -> Assert.False opts.Resumable
+    | other -> Assert.Fail(sprintf "expected Transfer, got %A" other)
+
+[<Fact>]
+let ``planMovement: --resumable on a non-transfer action is noted, never silently ignored (A2)`` () =
+    let p = Command.planMovement routeCfg { baseLive with Commit = true; Model = ModelSource.ModelFile "m.json"; Resumable = true }
+    Assert.Contains(p.Notes, fun (n: string) -> n.Contains "--resumable")
 
 [<Fact>]
 let ``planMovement: folder + config → PublishBundle`` () =
@@ -243,7 +260,7 @@ let private flowCfg =
     }
     """ |> mustOk
 
-let private preview = { Go = false; Fresh = false; AllowDrops = false; AllowCdc = false }
+let private preview = { Go = false; Fresh = false; AllowDrops = false; AllowCdc = false; Resumable = false }
 let private commit  = { preview with Go = true }
 let private flowOf name = Map.find name flowCfg.Flows
 let private specOf name opts = Command.resolveFlowSpec flowCfg (flowOf name) opts
@@ -501,6 +518,22 @@ let ``flow --allow-cdc threads the CDC-gate override onto the spec (item 3)`` ()
     | Error es -> Assert.Fail(sprintf "%A" es)
 
 [<Fact>]
+let ``parse: --resumable sets the per-run intent (A2)`` () =
+    let (_, o) = parseFlowIntent [ "golden"; "--resumable" ]
+    Assert.True o.Resumable
+
+[<Fact>]
+let ``parse: --resumable default off (A2 byte-identical)`` () =
+    let (_, o) = parseFlowIntent [ "golden" ]
+    Assert.False o.Resumable
+
+[<Fact>]
+let ``flow --resumable threads onto the spec (A2)`` () =
+    match specOf "spin" { preview with Resumable = true } with
+    | Ok s -> Assert.True s.Resumable
+    | Error es -> Assert.Fail(sprintf "%A" es)
+
+[<Fact>]
 let ``parse: a bare flow routes through plan to its engine face`` () =
     let plan = Command.plan flowCfg (Command.parse flowCfg [ "uat" ] |> mustOk)
     Assert.Equal(PlanAction.EmitBundle (ModelSource.ModelFile "model.json", None, "dist/onprem-uat"), plan.Action)
@@ -535,10 +568,38 @@ let ``report --store <path>: an explicit store overrides`` () =
 let ``explain <flow>: previews B (the flow model) against A_prior (the target store)`` () =
     // uat → onprem-uat (store "lifecycle/uat.json"); cfg model is "model.json".
     match (Command.plan flowCfg (Intent.Explain [ "uat" ])).Action with
-    | PlanAction.ExplainMigrateFromStore (store, modelB, _) ->
+    | PlanAction.ExplainMigrateFromStore (store, modelB, _, forceGenesis) ->
         Assert.Equal("lifecycle/uat.json", store)
         Assert.Equal("model.json", modelB)
+        Assert.False forceGenesis
     | other -> Assert.Fail(sprintf "expected ExplainMigrateFromStore, got %A" other)
+
+[<Fact>]
+let ``explain migrate --from empty --store forces genesis (D4)`` () =
+    match (Command.plan flowCfg (Intent.Explain [ "migrate"; "--to"; "b"; "--from"; "empty"; "--store"; "s.json" ])).Action with
+    | PlanAction.ExplainMigrateFromStore (store, toP, _, forceGenesis) ->
+        Assert.Equal("s.json", store)
+        Assert.Equal("b", toP)
+        Assert.True forceGenesis
+    | other -> Assert.Fail(sprintf "expected ExplainMigrateFromStore forcing genesis, got %A" other)
+
+[<Fact>]
+let ``explain migrate --from <model> (not empty) stays the two-model preview (D4 additive)`` () =
+    match (Command.plan flowCfg (Intent.Explain [ "migrate"; "--to"; "b"; "--from"; "a" ])).Action with
+    | PlanAction.ExplainMigratePreview ("a", "b", _) -> ()
+    | other -> Assert.Fail(sprintf "expected ExplainMigratePreview, got %A" other)
+
+[<Fact>]
+let ``explain migrate --store without --from empty does NOT force genesis (D4 default off)`` () =
+    match (Command.plan flowCfg (Intent.Explain [ "migrate"; "--to"; "b"; "--store"; "s.json" ])).Action with
+    | PlanAction.ExplainMigrateFromStore ("s.json", "b", _, forceGenesis) -> Assert.False forceGenesis
+    | other -> Assert.Fail(sprintf "expected ExplainMigrateFromStore (no force), got %A" other)
+
+[<Fact>]
+let ``explain <flow> --from empty forces genesis for the flow preview (D4)`` () =
+    match (Command.plan flowCfg (Intent.Explain [ "uat"; "--from"; "empty" ])).Action with
+    | PlanAction.ExplainMigrateFromStore (_, _, _, forceGenesis) -> Assert.True forceGenesis
+    | other -> Assert.Fail(sprintf "expected ExplainMigrateFromStore forcing genesis, got %A" other)
 
 [<Fact>]
 let ``explain <flow>: a target with no store is refused (publish + seal once first)`` () =
@@ -549,6 +610,26 @@ let ``explain <flow>: a target with no store is refused (publish + seal once fir
 [<Fact>]
 let ``parse: an unknown first token names the known flows`` () =
     Assert.Contains("cli.verb.unknown", errCodes (Command.parse flowCfg [ "nope" ]))
+
+[<Fact>]
+let ``parse: top-level diff <a> <b> aliases explain diff (A6)`` () =
+    // `diff a b` parses to Intent.Explain ["diff"; "a"; "b"] — the SAME tail the
+    // `explain diff` form produces, so it routes to the identical ExplainDiff.
+    match Command.parse flowCfg [ "diff"; "a"; "b" ] |> mustOk with
+    | Intent.Explain [ "diff"; "a"; "b" ] -> ()
+    | other -> Assert.Fail(sprintf "expected Explain [diff;a;b], got %A" other)
+
+[<Fact>]
+let ``parse: top-level diff routes through plan to ExplainDiff (A6)`` () =
+    match (Command.plan flowCfg (Command.parse flowCfg [ "diff"; "a"; "b"; "--format"; "json" ] |> mustOk)).Action with
+    | PlanAction.ExplainDiff ("a", "b", true, _) -> ()
+    | other -> Assert.Fail(sprintf "expected ExplainDiff, got %A" other)
+
+[<Fact>]
+let ``parse: top-level diff and explain diff produce the SAME action (A6 alias)`` () =
+    let viaTop  = (Command.plan flowCfg (Command.parse flowCfg [ "diff"; "a"; "b" ] |> mustOk)).Action
+    let viaLong = (Command.plan flowCfg (Command.parse flowCfg [ "explain"; "diff"; "a"; "b" ] |> mustOk)).Action
+    Assert.Equal(viaLong, viaTop)
 
 [<Fact>]
 let ``parse: a closed verb still wins over a flow lookup`` () =

--- a/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
@@ -113,7 +113,6 @@ let private v1MinimalFixture : string =
 // rationale and re-open trigger.
 // ---------------------------------------------------------------------------
 
-let private mkName s = Name.create s |> Result.value
 
 let private appCoreModuleKey = modKey "AppCore"
 let private userKindKey      = kindKey ["AppCore"; "User"]

--- a/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
@@ -27,7 +27,6 @@ open Projection.Tests.Fixtures
 //      addition: A1 unbounded.
 // ---------------------------------------------------------------------------
 
-let private mkName s = Name.create s |> Result.value
 
 let private parseSync (source: CatalogReader.SnapshotSource) : Result<Catalog> =
     TaskSync.run (fun () -> CatalogReader.parse source)

--- a/sidecar/projection/tests/Projection.Tests/PassRegistrationsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PassRegistrationsTests.fs
@@ -76,7 +76,6 @@ let ``A.4.7 slice γ: SymmetricClosure.registered carries Schema domain + DataIn
 // Category B — config + Catalog → Catalog factory.
 // ---------------------------------------------------------------------------
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 [<Fact>]
 let ``A.4.7 slice γ: NamingMorphism.registered factory produces DataIntent site`` () =

--- a/sidecar/projection/tests/Projection.Tests/PillarNineTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PillarNineTests.fs
@@ -39,7 +39,6 @@ open Projection.Tests.Fixtures
 // Per-file helpers
 // ---------------------------------------------------------------------------
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 let private shuffleModules (rng: int) (c: Catalog) : Catalog =
     // Deterministic-on-int "shuffle" via List.sortBy hash; preserves

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -57,6 +57,7 @@
     <Compile Include="LogicalNameEmissionTests.fs" />
     <Compile Include="LogicalNameRoundtripTests.fs" />
     <Compile Include="TighteningBindingTests.fs" />
+    <Compile Include="ModuleFilterBindingTests.fs" />
     <Compile Include="SpecialCircumstancesBindingTests.fs" />
     <Compile Include="SpecialCircumstancesDiagnosticsTests.fs" />
     <Compile Include="FkSelectivityDiagnosticsTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReferenceHasDbConstraintTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReferenceHasDbConstraintTests.fs
@@ -21,7 +21,6 @@ open Projection.Tests.IRBuilders
 let private mkKey (v: string) : SsKey =
     SsKey.synthesized "test" v |> Result.value
 
-let private mkName (v: string) : Name = Name.create v |> Result.value
 
 let private mkTableId (schema: string) (table: string) : TableId =
     TableId.create schema table |> Result.value

--- a/sidecar/projection/tests/Projection.Tests/RegisteredAllTransformsBidirectionalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RegisteredAllTransformsBidirectionalTests.fs
@@ -34,7 +34,6 @@ open Projection.Core.Passes
 open Projection.Pipeline
 open Projection.Tests.Fixtures
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 // ---------------------------------------------------------------------------
 // Totality — the unified registry covers every shipped surface.

--- a/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
@@ -98,6 +98,33 @@ let ``6.B.2: end-to-end — diff-derived renames re-point a source row onto the 
     Assert.Equal("bob@x", sinkRow.Values.[nm "Contact"])
     Assert.Equal("1", sinkRow.Values.[nm "Id"])
 
+// A5 — the migrate-with-data data leg re-points A→B because the data source is
+// at the OLD schema A. `executeWithData` now derives its rename map exactly as
+// `runWithRenames` does — `CatalogDiff.between sinkSource target` (A→B) — so a
+// row carrying the A name (EMAIL) is re-pointed onto the B name (CONTACT). This
+// pure witness pins the diff ORIENTATION the data leg wires: A = sinkSource
+// (source contract), B = target (sink contract).
+
+[<Fact>]
+let ``A5: the migrate-with-data rename map derives from between(sinkSource=A, target=B) and re-points A->B`` () =
+    let a = catOf (custKind "Email" "EMAIL")    // sinkSource — the data source's schema A
+    let b = catOf (custKind "Contact" "CONTACT") // target — the migrated sink schema B
+    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMap
+    // A row carrying the A-schema name re-points onto the B name (not lost to NULL).
+    let aRow = rowOf [ "Id", "1"; "Email", "alice@x" ]
+    let repointed = RenameProjection.repointRow map aRow
+    Assert.Equal("alice@x", repointed.Values.[nm "Contact"])
+    Assert.False(repointed.Values.ContainsKey(nm "Email"))
+
+[<Fact>]
+let ``A5: a no-renames A->B diff yields an empty rename map (the data leg stays a straight load)`` () =
+    // Default behavior is preserved: when A and B differ only in ways that are
+    // not renames (here, identical), the rename map is empty ⇒ identity repoint.
+    let a = catOf (custKind "Email" "EMAIL")
+    let b = catOf (custKind "Email" "EMAIL")
+    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMap
+    Assert.True(Map.isEmpty map)
+
 // =====================================================================
 // AC-I7 — the composed Transfer: a column rename AND a Dev→UAT re-key in
 // ONE run. `Transfer.runReconcilingWithRenames` threads BOTH legs through

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesDiagnosticsTests.fs
@@ -12,7 +12,6 @@ open Projection.Tests.IRBuilders
 /// the post-chain `TopologicalOrder`. Acceptance annotation via
 /// `Metadata.acceptedVia` cross-references the operator allowlist.
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 let private mkKindNoPk (kindName: string) (table: string) : Kind =
     let kKey = kindKey [ kindName ]

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterPropertyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterPropertyTests.fs
@@ -78,7 +78,6 @@ let private mustOk (r: FsResult<'a, EmitError>) : 'a =
 let private enrich (c: Catalog) : Catalog =
     (CanonicalizeIdentity.registered.Run c |> Lineage.map (fun d -> d.Value)).Value
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 let private bodyOf (k: SsKey) (cat: Catalog) : string =
     let artifact = SsdtDdlEmitter.emitSlices (enrich cat) |> mustOk

--- a/sidecar/projection/tests/Projection.Tests/SsdtSchemaFidelityPropertyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtSchemaFidelityPropertyTests.fs
@@ -55,7 +55,6 @@ let private mustOk (r: FsResult<'a, EmitError>) : 'a =
 let private enrich (c: Catalog) : Catalog =
     (CanonicalizeIdentity.registered.Run c |> Lineage.map (fun d -> d.Value)).Value
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 
 let private bodyOf (k: SsKey) (cat: Catalog) : string =
     let artifact = SsdtDdlEmitter.emitSlices (enrich cat) |> mustOk

--- a/sidecar/projection/tests/Projection.Tests/StaticPopulationEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticPopulationEmitterTests.fs
@@ -37,9 +37,6 @@ let private mustOk (r: Result<'a>) : 'a =
 let private mkKey (parts: string list) : SsKey =
     SsKey.synthesizedComposite "OS_TEST" parts |> mustOk
 
-let private mkName (s: string) : Name =
-    Name.create s |> mustOk
-
 /// Static-entity fixture: 3 columns, 2 rows. `Id` is IDENTITY-flagged
 /// so the emitter SHOULD bracket the InsertRow block with
 /// SetIdentityInsert toggles.

--- a/sidecar/projection/tests/Projection.Tests/StaticSeedsEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticSeedsEmitterTests.fs
@@ -25,9 +25,6 @@ let private mustOk r =
 let private mkKey (parts: string list) : SsKey =
     SsKey.synthesizedComposite "OS_TEST" parts |> mustOk
 
-let private mkName (s: string) : Name =
-    Name.create s |> mustOk
-
 /// Static-entity fixture with explicit Id values (so VALUES rows are
 /// deployable). Three rows × three columns (Id INT PK + Code TEXT +
 /// Label TEXT).

--- a/sidecar/projection/tests/Projection.Tests/StaticSeedsRemapTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticSeedsRemapTests.fs
@@ -27,7 +27,6 @@ let private mustOkEmit (r: Result<'a, EmitError>) : 'a =
     | Error e -> Assert.Fail (sprintf "expected Ok, got %A" e); Unchecked.defaultof<_>
 
 let private mkKey (parts: string list) : SsKey = SsKey.synthesizedComposite "OS_TEST_SR" parts |> mustOk
-let private mkName (s: string) : Name = Name.create s |> mustOk
 
 let private userKey  = mkKey ["User"]
 let private orderKey = mkKey ["Order"]

--- a/sidecar/projection/tests/Projection.Tests/TableRenameTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TableRenameTests.fs
@@ -57,7 +57,6 @@ let private mustFail (r: Result<'a>) : ValidationError list =
 let private hasCode (code: string) (errors: ValidationError list) : bool =
     errors |> List.exists (fun e -> e.Code = code)
 
-let private mkName (s: string) : Name = Name.create s |> mustOk
 let private mkTableId (schema: string) (table: string) : TableId =
     TableId.create schema table |> mustOk
 

--- a/sidecar/projection/tests/Projection.Tests/TopologicalOrderPassTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TopologicalOrderPassTests.fs
@@ -371,7 +371,6 @@ let ``contract: SCC enumeration is invariant under input permutation`` () =
 // ---------------------------------------------------------------------------
 
 let private mkKey s = testKey s
-let private mkName s = Name.create s |> Result.value
 
 let private kindWithFk (kindKey: string) (fkKey: string) (targetKey: SsKey) : Kind =
     let attrId = mkKey (kindKey + "_Id")

--- a/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
@@ -142,3 +142,21 @@ let ``AC-I5: a fully-mapped user-map passes the pre-write gate`` () =
 let ``AC-I5: --allow-drops downgrades the orphan to the post-write reported-drop path`` () =
     let reconciled = reconciledWith [ singleKey, SourceKey.ofString "999" ]
     Assert.True((Transfer.validateUserMap true reconciled).IsNone)
+
+// --- A1: cdcTrackedSink refusal routes through the Preflight classify seam ---
+//
+// `runTransfer`'s refusal branch derives its exit through `Preflight.refusalOf`
+// (the single `classify` seam) rather than a hand-rolled if/elif. The CDC
+// pre-flight refusal (`transfer.cdcTrackedSink`, raised on the Execute path in
+// `TransferRun.runCore`) must therefore exit 9 (`CdcTrackedSink`), not the
+// generic `else 3` the prior hand-derivation produced. This witnesses the seam
+// the CLI now shares with the gate composition (cf. PreflightAllTests `classify`).
+
+[<Fact>]
+let ``A1: a transfer.cdcTrackedSink refusal classifies to exit 9 through Preflight.refusalOf`` () =
+    let refusal =
+        Preflight.refusalOf
+            [ ValidationError.create "transfer.cdcTrackedSink"
+                "Sink has CDC-tracked table(s); refusing --execute." ]
+    Assert.Equal(9, refusal.ExitCode)
+    Assert.Equal(Preflight.CdcTrackedSink, refusal.Label)

--- a/sidecar/projection/tests/Projection.Tests/TransformRegistryCompletenessTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransformRegistryCompletenessTests.fs
@@ -64,7 +64,6 @@ let private ciRun (c: Catalog) : Lineage<Catalog> =
 // config so the per-config invocation here is a witness.
 // ---------------------------------------------------------------------------
 
-let private mkName (s: string) : Name = Name.create s |> Result.value
 let private emptyMask : VisibilityMask.Mask = { Hide = [] }
 let private hideOsNativeMask : VisibilityMask.Mask =
     { Hide = [ VisibilityMask.hideOrigin Origin.Native ] }

--- a/sidecar/projection/tests/Projection.Tests/TtyRendererTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TtyRendererTests.fs
@@ -89,6 +89,28 @@ let ``Tier-4 board: NOT YET names the runs-to-go`` () =
     let text = renderBoard r [ "green"; "red"; "green" ]
     Assert.Contains("NOT YET", text)
     Assert.Contains("3 green run", text)   // 10 - 7 = 3 to go
+    // §8 — the one lever, named: the streak holds, so the lever is the distance.
+    Assert.Contains("The lever", text)
+    Assert.Contains("3 more green round-trip verification", text)
+
+[<Fact>]
+let ``Tier-4 board: the lever names a broken streak as the single blocking item`` () =
+    // The most recent canary diverged → the honest one lever is restoring a green
+    // check, not the raw distance (§8 — one lever, named, with the next move).
+    let r : RunLedger.Readiness =
+        { TotalRuns = 9; CanaryRuns = 9; ConsecutiveGreen = 0
+          LastCanary = Some "red"; Threshold = 10; Eligible = false }
+    let text = renderBoard r [ "green"; "green"; "red" ]
+    Assert.Contains("The lever", text)
+    Assert.Contains("diverged", text)
+
+[<Fact>]
+let ``Tier-4 board: an eligible board names no lever (nothing in the way)`` () =
+    let r : RunLedger.Readiness =
+        { TotalRuns = 12; CanaryRuns = 12; ConsecutiveGreen = 10
+          LastCanary = Some "green"; Threshold = 10; Eligible = true }
+    let text = renderBoard r [ "green"; "green"; "green" ]
+    Assert.DoesNotContain("The lever", text)
 
 [<Fact>]
 let ``Tier-4 board: the timeline reads the recent checks in words and names the present run`` () =

--- a/sidecar/projection/tests/Projection.Tests/V1NullabilityParityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/V1NullabilityParityTests.fs
@@ -44,7 +44,6 @@ let private nullRun (catalog: Catalog) (policy: Policy) (profile: Profile) : Lin
 // ---------------------------------------------------------------------------
 
 let private mkKey s = testKey s
-let private mkName s = Name.create s |> Result.value
 
 /// Build a synthetic catalog with a single attribute matching the V1
 /// test's "Sample.SampleEntity.Mandatory" coordinate. V1 uses

--- a/sidecar/projection/tests/Projection.Tests/ViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ViewTests.fs
@@ -86,16 +86,39 @@ let ``Setup readback: configured state shows plainly, with no recommendation`` (
     Assert.Contains("200 ms", p)
     Assert.DoesNotContain("PROJECTION_LEDGER_DIR", p) // configured → no scold
 
+let private allGranted : (Preflight.WriteAction * bool) list =
+    Preflight.allWriteActions |> List.map (fun a -> a, true)
+
 [<Fact>]
 let ``Setup readback: a reachable target shows reachable + the ALTER grant`` () =
-    let p = plain (TtyRenderer.buildSetupView (Some "./runs") false 120L None (Some ("UAT", true, true)))
+    let p = plain (TtyRenderer.buildSetupView (Some "./runs") false 120L None (Some ("UAT", true, allGranted)))
     Assert.Contains("UAT", p)
     Assert.Contains("reachable", p)
     Assert.Contains("ALTER granted", p)
 
 [<Fact>]
+let ``Setup readback: a reachable target names the broader write grants (D3)`` () =
+    // D3 — INSERT / CREATE TABLE / DELETE surface, not ALTER alone.
+    let p = plain (TtyRenderer.buildSetupView (Some "./runs") false 120L None (Some ("UAT", true, allGranted)))
+    Assert.Contains("INSERT", p)
+    Assert.Contains("CREATE TABLE", p)
+    Assert.Contains("DELETE", p)
+
+[<Fact>]
+let ``Setup readback: missing write grants are named exactly (D3, survey-style phrasing)`` () =
+    // Only ALTER granted; the data writes (INSERT / CREATE TABLE / DELETE) are
+    // missing and read on their own line ("missing INSERT, CREATE TABLE, DELETE").
+    let grants =
+        Preflight.allWriteActions
+        |> List.map (fun a -> a, (a = Preflight.WriteAction.Alter))
+    let p = plain (TtyRenderer.buildSetupView (Some "./runs") false 120L None (Some ("UAT", true, grants)))
+    Assert.Contains("ALTER granted", p)
+    Assert.Contains("missing", p)
+    Assert.Contains("INSERT", p)
+
+[<Fact>]
 let ``Setup readback: an unreachable target is named, with no grant claimed`` () =
-    let p = plain (TtyRenderer.buildSetupView None false 120L None (Some ("UAT", false, false)))
+    let p = plain (TtyRenderer.buildSetupView None false 120L None (Some ("UAT", false, [])))
     Assert.Contains("unreachable", p)
     Assert.DoesNotContain("ALTER", p)   // the grant is unknowable until reachable
 

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -23,6 +23,7 @@ let private inScopeCodes : Set<string> =
           "profile.started"; "profile.completed"
           "emit.started"; "emit.completed"
           "deploy.started"; "canary.started"; "load.started"
+          "watch.runTitle"; "watch.runDone"
           "summary.stageCompleted"
           "config.validationFailed" ]
 
@@ -41,6 +42,11 @@ let private knownEmittableCodes : Set<string> =
           // the migrate leg's live stage stream (build → apply → verify) + the
           // data-transfer leg's load stage
           "deploy.started"; "canary.started"; "load.started"
+          // the live Watch board's render-synthesized frame codes (§13) — the
+          // run-title header + the terminal done-frame. Not LogSink envelopes: the
+          // board is a *rendering* of the run, so its frame copy is voiced through
+          // the catalog (one register) and consumed at render, never emitted.
+          "watch.runTitle"; "watch.runDone"
           // round-trip verification verdict
           "canary.diffEmpty"; "canary.divergence"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
@@ -73,7 +79,9 @@ let private samplePayload : Voice.Payload =
           "reason",      box "line 12, 'threshold' must be a number"
           "code",        box "pipeline.config.typeMismatch"
           "stage",       box "extract"
-          "outcome",     box "succeeded" ]
+          "outcome",     box "succeeded"
+          "followOn",    box "Verification follows."
+          "runIdentity", box 11 ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality

--- a/sidecar/projection/tests/Projection.Tests/WatchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchTests.fs
@@ -255,3 +255,85 @@ let ``Watch progress: an unknown total is a plain count-up — no fraction, no e
     Assert.Contains("142 applied", text)
     Assert.DoesNotContain("of 0", text)
     Assert.DoesNotContain("remaining", text)
+
+// ---------------------------------------------------------------------------
+// the run frame — the title header + the terminal done-frame (§13 D1)
+// ---------------------------------------------------------------------------
+
+let private allDone (keys: string list) : Watch.Board =
+    let seed = Watch.seeded keys
+    keys
+    |> List.fold
+        (fun b k ->
+            let started, _ = Watch.apply b (k + ".started") Map.empty
+            let done', _ =
+                Watch.apply started "summary.stageCompleted" (payload [ "stage", box k; "durationMs", box 100L ])
+            done')
+        seed
+
+[<Fact>]
+let ``Watch frame: no done-frame while the run is mid-flight`` () =
+    let board = Watch.seeded [ "extract"; "profile"; "emit" ]
+    let started, _ = Watch.apply board "extract.started" Map.empty
+    Assert.False(Watch.isTerminal started)
+    Assert.True((Watch.doneFrameText started).IsNone)
+
+[<Fact>]
+let ``Watch frame: the done-frame names the §13 follow-on once the arc lands`` () =
+    // a publish arc whose terminal stage is the change build → "Verification follows".
+    let board = allDone [ "extract"; "profile"; "emit" ]
+    Assert.True(Watch.isTerminal board)
+    match Watch.doneFrameText board with
+    | Some t -> Assert.Contains("Verification follows", t)
+    | None   -> Assert.Fail "expected a done-frame once the run is terminal"
+
+[<Fact>]
+let ``Watch frame: the migrate arc's verify terminal offers the record`` () =
+    let board = allDone [ "deploy"; "canary" ]
+    match Watch.doneFrameText board with
+    | Some t -> Assert.Contains("The record follows", t)
+    | None   -> Assert.Fail "expected a done-frame"
+
+[<Fact>]
+let ``Watch frame: a known run identity is voiced as 'Recorded as run N'`` () =
+    let seed = Watch.seededWith (Some "projection full-export") (Some "11") [ "emit" ]
+    let started, _ = Watch.apply seed "emit.started" Map.empty
+    let board, _ =
+        Watch.apply started "summary.stageCompleted" (payload [ "stage", box "emit"; "durationMs", box 100L ])
+    match Watch.doneFrameText board with
+    | Some t -> Assert.Contains("Recorded as run 11", t)
+    | None   -> Assert.Fail "expected a done-frame carrying the run identity"
+
+[<Fact>]
+let ``Watch frame: the title header voices the run in flight, never the raw code`` () =
+    let board = Watch.seededWith (Some "projection full-export") None [ "emit" ]
+    match Watch.titleText board with
+    | Some t ->
+        Assert.Contains("projection full-export", t)
+        Assert.Contains("run in flight", t)
+    | None   -> Assert.Fail "expected a title header on a framed board"
+
+[<Fact>]
+let ``Watch frame: an unframed board carries no title`` () =
+    Assert.True((Watch.titleText (Watch.seeded [ "emit" ])).IsNone)
+
+[<Fact>]
+let ``Watch frame: the run frame clears the twelve-rule banned list`` () =
+    let banned =
+        [ "your"; "you "; " i "; " we "; "that's real"; ", not "
+          "destroy"; "cleaned up"; "dig"; "oops"; "let's"; "refused" ]
+    let board = Watch.seededWith (Some "projection full-export") (Some "11") [ "extract"; "profile"; "emit" ]
+    let terminal = allDone [ "extract"; "profile"; "emit" ]
+    let lines =
+        [ Watch.titleText board
+          Watch.doneFrameText { terminal with RunIdentity = Some "11" } ]
+        |> List.choose id
+    for line in lines do
+        let lowered = line.ToLowerInvariant()
+        for b in banned do
+            Assert.False(lowered.Contains b, sprintf "run-frame line '%s' breaks the banned list: contains '%s'" line b)
+
+[<Fact>]
+let ``Watch frame: followOnAfter is total — every reachable terminal stage names a move`` () =
+    for stage in [ "extract"; "profile"; "emit"; "deploy"; "canary"; "load"; "somethingNew" ] do
+        Assert.False(System.String.IsNullOrWhiteSpace(Voice.followOnAfter stage))


### PR DESCRIPTION
Distills the ~125-file doc corpus to a ~30-item code-confirmed backlog.
Two-pass method: doc compilation, then 8 parallel src/tests confirmation
agents under an anti-false-positive discipline. Categorizes findings as
OPEN / PARTIAL / CLOSED-stale / DEFERRED / OUT-OF-CORPUS with file:line
evidence, so future sessions start from verified state rather than the
stale planning/audit docs.

https://claude.ai/code/session_01GjrxKeVNzGkJApfZNmzw37