### PR TITLE
cards Q2+Q3: the row stream becomes positional — RowQuantum end-to-end on the streaming path

### DIFF
--- a/sidecar/projection/CLAUDE.md
+++ b/sidecar/projection/CLAUDE.md
@@ -107,7 +107,10 @@ within their first session. Everything not on this list, this file only points t
    instance-wide state; never on the warm container.
 2. **A batch of `Could not open a connection` failures means the warm SQL container died**,
    not a regression. `scripts/warm-sql.sh restart`. Check `scripts/test.sh status` first,
-   always.
+   always. Same remedy for a second signature (2026-06-12): **a bulk load that hangs
+   indefinitely** (no error, zero rows) on a long-running warm container is a
+   RESOURCE_SEMAPHORE memory-grant stall — batch-size-independent; diagnose via
+   `sys.dm_exec_query_memory_grants`, then restart. (PERF_HARNESS §5.)
 3. **Never `pgrep`-guard a test run; never watch a run through `| tail`** — the guard matches
    itself and tail buffers to EOF. Launch bare in the background; poll `test.sh status`.
 4. **On any `Failed: N>0`, re-run with the TRX logger and grep the TRX** — console output

--- a/sidecar/projection/CLAUDE.md
+++ b/sidecar/projection/CLAUDE.md
@@ -228,10 +228,10 @@ the predecessor's table drifted against the code within weeks (the case is enume
   deferred feature (reflection, object expressions, type providers, SRTP, free monads,
   `IObservable`) has its re-open trigger there or in the entry that deferred it.
 - **Currently-fired promotions awaiting their gates** are tracked in `CONSTELLATION.md` §9.7:
-  `[<Struct>]` scoped to the row-grain carrier (fired by measured allocation priors; **its
-  gate — harness slice 2 — passed 2026-06-11**, so it lands with the Q-track) and units of
-  measure scoped to the `Run.diff` delta surface (fired by mixed quantities in one
-  expression; still gate-held on R1d).
+  `[<Struct>]` scoped to the row-grain carrier (fired by measured allocation priors; its
+  gate — harness slice 2 — passed 2026-06-11; **landed with the Q-track 2026-06-12**,
+  `RowQuantum`) and units of measure scoped to the `Run.diff` delta surface (fired by mixed
+  quantities in one expression; still gate-held on R1d).
 - **Three metaprogramming devices are sanctioned** (builder / active pattern /
   private-constructor module); quotations and type providers stay out absent a trigger.
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -402,10 +402,25 @@ avoided by the aggregated-sample shape.) **Replicated by re-imaging 2** (second 
 end-to-end 12.05 µs/row; materialize 483 ms = 4.83 µs/row = 40.1%); accumulator boundary
 read against its documentation and they agree: `t0` after `ReadAsync`, stop before
 `SsKey.synthesized`, one aggregated sample at EOF.
-**H4 · executeStream batch sweep.** S. Deps: H0.
-**H5 · The drains:** `staticPopulationDrain`, `physicalSchemaVerify`, `profilerDiscover`. M.
-Deps: H0.
-**H6 · `ossysParse` at ≥1k entities.** S. Deps: H0.
+**H4 · executeStream batch sweep — DONE 2026-06-12.** `Deploy.executeStreamWith batchSize`
+(the sibling wrapper supplying `DefaultBulkBatchSize` — passes the distinguishing test);
+declared scenarios `execute-stream-batch-100000x{1000,5000,10000}`. The sweep's first edition
+carried 20000 and the harness PRICED IT OUT live: the bulk-insert memory grant (539 MB
+requested) exceeds the 4 GiB container's big-query resource semaphore (~492 MB) and suspends
+on RESOURCE_SEMAPHORE indefinitely — a named infeasibility, not a slow point (PERF_HARNESS §5
+records it; the instrument falsifying its author's scale choice on first contact, again).
+First-run numbers in PERF_HARNESS §5.
+**H5 · The drains — DONE 2026-06-12:** `static-population-drain-100000` (pure emit
+isolated: **313 ms/100k = 3.1 µs/row** — the in-canary 3.4–3.7 s on the same label was ~90%
+consumer time between pulls, exactly the §1-3a caveat), `physical-schema-verify-100000`
+(ofCatalog 2× = 1094 ms, rows.hash 702 ms/200k = 3.5 µs/row, diff 242 ms — the bulk100k
+~14 s verify prior decomposes), `profiler-discover-150` (the discovery leg isolated over a
+150-table mesh; rows=0 by design — the scenario measures the discover-once round-trips, the
+axis the chapter-B.3 prior speaks to). Deps: H0 (met).
+**H6 · `ossysParse` at ≥1k entities — DONE 2026-06-12.** `ossys-parse-1000` over a
+JsonNode-synthesized V1 envelope (1000 entities × 8 attrs × 1 index, deterministic ssKeys):
+**~170 ms/1000 entities** at first run — the parse plane is cheap at estate scale; the
+PERF_OPPORTUNITIES A3/A4 priors are now one command to re-interrogate.
 
 ### Stage 2 — the spine (R2, corrected per RI-2)
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -347,13 +347,14 @@ in §6 item 10 with its wake condition. *Witness shipped:* the Docker-gated
 `LiveProfilerIntegrationTests` (6/6 green against the warm container — both drain paths
 exercised). S. Deps: none. Rollback: revert.
 
-**F6 · One static-fixture catalog builder.** Plane N7. Incision: a test-tree
-`StaticCatalogFixtures` module (parameterized: kind name, attribute shapes, rows) absorbing
-`staticSeedCatalog`, `wideSeedCatalog`, and the AC-X1 catalog build; `meshModel` stays (a
-cousin — FK mesh, no static rows). *Unlock:* the fourth instance never gets written; fixture
-determinism has one definition site. *Witness:* harness scenarios + AC-X1 outputs byte-stable
-across the move. S. Deps: none. Rollback: revert. Interleave filler — never block a gated
-card on it.
+**F6 · One static-fixture catalog builder — DONE 2026-06-12.** Plane N7. Shipped as
+`StaticCatalogFixtures.staticCatalog` (test tree, compiled before `MigrationCanaryTests` —
+the fsproj-order trap checked first per the risk register), absorbing FOUR instances, not
+three: `staticSeedCatalog`, `wideSeedCatalog`, and BOTH AC-X1 catalog builds (parts A and B
+each carried one, `OS_X1L`/`OS_X1B` — the card's census said three). The SsKey synthesis
+contract is documented on the module; instances keep their exact key shapes (byte-identical
+fixtures). `meshModel` stays (a cousin — FK mesh, no static rows). *Witness:* pure pool +
+the AC-X1 Docker pair green across the move. The H4–H6 scenarios build on it.
 
 **F7 · Retire the consumer-less streaming-digest apparatus — DONE 2026-06-12** (deleted per
 the dead-algebra precedent; the >100k canary was not being opened simultaneously, so the

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -355,7 +355,11 @@ determinism has one definition site. *Witness:* harness scenarios + AC-X1 output
 across the move. S. Deps: none. Rollback: revert. Interleave filler — never block a gated
 card on it.
 
-**F7 · Retire the consumer-less streaming-digest apparatus.** Plane N10. The fold surface
+**F7 · Retire the consumer-less streaming-digest apparatus — DONE 2026-06-12** (deleted per
+the dead-algebra precedent; the >100k canary was not being opened simultaneously, so the
+wire-it alternative correctly did not fire; blast radius matched the card plus two
+sites the card missed — `EventProjection.fs` carried two always-zero diff payload counts,
+deleted in the same commit). Plane N10. The fold surface
 (`RowDigester.State/empty/addInPlace/add/finalize`), `PhysicalSchema.withDigests`, the
 always-empty `RowDigests : Set<PhysicalRowDigest>` axis, its two diff arms, two `isEqual`
 clauses, and two render blocks — zero consumers, all arms structurally inert. Incision:

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -203,6 +203,23 @@ DECISIONS Active-deferrals index as *the* trigger registry, whose stated purpose
 silently-fired (and silently-armed) triggers. Fixed this session: `DECISIONS 2026-06-11 —
 the perf-harness verdicts`, plus an index row for the staged-bulk wake condition.
 
+**RI-13 (generation 4, 2026-06-12, the arc-cutter) — the Q-cards changed shape under the
+knife, per the F1/F3 precedent.** Executing the arc: (a) Q4's deletion content (the per-row
+`READSIDE_ROW` SsKey synthesis out of the stream) landed structurally AT Q2 — once
+`readRowsStream` emits quanta, the synthesis has nowhere to live in the pull; it moved to
+the ONE IR-grain boundary (`ReadSide.materializeStream`), where it carries its own
+aggregated label (`readside.rowstream.materializeIr`) so the relocated cost stays on the
+books (the §3.8/attribution rule, honored rather than dodged). (b) Q2 and Q3 shipped as ONE
+commit: the backlog's own sequencing finding proves Q2 is not independently win-bearing, and
+a Q2-only commit would have required staging a tree state that was never itself
+suite-verified — the witness chain (pure pool + canary suite + full Docker pool, green at
+the commit) outranks the card count. (c) Q3's `SurrogateCapture` incision generalized the
+ladder over the row carrier (a staged `getterOf : Attribute -> ('row -> string)`) instead of
+duplicating it — A40 applied at the carrier axis; the materialized path keeps `StaticRow`
+through the same functions. The journal fingerprint bytes are unchanged — existing journals
+resume across the carrier change (the RI-7 byte-stability discipline, applied to the
+fingerprint plane).
+
 ---
 
 ## 2 — The cleavage-plane inventory
@@ -496,11 +513,16 @@ and a lossless `toValues` round-trip. The property test is the type's second con
 zero-consumer tension resolved). S. Deps: gate (open). Rollback: revert; types unused until
 Q2.
 
-**Q2 · The stream re-typed.** `readRowsStream` emits `RowQuantum` (`[<Struct>]`, per the
-fired promotion); `Ingestion.streamKind` re-typed; the buffered `readRows` path converts at
-the boundary via `StaticRow.ofQuantum basis` (IR grain unchanged, 100k threshold unchanged).
-*Witness:* `` `R4: ofQuantum ∘ toQuantum = id` `` + canary hashes byte-identical (Q1's
-permutation). M. Deps: Q1.
+**Q2 · The stream re-typed — DONE 2026-06-12** (with Q3, one commit; RI-13). `readRowsStream`
+emits `RowQuantum` (`[<Struct>]`, per the fired promotion); `Ingestion.streamKind` re-typed;
+`streamsInOrder` DELETED rather than re-typed — its single consumer was `collectInOrder` and
+the streaming realization streams per kind inside its own chunk loop, so the re-typed triple
+would have shipped consumer-less (the dead-algebra precedent; a boundary-map correction —
+the map said "re-type", the census at the cut said "delete"); the buffered `readRows` path and
+`collectInOrder` convert at the ONE IR-grain boundary (`ReadSide.materializeStream` →
+`StaticRow.ofQuantum` — Map + `READSIDE_ROW` Identifier minted there, preview/canary scale),
+which carries the `materializeIr` aggregated label. *Witness shipped:* `` `R4: ofQuantum ∘
+toQuantum = id` `` + pure pool + canary suite green at the commit.
 
 > **Sequencing finding (re-imaging 2, Q1-session):** Q2 is **coupled to Q3+Q4**, not
 > independently win-bearing. `readRowsStream`'s streaming consumers (`TransferRun.toCellsOver`/
@@ -537,17 +559,27 @@ permutation). M. Deps: Q1.
 > - `RowDigester`'s fold is dead (N10/F7) — the arc does NOT need to wire quanta into it;
 >   `hashQuantumBytes` already covers the hash plane (Q1, witnessed).
 
-**Q3 · In-flight consumers.** `TransferRun.toCellsOver`/`pkOf`/`writeChunk`,
-`SurrogateRemap` ordinal overload (the A40 `*With` shape extended), `SurrogateCapture` —
-in-flight sites only (~the streaming subset of the 19; IR-grain consumers untouched).
-*Witness:* reverse-leg property + scale suites, green, with the before/after delta in the
-commit message per the bench protocol. M. Deps: Q2.
+**Q3 · In-flight consumers — DONE 2026-06-12** (with Q2, one commit; RI-13). The streaming
+realization consumes quanta end-to-end: renames are HEADER operations (`RowBasis.rename`,
+once per kind — the per-row walk deleted, not ported; the materialized path keeps
+`RenameProjection` at its scale); PK fingerprints + phase-2 identity re-keys index cells
+through the basis (`RowQuantum.cellGetter`, ordinals resolved once per kind); FK re-point at
+the quantum grain (`SurrogateRemap.remapQuantumFksWith` + `fkOrdinalsTargeting`, Name-ordered
+so skip diagnostics are identical, copy-on-write cells); the capture ladder carrier-generic
+(`SurrogateCapture` staged `getterOf` — A40 at the carrier axis); bulk lanes project via
+`quantumCellsOver`. Journal fingerprint bytes unchanged — journals resume across the carrier
+change. *Witnesses shipped:* `` `Q3: remapQuantumFksWith equals remapRowFksWith over any
+total rows` `` (FsCheck) + `` `Q3: RowBasis.rename — the header rename equals the per-row
+rename walk` `` + full Docker pool (reverse-leg Streaming/Canary/Property/Scale suites)
+green at the commit.
 
-**Q4 · Delete the per-row SsKey from the stream.** The `READSIDE_ROW` synthesis and its
-measured sprintf (`ReadSide.fs:921-930`) go; identity at row grain is the PK cell through
-the basis. The IR-grain `Identifier` consumers (sort passes, `DataInsertRow`) are out of
-scope and unaffected. *Witness:* H3 re-run shows the materialize label's drop. S. Deps: Q2,
-Q3.
+**Q4 · Delete the per-row SsKey from the stream — DONE 2026-06-12** (deletion content landed
+structurally at Q2, per RI-13; this card closed as the arc's measurement). The `READSIDE_ROW`
+synthesis and its sprintf are out of the stream — identity at row grain is the PK cell
+through the basis; the synthesis survives ONLY at the IR-grain boundary
+(`materializeStream`), where the IR-grain `Identifier` consumers (sort passes,
+`DataInsertRow`) still receive it unchanged. *Witness:* H3 re-run (same host, same warm
+container, back-to-back with the BEFORE) — see PERF_HARNESS §5 Q-arc results.
 
 ### Stage 6 — licensed parallelism (R5, corrected per RI-5)
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -753,6 +753,7 @@ is also the resume story after the interruption ends.
 | FS3511 Release shapes | any task-CE work in L2/Q2/Q3 | the survival rules; hoist and bind single values |
 | perf-gate baseline drift | P2, Q3, anything that legitimately moves a floor | `PERF_GATE_RECORD=1` + the DECISIONS amendment, never silent |
 | Docker soft-skip masking | every Docker-gated witness above | confirm via TRX / `test.sh status` when the verdict matters |
+| warm-container memory-grant stall | any bulk load that hangs indefinitely (no error, no rows) on a long-running warm container | it is a RESOURCE_SEMAPHORE wait, not a code bug and not the batch knob (the grant ~535 MB is batch-size-independent): check `sys.dm_exec_query_memory_grants` + `_resource_semaphores`, then `warm-sql.sh restart` (PERF_HARNESS §5, 2026-06-12) |
 
 ---
 

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21555,3 +21555,54 @@ Evidence of record: `PERF_HARNESS.md` §5 slice-1/slice-2 results
 blocks; `bench/perf/` artifacts are gitignored by design, so the
 witnesses are the re-runnable scenarios themselves. No perf-gate
 baseline moved.
+
+## 2026-06-12 — The Q-arc lands: the in-flight row carrier is positional (Q2+Q3+Q4, one arc, RI-13)
+
+The CONSTELLATION_BACKLOG stage-5 critical path executed as one focused
+arc under the open H3 gate (materialize = 40–42% of stream wall,
+confirmed on three hosts including this one's BEFORE: 420 ms / 985 ms
+end-to-end = 42.6% at 100k×12 warm).
+
+**The decision.** `ReadSide.readRowsStream` emits `RowQuantum` (cells
+positional against `Kind.rowBasis`); the Map + `READSIDE_ROW` SsKey
+mint lives ONLY at the IR-grain boundary (`ReadSide.materializeStream`
+→ `StaticRow.ofQuantum`), which the buffered `readRows`,
+`Ingestion.collectInOrder`/`streamKindRows`, and the reconcile read use
+at preview/canary scale. The streaming realization consumes quanta
+end-to-end: renames are basis-header operations (`RowBasis.rename`,
+once per kind — the per-row rename walk is deleted on that path, not
+ported); PK/identity access is by precomputed ordinal
+(`RowQuantum.cellGetter`); FK re-point is
+`SurrogateRemap.remapQuantumFksWith` over `fkOrdinalsTargeting`
+(Name-ordered — identical skip diagnostics — copy-on-write cells); the
+capture ladder is carrier-generic via a staged
+`getterOf : Attribute -> ('row -> string)` (A40 at the carrier axis —
+the materialized path keeps `StaticRow` through the same functions).
+
+**Attribution (the §3.8 rule, honored).** The `materialize` label now
+brackets the cells build inside the pull; the relocated Map/SsKey cost
+carries its own aggregated label (`readside.rowstream.materializeIr`)
+at the boundary. The win's witness is the end-to-end `.all` number,
+not the label.
+
+**Byte-stability ledger.** Canary row hashes: unchanged by
+construction (Q1's name-sorted permutation; `hashQuantumBytes` ≡
+`hashRowBytes`, FsCheck-witnessed). Journal fingerprints (first/last
+PK + raw count): same bytes — existing journals resume across the
+carrier change. IR-grain `StaticRow`s rebuilt at the boundary:
+identical Maps and identifiers (`R4: ofQuantum ∘ toQuantum = id`).
+
+**The measured outcome (Q4's number; `perf-harness.sh` readside-rowstream
+100k×12, warm, back-to-back with the BEFORE on this host, three AFTER
+runs):** end-to-end 985 ms → 652/753/867 ms, mean 757 ms (9.85 →
+~7.6 µs/row, **−23% end-to-end**, ~101.5k → ~132k rows/sec at the best
+run); materialize 420 ms → 126/154/188 ms, mean 156 ms (4.20 →
+~1.56 µs/row, **−63%** — cells build only; the boundary conversion is
+not paid by the drain or the streaming realization). Count drift zero
+(100000/100000); the materialize delta is far beyond 2× run-to-run
+jitter, the end-to-end delta beyond it on the mean.
+
+Cards Q2/Q3/Q4 closed in two commits (Q2+Q3 coupled per the backlog's
+sequencing finding; Q4 = the measurement + docs) — the card-shape
+changes are RI-13. Witnesses at every commit: pure pool, canary suite,
+full Docker pool. No perf-gate baseline moved.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -52,9 +52,11 @@ card, per the protocol. J5 — a writable UAT connection — still trumps
 everything.
 
 Witness state at close: pure pool 3056/0/211 green at every commit;
-canary suite 103/0/4; full Docker pool 222/0 at the arc commit and the
-full suite re-run at close (see the final commit). Six commits, every
-one green, every number in its commit message.
+canary suite 103/0/4; full Docker pool 222/0 at the arc commit and
+229/0 (876 s) at the close re-run (`test.sh all`: fast exit 0, docker
+exit 0 — the gated perf facts soft-skip there by design and were each
+exercised gate-open this session). Six commits, every one green, every
+number in its commit message.
 
 Hold the spine; balance the books; keep the patient breathing; re-run
 the witnesses you inherit before you stand on them.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,64 @@
+# Handoff addendum — 2026-06-12, generation 4 CLOSE (the Q-arc is CUT and measured; the substrate is COMPLETE; F6/F7 closed)
+
+To the next agent.
+
+The arc-cutter's session is done. What you inherit, in order of weight:
+
+**1. The Q-track critical path is CLOSED (Q1→Q2→Q3→Q4, all DONE).** The
+in-flight row carrier is positional: `readRowsStream` emits `RowQuantum`
+against `Kind.rowBasis`; the Map + `READSIDE_ROW` mint lives ONLY at the
+IR-grain boundary (`ReadSide.materializeStream`, its own `materializeIr`
+label); the streaming realization consumes quanta end-to-end — renames
+are basis-header operations (`RowBasis.rename`, the per-row walk is
+DELETED on that path), PK/FK/identity access is by precomputed ordinal,
+the capture ladder is carrier-generic (staged `getterOf`, A40). **The
+measured win: end-to-end 985→757 ms mean (−23%, ~7.6 µs/row, up to 133k
+rows/sec); carrier build 4.20→1.56 µs/row (−63%).** Byte-stability held
+everywhere it had to: canary row hashes (Q1's permutation), journal
+fingerprints (existing journals resume), IR-grain rows
+(`R4: ofQuantum ∘ toQuantum = id`). RI-13 records where the cards
+changed shape under the knife: Q4's deletion landed at Q2;
+`streamsInOrder` was deleted (consumer-less), not re-typed; Q2+Q3
+shipped as one verified commit per the coupling finding. Read
+`DECISIONS 2026-06-12 — The Q-arc lands` before touching the read path.
+
+**2. The measurement substrate is COMPLETE (H0–H7 all closed).** Twelve
+declared scenarios, every one exercised gate-open this session; numbers
+in PERF_HARNESS §5. The new verdicts: the 5000 bulk default VINDICATED
+(31.3k rows/sec ≈ 10k's 31.4k; 1k pays +27%); pure static-population
+emit is 3.1 µs/row (the in-canary number was ~90% consumer time — the
+3a caveat, quantified); profiler discovery ≈ 4 ms/table (the B.3 prior
+CONFIRMED — leave it); ossys-parse ~170 ms/1000 entities (cheap; A3/A4
+stay unfired); physical-schema-verify decomposes the ~14 s bulk100k
+verify prior (rows.hash 3.5 µs/row is its biggest part — an UNMEASURED-
+until-now candidate if a future gate demands it). One trap with teeth,
+new in PERF_HARNESS §5: an indefinitely-suspended bulk load on the warm
+container is a MEMORY-GRANT stall (`sys.dm_exec_query_memory_grants` +
+`_resource_semaphores`, grant ~535 MB batch-size-INDEPENDENT) — the
+day-old container's semaphore shrinks below it; `warm-sql.sh restart`
+is the remedy. Do not blame the batch knob; I did, for half an hour.
+
+**3. F6 and F7 closed** (the fixture builder absorbed FOUR instances,
+not the card's three; the dead digest fold is deleted, recipes kept).
+Stage 0 and Stage 1 of the backlog are now ENTIRELY done.
+
+**Your queue, by the backlog's own graph:** the S-track (S1→S5, the
+spine — the structural critical path to R1e, untouched and ready in its
+parallel lane); then L1–L4 (F4's pinned journal surface awaits), then
+the R1 stage. The armed items (§6) still have named wake conditions —
+including F1-hex (item 13) and staged-bulk (item 9). The perf substrate
+is no longer the work; it is the instrument — capture before/after per
+card, per the protocol. J5 — a writable UAT connection — still trumps
+everything.
+
+Witness state at close: pure pool 3056/0/211 green at every commit;
+canary suite 103/0/4; full Docker pool 222/0 at the arc commit and the
+full suite re-run at close (see the final commit). Six commits, every
+one green, every number in its commit message.
+
+Hold the spine; balance the books; keep the patient breathing; re-run
+the witnesses you inherit before you stand on them.
+
 # Handoff addendum — 2026-06-11, builder session 2 CLOSE (H7 + the Q-arc boundary map + plane N10; the arc is yours)
 
 To the next agent.

--- a/sidecar/projection/PERF_HARNESS.md
+++ b/sidecar/projection/PERF_HARNESS.md
@@ -524,3 +524,18 @@ The 1b attribution claim is CONFIRMED in-harness: the carrier build is
 comparable to the wire read at scale. **The R4/Q-track gate is OPEN**
 (CONSTELLATION_BACKLOG stage 5). The −22% Map.add and −6× basis-concat
 candidate swaps are now one-command re-runnable claims against this scenario.
+
+**Q-arc results (2026-06-12, in-harness — `readside-rowstream 100000`, 12 cols, warm
+container, BEFORE/AFTER back-to-back on one host; CONSTELLATION_BACKLOG Q2–Q4):**
+
+| Path | BEFORE (StaticRow carrier) | AFTER (RowQuantum carrier) | Δ |
+|---|---|---|---|
+| ReadSide end-to-end (`readside.readRowsStream.all`) | 985 ms = 9.85 µs/row | 652/753/867 ms (3 runs, mean 757) ≈ 7.6 µs/row | **−23%** (mean) |
+| carrier build (`readside.rowstream.materialize`) | 420 ms = 4.20 µs/row (Map + SsKey + cells) | 126/154/188 ms (mean 156) ≈ 1.56 µs/row (cells only) | **−63%** (mean) |
+
+Attribution note (the §3.8 rule): after the arc, `materialize` brackets the
+cells build only; the Map + SsKey mint moved to the IR-grain boundary
+(`ReadSide.materializeStream`) and carries its own aggregated label
+(`readside.rowstream.materializeIr`), which the drain scenario and the
+streaming realization never pay. The win's witness is the END-TO-END number,
+not the label.

--- a/sidecar/projection/PERF_HARNESS.md
+++ b/sidecar/projection/PERF_HARNESS.md
@@ -1,10 +1,14 @@
 # PERF_HARNESS — the before/after measurement fleet (architecture + backlog)
 
-**Status (2026-06-11, amended same day).** Design committed; **slices 0–2 BUILT**
-(builder session 1, PR #596: the spine + `ssdt-emit-only`, the seed-MERGE pair —
-cliff REFUTED, the ReadSide drain — Q-gate OPEN; results in §5; both verdicts
-independently replicated by the follow-on session). Slices 3–5 remain open,
-sequenced by `CONSTELLATION_BACKLOG.md` (H4/H5/H6, behind its H7). This document
+**Status (2026-06-11, amended same day; slices 3–5 added 2026-06-12).** Design
+committed; **slices 0–5 BUILT** (slices 0–2: builder session 1, PR #596 — the
+spine + `ssdt-emit-only`, the seed-MERGE pair — cliff REFUTED, the ReadSide
+drain — Q-gate OPEN, both verdicts independently replicated; slices 3–5:
+generation 4 — the `execute-stream-batch` sweep over `executeStreamWith`, the
+three drains `static-population-drain`/`physical-schema-verify`/
+`profiler-discover`, and `ossys-parse` over a synthesized 1000-entity
+envelope; first-run numbers in §5). The substrate is COMPLETE against the
+declared catalog (H7). This document
 is the architectural source of record for the perf harness. The recommendations
 in §3 are RESOLVED (home: test project + shell orchestrator; comparison:
 single-run deterministic delta with a named promotion trigger) — an agent
@@ -539,3 +543,28 @@ cells build only; the Map + SsKey mint moved to the IR-grain boundary
 (`readside.rowstream.materializeIr`), which the drain scenario and the
 streaming realization never pay. The win's witness is the END-TO-END number,
 not the label.
+
+**Slice 3–5 first-run results (2026-06-12, in-harness — the substrate completes):**
+
+| Scenario | Measurement | Number |
+|---|---|---|
+| `static-population-drain-100000` (3a, pure) | `emit.staticPopulation.statements.stream` with no consumer | **313 ms / 100k = 3.1 µs/row pure emit** — the same label read 3.4–3.7 s in-canary, so ~90% of the in-canary number is consumer time between pulls (the §1-3a caveat, now quantified) |
+| `physical-schema-verify-100000` (X1, pure) | `physicalSchema.ofCatalog` ×2 / `rows.hash` / `diff` | 1094 ms (2 calls) / 702 ms per 200k hashes = **3.5 µs/row hash** / 242 ms diff — the bulk100k ~14 s verify prior decomposes into attributable parts |
+| `ossys-parse-1000` (1d, pure) | `adapter.osm.parse.*` over a 1000-entity × 8-attr synthesized envelope | **~170 ms / 1000 entities** — the parse plane is cheap at estate scale; A3/A4 priors stay un-fired |
+| `profiler-discover-150` (1a, Docker) | `profile.live.captureEvidenceCache` over a 150-table mesh | **607 ms / 150 tables ≈ 4 ms/table** (discoverKind 532 ms / 150) — the chapter-B.3 "already optimized, leave it" prior is CONFIRMED with a number |
+| `execute-stream-batch-100000x{1000,5000,10000}` (4a, Docker) | `deploy.executeStream` rows/sec per batch size (fresh container) | 1000: 4065 ms = **24.6k rows/sec** (100 batches); 5000: 3200 ms = **31.3k**; 10000: 3186 ms = **31.4k** — the 5000 default is VINDICATED (5k≈10k within noise; 1k pays ~27% round-trip overhead; the session-35 rationale holds in-harness) |
+
+**The RESOURCE_SEMAPHORE finding (named, 2026-06-12; diagnosis sharpened
+live):** the sweep's first run suspended indefinitely on a bulk-insert
+memory grant. Initially read as a 20000-batch problem; the re-run at
+`batchSize=1000` requested the SAME ~535 MB (ideal 607 MB) — the grant is
+the bulk-insert SORT estimate over the indexed target and is
+batch-size-INDEPENDENT. The real cause: on a warm container that has run a
+day's pools, SQL's big-query semaphore target had shrunk below the grant
+(~488 MB available < 535 requested) — memory-pressure drift, the
+environmental signature class. The remedy is `warm-sql.sh restart` (fresh
+semaphore ≥ the grant; the same loads ran fine at 07:26). Two consequences:
+(a) the sweep's top stays 10000 — sufficient for the slope question;
+(b) any indefinitely-suspended bulk load on the warm container should be
+diagnosed via `sys.dm_exec_query_memory_grants` +
+`sys.dm_exec_query_resource_semaphores` BEFORE blaming the batch knob.

--- a/sidecar/projection/src/Projection.Adapters.Sql/Ingestion.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/Ingestion.fs
@@ -14,27 +14,32 @@ open Projection.Core
 module Ingestion =
 
     /// Stream one kind's rows from the Source connection (the row-reader
-    /// leg, named in Transfer vocabulary).
-    let streamKind (cnn: SqlConnection) (kind: Kind) : AsyncStream<StaticRow> =
+    /// leg, named in Transfer vocabulary). Quanta are positional against
+    /// `Kind.rowBasis kind` (Q2 — the in-flight carrier).
+    let streamKind (cnn: SqlConnection) (kind: Kind) : AsyncStream<RowQuantum> =
         ReadSide.readRowsStream cnn kind
 
-    /// Per-kind row streams in topological order. Kinds in the order but
-    /// absent from the catalog are skipped. The streams are lazy — nothing
-    /// is read until a consumer pulls.
-    let streamsInOrder
-        (cnn: SqlConnection)
-        (catalog: Catalog)
-        (topo: TopologicalOrder)
-        : (SsKey * AsyncStream<StaticRow>) list =
-        topo.Order
-        |> List.choose (fun key ->
-            Catalog.tryFindKind key catalog
-            |> Option.map (fun k -> key, streamKind cnn k))
+    /// Stream one kind's rows rebuilt at the IR grain (`StaticRow`, Map +
+    /// `READSIDE_ROW` identity minted per row) — the materialized-scale
+    /// boundary for consumers that hold whole row sets (reconcile reads,
+    /// preview/canary collection). The streaming realization consumes
+    /// `streamKind` directly and never pays this conversion.
+    let streamKindRows (cnn: SqlConnection) (kind: Kind) : AsyncStream<StaticRow> =
+        streamKind cnn kind |> ReadSide.materializeStream kind
+
+    // `streamsInOrder` (per-kind streams in topological order) was deleted
+    // here (Q3, 2026-06-12): its single consumer was `collectInOrder`, which
+    // now converts at the IR-grain boundary directly, and the streaming
+    // realization streams per kind via `streamKind` inside its own
+    // chunk loop — zero consumers remained (the dead-algebra precedent,
+    // DECISIONS 2026-06-04). Re-introduce per the two-consumer threshold.
 
     /// Materialize every kind's rows into the `Map<SsKey, StaticRow list>`
-    /// that the pure `TransferPlan.build` consumes. Reads each kind in
+    /// that the pure `TransferPlan.build` consumes — the materialized
+    /// path's SINGLE conversion point back to the IR grain (Q2: Map +
+    /// Identifier minted here, via `streamKindRows`). Reads each kind in
     /// topological order, one open reader at a time (Source-friendly). For
-    /// preview / canary scale; a streaming realization (Slice C) consumes
+    /// preview / canary scale; the streaming realization consumes
     /// `streamsInOrder` directly without materializing.
     let collectInOrder
         (cnn: SqlConnection)
@@ -58,7 +63,12 @@ module Ingestion =
                     let! rows = AsyncStream.toList stream
                     return! loop (Map.add key rows acc) rest
             }
-        loop Map.empty (streamsInOrder cnn catalog topo)
+        let rowStreams =
+            topo.Order
+            |> List.choose (fun key ->
+                Catalog.tryFindKind key catalog
+                |> Option.map (fun k -> key, streamKindRows cnn k))
+        loop Map.empty rowStreams
 
     /// Registry metadata (pillar 9). The ingestion adapter leg classifies
     /// entirely as `DataIntent` — lifting a substrate's rows is observation,

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -1,10 +1,11 @@
 namespace Projection.Adapters.Sql
 
 // LINT-ALLOW-FILE-MUTATION: SQL streaming reader lifetime —
-//   cmdOpt / readerOpt / rowIdx / disposed and per-batch hasMore
-//   mutables encapsulated behind the AsyncStream<StaticRow> pull
-//   abstraction. BCL's SqlDataReader is itself a mutable cursor;
-//   the lifetime state machine is reified per audit Lens-2 Tier-2.
+//   cmdOpt / readerOpt / disposed and per-batch hasMore mutables
+//   encapsulated behind the AsyncStream<RowQuantum> pull abstraction
+//   (rowIdx lives at the IR-grain boundary, `materializeStream`).
+//   BCL's SqlDataReader is itself a mutable cursor; the lifetime
+//   state machine is reified per audit Lens-2 Tier-2.
 
 open System.Threading.Tasks
 open Microsoft.Data.SqlClient
@@ -823,18 +824,21 @@ module ReadSide =
                             (sprintf "ReadSide.Binary: unexpected runtime type %s" (other.GetType().FullName))
                 System.Convert.ToHexString bytes
 
-    /// Stream a table's rows as an `AsyncStream<StaticRow>` — pull-
-    /// based, bench-instrumented, no row materialization. Per
+    /// Stream a table's rows as an `AsyncStream<RowQuantum>` — pull-
+    /// based, bench-instrumented, positional against `Kind.rowBasis kind`
+    /// (Q2: the in-flight carrier is the quantum; the typed Map vocabulary
+    /// lives at the stream's header, not in every element). Per
     /// session-34, the streaming readside is the canonical row
     /// source; `readRows` is a buffered wrapper retained for the
     /// existing per-row PhysicalSchema axis where small-table
-    /// granularity is wanted.
+    /// granularity is wanted — it rebuilds `StaticRow`s at the IR-grain
+    /// boundary via `materializeStream`.
     ///
     /// The reader's lifetime tracks the stream: the underlying
     /// `SqlCommand` and `SqlDataReader` open on first pull and
     /// dispose on EOF or exception. Callers must drain to `None`
     /// (or accept that abandoned streams clean up at GC).
-    let readRowsStream (cnn: SqlConnection) (kind: Kind) : AsyncStream<StaticRow> =
+    let readRowsStream (cnn: SqlConnection) (kind: Kind) : AsyncStream<RowQuantum> =
         // Bracket-quoting flows through ScriptDom's
         // `Identifier.EncodeIdentifier` (canonical, vendor-supplied
         // SQL-identifier encoder). Eliminates the prior `sprintf
@@ -873,9 +877,9 @@ module ReadSide =
                 "SELECT ", columns,
                 " FROM ", qualified,
                 " ORDER BY ", encode pkCol)
+        let attrs = List.toArray kind.Attributes
         let mutable cmdOpt : SqlCommand option = None
         let mutable readerOpt : SqlDataReader option = None
-        let mutable rowIdx = 0
         let mutable disposed = false
         let dispose () =
             if not disposed then
@@ -900,11 +904,14 @@ module ReadSide =
             }
         // PERF_HARNESS §3.6 label 1 accumulator: per-row carrier-build ticks,
         // recorded as ONE aggregated sample at EOF (a per-row Bench.scope
-        // would distort at 100k rows). Boundary: includes per-column
-        // IsDBNull/GetValue + formatRawValue + the Map build + the basis
-        // string; excludes ReadAsync (the wire row-fetch) and the SsKey ctor.
+        // would distort at 100k rows). Boundary (Q4 end-state): includes
+        // per-column IsDBNull/GetValue + formatRawValue + the cells-array
+        // build; excludes ReadAsync (the wire row-fetch). The Map + SsKey
+        // build this label used to bracket moved to the IR-grain boundary
+        // (`materializeStream`), which carries its own label — the label
+        // rides the carrier build wherever it lives (the attribution rule).
         let mutable materializeTicks = 0L
-        let pull () : Task<StaticRow option> =
+        let pull () : Task<RowQuantum option> =
             task {
                 if disposed then return None
                 else
@@ -920,32 +927,16 @@ module ReadSide =
                             return None
                         else
                             let t0 = System.Diagnostics.Stopwatch.GetTimestamp()
-                            let values =
-                                kind.Attributes
-                                |> List.mapi (fun i a ->
-                                    let raw : obj | null =
-                                        if r.IsDBNull i then null
-                                        else r.GetValue i
-                                    a.Name, formatRawValue a.Type raw)
-                                |> Map.ofList
-                            let basis =
-                                sprintf
-                                    "%s.%s.%d"
-                                    (TableId.schemaText kind.Physical)
-                                    (TableId.tableText kind.Physical)
-                                    rowIdx
-                            rowIdx <- rowIdx + 1
+                            let cells = Array.zeroCreate<string> attrs.Length
+                            for i in 0 .. attrs.Length - 1 do
+                                let raw : obj | null =
+                                    if r.IsDBNull i then null
+                                    else r.GetValue i
+                                cells.[i] <- formatRawValue attrs.[i].Type raw
                             materializeTicks <-
                                 materializeTicks
                                 + (System.Diagnostics.Stopwatch.GetTimestamp() - t0)
-                            match SsKey.synthesized "READSIDE_ROW" basis with
-                            | Ok rowKey ->
-                                return Some { Identifier = rowKey; Values = values }
-                            | Error _ ->
-                                // SsKey.synthesized only fails on blank input;
-                                // basis is non-blank by construction.
-                                dispose ()
-                                return None
+                            return Some { Cells = cells }
                     with ex ->
                         dispose ()
                         return raise ex
@@ -953,6 +944,46 @@ module ReadSide =
         pull
         |> AsyncStream.probe (sprintf "readside.readRowsStream.%s.%s" (TableId.schemaText kind.Physical) (TableId.tableText kind.Physical))
         |> AsyncStream.probe "readside.readRowsStream.all"
+
+    /// The IR-grain boundary (Q2): rebuild `StaticRow`s from an in-flight
+    /// quantum stream — the Map mint plus the `READSIDE_ROW` row identity
+    /// (`<schema>.<table>.<rowIdx>`, exactly the pre-Q2 synthesis). This is
+    /// the ONLY place readback rows re-enter the IR grain; the streaming
+    /// realization consumes quanta directly and never pays this. The
+    /// aggregated `materializeIr` sample keeps the relocated Map/SsKey cost
+    /// on the books (the attribution rule: a label rides the carrier build
+    /// wherever it lives).
+    let materializeStream (kind: Kind) (stream: AsyncStream<RowQuantum>) : AsyncStream<StaticRow> =
+        let basis = Kind.rowBasis kind
+        let mutable rowIdx = 0
+        let mutable irTicks = 0L
+        fun () ->
+            task {
+                match! stream () with
+                | None ->
+                    Bench.recordSample
+                        "readside.rowstream.materializeIr"
+                        (irTicks * 1000L / System.Diagnostics.Stopwatch.Frequency)
+                    return None
+                | Some q ->
+                    let t0 = System.Diagnostics.Stopwatch.GetTimestamp()
+                    let rowBasisText =
+                        sprintf
+                            "%s.%s.%d"
+                            (TableId.schemaText kind.Physical)
+                            (TableId.tableText kind.Physical)
+                            rowIdx
+                    rowIdx <- rowIdx + 1
+                    match SsKey.synthesized "READSIDE_ROW" rowBasisText with
+                    | Ok rowKey ->
+                        let row = StaticRow.ofQuantum basis rowKey q
+                        irTicks <- irTicks + (System.Diagnostics.Stopwatch.GetTimestamp() - t0)
+                        return Some row
+                    | Error _ ->
+                        // SsKey.synthesized only fails on blank input;
+                        // rowBasisText is non-blank by construction.
+                        return None
+            }
 
     /// Buffered wrapper: probe COUNT(*), and if ≤ `maxRows`, drain
     /// `readRowsStream` into a list. Above threshold, return `None`
@@ -985,7 +1016,7 @@ module ReadSide =
             elif count = 0 then
                 return Some []
             else
-                let stream = readRowsStream cnn kind
+                let stream = readRowsStream cnn kind |> materializeStream kind
                 let! rows = AsyncStream.toList stream
                 return Some rows
         }

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -1743,8 +1743,8 @@ module ReadSide =
                         // axis; above, the round-trip falls back to
                         // schema-only (no rows in IR). Streaming
                         // realizations (`readRowsStream`) bypass the
-                        // threshold and feed digesters directly without
-                        // IR materialization — chapter-4.1 territory.
+                        // threshold entirely — quanta flow without IR
+                        // materialization.
                         let maxRows = 100_000
                         let kindsWithRows = ResizeArray<Kind>(List.length kindsWithRefs)
                         for k in kindsWithRefs do

--- a/sidecar/projection/src/Projection.Core/Catalog.fs
+++ b/sidecar/projection/src/Projection.Core/Catalog.fs
@@ -124,6 +124,24 @@ module RowBasis =
     /// this, never a per-row sort.
     let nameSortedOrder (b: RowBasis) : int[] = b.NameSortedPerm
 
+    /// Ordinal of `name` in the basis, if present. Resolved once per
+    /// stream/kind by consumers (never per row) — the quantum's by-key
+    /// access path (Q3).
+    let tryOrdinal (name: Name) (b: RowBasis) : int option =
+        b.Names |> Array.tryFindIndex (fun n -> n = name)
+
+    /// Rename basis columns through a source→sink Name re-key map — the
+    /// basis-level realization of a column rename (Q3): under a positional
+    /// carrier a rename is a HEADER operation done once per stream; the
+    /// quanta are untouched. Names absent from the map pass through; the
+    /// name-sorted permutation is recomputed (renames can reorder names).
+    /// Empty map → the same basis (the no-rename stream is byte-identical).
+    let rename (map: Map<Name, Name>) (b: RowBasis) : RowBasis =
+        if Map.isEmpty map then b
+        else
+            ofNames
+                [ for n in b.Names -> Map.tryFind n map |> Option.defaultValue n ]
+
 [<RequireQualifiedAccess>]
 module RowQuantum =
 
@@ -141,6 +159,33 @@ module RowQuantum =
     /// path). Total over the basis by construction.
     let toValues (basis: RowBasis) (q: RowQuantum) : Map<Name, string> =
         Array.zip (RowBasis.names basis) q.Cells |> Map.ofArray
+
+    /// STAGED by-name accessor: resolve the ordinal once per kind/stream,
+    /// index per row (Q3 — the quantum counterpart of `Map.tryFind name
+    /// row.Values |> Option.defaultValue ""`; a name absent from the basis
+    /// reads as the empty raw, exactly as an absent Map key does).
+    let cellGetter (basis: RowBasis) (name: Name) : (RowQuantum -> string) =
+        match RowBasis.tryOrdinal name basis with
+        | Some ix -> fun q -> q.Cells.[ix]
+        | None -> fun _ -> ""
+
+[<RequireQualifiedAccess>]
+module StaticRow =
+
+    /// The Map-carried row's by-name accessor, empty-raw default — named
+    /// once so the carrier-generic consumers (Q3: the capture ladder, the
+    /// cell projections) read identically over both grains.
+    let valueOrEmpty (name: Name) (row: StaticRow) : string =
+        Map.tryFind name row.Values |> Option.defaultValue ""
+
+    /// The IR-grain boundary: rebuild a `StaticRow` from an in-flight
+    /// quantum (Q2 — `RowQuantum.ofStaticRow`'s inverse over a total row;
+    /// witness `R4: ofQuantum ∘ toQuantum = id`). The caller supplies the
+    /// row identity — quanta deliberately carry none (identity at row
+    /// grain is the PK cell through the basis); the IR grain still does.
+    let ofQuantum (basis: RowBasis) (identifier: SsKey) (q: RowQuantum) : StaticRow =
+        { Identifier = identifier
+          Values = RowQuantum.toValues basis q }
 
 
 /// SQL Server "extended property" — a named string annotation attached to
@@ -1302,6 +1347,13 @@ module Kind =
     /// contain multiple entries for composite-key kinds.
     let primaryKey (k: Kind) : Attribute list =
         k.Attributes |> List.filter (fun a -> a.IsPrimaryKey)
+
+    /// The kind's row basis: its attribute Names in attribute order — the
+    /// per-stream header every in-flight `RowQuantum` read from this kind
+    /// is positional against (Q2). Established once per stream, never per
+    /// row.
+    let rowBasis (k: Kind) : RowBasis =
+        RowBasis.ofNames (k.Attributes |> List.map (fun a -> a.Name))
 
     /// The static-population rows attached to this kind via
     /// `Modality.Static`, or `[]` if the kind carries no static

--- a/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
+++ b/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
@@ -177,25 +177,6 @@ type PhysicalRow =
         Hash : string
     }
 
-/// Per-table aggregate row fingerprint. Per session-35 — covers
-/// tables whose row counts exceed `Modality.Static`'s materialization
-/// budget, so structural-fidelity comparison still has a row axis at
-/// enterprise scale (1M+ row tables) without holding rows in IR
-/// memory. Order-independent: the aggregate combines per-row SHA256
-/// hashes by sum-mod-2^256, so ingest order is irrelevant.
-///
-/// Two aggregates with the same `(Count, AggregateHash)` represent
-/// identical multisets with overwhelming probability. A drift either
-/// shifts the count or perturbs the sum; both surface as a non-empty
-/// diff entry on the `RowDigests` axis.
-type PhysicalRowDigest =
-    {
-        Schema : string
-        Table : string
-        Count : int64
-        AggregateHash : string
-    }
-
 /// A binding from a deployed physical coordinate to its logical
 /// name. Slice D.1.c addition — closes the chapter-D logical-name-
 /// emission arc by giving the canary's PhysicalSchema diff a fifth
@@ -240,7 +221,6 @@ type PhysicalSchema =
         Columns : Set<PhysicalColumn>
         ForeignKeys : Set<PhysicalForeignKey>
         Rows : Set<PhysicalRow>
-        RowDigests : Set<PhysicalRowDigest>
         /// Slice D.1.c — logical-name bindings (the kind's / attribute's
         /// `Name` projected alongside the deployed physical coordinate).
         /// Populated from `Kind.Name` + `Attribute.Name` in `ofCatalog`;
@@ -274,8 +254,6 @@ type PhysicalSchemaDiff =
         ExtraForeignKeys : PhysicalForeignKey list
         MissingRows : PhysicalRow list
         ExtraRows : PhysicalRow list
-        MissingRowDigests : PhysicalRowDigest list
-        ExtraRowDigests : PhysicalRowDigest list
         /// Slice D.1.c — logical-name bindings that appear in source
         /// but not target (Missing) / target but not source (Extra).
         /// Set-difference on the binding's full record (Schema + Table
@@ -296,44 +274,19 @@ type PhysicalSchemaDiff =
         ExtraIndexes : PhysicalIndex list
     }
 
-/// Streaming aggregate row-hash builder. Per session-35 — folds an
-/// arbitrary row stream into a `(count, aggregateHash)` pair without
-/// materializing rows in memory. The aggregate is the sum-mod-2^256
-/// of per-row SHA256s; commutative and associative, so streaming
-/// order doesn't matter (multiset equality survives reordering).
-///
-/// **Consumer status (verified 2026-06-11, re-imaging 2).** The fold
-/// surface (`empty`/`add`/`finalize`) and `PhysicalSchema.withDigests`
-/// have ZERO call sites at HEAD — the intended large-table canary
-/// wiring never landed, so `RowDigests` is always empty and its diff
-/// arms are structurally dead. The module's LIVE consumers are the hash
-/// recipes: `hashRowBytes` (← `hashStaticRow` ← `ofCatalog`, the
-/// canary's actual per-row hash path) and `hashQuantumBytes` (the
-/// Q-track). Disposition is CONSTELLATION_BACKLOG card F7: delete the
-/// dead fold per the dead-algebra precedent, or wire it as the >100k
-/// data-round-trip fold — decided there, not silently here.
-/// Sync (Core-friendly); async wrapping happens at the call site.
+/// The canonical per-row content-hash recipes (both canary paths and
+/// the Q-track hash through here). The streaming sum-mod-2^256
+/// aggregate fold (`State`/`empty`/`add`/`finalize` + the
+/// `PhysicalSchema.RowDigests` axis it fed) was DELETED 2026-06-12
+/// (CONSTELLATION_BACKLOG card F7, plane N10): zero call sites at HEAD
+/// — the intended large-table canary wiring never landed, so the axis
+/// was always empty and every diff/render arm structurally dead (the
+/// dead-algebra precedent, DECISIONS 2026-06-04). If the >100k
+/// data-round-trip canary ever opens, rebuild the fold over quanta via
+/// `hashQuantumBytes` (cheap — git preserves the old fold at this
+/// file's history).
 [<RequireQualifiedAccess>]
 module RowDigester =
-
-    type State =
-        {
-            Count : int64
-            Acc : byte[]   // 32-byte running sum mod 2^256
-        }
-
-    let empty () : State = { Count = 0L; Acc = Array.zeroCreate 32 }
-
-    /// Big-endian add-with-carry of a 32-byte addend into a 32-byte
-    /// accumulator, mod 2^256. Mutates the accumulator in place to
-    /// avoid per-row allocation; the State carries this same array
-    /// across folds.
-    let private addInPlace (acc: byte[]) (addend: byte[]) : unit =
-        let mutable carry = 0
-        for i in 31 .. -1 .. 0 do
-            let s = int acc[i] + int addend[i] + carry
-            acc[i] <- byte (s &&& 0xFF)
-            carry <- s >>> 8
 
     /// THE canonical per-row content hash: sort `Values` by column name,
     /// build the `<name>=<value>` string joined by the RS (\x1e)
@@ -379,20 +332,6 @@ module RowDigester =
             first <- false
         let bytes = System.Text.Encoding.UTF8.GetBytes(sb.ToString())
         System.Security.Cryptography.SHA256.HashData(System.ReadOnlySpan<byte>(bytes))
-
-    let add (row: StaticRow) (s: State) : State =
-        let h = hashRowBytes row
-        addInPlace s.Acc h
-        { s with Count = s.Count + 1L }
-
-    let finalize
-        (schema: string) (table: string) (s: State) : PhysicalRowDigest =
-        {
-            Schema = schema
-            Table = table
-            Count = s.Count
-            AggregateHash = System.Convert.ToHexString s.Acc
-        }
 
 [<RequireQualifiedAccess>]
 module PhysicalSchema =
@@ -616,8 +555,8 @@ module PhysicalSchema =
         kindEps @ attrEps
 
     /// Hex form of the row hash — used by `PhysicalRow.Hash` so per-row
-    /// granular diffs render as a stable string. The bytes form
-    /// (`RowDigester.hashRowBytes`) feeds the per-table aggregate path.
+    /// granular diffs render as a stable string, over the one canonical
+    /// recipe (`RowDigester.hashRowBytes`).
     let private hashStaticRow (row: StaticRow) : string =
         System.Convert.ToHexString (RowDigester.hashRowBytes row)
 
@@ -690,10 +629,6 @@ module PhysicalSchema =
     /// tuples PLUS the set of `(src, tgt)` FK tuples reachable
     /// through every Module's Kinds. Modules, Origin, Modality,
     /// non-PK Indexes are projected out by construction.
-    ///
-    /// Per session-35 — `RowDigests` defaults empty; bulk-table
-    /// digests are layered on via `withDigests` when the canary
-    /// computes them out-of-band (streaming readside fold).
     let ofCatalog (c: Catalog) : PhysicalSchema =
         use _ = Bench.scope "physicalSchema.ofCatalog"
         let kinds = c.Modules |> List.collect (fun m -> m.Kinds)
@@ -740,21 +675,13 @@ module PhysicalSchema =
             Columns = columns
             ForeignKeys = foreignKeys
             Rows = rows
-            RowDigests = Set.empty
             LogicalNameBindings = logicalNameBindings
             Annotations = annotations
             Indexes = indexes
         }
 
-    /// Layer per-table aggregate row digests onto an existing
-    /// PhysicalSchema. Used when row data is too large to materialize
-    /// into the Catalog's `Modality.Static`; the digests come from
-    /// `RowDigester` folds over the streaming readside.
-    let withDigests (digests: seq<PhysicalRowDigest>) (s: PhysicalSchema) : PhysicalSchema =
-        { s with RowDigests = s.RowDigests + Set.ofSeq digests }
-
-    /// Diff two `PhysicalSchema` values across four axes (columns +
-    /// FKs + per-row hashes + per-table digests). Per session-35 —
+    /// Diff two `PhysicalSchema` values across its axes (columns +
+    /// FKs + per-row hashes + bindings + annotations + indexes). Per session-35 —
     /// `Set.difference` switched to `HashSet.ExceptWith` form for
     /// large-row diffs (`PhysicalSchema.diff` was the dominant cost
     /// when canaries fail with millions of mismatched rows).
@@ -775,8 +702,6 @@ module PhysicalSchema =
             ExtraForeignKeys           = setDifference target.ForeignKeys         source.ForeignKeys
             MissingRows                = setDifference source.Rows                target.Rows
             ExtraRows                  = setDifference target.Rows                source.Rows
-            MissingRowDigests          = setDifference source.RowDigests          target.RowDigests
-            ExtraRowDigests            = setDifference target.RowDigests          source.RowDigests
             MissingLogicalNameBindings = setDifference source.LogicalNameBindings target.LogicalNameBindings
             ExtraLogicalNameBindings   = setDifference target.LogicalNameBindings source.LogicalNameBindings
             MissingAnnotations         = setDifference source.Annotations         target.Annotations
@@ -793,8 +718,6 @@ module PhysicalSchema =
         && List.isEmpty d.ExtraForeignKeys
         && List.isEmpty d.MissingRows
         && List.isEmpty d.ExtraRows
-        && List.isEmpty d.MissingRowDigests
-        && List.isEmpty d.ExtraRowDigests
         && List.isEmpty d.MissingLogicalNameBindings
         && List.isEmpty d.ExtraLogicalNameBindings
         && List.isEmpty d.MissingAnnotations
@@ -803,8 +726,8 @@ module PhysicalSchema =
         && List.isEmpty d.ExtraIndexes
 
     /// Schema-structural equality: columns + FKs + logical-name bindings +
-    /// annotations match, **ignoring row data** (`Missing`/`ExtraRows` +
-    /// `*RowDigests`). The right predicate for a *schema* migration's
+    /// annotations match, **ignoring row data** (`Missing`/`ExtraRows`).
+    /// The right predicate for a *schema* migration's
     /// verification — `migrate A B` must make B' reproduce B's **structure**;
     /// the rows B' carries are the **preserved/migrated data** (the whole point
     /// of a differential over a drop+recreate), not part of the schema target B
@@ -862,13 +785,6 @@ module PhysicalSchema =
                 r.Schema
                 r.Table
                 (r.Hash.Substring(0, min 16 r.Hash.Length))
-        let renderDigest (d: PhysicalRowDigest) : string =
-            sprintf
-                "  [%s].[%s] count=%d aggregate=%s"
-                d.Schema
-                d.Table
-                d.Count
-                (d.AggregateHash.Substring(0, min 16 d.AggregateHash.Length))
         let renderBinding (b: LogicalNameBinding) : string =
             match b.Column with
             | None ->
@@ -931,8 +847,6 @@ module PhysicalSchema =
                 block "Extra FKs in target (target has, source did not)" renderFk d.ExtraForeignKeys
                 truncatedBlock "Missing rows in target (source had, target lost)" renderRow d.MissingRows
                 truncatedBlock "Extra rows in target (target has, source did not)" renderRow d.ExtraRows
-                truncatedBlock "Missing row digests in target (source had, target lost)" renderDigest d.MissingRowDigests
-                truncatedBlock "Extra row digests in target (target has, source did not)" renderDigest d.ExtraRowDigests
                 truncatedBlock "Missing logical-name bindings in target (source had, target lost)" renderBinding d.MissingLogicalNameBindings
                 truncatedBlock "Extra logical-name bindings in target (target has, source did not)" renderBinding d.ExtraLogicalNameBindings
                 truncatedBlock "Missing annotations in target (triggers/checks/sequences/extprops source had, target lost)" renderAnnotation d.MissingAnnotations

--- a/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
+++ b/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
@@ -173,6 +173,15 @@ type RemappedRows =
         Skipped : UnresolvedReference list
     }
 
+/// `RemappedRows`' sibling at the in-flight quantum grain (Q3): the quanta
+/// kept (FK cells re-pointed, copy-on-write) and the references dropped
+/// because the remap had no matched identity.
+type RemappedQuanta =
+    {
+        Rows    : RowQuantum list
+        Skipped : UnresolvedReference list
+    }
+
 
 [<RequireQualifiedAccess>]
 module SurrogateRemap =
@@ -231,6 +240,64 @@ module SurrogateRemap =
             | Error uref -> skipped <- uref :: skipped
         { Rows    = List.rev kept
           Skipped = List.rev skipped }
+
+    /// Resolve `fkColumnsTargeting`'s Name-keyed targets onto a basis as
+    /// ordinals, ONCE per kind/stream (Q3) — never per row. Emitted in
+    /// Name order (the order `remapRowFksWith`'s Map fold visits), so the
+    /// quantum remap reports the same first-unresolved column a Map-carried
+    /// remap would. A column absent from the basis carries no value on
+    /// this stream and is dropped from the target set.
+    let fkOrdinalsTargeting
+        (basis: RowBasis)
+        (fkTargets: Map<Name, SsKey>)
+        : (int * Name * SsKey) list =
+        fkTargets
+        |> Map.toList
+        |> List.choose (fun (col, target) ->
+            RowBasis.tryOrdinal col basis
+            |> Option.map (fun ix -> ix, col, target))
+
+    /// `remapRowFksWith` at the quantum grain (A40 — same algorithm, the
+    /// row carrier is the parameterized axis). FK targets arrive as basis
+    /// ordinals (`fkOrdinalsTargeting`); a re-point copies the cells array
+    /// once per changed row (copy-on-write — quanta are immutable values);
+    /// an unresolvable non-NULL FK drops the row (skip-and-diagnose),
+    /// exactly as the Map-carried remap does. Pure and order-preserving
+    /// (T1 determinism).
+    let remapQuantumFksWith
+        (tryFindAssigned: SsKey -> string -> string option)
+        (fkTargets: (int * Name * SsKey) list)
+        (rows: RowQuantum list)
+        : RemappedQuanta =
+        if List.isEmpty fkTargets then { Rows = rows; Skipped = [] }
+        else
+            let mutable kept : RowQuantum list = []
+            let mutable skipped : UnresolvedReference list = []
+            for q in rows do
+                let mutable cells = q.Cells
+                let mutable copied = false
+                let mutable failure : UnresolvedReference option = None
+                for (ix, col, target) in fkTargets do
+                    if Option.isNone failure then
+                        let v = cells.[ix]
+                        if v <> "" then
+                            match tryFindAssigned target v with
+                            | Some assigned ->
+                                if not copied then
+                                    cells <- Array.copy cells
+                                    copied <- true
+                                cells.[ix] <- assigned
+                            | None ->
+                                failure <-
+                                    Some
+                                        { Column = col
+                                          Target = target
+                                          UnresolvedSource = SourceKey.ofString v }
+                match failure with
+                | None -> kept <- { Cells = cells } :: kept
+                | Some uref -> skipped <- uref :: skipped
+            { Rows    = List.rev kept
+              Skipped = List.rev skipped }
 
     /// Apply a `SurrogateRemapContext` to one kind's rows — the
     /// context-backed projection of `remapRowFksWith`.

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -76,8 +76,8 @@ type ToleratedDivergence =
 
     /// Static-entity populations (INSERT statements) are absent
     /// from `PhysicalSchema`'s comparison surface (same docstring).
-    /// The data-plane axis is covered by `PhysicalSchema.Rows` /
-    /// `RowDigests` when the canary opts into the data round-trip;
+    /// The data-plane axis is covered by `PhysicalSchema.Rows`
+    /// when the canary opts into the data round-trip;
     /// chapter 4.1.B will retire this variant for population kinds.
     /// @ladder StaticPopulationsUnreflected Data AcceptedFaithful
     | StaticPopulationsUnreflected

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -526,7 +526,12 @@ module Deploy =
     /// `deploy.bulk.copyRows.batchSize`) record batch-level
     /// throughput. Operators reading the bench table see the row
     /// count, batch count, total wall time per realization.
-    let executeStream (cnn: SqlConnection) (statements: seq<Statement>) : Task<unit> =
+    /// `executeStream` with an explicit bulk batch size — the sibling
+    /// wrapper supplies `DefaultBulkBatchSize` (the F# default-argument
+    /// idiom). The knob exists for the perf harness's batch sweep
+    /// (PERF_HARNESS §4 slice 3 / CONSTELLATION_BACKLOG H4); production
+    /// callers use `executeStream`.
+    let executeStreamWith (batchSize: int) (cnn: SqlConnection) (statements: seq<Statement>) : Task<unit> =
         task {
             use _ = Bench.scope "deploy.executeStream"
             let buffer = ResizeArray<CellValue list>()
@@ -653,7 +658,7 @@ module Deploy =
                         currentTable <- Some table
                         currentShape <- Some shape
                     buffer.Add values
-                    if buffer.Count >= DefaultBulkBatchSize then
+                    if buffer.Count >= batchSize then
                         do! flushBulk ()
                         currentTable <- Some table
                         currentShape <- Some shape
@@ -661,6 +666,9 @@ module Deploy =
             do! flushBulk ()
             do! flushDdl ()
         }
+
+    let executeStream (cnn: SqlConnection) (statements: seq<Statement>) : Task<unit> =
+        executeStreamWith DefaultBulkBatchSize cnn statements
 
     /// `countUserTables` SQL — typed component list joined by
     /// `String.concat " "` per the no-string-concatenation discipline

--- a/sidecar/projection/src/Projection.Pipeline/EventProjection.fs
+++ b/sidecar/projection/src/Projection.Pipeline/EventProjection.fs
@@ -245,8 +245,6 @@ module EventProjection =
                     "extraIndexes",               box (List.length diff.ExtraIndexes)
                     "missingRows",                box (List.length diff.MissingRows)
                     "extraRows",                  box (List.length diff.ExtraRows)
-                    "missingRowDigests",          box (List.length diff.MissingRowDigests)
-                    "extraRowDigests",            box (List.length diff.ExtraRowDigests)
                     "missingAnnotations",         box (List.length diff.MissingAnnotations)
                     "extraAnnotations",           box (List.length diff.ExtraAnnotations)
                     "missingLogicalNameBindings", box (List.length diff.MissingLogicalNameBindings)

--- a/sidecar/projection/src/Projection.Pipeline/SurrogateCapture.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SurrogateCapture.fs
@@ -79,18 +79,27 @@ module SurrogateCapture =
 
     /// The staged chunk's cells: the source key first, then every insert
     /// column (deferred cycle columns as NULL — Phase 2 re-points them).
-    let private captureCells (identityAttr: Attribute) (insertCols: Attribute list) (deferred: Set<Name>) (rows: StaticRow list) : CellValue list list =
+    /// Generic over the row carrier (Q3, A40): `getterOf` is STAGED — the
+    /// per-column accessor is resolved once per chunk, then applied per
+    /// row (a Map lookup for `StaticRow`, an ordinal index for
+    /// `RowQuantum`).
+    let private captureCells (getterOf: Attribute -> ('row -> string)) (identityAttr: Attribute) (insertCols: Attribute list) (deferred: Set<Name>) (rows: 'row list) : CellValue list list =
+        let idGet = getterOf identityAttr
+        let colGets =
+            insertCols
+            |> List.map (fun a ->
+                let get =
+                    if Set.contains a.Name deferred then (fun _ -> "")
+                    else getterOf a
+                ColumnRealization.columnNameText a.Column, a.Type, get)
         rows
         |> List.map (fun row ->
             { Column = "__SRC_KEY"
               Type = identityAttr.Type
-              Raw = Map.tryFind identityAttr.Name row.Values |> Option.defaultValue "" }
-            :: (insertCols
-                |> List.map (fun a ->
-                    let raw =
-                        if Set.contains a.Name deferred then ""
-                        else Map.tryFind a.Name row.Values |> Option.defaultValue ""
-                    { Column = ColumnRealization.columnNameText a.Column; Type = a.Type; Raw = raw })))
+              Raw = idGet row }
+            :: (colGets
+                |> List.map (fun (col, ty, get) ->
+                    { Column = col; Type = ty; Raw = get row })))
 
     /// Clone the staging table's column types FROM THE SINK TABLE
     /// (`SELECT TOP 0 … INTO`; ISNULL strips the IDENTITY property — a
@@ -179,37 +188,37 @@ module SurrogateCapture =
 
     /// The floor rung — per row: INSERT (identity omitted, deferred NULLed)
     /// then `SCOPE_IDENTITY()`. Module-level tail-recursive continuation.
+    /// `litGets` are the pre-staged per-column literal getters; `idGet`
+    /// the source-key getter (Q3 — resolved once per chunk by
+    /// `captureChunk`, generic over the row carrier).
     let rec private rowwiseChunk
-        (sink: SqlConnection) (kind: Kind) (identityAttr: Attribute) (insertCols: Attribute list) (deferred: Set<Name>)
-        (rows: StaticRow list)
+        (sink: SqlConnection) (kind: Kind) (idGet: 'row -> string) (litGets: (Attribute * ('row -> string)) list)
+        (rows: 'row list)
         (acc: (string * string) list)
         : Task<(string * string) list> =
         task {
             match rows with
             | [] -> return List.rev acc
             | row :: rest ->
-                let lit (a: Attribute) =
-                    let raw =
-                        if Set.contains a.Name deferred then ""
-                        else Map.tryFind a.Name row.Values |> Option.defaultValue ""
-                    raw |> SqlLiteral.ofRaw a.Type |> SqlLiteral.toString
+                let lit (get: 'row -> string) (a: Attribute) =
+                    get row |> SqlLiteral.ofRaw a.Type |> SqlLiteral.toString
                 let insertSql =
-                    if List.isEmpty insertCols then
+                    if List.isEmpty litGets then
                         sprintf "INSERT INTO %s DEFAULT VALUES; SELECT CAST(SCOPE_IDENTITY() AS BIGINT);"
                             (Render.tableQualified kind.Physical)
                     else
                         sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT CAST(SCOPE_IDENTITY() AS BIGINT);"
                             (Render.tableQualified kind.Physical)
-                            (insertCols |> List.map quotedCol |> String.concat ", ")
-                            (insertCols |> List.map lit |> String.concat ", ")
+                            (litGets |> List.map (fst >> quotedCol) |> String.concat ", ")
+                            (litGets |> List.map (fun (a, get) -> lit get a) |> String.concat ", ")
                 use cmd = sink.CreateCommand()
                 cmd.CommandText <- insertSql
                 let! scalar = cmd.ExecuteScalarAsync()
                 let assigned =
                     if isNull scalar || scalar = box System.DBNull.Value then ""
                     else string scalar
-                let src = Map.tryFind identityAttr.Name row.Values |> Option.defaultValue ""
-                return! rowwiseChunk sink kind identityAttr insertCols deferred rest ((src, assigned) :: acc)
+                let src = idGet row
+                return! rowwiseChunk sink kind idGet litGets rest ((src, assigned) :: acc)
         }
 
     /// Realize one chunk on ONE named rung. Staged rungs share the staging
@@ -217,21 +226,27 @@ module SurrogateCapture =
     let captureChunk
         (sink: SqlConnection)
         (kind: Kind)
+        (getterOf: Attribute -> ('row -> string))
         (identityAttr: Attribute)
         (deferred: Set<Name>)
         (lane: CaptureLane)
-        (rows: StaticRow list)
+        (rows: 'row list)
         : Task<(string * string) list> =
         task {
             let insertCols = insertColsOf kind
             match lane with
             | CaptureLane.RowwiseScopeIdentity ->
-                return! rowwiseChunk sink kind identityAttr insertCols deferred rows []
+                let idGet = getterOf identityAttr
+                let litGets =
+                    insertCols
+                    |> List.map (fun a ->
+                        a, (if Set.contains a.Name deferred then (fun _ -> "") else getterOf a))
+                return! rowwiseChunk sink kind idGet litGets rows []
             | CaptureLane.StagedMergeOutput
             | CaptureLane.StagedMergeOutputInto ->
                 do! createStaging sink kind identityAttr insertCols
                 try
-                    do! Bulk.copyRowsSession sink StagingTable (captureCells identityAttr insertCols deferred rows)
+                    do! Bulk.copyRowsSession sink StagingTable (captureCells getterOf identityAttr insertCols deferred rows)
                     match lane with
                     | CaptureLane.StagedMergeOutput -> return! mergeOutputChunk sink kind identityAttr insertCols
                     | _                             -> return! mergeOutputIntoChunk sink kind identityAttr insertCols
@@ -255,10 +270,11 @@ module SurrogateCapture =
         (sink: SqlConnection)
         (kind: Kind)
         (kindKey: SsKey)
+        (getterOf: Attribute -> ('row -> string))
         (identityAttr: Attribute)
         (deferred: Set<Name>)
         (preferred: CaptureLane)
-        (rows: StaticRow list)
+        (rows: 'row list)
         : Task<(string * string) list * CaptureLane * LaneDescent list> =
         let rec attempt (lanes: CaptureLane list) (descents: LaneDescent list) : Task<(string * string) list * CaptureLane * LaneDescent list> =
             task {
@@ -268,11 +284,11 @@ module SurrogateCapture =
                     // and an INSERT failure is not a capability refusal.
                     return invalidOp "capture ladder exhausted"
                 | [ last ] ->
-                    let! pairs = captureChunk sink kind identityAttr deferred last rows
+                    let! pairs = captureChunk sink kind getterOf identityAttr deferred last rows
                     return pairs, last, List.rev descents
                 | lane :: (next :: _ as rest) ->
                     try
-                        let! pairs = captureChunk sink kind identityAttr deferred lane rows
+                        let! pairs = captureChunk sink kind getterOf identityAttr deferred lane rows
                         return pairs, lane, List.rev descents
                     with :? SqlException as ex when isCapabilityRefusal ex ->
                         return!

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -142,6 +142,34 @@ module Transfer =
             (kind.Attributes |> List.filter (fun a -> not (a.IsPrimaryKey && a.IsIdentity)))
             deferred rows
 
+    /// Q3 — the cell projections at the quantum grain (A40 siblings of
+    /// `toCellsOver`; the streaming realization's lanes consume these):
+    /// per-column getters are STAGED against the stream's (renamed) basis
+    /// once per kind, then applied per row. Deferred FK columns emit the
+    /// empty raw (SQL NULL under KeepNulls), exactly as the Map-carried
+    /// projection does.
+    let private quantumCellsOver (basis: RowBasis) (attrs: Attribute list) (deferred: Set<Name>) (rows: RowQuantum list) : CellValue list list =
+        let cols =
+            attrs
+            |> List.map (fun a ->
+                let get =
+                    if Set.contains a.Name deferred then (fun _ -> "")
+                    else RowQuantum.cellGetter basis a.Name
+                ColumnRealization.columnNameText a.Column, a.Type, get)
+        rows
+        |> List.map (fun q ->
+            cols |> List.map (fun (col, ty, get) -> { Column = col; Type = ty; Raw = get q }))
+
+    let private quantumCellRows (basis: RowBasis) (kind: Kind) (deferred: Set<Name>) (rows: RowQuantum list) : CellValue list list =
+        quantumCellsOver basis kind.Attributes deferred rows
+
+    /// The minted-bulk-lane projection at the quantum grain — every
+    /// attribute EXCEPT the IDENTITY PK (the Sink mints it).
+    let private quantumCellRowsExcludingIdentity (basis: RowBasis) (kind: Kind) (deferred: Set<Name>) (rows: RowQuantum list) : CellValue list list =
+        quantumCellsOver basis
+            (kind.Attributes |> List.filter (fun a -> not (a.IsPrimaryKey && a.IsIdentity)))
+            deferred rows
+
     /// Phase-2 UPDATE for one row: set the deferred FK columns to their
     /// (already remapped, plan-side) values, keyed by the kind's primary
     /// key. `None` when the kind has no PK or no deferred columns.
@@ -161,6 +189,31 @@ module Transfer =
                     (Render.tableQualified kind.Physical)
                     (deferredAttrs |> List.map clause |> String.concat ", ")
                     (pkAttrs |> List.map clause |> String.concat " AND "))
+
+    /// `phase2UpdateSql` at the quantum grain (Q3): the per-attribute
+    /// literal getters are staged against the stream's basis once per
+    /// kind; the returned closure renders one row's UPDATE. A kind with
+    /// no PK or no deferred columns resolves to a constant `None` closure
+    /// once, never per row.
+    let private phase2UpdateSqlQuantum (basis: RowBasis) (kind: Kind) (deferred: Set<Name>) : (RowQuantum -> string option) =
+        let pkAttrs = kind.Attributes |> List.filter (fun a -> a.IsPrimaryKey)
+        let deferredAttrs = kind.Attributes |> List.filter (fun a -> Set.contains a.Name deferred)
+        if List.isEmpty pkAttrs || List.isEmpty deferredAttrs then (fun _ -> None)
+        else
+            let clauseOf (a: Attribute) : RowQuantum -> string =
+                let get = RowQuantum.cellGetter basis a.Name
+                fun q ->
+                    sprintf "%s = %s"
+                        (Render.quote (ColumnRealization.columnNameText a.Column))
+                        (get q |> SqlLiteral.ofRaw a.Type |> SqlLiteral.toString)
+            let setClauses = deferredAttrs |> List.map clauseOf
+            let whereClauses = pkAttrs |> List.map clauseOf
+            fun q ->
+                Some (
+                    sprintf "UPDATE %s SET %s WHERE %s;"
+                        (Render.tableQualified kind.Physical)
+                        (setClauses |> List.map (fun render -> render q) |> String.concat ", ")
+                        (whereClauses |> List.map (fun render -> render q) |> String.concat " AND "))
 
     /// The chunk size every capture rung consumes (the staged rungs amortize
     /// one MERGE per chunk; the bench rationale and the rung mechanics live
@@ -193,7 +246,9 @@ module Transfer =
                 // Single-value bind then destructure — a tuple `let!` is not
                 // statically compilable under Release (FS3511).
                 let! outcome =
-                    SurrogateCapture.captureChunkDescending sink kind kindKey identityAttr deferred lane chunk
+                    SurrogateCapture.captureChunkDescending sink kind kindKey
+                        (fun (a: Attribute) -> StaticRow.valueOrEmpty a.Name)
+                        identityAttr deferred lane chunk
                 let pairs, succeededLane, newDescents = outcome
                 pairs |> List.iter (fun (srcVal, assignedVal) -> PackedSurrogateRemap.capture kindKey srcVal assignedVal remap)
                 return! captureChunks sink kind identityAttr deferred kindKey remap succeededLane (descents @ newDescents) rest
@@ -581,7 +636,7 @@ module Transfer =
                     match Kind.primaryKey k with
                     | pk :: _ ->
                         let srcRows = Map.tryFind kind sourceRows |> Option.defaultValue []
-                        let! sinkRows = AsyncStream.toList (Ingestion.streamKind sink k)
+                        let! sinkRows = AsyncStream.toList (Ingestion.streamKindRows sink k)
                         let result = Reconciliation.reconcileKind kind pk.Name strategy srcRows sinkRows
                         for KeyValue (rk, inner) in result.Remap.Assignments do
                             for KeyValue (src, assigned) in inner do
@@ -998,26 +1053,34 @@ module Transfer =
         let remap = PackedSurrogateRemap.create ()
         let journalIndex = journal |> Option.map CaptureJournal.load
 
-        let repoint (excluding: Set<Name>) (kind: Kind) (rows: StaticRow list) : RemappedRows =
+        // Q3: the re-point at the quantum grain — FK ordinals resolved
+        // against the stream's renamed basis once per call (cheap; the
+        // chunk behind it is 50k rows), cells re-pointed copy-on-write.
+        let repoint (basis: RowBasis) (excluding: Set<Name>) (kind: Kind) (rows: RowQuantum list) : RemappedQuanta =
             let fkTargets =
                 SurrogateRemap.fkColumnsTargeting assignedBySinkKinds kind
                 |> Map.filter (fun col _ -> not (Set.contains col excluding))
             if Map.isEmpty fkTargets then { Rows = rows; Skipped = [] }
-            else SurrogateRemap.remapRowFksWith (PackedSurrogateRemap.tryFind remap) fkTargets rows
-
-        let rename (rows: StaticRow list) : StaticRow list =
-            if Map.isEmpty renameMap then rows else RenameProjection.repointRows renameMap rows
+            else
+                SurrogateRemap.remapQuantumFksWith
+                    (PackedSurrogateRemap.tryFind remap)
+                    (SurrogateRemap.fkOrdinalsTargeting basis fkTargets)
+                    rows
 
         // One chunk of one kind — a journal skip or a lane write, each
-        // ending in a journal append so the chunk is durably done.
-        let writeChunk (kind: Kind) (load: DataLoadKind) (pkName: Name) (lane: CaptureLane) (chunkIx: int) (chunkRaw: StaticRow list)
+        // ending in a journal append so the chunk is durably done. The
+        // chunk's quanta are positional against `basis` — the stream's
+        // RENAMED header (Q3: the rename happened once at the basis,
+        // never per row); `pkOf` indexes the sink PK's cell through it.
+        // The journal fingerprint (first/last PK + raw count) is the same
+        // bytes the Map-carried path produced — journals resume across
+        // the carrier change.
+        let writeChunk (kind: Kind) (load: DataLoadKind) (basis: RowBasis) (pkOf: RowQuantum -> string) (lane: CaptureLane) (chunkIx: int) (chunkRaw: RowQuantum list)
             : Task<Result<int * LaneDescent list * (SsKey * UnresolvedReference) list * CaptureLane>> =
             task {
-                let renamed = rename chunkRaw
-                let pkOf (row: StaticRow) = Map.tryFind pkName row.Values |> Option.defaultValue ""
-                let firstPk = renamed |> List.tryHead |> Option.map pkOf |> Option.defaultValue ""
-                let lastPk = renamed |> List.tryLast |> Option.map pkOf |> Option.defaultValue ""
-                let rawCount = List.length renamed
+                let firstPk = chunkRaw |> List.tryHead |> Option.map pkOf |> Option.defaultValue ""
+                let lastPk = chunkRaw |> List.tryLast |> Option.map pkOf |> Option.defaultValue ""
+                let rawCount = List.length chunkRaw
                 let journaled =
                     journalIndex
                     |> Option.bind (fun index ->
@@ -1033,7 +1096,7 @@ module Transfer =
                 | Some _ ->
                     return Result.failureOf (sourceDriftRefusal load.Kind chunkIx)
                 | None ->
-                    let remapped = repoint load.DeferredFkColumns kind renamed
+                    let remapped = repoint basis load.DeferredFkColumns kind chunkRaw
                     let skips = remapped.Skipped |> List.map (fun u -> load.Kind, u)
                     let! laneOutcome =
                         task {
@@ -1042,19 +1105,21 @@ module Transfer =
                                 match kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity) with
                                 | Some _ when not (Set.contains load.Kind fkTargetKinds) ->
                                     do! Bulk.copyRowsSinkMinted sink kind.Physical
-                                            (toCellRowsExcludingIdentity kind load.DeferredFkColumns remapped.Rows)
+                                            (quantumCellRowsExcludingIdentity basis kind load.DeferredFkColumns remapped.Rows)
                                     return [], lane, []
                                 | Some idAttr ->
                                     let! outcome =
-                                        SurrogateCapture.captureChunkDescending sink kind load.Kind idAttr load.DeferredFkColumns lane remapped.Rows
+                                        SurrogateCapture.captureChunkDescending sink kind load.Kind
+                                            (fun (a: Attribute) -> RowQuantum.cellGetter basis a.Name)
+                                            idAttr load.DeferredFkColumns lane remapped.Rows
                                     let pairs, succeeded, descents = outcome
                                     pairs |> List.iter (fun (src, assigned) -> PackedSurrogateRemap.capture load.Kind src assigned remap)
                                     return pairs, succeeded, descents
                                 | None ->
-                                    do! Bulk.copyRows sink kind.Physical (toCellRows kind load.DeferredFkColumns remapped.Rows)
+                                    do! Bulk.copyRows sink kind.Physical (quantumCellRows basis kind load.DeferredFkColumns remapped.Rows)
                                     return [], lane, []
                             | _ ->
-                                do! Bulk.copyRows sink kind.Physical (toCellRows kind load.DeferredFkColumns remapped.Rows)
+                                do! Bulk.copyRows sink kind.Physical (quantumCellRows basis kind load.DeferredFkColumns remapped.Rows)
                                 return [], lane, []
                         }
                     let pairs, succeededLane, descents = laneOutcome
@@ -1077,8 +1142,8 @@ module Transfer =
         // the write await). On a refusal/crash the in-flight prefetch is
         // abandoned (its read completes or faults unobserved — harmless,
         // the source connection is read-only).
-        let rec loadKindChunks (kind: Kind) (load: DataLoadKind) (pkName: Name) (stream: Projection.Adapters.Sql.AsyncStream<StaticRow>)
-                               (pending: Task<StaticRow list>)
+        let rec loadKindChunks (kind: Kind) (load: DataLoadKind) (basis: RowBasis) (pkOf: RowQuantum -> string) (stream: Projection.Adapters.Sql.AsyncStream<RowQuantum>)
+                               (pending: Task<RowQuantum list>)
                                (chunkIx: int) (lane: CaptureLane)
                                (ingested: int) (written: int)
                                (skips: (SsKey * UnresolvedReference) list) (descents: LaneDescent list)
@@ -1089,10 +1154,10 @@ module Transfer =
                     return Result.success ({ Ingested = ingested; Written = written }, skips, descents)
                 else
                     let nextPending = Projection.Adapters.Sql.AsyncStream.nextBatch CaptureChunkSize stream
-                    match! writeChunk kind load pkName lane chunkIx chunkRaw with
+                    match! writeChunk kind load basis pkOf lane chunkIx chunkRaw with
                     | Error es -> return Result.failure es
                     | Ok (written', newDescents, newSkips, lane') ->
-                        return! loadKindChunks kind load pkName stream nextPending (chunkIx + 1) lane'
+                        return! loadKindChunks kind load basis pkOf stream nextPending (chunkIx + 1) lane'
                                     (ingested + List.length chunkRaw) (written + written')
                                     (skips @ newSkips) (descents @ newDescents)
             }
@@ -1116,9 +1181,15 @@ module Transfer =
                             |> List.tryFind (fun a -> a.IsPrimaryKey)
                             |> Option.defaultValue (List.head kind.Attributes)
                             |> fun a -> a.Name
+                        // Q3: the rename is a HEADER operation — the source
+                        // basis re-keys to sink names once per kind; the
+                        // quanta are untouched (the streaming path's
+                        // per-row rename walk is deleted, not ported).
+                        let basis = RowBasis.rename renameMap (Kind.rowBasis ingestKind)
+                        let pkOf = RowQuantum.cellGetter basis pkName
                         let stream = Ingestion.streamKind source ingestKind
                         let firstChunk = Projection.Adapters.Sql.AsyncStream.nextBatch CaptureChunkSize stream
-                        match! loadKindChunks kind load pkName stream firstChunk 0 CaptureLane.StagedMergeOutput 0 0 [] [] with
+                        match! loadKindChunks kind load basis pkOf stream firstChunk 0 CaptureLane.StagedMergeOutput 0 0 [] [] with
                         | Error es -> return Result.failure es
                         | Ok (streamed, kindSkips, kindDescents) ->
                             LogSink.recordStageProgress "load" (loaded + 1) loadTotal loadSw.ElapsedMilliseconds
@@ -1132,14 +1203,15 @@ module Transfer =
         // lift: WHERE keyed on the ASSIGNED PK; an unresolved deferred
         // value is a NAMED erasure). UPDATEs are idempotent, so a resumed
         // run repeating them is harmless.
-        let rec phase2Chunks (kind: Kind) (load: DataLoadKind) (idAttr: Attribute option) (stream: Projection.Adapters.Sql.AsyncStream<StaticRow>)
+        let rec phase2Chunks (kind: Kind) (load: DataLoadKind) (basis: RowBasis) (idAttr: Attribute option) (renderUpdate: RowQuantum -> string option)
+                             (stream: Projection.Adapters.Sql.AsyncStream<RowQuantum>)
                              (skips: (SsKey * UnresolvedReference) list)
             : Task<(SsKey * UnresolvedReference) list> =
             task {
                 let! chunkRaw = Projection.Adapters.Sql.AsyncStream.nextBatch CaptureChunkSize stream
                 if List.isEmpty chunkRaw then return skips
                 else
-                    let remapped2 = repoint Set.empty kind (rename chunkRaw)
+                    let remapped2 = repoint basis Set.empty kind chunkRaw
                     let newSkips =
                         remapped2.Skipped
                         |> List.filter (fun u -> Set.contains u.Column load.DeferredFkColumns)
@@ -1147,18 +1219,30 @@ module Transfer =
                     let rowsForUpdate =
                         match load.Disposition, idAttr with
                         | IdentityDisposition.AssignedBySink, Some idAttr ->
-                            remapped2.Rows
-                            |> List.choose (fun row ->
-                                match Map.tryFind idAttr.Name row.Values with
-                                | Some srcVal when srcVal <> "" ->
-                                    PackedSurrogateRemap.tryFind remap load.Kind srcVal
-                                    |> Option.map (fun assigned -> { row with Values = Map.add idAttr.Name assigned row.Values })
-                                | _ -> None)
+                            // The PK cell re-keys to the ASSIGNED surrogate
+                            // (copy-on-write) so the UPDATE's WHERE hits the
+                            // sink row. A PK column absent from the basis
+                            // can carry no remappable source key — every
+                            // row drops, exactly as the Map-carried path's
+                            // absent-key lookup dropped them.
+                            match RowBasis.tryOrdinal idAttr.Name basis with
+                            | None -> []
+                            | Some idIx ->
+                                remapped2.Rows
+                                |> List.choose (fun q ->
+                                    match q.Cells.[idIx] with
+                                    | "" -> None
+                                    | srcVal ->
+                                        PackedSurrogateRemap.tryFind remap load.Kind srcVal
+                                        |> Option.map (fun assigned ->
+                                            let cells = Array.copy q.Cells
+                                            cells.[idIx] <- assigned
+                                            { Cells = cells }))
                         | _ -> remapped2.Rows
-                    let updates = rowsForUpdate |> List.choose (phase2UpdateSql kind load.DeferredFkColumns)
+                    let updates = rowsForUpdate |> List.choose renderUpdate
                     if not (List.isEmpty updates) then
                         do! Deploy.executeBatch sink (String.concat "\n" updates)
-                    return! phase2Chunks kind load idAttr stream (skips @ newSkips)
+                    return! phase2Chunks kind load basis idAttr renderUpdate stream (skips @ newSkips)
             }
 
         let rec phase2 (loads: DataLoadKind list) (skips: (SsKey * UnresolvedReference) list)
@@ -1172,8 +1256,10 @@ module Transfer =
                         match Catalog.tryFindKind load.Kind catalog, Catalog.tryFindKind load.Kind ingestCatalog with
                         | Some kind, Some ingestKind ->
                             let idAttr = kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity)
+                            let basis = RowBasis.rename renameMap (Kind.rowBasis ingestKind)
+                            let renderUpdate = phase2UpdateSqlQuantum basis kind load.DeferredFkColumns
                             let stream = Ingestion.streamKind source ingestKind
-                            let! kindSkips = phase2Chunks kind load idAttr stream []
+                            let! kindSkips = phase2Chunks kind load basis idAttr renderUpdate stream []
                             return! phase2 rest (skips @ kindSkips)
                         | _ -> return! phase2 rest skips
             }

--- a/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
@@ -90,9 +90,9 @@ module PhysicalSchemaReader =
     /// ```
     ///
     /// on the (Columns, ForeignKeys) axes. The full PhysicalSchema
-    /// shape adds Rows (static seeds) and RowDigests (streaming row
-    /// hashes); both are populated by sibling readers (StaticSeeds
-    /// adapter / RowDigester) outside this module's scope.
+    /// shape adds Rows (static seeds), populated by the StaticSeeds
+    /// sibling reader outside this module's scope. (The RowDigests
+    /// axis was deleted 2026-06-12 — backlog card F7.)
     let ofStatementStream (statements: seq<Statement>) : PhysicalSchema =
         use _ = Bench.scope "physicalSchemaReader.ofStatementStream"
         let columns =
@@ -143,7 +143,6 @@ module PhysicalSchemaReader =
             Columns = columns
             ForeignKeys = foreignKeys
             Rows = Set.empty
-            RowDigests = Set.empty
             LogicalNameBindings = logicalNameBindings
             // Wave-1 slice 1.3 — the in-process AST reader projects the
             // SCHEMA adjunction (columns + FKs + logical names + computed,

--- a/sidecar/projection/tests/Projection.Tests/AdjunctionLawTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/AdjunctionLawTests.fs
@@ -186,10 +186,10 @@ let ``H-050 in-process adjunction: PhysicalSchema.diff is empty across the two p
     let viaStream =
         PhysicalSchemaReader.ofStatementStream (SsdtDdlEmitter.statements sampleCatalog)
     let diff = PhysicalSchema.diff viaCatalog viaStream
-    // Columns + FKs must agree across the two projections. Rows and
-    // RowDigests are deliberately not populated by ofStatementStream
+    // Columns + FKs must agree across the two projections. Rows are
+    // deliberately not populated by ofStatementStream
     // (the Statement stream doesn't carry static-row content the way
-    // a populated Catalog does); those axes are out of scope for the
+    // a populated Catalog does); that axis is out of scope for the
     // structural adjunction.
     Assert.Empty diff.MissingColumns
     Assert.Empty diff.ExtraColumns

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -755,25 +755,13 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
     [<Fact>]
     member _.``AC-X1: the full-export seed bundle is non-overwriting and CDC-silent on a fresh-blank-DB re-run`` () =
         if not (Deploy.Docker.ensureRunning ()) then () else
-        let mkKey (parts: string list) = SsKey.synthesizedComposite "OS_X1L" parts |> Result.value
-        let nmx (s: string) = Name.create s |> Result.value
-        let kindKey = mkKey ["Mod"; "Country"]
-        let row code label =
-            { Identifier = mkKey ["Mod"; "Country"; "Row"; code]
-              Values = Map.ofList [ nmx "Id", code; nmx "Code", code; nmx "Label", label ] }
-        let country =
-            { SsKey = kindKey; Name = nmx "Country"; Origin = Native
-              Modality = [ Static [ row "1" "United States"; row "2" "Canada" ] ]
-              Physical = mkTableId "dbo" "Country"
-              Attributes =
-                [ { Attribute.create (mkKey ["Mod";"Country";"Id"]) (nmx "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
-                  { Attribute.create (mkKey ["Mod";"Country";"Code"]) (nmx "Code") Text with Column = ColumnRealization.create ("CODE") (false) |> Result.value; IsMandatory = true }
-                  { Attribute.create (mkKey ["Mod";"Country";"Label"]) (nmx "Label") Text with Column = ColumnRealization.create ("LABEL") (false) |> Result.value; IsMandatory = true } ]
-              References = []; Indexes = []; Description = None; IsActive = true
-              Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
         let catalog =
-            Catalog.create [ { SsKey = mkKey ["Mod"]; Name = nmx "Mod"; Kinds = [ country ]; IsActive = true; ExtendedProperties = [] } ] []
-            |> Result.value
+            StaticCatalogFixtures.staticCatalog "OS_X1L" "Mod" [ "Mod"; "Country" ] "Country" "Country"
+                [ StaticCatalogFixtures.pk "Id" "ID" Integer
+                  StaticCatalogFixtures.attr "Code" "CODE" Text
+                  StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+                [ "1", [ "1"; "1"; "United States" ]
+                  "2", [ "2"; "2"; "Canada" ] ]
         let policy =
             { Policy.empty with Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
         let outputs =
@@ -826,24 +814,13 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
     [<Fact>]
     member _.``AC-X1: the full-export load leg measures the data movement and records it; the re-load is CDC-silent`` () =
         if not (Deploy.Docker.ensureRunning ()) then () else
-        let mkKey (parts: string list) = SsKey.synthesizedComposite "OS_X1B" parts |> Result.value
-        let nmx (s: string) = Name.create s |> Result.value
-        let row code label =
-            { Identifier = mkKey ["Mod"; "Country"; "Row"; code]
-              Values = Map.ofList [ nmx "Id", code; nmx "Code", code; nmx "Label", label ] }
-        let country =
-            { SsKey = mkKey ["Mod"; "Country"]; Name = nmx "Country"; Origin = Native
-              Modality = [ Static [ row "1" "United States"; row "2" "Canada" ] ]
-              Physical = mkTableId "dbo" "Country"
-              Attributes =
-                [ { Attribute.create (mkKey ["Mod";"Country";"Id"]) (nmx "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
-                  { Attribute.create (mkKey ["Mod";"Country";"Code"]) (nmx "Code") Text with Column = ColumnRealization.create ("CODE") (false) |> Result.value; IsMandatory = true }
-                  { Attribute.create (mkKey ["Mod";"Country";"Label"]) (nmx "Label") Text with Column = ColumnRealization.create ("LABEL") (false) |> Result.value; IsMandatory = true } ]
-              References = []; Indexes = []; Description = None; IsActive = true
-              Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
         let catalog =
-            Catalog.create [ { SsKey = mkKey ["Mod"]; Name = nmx "Mod"; Kinds = [ country ]; IsActive = true; ExtendedProperties = [] } ] []
-            |> Result.value
+            StaticCatalogFixtures.staticCatalog "OS_X1B" "Mod" [ "Mod"; "Country" ] "Country" "Country"
+                [ StaticCatalogFixtures.pk "Id" "ID" Integer
+                  StaticCatalogFixtures.attr "Code" "CODE" Text
+                  StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+                [ "1", [ "1"; "1"; "United States" ]
+                  "2", [ "2"; "2"; "Canada" ] ]
         let policy =
             { Policy.empty with Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
         let outputs =

--- a/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
+++ b/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
@@ -260,6 +260,206 @@ let readsideRowStream (rows: int) : PerfScenario =
             } }
 
 // -------------------------------------------------------------------------
+// Slice 3 (H4) — the executeStream batch sweep (PERF_HARNESS §4 slice 3 /
+// §1 activity 4a): the same controlled InsertRow stream realized at
+// different bulk batch sizes through `Deploy.executeStreamWith` (the
+// batch-size sibling the sweep fired). rows/sec per batch size answers
+// whether the 5000 default (session-35 bench) still holds.
+// -------------------------------------------------------------------------
+
+/// Activity 4a: deploy the schema, then realize the static-population
+/// InsertRow stream at an explicit bulk batch size; COUNT(*)-verified.
+// PERF-SCENARIO: execute-stream-batch 100000x1000|100000x5000|100000x10000 | keylabels=deploy.executeStream,deploy.bulk.copyRows,deploy.bulk.copyRows.batchSize
+// (The sweep's first run priced batchSize=20000 out: its bulk-insert
+// memory grant — 539 MB requested, 607 ideal — EXCEEDS the big-query
+// resource semaphore (~492 MB) on the 4 GiB warm container and stalls
+// on RESOURCE_SEMAPHORE indefinitely. 20000 is not "slower", it is
+// grant-infeasible at this container size; the top of the sweep is
+// 10000. PERF_HARNESS §5 records the finding.)
+let executeStreamBatch (rows: int) (batchSize: int) : PerfScenario =
+    let catalog = wideSeedCatalog rows
+    { Name = sprintf "execute-stream-batch-%dx%d" rows batchSize
+      Tag = "perf.deploy.executeStreamBatch"
+      KeyLabels = [ "deploy.executeStream"; "deploy.bulk.copyRows"; "deploy.bulk.copyRows.batchSize" ]
+      Run =
+        fun ctx ->
+            task {
+                do!
+                    ctx.WithDatabase (sprintf "PerfBatch%d" batchSize) (fun cnn ->
+                        task {
+                            do! Deploy.executeBatch cnn (SsdtDdlEmitter.statements catalog |> Render.toText)
+                            do! Deploy.executeStreamWith batchSize cnn (StaticPopulationEmitter.statements catalog)
+                            use check = new SqlCommand("SELECT COUNT(*) FROM [dbo].[PerfWide];", cnn)
+                            let! loaded = check.ExecuteScalarAsync()
+                            if Convert.ToInt32 loaded <> rows then
+                                failwithf "execute-stream-batch loaded %A rows, expected %d" loaded rows
+                        })
+            } }
+
+// -------------------------------------------------------------------------
+// Slice 4 (H5) — the drains: the pure static-population emit (3a), the
+// pure PhysicalSchema verify block (X1's cross-stage cost), and the
+// profiler discovery leg (1a — the "already optimized, leave it" prior,
+// finally measured in isolation).
+// -------------------------------------------------------------------------
+
+/// Activity 3a: drain `StaticPopulationEmitter.statements` to a sink
+/// WITHOUT deploying — the streamProbe label finally measures pure emit
+/// cost (in the canary its wall-time includes the consumer's SQL
+/// round-trips between pulls).
+// PERF-SCENARIO: static-population-drain 100000 | keylabels=emit.staticPopulation.statements.stream
+let staticPopulationDrain (rows: int) : PerfScenario =
+    let catalog = wideSeedCatalog rows
+    { Name = sprintf "static-population-drain-%d" rows
+      Tag = "perf.emit.staticPopulationDrain"
+      KeyLabels = [ "emit.staticPopulation.statements.stream" ]
+      Run =
+        fun _ ->
+            task {
+                let mutable n = 0
+                for _ in StaticPopulationEmitter.statements catalog do
+                    n <- n + 1
+                if n < rows then
+                    failwithf "static-population-drain drained %d statements for %d rows" n rows
+            } }
+
+/// Cross-stage X1: the canary's verify block in isolation — ofCatalog
+/// (with per-row hashing) twice + diff over identical in-memory rows.
+/// No Docker; the ~14 s bulk100k prior becomes attributable.
+// PERF-SCENARIO: physical-schema-verify 100000 | keylabels=physicalSchema.ofCatalog,physicalSchema.diff,physicalSchema.rows.hash
+let physicalSchemaVerify (rows: int) : PerfScenario =
+    let catalog = wideSeedCatalog rows
+    { Name = sprintf "physical-schema-verify-%d" rows
+      Tag = "perf.physicalSchema.verify"
+      KeyLabels = [ "physicalSchema.ofCatalog"; "physicalSchema.diff"; "physicalSchema.rows.hash" ]
+      Run =
+        fun _ ->
+            task {
+                let source = PhysicalSchema.ofCatalog catalog
+                let target = PhysicalSchema.ofCatalog catalog
+                let d = PhysicalSchema.diff source target
+                if not (PhysicalSchema.isEqual d) then
+                    failwith "physical-schema-verify: identical catalogs diffed unequal"
+            } }
+
+/// Activity 1a: the profiler's discovery leg over a pre-deployed
+/// FK-mesh estate (table-count scaling — the EvidenceCache
+/// discover-once cost, chapter-B.3's optimization target). The catalog
+/// is `meshModel` (no Static marks, so every kind is profiled — the 4.4
+/// trap does not bite); rows/table is zero by design: this scenario
+/// isolates DISCOVERY round-trips, the axis the prior speaks to (the
+/// row-bearing read path has its own scenarios).
+// PERF-SCENARIO: profiler-discover 150 | keylabels=profile.live.captureEvidenceCache,profile.live.discoverKind,profile.cache.deriveColumnProfiles
+let profilerDiscover (tables: int) : PerfScenario =
+    let catalog = ReverseLegScaleFixtures.meshModel tables
+    { Name = sprintf "profiler-discover-%d" tables
+      Tag = "perf.profile.discover"
+      KeyLabels = [ "profile.live.captureEvidenceCache"; "profile.live.discoverKind"; "profile.cache.deriveColumnProfiles" ]
+      Run =
+        fun ctx ->
+            task {
+                do!
+                    ctx.WithDatabase (sprintf "PerfProf%d" tables) (fun cnn ->
+                        task {
+                            do! Deploy.executeStream cnn (SsdtDdlEmitter.statements catalog)
+                            match! Projection.Adapters.Sql.LiveProfiler.attach cnn catalog Profile.empty with
+                            | Error es -> failwithf "profiler-discover failed: %A" es
+                            | Ok _ -> ()
+                        })
+            } }
+
+// -------------------------------------------------------------------------
+// Slice 5 (H6) — the OSSYS JSON parse at estate scale (PERF_HARNESS §1
+// activity 1d). The V1-shaped envelope is synthesized via JsonNode
+// (typed-AST-first; no string assembly) at N entities × 8 attributes
+// × 1 index; `OssysJsonReader.parseJsonString` is the production entry.
+// -------------------------------------------------------------------------
+
+/// Deterministic v1-envelope synthesis. GUID-shaped ssKeys derive from
+/// the entity/attribute ordinals, so the JSON is byte-stable per scale.
+let private ossysEnvelopeJson (entities: int) : string =
+    let guidOf (kind: int) (i: int) (j: int) =
+        sprintf "%08d-%04d-4%03d-8%03d-%012d" kind (i % 10000) (i % 1000) (j % 1000) (i * 100 + j)
+    let node = System.Text.Json.Nodes.JsonObject()
+    let modules = System.Text.Json.Nodes.JsonArray()
+    let perModule = 100
+    let moduleCount = max 1 ((entities + perModule - 1) / perModule)
+    let mutable entityIx = 0
+    for m in 1 .. moduleCount do
+        let entitiesArr = System.Text.Json.Nodes.JsonArray()
+        let inModule = min perModule (entities - entityIx)
+        for e in 1 .. inModule do
+            entityIx <- entityIx + 1
+            let i = entityIx
+            let attrs = System.Text.Json.Nodes.JsonArray()
+            let attrSpec =
+                ("Id", "ID", "Identifier", true, true)
+                :: [ for c in 1 .. 7 -> (sprintf "C%02d" c, sprintf "C%02d" c, "Text", false, false) ]
+            attrSpec
+            |> List.iteri (fun j (name, phys, dt, isId, isAuto) ->
+                let a = System.Text.Json.Nodes.JsonObject()
+                a["ssKey"] <- guidOf 2 i j
+                a["name"] <- name
+                a["physicalName"] <- phys
+                a["dataType"] <- dt
+                a["isMandatory"] <- isId
+                a["isIdentifier"] <- isId
+                a["isAutoNumber"] <- isAuto
+                a["isReference"] <- 0
+                attrs.Add a)
+            let idx = System.Text.Json.Nodes.JsonObject()
+            idx["name"] <- sprintf "IX_E%06d" i
+            idx["isPrimary"] <- true
+            idx["isUnique"] <- true
+            let idxCols = System.Text.Json.Nodes.JsonArray()
+            let col = System.Text.Json.Nodes.JsonObject()
+            col["attribute"] <- "Id"
+            col["ordinal"] <- 1
+            idxCols.Add col
+            idx["columns"] <- idxCols
+            let indexes = System.Text.Json.Nodes.JsonArray()
+            indexes.Add idx
+            let ent = System.Text.Json.Nodes.JsonObject()
+            ent["ssKey"] <- guidOf 1 i 0
+            ent["name"] <- sprintf "Entity%06d" i
+            ent["physicalName"] <- sprintf "OSUSR_P_E%06d" i
+            ent["db_schema"] <- "dbo"
+            ent["isExternal"] <- false
+            ent["isStatic"] <- false
+            ent["isActive"] <- true
+            ent["attributes"] <- attrs
+            ent["indexes"] <- indexes
+            entitiesArr.Add ent
+        let md = System.Text.Json.Nodes.JsonObject()
+        md["ssKey"] <- guidOf 3 m 0
+        md["name"] <- sprintf "Module%03d" m
+        md["physicalName"] <- sprintf "Module%03d" m
+        md["isActive"] <- true
+        md["entities"] <- entitiesArr
+        modules.Add md
+    node["modules"] <- modules
+    node.ToJsonString()
+
+/// Activity 1d: `OssysJsonReader.parseJsonString` over the synthesized
+/// envelope — the PERF_OPPORTUNITIES A3/A4 priors become measurable.
+// PERF-SCENARIO: ossys-parse 1000 | keylabels=adapter.osm.parse.attribute,adapter.osm.parse.index
+let ossysParse (entities: int) : PerfScenario =
+    { Name = sprintf "ossys-parse-%d" entities
+      Tag = "perf.adapter.osm.parse"
+      KeyLabels = [ "adapter.osm.parse.attribute"; "adapter.osm.parse.index" ]
+      Run =
+        fun _ ->
+            task {
+                let json = ossysEnvelopeJson entities
+                match Projection.Adapters.Osm.OssysJsonReader.parseJsonString json with
+                | Error es -> failwithf "ossys-parse failed: %A" es
+                | Ok catalog ->
+                    let kinds = Catalog.allKinds catalog |> List.length
+                    if kinds <> entities then
+                        failwithf "ossys-parse lifted %d kinds, expected %d" kinds entities
+            } }
+
+// -------------------------------------------------------------------------
 // H7 (CONSTELLATION_BACKLOG plane N9; CONSTELLATION §9.8.11) — the catalog
 // as the fifth declare-once system. `all` is the single definition site;
 // the gated facts below index into it by name (an undeclared name fails
@@ -304,7 +504,35 @@ let all : ScenarioDecl list =
       { Name = "readside-rowstream-100000"
         Docker = true
         Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
-        Make = fun () -> readsideRowStream 100000 } ]
+        Make = fun () -> readsideRowStream 100000 }
+      { Name = "execute-stream-batch-100000x1000"
+        Docker = true
+        Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
+        Make = fun () -> executeStreamBatch 100000 1000 }
+      { Name = "execute-stream-batch-100000x5000"
+        Docker = true
+        Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
+        Make = fun () -> executeStreamBatch 100000 5000 }
+      { Name = "execute-stream-batch-100000x10000"
+        Docker = true
+        Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
+        Make = fun () -> executeStreamBatch 100000 10000 }
+      { Name = "static-population-drain-100000"
+        Docker = false
+        Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
+        Make = fun () -> staticPopulationDrain 100000 }
+      { Name = "physical-schema-verify-100000"
+        Docker = false
+        Scale = { Rows = 100000; Tables = 1; ColumnsPerTable = 12 }
+        Make = fun () -> physicalSchemaVerify 100000 }
+      { Name = "profiler-discover-150"
+        Docker = true
+        Scale = { Rows = 0; Tables = 150; ColumnsPerTable = 4 }
+        Make = fun () -> profilerDiscover 150 }
+      { Name = "ossys-parse-1000"
+        Docker = false
+        Scale = { Rows = 0; Tables = 1000; ColumnsPerTable = 8 }
+        Make = fun () -> ossysParse 1000 } ]
 
 /// Run one DECLARED scenario: gate first (no fixture construction on the
 /// skip path), then build, then verify the declared name against the
@@ -349,3 +577,24 @@ let ``PerfHarness: seed-merge-execute 10000`` () = runDeclared "seed-merge-execu
 
 [<Fact>]
 let ``PerfHarness: readside-rowstream 100000`` () = runDeclared "readside-rowstream-100000"
+
+[<Fact>]
+let ``PerfHarness: execute-stream-batch 100000x1000`` () = runDeclared "execute-stream-batch-100000x1000"
+
+[<Fact>]
+let ``PerfHarness: execute-stream-batch 100000x5000`` () = runDeclared "execute-stream-batch-100000x5000"
+
+[<Fact>]
+let ``PerfHarness: execute-stream-batch 100000x10000`` () = runDeclared "execute-stream-batch-100000x10000"
+
+[<Fact>]
+let ``PerfHarness: static-population-drain 100000`` () = runDeclared "static-population-drain-100000"
+
+[<Fact>]
+let ``PerfHarness: physical-schema-verify 100000`` () = runDeclared "physical-schema-verify-100000"
+
+[<Fact>]
+let ``PerfHarness: profiler-discover 150`` () = runDeclared "profiler-discover-150"
+
+[<Fact>]
+let ``PerfHarness: ossys-parse 1000`` () = runDeclared "ossys-parse-1000"

--- a/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
+++ b/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
@@ -143,49 +143,14 @@ let private seedPolicy : Policy =
 
 /// AC-X1's blessed static-kind shape (MigrationCanaryTests), parameterized
 /// by rows/kind (§3.7: production smart constructors + deterministic values).
+/// Built on the F6 single-definition-site fixture builder.
 let private staticSeedCatalog (rowsPerKind: int) : Catalog =
-    let mkKey parts =
-        SsKey.synthesizedComposite "PERF_SEED" parts |> Result.value
-    let nmx s = Name.create s |> Result.value
-    let row (i: int) =
-        { Identifier = mkKey [ "Lookup"; "Row"; string i ]
-          Values =
-            Map.ofList
-                [ nmx "Id", string i
-                  nmx "Code", sprintf "C%06d" i
-                  nmx "Label", sprintf "Perf label %d" i ] }
-    let lookup =
-        { SsKey = mkKey [ "Lookup" ]
-          Name = nmx "PerfLookup"
-          Origin = Native
-          Modality = [ Static [ for i in 1 .. rowsPerKind -> row i ] ]
-          Physical = TableId.create "dbo" "PerfLookup" |> Result.value
-          Attributes =
-            [ { Attribute.create (mkKey [ "Lookup"; "Id" ]) (nmx "Id") Integer with
-                  Column = ColumnRealization.create "ID" false |> Result.value
-                  IsPrimaryKey = true
-                  IsMandatory = true }
-              { Attribute.create (mkKey [ "Lookup"; "Code" ]) (nmx "Code") Text with
-                  Column = ColumnRealization.create "CODE" false |> Result.value
-                  IsMandatory = true }
-              { Attribute.create (mkKey [ "Lookup"; "Label" ]) (nmx "Label") Text with
-                  Column = ColumnRealization.create "LABEL" false |> Result.value
-                  IsMandatory = true } ]
-          References = []
-          Indexes = []
-          Description = None
-          IsActive = true
-          Triggers = []
-          ColumnChecks = []
-          ExtendedProperties = [] }
-    Catalog.create
-        [ { SsKey = mkKey [ "Mod" ]
-            Name = nmx "PerfSeedMod"
-            Kinds = [ lookup ]
-            IsActive = true
-            ExtendedProperties = [] } ]
-        []
-    |> Result.value
+    StaticCatalogFixtures.staticCatalog "PERF_SEED" "PerfSeedMod" [ "Lookup" ] "PerfLookup" "PerfLookup"
+        [ StaticCatalogFixtures.pk "Id" "ID" Integer
+          StaticCatalogFixtures.attr "Code" "CODE" Text
+          StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+        [ for i in 1 .. rowsPerKind ->
+            string i, [ string i; sprintf "C%06d" i; sprintf "Perf label %d" i ] ]
 
 /// Activity 3b: the rendered-MERGE TEXT emission at scale, no Docker.
 // PERF-SCENARIO: seed-merge-render 1000|10000 | keylabels=emit.staticSeeds.renderMerge,compose.data.composeRendered
@@ -251,46 +216,12 @@ let seedMergeExecute (rowsPerKind: int) : PerfScenario =
 /// rows loaded via the bulk path (StaticPopulationEmitter → executeStream →
 /// SqlBulkCopy folding), then drained back through readRowsStream.
 let private wideSeedCatalog (rows: int) : Catalog =
-    let mkKey parts = SsKey.synthesizedComposite "PERF_WIDE" parts |> Result.value
-    let nmx s = Name.create s |> Result.value
     let colNames = [ for c in 1 .. 11 -> sprintf "C%02d" c ]
-    let row (i: int) =
-        { Identifier = mkKey [ "Wide"; "Row"; string i ]
-          Values =
-            Map.ofList
-                ((nmx "Id", string i)
-                 :: [ for c in colNames -> nmx c, sprintf "%s-%06d" c i ]) }
-    let attrs =
-        { Attribute.create (mkKey [ "Wide"; "Id" ]) (nmx "Id") Integer with
-            Column = ColumnRealization.create "ID" false |> Result.value
-            IsPrimaryKey = true
-            IsMandatory = true }
-        :: [ for c in colNames ->
-                { Attribute.create (mkKey [ "Wide"; c ]) (nmx c) Text with
-                    Column = ColumnRealization.create (c.ToUpperInvariant()) false |> Result.value
-                    IsMandatory = true } ]
-    let wide =
-        { SsKey = mkKey [ "Wide" ]
-          Name = nmx "PerfWide"
-          Origin = Native
-          Modality = [ Static [ for i in 1 .. rows -> row i ] ]
-          Physical = TableId.create "dbo" "PerfWide" |> Result.value
-          Attributes = attrs
-          References = []
-          Indexes = []
-          Description = None
-          IsActive = true
-          Triggers = []
-          ColumnChecks = []
-          ExtendedProperties = [] }
-    Catalog.create
-        [ { SsKey = mkKey [ "Mod" ]
-            Name = nmx "PerfWideMod"
-            Kinds = [ wide ]
-            IsActive = true
-            ExtendedProperties = [] } ]
-        []
-    |> Result.value
+    StaticCatalogFixtures.staticCatalog "PERF_WIDE" "PerfWideMod" [ "Wide" ] "PerfWide" "PerfWide"
+        (StaticCatalogFixtures.pk "Id" "ID" Integer
+         :: [ for c in colNames -> StaticCatalogFixtures.attr c (c.ToUpperInvariant()) Text ])
+        [ for i in 1 .. rows ->
+            string i, (string i :: [ for c in colNames -> sprintf "%s-%06d" c i ]) ]
 
 /// Activity 1b: deploy + bulk-load the fixture once, then drain
 /// `ReadSide.readRowsStream` to EOF — the per-row carrier cost isolated by

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -48,6 +48,7 @@
     <Compile Include="UuidV5Tests.fs" />
     <Compile Include="IRBuilders.fs" />
     <Compile Include="Fixtures.fs" />
+    <Compile Include="StaticCatalogFixtures.fs" />
     <Compile Include="ConfigTests.fs" />
     <Compile Include="CatalogTests.fs" />
     <Compile Include="ModuleFilterTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
@@ -543,7 +543,9 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                           { Identifier = ReverseLegFixtures.aKey "Floor" "r2"
                             Values = Map.ofList [ ReverseLegFixtures.nm "Id", "1001"; ReverseLegFixtures.nm "Email", "floor-b@x" ] } ]
                     let! pairs =
-                        SurrogateCapture.captureChunk sink customer idAttr Set.empty
+                        SurrogateCapture.captureChunk sink customer
+                            (fun (a: Attribute) -> StaticRow.valueOrEmpty a.Name)
+                            idAttr Set.empty
                             CaptureLane.RowwiseScopeIdentity rows
                     Assert.Equal<(string * string) list>([ ("1000", "1"); ("1001", "2") ], pairs)
                     let! n = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_CUSTOMER]"

--- a/sidecar/projection/tests/Projection.Tests/RowQuantumTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RowQuantumTests.fs
@@ -4,6 +4,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Projection.Core
+open Projection.Pipeline
 
 // CONSTELLATION_BACKLOG card Q1 (the row-quantum foundation, under the
 // open H3 gate). `RowBasis` carries a per-stream column basis + a
@@ -77,6 +78,86 @@ let ``Q1: nameSortedOrder is a permutation of the column indices`` () =
     // Walking the order visits names in ascending string order.
     let visited = order |> Array.map (fun i -> Name.value (RowBasis.names basis).[i])
     Assert.Equal<string[]>(Array.sort visited, visited)
+
+// -- Q2: the IR-grain boundary round-trip ----------------------------------
+
+[<Fact>]
+let ``R4: ofQuantum ∘ toQuantum = id — the IR-grain boundary loses nothing over a total row`` () =
+    // The Q2 boundary law: a total StaticRow projected onto the basis
+    // (toQuantum = RowQuantum.ofStaticRow) and rebuilt at the IR grain
+    // (StaticRow.ofQuantum) is the SAME row — Values and Identifier both.
+    let names, row =
+        rowOf [ "Zebra", "z"; "Mango", "x=y"; "Apple", ""; "Delta", "d" ]
+    let basis = RowBasis.ofNames names
+    let rebuilt =
+        StaticRow.ofQuantum basis row.Identifier (RowQuantum.ofStaticRow basis row)
+    Assert.Equal<StaticRow>(row, rebuilt)
+
+// -- Q3: the carrier-equivalence laws --------------------------------------
+// The streaming realization's per-row operations moved from the Map-carried
+// `StaticRow` to the positional `RowQuantum`. These laws pin that the move
+// changed the carrier and nothing else: same kept rows, same re-pointed
+// values, same skip diagnostics, same renamed headers.
+
+let private targetA : SsKey = SsKey.synthesized "OS_TEST_RQ" "TargetA" |> mustOk
+let private targetB : SsKey = SsKey.synthesized "OS_TEST_RQ" "TargetB" |> mustOk
+
+[<Property>]
+let ``Q3: remapQuantumFksWith equals remapRowFksWith over any total rows`` (seeds: (int * int) list) =
+    // Columns: Id (never a target), FkA → TargetA, FkB → TargetB. The
+    // lookup resolves even-valued surrogates only, so kept/skipped both
+    // exercise; FkB is sometimes NULL ("") to exercise the pass-through.
+    let names = [ "Id"; "FkA"; "FkB" ] |> List.map nm
+    let basis = RowBasis.ofNames names
+    let fkTargets = Map.ofList [ nm "FkA", targetA; nm "FkB", targetB ]
+    let tryFind (_target: SsKey) (v: string) : string option =
+        if (int v) % 2 = 0 then Some ("assigned-" + v) else None
+    let rows =
+        seeds
+        |> List.mapi (fun i (a, b) ->
+            { Identifier = anyKey ()
+              Values =
+                Map.ofList
+                    [ nm "Id", string i
+                      nm "FkA", string (abs a % 10)
+                      nm "FkB", (if b % 3 = 0 then "" else string (abs b % 10)) ] })
+    let viaRows = SurrogateRemap.remapRowFksWith tryFind fkTargets rows
+    let viaQuanta =
+        SurrogateRemap.remapQuantumFksWith
+            tryFind
+            (SurrogateRemap.fkOrdinalsTargeting basis fkTargets)
+            (rows |> List.map (RowQuantum.ofStaticRow basis))
+    (viaQuanta.Rows |> List.map (RowQuantum.toValues basis))
+        = (viaRows.Rows |> List.map (fun r -> r.Values))
+    && viaQuanta.Skipped = viaRows.Skipped
+
+[<Fact>]
+let ``Q3: RowBasis.rename — the header rename equals the per-row rename walk`` () =
+    // Under a positional carrier a rename is a basis (header) operation
+    // done once per stream; this pins it against the Map-carried
+    // `RenameProjection.repointRow` it replaces on the streaming path.
+    let names = [ "OldA"; "Keep"; "OldB" ] |> List.map nm
+    let map = Map.ofList [ nm "OldA", nm "NewA"; nm "OldB", nm "NewB" ]
+    let basis = RowBasis.ofNames names
+    let renamed = RowBasis.rename map basis
+    let row =
+        { Identifier = anyKey ()
+          Values = Map.ofList [ nm "OldA", "a"; nm "Keep", "k"; nm "OldB", "b=x" ] }
+    let q = RowQuantum.ofStaticRow basis row
+    Assert.Equal<Map<Name, string>>(
+        (RenameProjection.repointRow map row).Values,
+        RowQuantum.toValues renamed q)
+    // Empty map → the same basis (the no-rename stream is byte-identical).
+    Assert.Equal<RowBasis>(basis, RowBasis.rename Map.empty basis)
+
+[<Fact>]
+let ``Q3: cellGetter reads by name through the basis; absent names read empty`` () =
+    let names = [ "Zebra"; "Apple" ] |> List.map nm
+    let basis = RowBasis.ofNames names
+    let q : RowQuantum = { Cells = [| "z"; "a" |] }
+    Assert.Equal<string>("z", RowQuantum.cellGetter basis (nm "Zebra") q)
+    Assert.Equal<string>("a", RowQuantum.cellGetter basis (nm "Apple") q)
+    Assert.Equal<string>("", RowQuantum.cellGetter basis (nm "Missing") q)
 
 // -- the property: byte-identity over any total row, any column order -----
 

--- a/sidecar/projection/tests/Projection.Tests/StaticCatalogFixtures.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticCatalogFixtures.fs
@@ -1,0 +1,79 @@
+module Projection.Tests.StaticCatalogFixtures
+
+open Projection.Core
+
+// CONSTELLATION_BACKLOG card F6 (plane N7) — the ONE static-fixture
+// catalog builder. The same hand-rolled one-module / one-kind /
+// Static-population `Catalog.create` chain had shipped four times
+// (`staticSeedCatalog` + `wideSeedCatalog` in PerfHarnessScenarios, the
+// two AC-X1 builds in MigrationCanaryTests); this module is their single
+// definition site, so the fifth instance never gets written and fixture
+// determinism has one home. `meshModel` is a cousin (FK mesh, no static
+// rows) and deliberately stays separate.
+//
+// Determinism contract: SsKeys synthesize as
+//   module    = [ "Mod" ]
+//   kind      = kindKeyParts
+//   attribute = kindKeyParts @ [ attr.Name ]
+//   row       = kindKeyParts @ [ "Row"; rowTag ]
+// under the instance's keyPrefix — byte-identical to every absorbed
+// instance (the move's witness is the existing suites staying green).
+
+type StaticAttrSpec =
+    { Name : string
+      Column : string
+      Type : PrimitiveType
+      IsPrimaryKey : bool }
+
+let attr (name: string) (column: string) (ty: PrimitiveType) : StaticAttrSpec =
+    { Name = name; Column = column; Type = ty; IsPrimaryKey = false }
+
+let pk (name: string) (column: string) (ty: PrimitiveType) : StaticAttrSpec =
+    { attr name column ty with IsPrimaryKey = true }
+
+/// Build the shared static-population catalog shape. `rows` are
+/// `(rowTag, cells-in-attribute-order)`; every attribute is mandatory
+/// (the shared shape of all absorbed instances — a non-mandatory or
+/// FK-bearing fixture is `meshModel` territory, not this builder's).
+let staticCatalog
+    (keyPrefix: string)
+    (moduleName: string)
+    (kindKeyParts: string list)
+    (kindName: string)
+    (physicalTable: string)
+    (attrs: StaticAttrSpec list)
+    (rows: (string * string list) list)
+    : Catalog =
+    let mkKey parts = SsKey.synthesizedComposite keyPrefix parts |> Result.value
+    let nmx s = Name.create s |> Result.value
+    let attrNames = attrs |> List.map (fun a -> nmx a.Name)
+    let row (tag: string, cells: string list) =
+        { Identifier = mkKey (kindKeyParts @ [ "Row"; tag ])
+          Values = List.zip attrNames cells |> Map.ofList }
+    let attribute (a: StaticAttrSpec) =
+        { Attribute.create (mkKey (kindKeyParts @ [ a.Name ])) (nmx a.Name) a.Type with
+            Column = ColumnRealization.create a.Column false |> Result.value
+            IsPrimaryKey = a.IsPrimaryKey
+            IsMandatory = true }
+    let kind =
+        { SsKey = mkKey kindKeyParts
+          Name = nmx kindName
+          Origin = Native
+          Modality = [ Static (rows |> List.map row) ]
+          Physical = TableId.create "dbo" physicalTable |> Result.value
+          Attributes = attrs |> List.map attribute
+          References = []
+          Indexes = []
+          Description = None
+          IsActive = true
+          Triggers = []
+          ColumnChecks = []
+          ExtendedProperties = [] }
+    Catalog.create
+        [ { SsKey = mkKey [ "Mod" ]
+            Name = nmx moduleName
+            Kinds = [ kind ]
+            IsActive = true
+            ExtendedProperties = [] } ]
+        []
+    |> Result.value


### PR DESCRIPTION
Q2 — ReadSide.readRowsStream emits RowQuantum (cells in attribute order
against Kind.rowBasis); the Map + READSIDE_ROW SsKey mint moved out of
the stream to the ONE IR-grain boundary (ReadSide.materializeStream ->
StaticRow.ofQuantum), which carries its own aggregated label
(readside.rowstream.materializeIr) so the relocated cost stays on the
books (the attribution rule). The materialize label now brackets the
cells build only. Ingestion.streamKind re-typed; collectInOrder /
streamKindRows are the materialized-scale conversion points
(preview/canary scale — cost unchanged where it doesn't matter).
streamsInOrder DELETED, not re-typed: its single consumer was
collectInOrder, so the re-typed triple would have shipped consumer-less
(dead-algebra precedent, DECISIONS 2026-06-04).

Q3 — the streaming realization consumes quanta end-to-end:
- renames are HEADER operations (RowBasis.rename, once per kind); the
  streaming path's per-row rename walk is deleted, not ported (the
  materialized path keeps RenameProjection at its scale);
- PK fingerprints + phase-2 identity re-keys index cells through the
  basis (RowQuantum.cellGetter — ordinals resolved once per kind);
- FK re-point at the quantum grain: SurrogateRemap.remapQuantumFksWith
  over fkOrdinalsTargeting (Name-ordered — identical first-unresolved
  skip diagnostics; copy-on-write cells);
- the capture ladder is carrier-generic (SurrogateCapture's staged
  getterOf : Attribute -> ('row -> string) — A40 at the carrier axis;
  the materialized path passes StaticRow.valueOrEmpty);
- the bulk lanes project cells via quantumCellsOver (getters staged
  once per kind).

Q2 ships WITH Q3 per the backlog's sequencing finding (Q2 is coupled,
not independently win-bearing); Q4's deletion content (the per-row
SsKey synthesis out of the stream) landed structurally at Q2 — the
cards changed shape under the knife, recorded as RI-13. The journal
fingerprint bytes (first/last PK + raw count) are unchanged: existing
journals resume across the carrier change.

Witnesses, green at this commit: pure pool 3056/0/211 (54s) incl. the
new laws (R4 ofQuantum∘toQuantum=id; Q3 remapQuantumFksWith ≡
remapRowFksWith FsCheck; RowBasis.rename ≡ per-row repointRow; Q1's
hashQuantumBytes byte-identity standing); canary suite 103/0/4 (386s);
full Docker pool 222/0 (882s) incl. ReverseLeg Streaming/Canary/
Property/Scale and the byte-identical comprehensive canary. The H3
re-run (the arc's number) lands with the Q4 docs commit.

https://claude.ai/code/session_01NsZaRrFRyrFaVoVdikhawM