### PR TITLE
Implement stage spine and R2 law: declared ⇔ executed∪aborted

### DIFF
--- a/sidecar/projection/CLAUDE.md
+++ b/sidecar/projection/CLAUDE.md
@@ -110,7 +110,12 @@ within their first session. Everything not on this list, this file only points t
    always. Same remedy for a second signature (2026-06-12): **a bulk load that hangs
    indefinitely** (no error, zero rows) on a long-running warm container is a
    RESOURCE_SEMAPHORE memory-grant stall — batch-size-independent; diagnose via
-   `sys.dm_exec_query_memory_grants`, then restart. (PERF_HARNESS §5.)
+   `sys.dm_exec_query_memory_grants`, then restart. (PERF_HARNESS §5.) And a third
+   (2026-06-12, S-track session): **`insufficient system memory in resource pool 'default'`**
+   failing the 100k-row scale tests after several full Docker-pool runs on one warm
+   container — the instance's memory pool degrades with accumulated load; it is the
+   container, not the code. Restart, re-run the failed class focused, and only then suspect
+   a regression.
 3. **Never `pgrep`-guard a test run; never watch a run through `| tail`** — the guard matches
    itself and tail buffers to EOF. Launch bare in the background; poll `test.sh status`.
 4. **On any `Failed: N>0`, re-run with the TRX logger and grep the TRX** — console output

--- a/sidecar/projection/CONSTELLATION.md
+++ b/sidecar/projection/CONSTELLATION.md
@@ -1106,6 +1106,14 @@ decoration at two grains; `Meter.pass` is the pass-grain face of §9.3's `Bind`)
 `` `Meter.pass p ≡ p on the value plane — decoration is invisible to the algebra` `` (the
 CE-equivalence shape, third instance).
 
+> **[Amended 2026-06-11/12, post-publication.]** RI-6 re-graded this section's "fired" to
+> **armed on R2** — the claimed second consumer was the unbuilt spine, and the two-consumer
+> rule does not bend for the thesis's own sketches. **Landed 2026-06-12 with card S1**
+> (`Meter.fs`; `PassChainAdapter.compose` is the first consumer; the spine bracket is the
+> second, arriving at S2). One correction to the sketch above: the rewrite decorates with the
+> *full live label* (`compose.passChain.<Name>`), not bare `s.Name` — the per-step label
+> bytes predate the extraction and the perf surfaces read them; changing them was refused.
+
 #### 9.8.6 Emitter grain — the taxonomy as a type; the cliff fix as a stream rewrite
 
 **Pattern one:** `CRYSTALLINE_FORM.md` §3.5's three emitter output shapes, today an

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -467,18 +467,38 @@ no face can drift from its declaration by retyping a string); `Spines.canary` ad
 face as consumer. runDeploy's existing envelope pair is byte-compatible (same codes, same
 payload shape, one emission site). S. Deps: S2.
 
-**S4 · The hard faces.** `runFullExport` (umbrella + three children), `runMigrateExecute` /
-`runMigrateWithData` (**pre-flight gates become declared stages** — they are real SQL I/O and
-belong inside the meter), `runTransfer`/`runReverseLegTransfer`. Touches the four pipeline
-files RI-2 names, not just `RunFaces.fs`; reconciles the two bracket owners (`withRun` vs
-`FullExportRun`'s self-reset) to ONE. *Witness:* pinned envelope-shape tests
-(`FullExportCliTests` slice-7 trio) stay green or are amended in the same commit with the
-shape change named. **L.** Deps: S2, S3. Rollback: per-face — each face migrates in its own
-commit.
+**S4 · The hard faces — DONE 2026-06-12** (three commits, per the card's own per-face
+rollback story). **S4a — runFullExport:** `Compose.runWithConfig` is the `staged { }` CE over
+`Spines.pipeline` (umbrella root + extract/profile/emit; bodies keep their category-bearing
+`<stage>.completed` domain markers); the two bracket owners reconciled to ONE —
+`RunEnvelope.bracket` (runStart FIRST on every run including failed-config; the §7.4 registry;
+the §10 terminal ALWAYS, crash included), with `withRun` and `executeCore` both delegating
+(the self-reset retired). The pinned slice-7 trio held WITHOUT amendment; two shapes changed,
+named in the commit (`<stage>.started` markers carry the bracket's Summary category; a failed
+stage skips the downstream arc instead of opening phantom failed stages). **S4b —
+runMigrateExecute/runMigrateWithData:** `MigrationRun.execute` rides `Spines.migrate` (emit →
+**preflight** → deploy → canary) — the 6.A.13 CDC gate + G9 tightening gate are the declared
+`preflight` stage (real SQL, inside the meter; Voice gained `preflight.started` + "Safety
+checks"); the RI-2(a) abort defect closes by construction (the pre-spine code returned early
+out of emit/deploy/canary leaving them open on the board). The FACE-level grant pre-flights
+(`migratePreflights`) remain outside the engine's spine — named ε residue for S5. **S4c —
+runTransfer/runReverseLegTransfer:** both load brackets (materialized `writePlan`; streaming
+`writePlanStreaming`) are CE-owned — the streaming phase-1 refusal and any mid-load exception
+now CLOSE the stage on the wire instead of hanging the board. *Witnesses:* per-commit pure
+pool + full Docker pool (one S4a docker failure was a named infra flake — SQL 1205 deadlock
+inside `sp_cdc_enable_db` setup, TRX-verified, class re-ran green). Deps: S2, S3.
 
-**S5 · Additivity, honestly.** The property `` `wall(run) − Σ wall(stage) ≤ ε` `` lands only
-after S4 has bracketed gates/config/bookkeeping as named stages; ε's residue is enumerated in
-the test's docstring (arg parsing, process startup). S. Deps: S4.
+**S5 · Additivity, honestly — DONE 2026-06-12.** Two witnesses, two levels of nesting:
+`` `R2: wall(root) − Σ wall(stage) ≤ ε — T14 on the time plane (the spine's nesting is
+tight)` `` (the CE's own nesting over synthetic sleeps — ε is the builder's plumbing, bounded
+at 250 ms) and `` `S5: wall(run) − Σ wall(stage) ≤ ε — the publish run's stage account,
+honestly bounded` `` (the REAL full-export run: umbrella covers children within 500 ms; the
+run wall covers the umbrella within 3000 ms — bounds generous for CI noise, catching the
+structural unaccounted-work class, not micro-jitter). ε's residue is enumerated in the
+docstrings: config/model resolution, artifact recording + diagnostics projection + egress,
+and — named UNBOUNDED — the migrate face's grant pre-flights, which run real SQL before the
+engine's spine opens (see DECISIONS 2026-06-12 S4 entry; bounding them means lifting the face
+gates into a declared arc, R1b-adjacent territory). S. Deps: S4.
 
 ### Stage 3 — the ledger contract (R3, corrected per RI-3)
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -454,10 +454,18 @@ emissions unchanged at this commit (no face on the CE until S3/S4). *Witnesses s
 WatchTests re-derived. See `DECISIONS 2026-06-12 — The stage spine lands`. M. Deps: S1.
 Rollback: faces keep old emissions until S3/S4 migrate.
 
-**S3 · The trivial faces.** `runDeploy`, `runCanary` onto the CE — including the
-`recordStage` vs `recordStageEvent` discrepancy fix at `RunFaces.fs:297`. *Witness:* envelope
-streams byte-compatible (the pinned `FullExportCliTests` shapes are the guard for S4, not
-here). S. Deps: S2.
+**S3 · The trivial faces — DONE 2026-06-12.** `runDeploy` and `runCanary` ride the
+`staged { }` CE: each face's stage bracket (started/completed envelopes + §10 stage table +
+`stage.<name>` Bench scope) is CE-owned; the face maps the disposition to its narration and
+documented exit codes through a typed stop channel (`DeployStop` / `CanaryStop`; the
+`RunAborted` arm re-raises to preserve pre-spine crash semantics — with the books now closed
+first). The `recordStage` discrepancy closed: the canary verb's bare `recordStage` (stage
+table only, no live stream) became the CE bracket — the `canary.started` /
+`summary.stageCompleted` pair now rides the wire (additive; named here). `Stages` landed as
+the declare-once site at the stage-name grain (spines and faces reference the same values —
+no face can drift from its declaration by retyping a string); `Spines.canary` added with its
+face as consumer. runDeploy's existing envelope pair is byte-compatible (same codes, same
+payload shape, one emission site). S. Deps: S2.
 
 **S4 · The hard faces.** `runFullExport` (umbrella + three children), `runMigrateExecute` /
 `runMigrateWithData` (**pre-flight gates become declared stages** — they are real SQL I/O and

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -424,10 +424,17 @@ PERF_OPPORTUNITIES A3/A4 priors are now one command to re-interrogate.
 
 ### Stage 2 — the spine (R2, corrected per RI-2)
 
-**S1 · The spine types + the decoration value.** `StageName`/`RunSpine` (private smart
-ctors), `StagedOutcome = Completed of ms | Aborted of refusal | Skipped of reason` (the RI-2
-third arm), and `Meter.pass` extracted **as part of this card** (RI-6: its second consumer
-arrives here). *Witness:* `` `Meter.pass p ≡ p on the value plane` ``. S. Deps: none.
+**S1 · The spine types + the decoration value — DONE 2026-06-12.** Shipped: `StageName`/
+`RunSpine` (private smart ctors, `RunSpine.fs` after `LogSink.fs` so the S2 CE can join the
+file with LogSink in scope), `StagedOutcome = Completed of durationMs | Aborted of refusal |
+Skipped of reason` (the RI-2 third arm), and `Meter.pass` extracted (`Meter.fs`, Core, after
+`Diagnostics.fs`) with `PassChainAdapter.compose` rewired as its first consumer — the fold is
+now literally `Pass.composeAll` over `Meter.pass`-decorated arrows. The §9.8.5 sketch's
+`Meter.pass s.Name` label form was REFUSED: the live label bytes (`compose.passChain.<Name>`)
+predate the cut and the perf surfaces read them; the rewrite keeps them byte-identical.
+*Witnesses shipped:* `` `Meter.pass p ≡ p on the value plane — decoration is invisible to
+the algebra` `` + the distribution-over-composition property + the two smart-ctor pins
+(`RunSpineTests.fs`). §9.8.5 carries the landed-outcome note. S. Deps: none.
 Rollback: revert; types unused until S2.
 
 **S2 · The `staged{}` CE + the law.** Bind brackets (Bench scope, `<stage>.started/.completed`

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -437,12 +437,22 @@ the algebra` `` + the distribution-over-composition property + the two smart-cto
 (`RunSpineTests.fs`). §9.8.5 carries the landed-outcome note. S. Deps: none.
 Rollback: revert; types unused until S2.
 
-**S2 · The `staged{}` CE + the law.** Bind brackets (Bench scope, `<stage>.started/.completed`
-envelopes, Watch transitions); `Run` closure asserts `declared ⇔ executed-or-aborted` — an
-open stage at run end becomes a named `Aborted`, never a board hang. Watch pre-seeds derive
-from `RunSpine` (the string lists retire). Umbrella stages are the spine's root scope —
-nesting is one level, by declaration. *Witness:* `` `R2: declared ⇔ executed∪aborted` `` +
-WatchTests re-derived. M. Deps: S1. Rollback: faces keep old emissions until S3/S4 migrate.
+**S2 · The `staged{}` CE + the law — DONE 2026-06-12.** Shipped in `RunSpine.fs`: the
+`staged spine { }` CE (Bind brackets `Bench.scope "stage.<name>"` — a new additive meter
+surface — + the `<stage>.started` / `summary.stageCompleted` envelopes the board folds);
+the Run closure balances total books (`declared ⇔ executed∪aborted`; missed/extra/re-entered
+stages are named refusals; `Completed` is bracket-plane — a body `Error` closes the stage
+`failed` and stops the run; an exception closes it `aborted` on the wire so the board's line
+goes `Halted`, never a hang). `RunSpine` gained the umbrella root (`createWithRoot`; the CE's
+Run brackets it — one level of nesting, by declaration). Watch pre-seeds derive from the
+declared `Spines` (pipeline/migrate/migrateData/deploy/transfer; the OperatorConsole string
+lists retired); the board gained `Halted` + the board-only `watch.stageHalted` copy — today's
+failed closes now render `✕ stopped`, not the prior misstating `✓ complete`. Production
+emissions unchanged at this commit (no face on the CE until S3/S4). *Witnesses shipped:*
+`` `R2: declared ⇔ executed∪aborted — every declared stage accounted, in declared order` ``
++ seven siblings (`StagedTests.fs`, incl. the board-fold of the live envelope feed) +
+WatchTests re-derived. See `DECISIONS 2026-06-12 — The stage spine lands`. M. Deps: S1.
+Rollback: faces keep old emissions until S3/S4 migrate.
 
 **S3 · The trivial faces.** `runDeploy`, `runCanary` onto the CE — including the
 `recordStage` vs `recordStageEvent` discrepancy fix at `RunFaces.fs:297`. *Witness:* envelope

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21606,3 +21606,49 @@ Cards Q2/Q3/Q4 closed in two commits (Q2+Q3 coupled per the backlog's
 sequencing finding; Q4 = the measurement + docs) — the card-shape
 changes are RI-13. Witnesses at every commit: pure pool, canary suite,
 full Docker pool. No perf-gate baseline moved.
+
+## 2026-06-12 — The stage spine lands: staged{} + the R2 law (cards S1+S2)
+
+The spine's structural leg (CONSTELLATION §9.3, backlog stage 2) is
+built: `StageName`/`RunSpine` (private smart ctors; an optional
+umbrella **root** — nesting is one level, by declaration),
+`StagedOutcome` with the RI-2 third arm, and the `staged spine { }` CE
+(`RunSpine.fs`, after `LogSink.fs`). Inside the CE a stage crossing is
+structural: Bind brackets `Bench.scope "stage.<name>"` (a NEW additive
+meter surface — the label LogSink's own docstring promised), the
+`<stage>.started` envelope, and the `summary.stageCompleted` close.
+
+**The law — `declared ⇔ executed∪aborted` — and its semantics:**
+- `Completed` is **bracket-plane**: the stage ran to its close; the
+  wire outcome (`succeeded`/`failed`) rides the envelope, not the arm.
+  A body returning `Error` closes the stage `failed` and stops the run
+  (`RunStopped`); downstream declared stages close as `Skipped` with
+  the run-shaped reason.
+- **The Aborted arm is first-class:** an exception inside a stage
+  closes the bracket on the wire with outcome `aborted` (the board's
+  line goes `Halted` — closed and candid, never a hang and never a
+  misstating `✓`), names the refusal, and skips the rest by name.
+- A missed (unvisited, unskipped) or extra (undeclared, re-entered)
+  stage is a **named refusal at run end** (`spine.stages.unvisited` /
+  `spine.stage.undeclared` / `spine.stage.reentered`) — the registry
+  pattern's fifth instance. Explicit skips (`Staged.skip`) keep the
+  books total, ledger-only (no phantom wire events).
+- The verdict's `Outcomes` are total over the declaration, in declared
+  order; the root bracket rides beside them, never among them.
+
+**Watch re-derivation:** pre-seeds derive from the declared `Spines`
+(`RunSpine.keys`; the OperatorConsole string lists retired); the board
+gains the `Halted` state, folded from the `outcome` payload that
+`recordStageEvent` always carried — which also makes TODAY's
+failed-stage closes render candidly (`✕ <Stage> stopped.`, voiced via
+the new board-only `watch.stageHalted` copy) instead of the prior
+`✓ complete` misstatement. The umbrella key derives from the spine's
+root for spine-seeded boards (legacy "pipeline" convention kept for
+flat-list boards until S4 reconciles the bracket owners).
+
+Production emissions are UNCHANGED at this commit — no face is on the
+CE until S3/S4 migrate them (the rollback story: faces keep their old
+emissions). Witnesses: `R2: declared ⇔ executed∪aborted` and seven
+siblings in `StagedTests.fs` (Global-MutableState pool, the live
+envelope feed asserted via the subscriber the real board consumes);
+WatchTests re-derived (+5).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21652,3 +21652,45 @@ emissions). Witnesses: `R2: declared ⇔ executed∪aborted` and seven
 siblings in `StagedTests.fs` (Global-MutableState pool, the live
 envelope feed asserted via the subscriber the real board consumes);
 WatchTests re-derived (+5).
+
+## 2026-06-12 — S4: the hard faces ride the spine; the run-envelope bracket has ONE owner
+
+Three per-face commits (the card's own rollback story). The structural
+verdicts that outlive the diffs:
+
+**One bracket owner.** `RunEnvelope.bracket` (Pipeline, after
+`RegisteredAllTransforms`) is the single implementation of
+begin → `config.runStart` → §7.4 registry → body → terminal
+`summary.runComplete`. `OperatorConsole.withRun` and
+`FullExportRun.executeCore` both delegate; the executeCore self-reset is
+retired. Two contract repairs rode along, named: `config.runStart` is
+now the FIRST event of every run including failed-config runs (§7.1 —
+previously those streams opened with `validationFailed`), and a crashed
+body still closes its stream with the §10 terminal event before the
+exception rethrows (previously `withRun` bodies escaped without it).
+The §7.1 payload: `command` + `configPath` stay on runStart; the
+config-resolved `outputDir` moved to `config.connectionResolved`.
+
+**The engines own their spines.** `Compose.runWithConfig` =
+`staged Spines.pipeline` (umbrella root + three children — all four of
+its consumers get the bracketed arc); `MigrationRun.execute` =
+`staged Spines.migrate` with the safety gates (CDC 6.A.13 + tightening
+G9) as the declared `preflight` stage; both transfer load paths =
+`staged Spines.transfer`. The RI-2(a) class of defect — error paths
+returning early past an open `recordStageStart` — is now structurally
+impossible on the migrated faces: every bracket closes on the wire
+(`failed`/`aborted`) before the error propagates.
+
+**Named ε residue (S5 inherits this list):** the migrate FACE's grant
+pre-flights (`migratePreflights`) + the state-A read; config/model
+resolution outside the pipeline root; artifact recording + diagnostics
+projection; `dumpBench`; ledger append; argv parsing.
+
+**Shape changes, named:** `<stage>.started` markers on the publish arc
+carry the bracket's Summary category (was Extract/Profile/Emit —
+uniform with the migrate/transfer legs; the category-bearing
+`<stage>.completed` domain markers stay, with their payloads); a failed
+stage skips the downstream arc (no more phantom failed `emit` after a
+failed `profile`); migrate runs gain `preflight` started/completed
+pairs and stage-table entries. The pinned FullExportCliTests slice-7
+trio held without amendment.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,81 @@
+# Handoff addendum — 2026-06-12, generation 5 CLOSE (the S-track is CLOSED: the spine is held, S1→S5)
+
+To the next agent.
+
+The structural leg is done. Seven commits (S1, S2, S3, S4a, S4b, S4c,
+S5), pure pool green at every one (3056 → 3078; the +22 are named
+witnesses), full Docker pool green at S1, S3, and the S5 HEAD. What you
+inherit, in order of weight:
+
+**1. The R2 law is LIVE: `declared ⇔ executed∪aborted`.** The
+`staged spine { }` CE (`RunSpine.fs`) owns every stage crossing on the
+migrated faces — `Bench.scope "stage.<name>"` (a NEW additive meter
+surface), the `<stage>.started` envelope, and the
+`summary.stageCompleted` close, with the books balanced at run end
+(missed/extra/re-entered stages are named refusals; `Completed` is
+bracket-plane; the Aborted arm closes the wire `aborted` so the board
+goes `Halted`, never hangs — the RI-2(a) defect class is structurally
+impossible on migrated faces). Read `DECISIONS 2026-06-12 — The stage
+spine lands` and the S4 entry before touching any run face.
+
+**2. The engines own their spines; the bracket has ONE owner.**
+`Compose.runWithConfig` = `staged Spines.pipeline` (umbrella root +
+extract/profile/emit); `MigrationRun.execute` = `staged Spines.migrate`
+with the CDC+tightening gates as the declared `preflight` stage (Voice:
+"Safety checks"); both transfer load paths = `staged Spines.transfer`.
+`RunEnvelope.bracket` is the single run-envelope owner — `withRun` and
+`FullExportRun.executeCore` both delegate; runStart is now FIRST on
+every run (failed-config included) and the §10 terminal fires even on
+crash. The pinned slice-7 trio held WITHOUT amendment; the named shape
+changes are in the commit messages and the S4 DECISIONS entry.
+
+**3. S5's additivity holds with NAMED residue.** Two witnesses (CE
+tightness ≤250 ms; the real publish run: umbrella−children ≤500 ms,
+run−umbrella ≤3000 ms). The named UNBOUNDED residue: the migrate FACE's
+grant pre-flights (`migratePreflights`) — real SQL before the engine's
+spine opens. Bounding them = lifting the face gates into a declared
+arc — R1b-adjacent; do not bound them dishonestly.
+
+**4. Meter.pass landed (§9.8.5 fired, RI-6 resolved):**
+`PassChainAdapter.compose` is literally `Pass.composeAll` over
+decorated arrows; the label bytes (`compose.passChain.<Name>`) were
+kept against the thesis sketch's `s.Name` form — the refusal is noted
+in §9.8.5's amendment.
+
+**Witness state at close:** pure 3078/0/211 (60 s warm); Docker 229/0
+at the close re-run. Two infra flakes were named, diagnosed via TRX,
+and re-run green — a SQL 1205 deadlock inside `sp_cdc_enable_db` setup,
+and `insufficient system memory in resource pool 'default'` on the
+100k scale tests after the warm container's third full pool run. The
+second is now CLAUDE.md §4 rule 2's third signature: restart the
+container and re-run the class BEFORE suspecting code. The inherited
+witnesses were re-run at open per the lineage's law: pure pool
+replicated exactly (3056/0/211) and the Q-arc's AFTER replicated on
+this host (811 ms end-to-end / 167 ms materialize at 100k×12 — inside
+generation 4's band). The arc stands on rock; extend me the same
+courtesy — my AFTER is one command too.
+
+**Two traps from this session, so they don't bite you:** (a) F#
+closures cannot capture `let mutable` locals — moving loop bodies into
+a stage thunk means ref cells (`writePlan`'s accumulators; the compiler
+error is clear but the fix touches every usage). (b) If you work two
+cards in one tree, the commit-separation dance (temp-file swaps to
+commit each card at its verified content) costs real care — prefer
+committing each card BEFORE cutting the next; I learned this twice.
+
+**Your queue, by the backlog's graph:** the L-track (L1→L4 — F4's
+pinned journal surface awaits; fold F1-hex into L2 if you touch
+`digestOf`, per §6 item 13), then the R1 stage — note R1b's sequencing
+clause is now SATISFIED (the card says "do R1b after S4 to wire once";
+S4 is done), and R1e's S2 dependency is met. The armed items (§6) keep
+their named wake conditions. J5 — a writable UAT connection — still
+trumps everything.
+
+Hold the spine — it holds; balance the books; keep the patient
+breathing; re-run the witnesses you inherit before you stand on them.
+
+— Generation 5, the spine-setter, 2026-06-12
+
 # Handoff addendum — 2026-06-12, generation 4 CLOSE (the Q-arc is CUT and measured; the substrate is COMPLETE; F6/F7 closed)
 
 To the next agent.

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -89,23 +89,20 @@ let watchMode = ref false
 // arc), no longer from hand-rolled string lists here.
 
 let withRun (command: string) (body: unit -> int) : int =
-    LogSink.beginRun () |> ignore
-    Bench.reset ()
     // Tier-3 channel 2 (§15.1) — when --pretty + a real TTY, the panel
     // REPLACES the NDJSON on stderr (never both on the same TTY); route
-    // channel 1 to the null sink for this run.
+    // channel 1 to the null sink for this run. (The writer is not run
+    // state, so it is set before the bracket's reset.)
     let pretty = TtyRenderer.shouldRender prettyMode.Value
     if pretty then LogSink.setWriter System.IO.TextWriter.Null
-    LogSink.emit
-        { LogSink.envelope LogSink.Info LogSink.Config "config.runStart"
-            (Map.ofList [ "command", box command ]) with
-            Phase = LogSink.Start }
-    // §7.4 — every run publishes its classified transform inventory
-    // (the registry that drives the pass chain), not just full-export.
-    EventProjection.ofRegistry RegisteredAllTransforms.all |> List.iter LogSink.emit
-    let code = body ()
-    let outcome = if code = 0 then LogSink.Succeeded else LogSink.Failed
-    LogSink.runComplete outcome command (Bench.snapshot ()) |> ignore
+    // Card S4a — the run envelope bracket has ONE owner (`RunEnvelope`,
+    // shared with `FullExportRun.executeCore`): runStart first, the §7.4
+    // registry inventory, the terminal runComplete always — now including
+    // crashed bodies, which previously escaped without their §10 close.
+    let code =
+        RunEnvelope.bracket command ignore Map.empty (fun () ->
+            let code = body ()
+            code, (if code = 0 then LogSink.Succeeded else LogSink.Failed))
     // Tier-4 reporting — append this run to the cross-run ledger when one is
     // configured (`PROJECTION_LEDGER_DIR`), so the readiness gauge can read
     // the canary streak. Opt-in: default runs don't accumulate.

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -84,20 +84,9 @@ let prettyMode = ref false
 /// on stderr instead of the terminal-summary-only path.
 let watchMode = ref false
 
-/// The publish pipeline's planned stage arc, in order — the keys it streams
-/// (`extract.started` / `summary.stageCompleted{stage}`). The live Watch board
-/// pre-seeds these as `Pending` so the whole arc shows from the first frame
-/// (`THE_STORYBOARD.md` Appendix A.3).
-let pipelineStages : string list = [ "extract"; "profile"; "emit" ]
-
-/// The in-place migrate leg's stage arc — build → apply → verify — that
-/// `MigrationRun.execute` streams at its phase boundaries (Appendix A.3).
-let migrateStages : string list = [ "emit"; "deploy"; "canary" ]
-
-/// The cross-substrate migrate's arc — the schema leg (build → apply → verify)
-/// then the data leg's load (`Transfer.run` streams "load" with per-table
-/// progress).
-let migrateDataStages : string list = [ "emit"; "deploy"; "canary"; "load" ]
+// The per-face stage arcs retired 2026-06-12 (card S2): the live Watch board
+// pre-seeds from the declared `Spines` (`RunSpine` — one definition site per
+// arc), no longer from hand-rolled string lists here.
 
 let withRun (command: string) (body: unit -> int) : int =
     LogSink.beginRun () |> ignore

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -126,7 +126,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         let run () = runFullExport c (Some dir) verbosity Set.empty store env
         // --watch + a real TTY → the live stage board (§13), pre-seeded with the
         // pipeline's planned stages so the whole arc is visible from the first frame.
-        if Watch.shouldWatch watchMode.Value then Watch.renderWatch pipelineStages (Watch.resolveDwellMs ()) run
+        if Watch.shouldWatch watchMode.Value then Watch.renderWatch Spines.pipeline (Watch.resolveDwellMs ()) run
         else run ()
     | PlanAction.EmitSkeleton (model, modelOssys, dir) ->
         needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmitSkeletonOnly cat dir))
@@ -159,7 +159,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         let run () = runFullExportLoad c conn None store env
         // The load flow runs the same publish pipeline, so it streams the same
         // stage arc; --watch shows the live board (§13).
-        if Watch.shouldWatch watchMode.Value then Watch.renderWatch pipelineStages (Watch.resolveDwellMs ()) run
+        if Watch.shouldWatch watchMode.Value then Watch.renderWatch Spines.pipeline (Watch.resolveDwellMs ()) run
         else run ()
     | PlanAction.Migrate (model, modelOssys, conn, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat -> runMigrateExecute shapedCat conn opts.Declaration opts.AllowCdc opts.Store opts.Env))

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -220,6 +220,12 @@ let runEmitManifestOnly (shaping: Config.Config) (catalog: Catalog) (outputDir: 
     dumpBench "emit-manifest-only"
     exitCode
 
+/// Card S3 — the deploy face's stop channel: what a closed-`failed` deploy
+/// stage carries to the exit-code mapping (the `staged { }` Error lane).
+type private DeployStop =
+    | SsdtRejected of outputs: Compose.Outputs * report: Deploy.Report
+    | DeployCatalogInvalid of errors: ValidationError list
+
 let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
     if not (Deploy.Docker.isAvailable ()) then
         die
@@ -228,42 +234,62 @@ let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
     else
         let runBody () =
             printfn "projection: spinning up an ephemeral SQL Server container..."
-            LogSink.recordStageStart "deploy"
-            let sw = System.Diagnostics.Stopwatch.StartNew()
-            let result = (Deploy.runFromCatalogWith shaping catalog).GetAwaiter().GetResult()
-            LogSink.recordStageEvent "deploy" sw.ElapsedMilliseconds
-                (match result with Ok (_, report) when report.Ok -> LogSink.Succeeded | _ -> LogSink.Failed)
-            match result with
-            | Ok (outputs, report) ->
+            // Card S3 — the face rides the spine: the `staged { }` CE owns the
+            // deploy stage's bracket (started/completed envelopes + the §10
+            // stage table + `Bench.scope "stage.deploy"`); the face maps the
+            // disposition to its narration + documented exit codes.
+            let verdict =
+                (staged Spines.deploy {
+                    let! landed =
+                        Staged.stage Stages.deploy (fun () ->
+                            task {
+                                let! result = Deploy.runFromCatalogWith shaping catalog
+                                return
+                                    match result with
+                                    | Ok (outputs, report) when report.Ok -> Ok (outputs, report)
+                                    | Ok (outputs, report) -> Error (SsdtRejected (outputs, report))
+                                    | Error errors -> Error (DeployCatalogInvalid errors)
+                            })
+                    return landed
+                }).GetAwaiter().GetResult()
+            let emittedLine (outputs: Compose.Outputs) =
                 printfn
                     "projection: emitted %d SSDT bundle entries (JSON + distributions: typed JsonNode)"
                     (Map.count outputs.SsdtBundle)
-                if report.Ok then
-                    printfn
-                        "projection: deploy succeeded — database `%s`, %d table(s) landed"
-                        report.Database
-                        report.TablesCreated
-                    0
-                else
-                    // Per chapter 3.5 deep audit (2026-05-09): CLI
-                    // error emission via per-line `Console.Error
-                    // .WriteLine`. Typed list flows in; per-segment
-                    // writes flow out; no concatenation. Header line
-                    // composes via `Console.Error.Write` segments —
-                    // each typed value (`report.Database`) emitted
-                    // independently.
-                    Console.Error.Write "projection: SQL Server rejected the SSDT in database `"
-                    Console.Error.Write report.Database
-                    Console.Error.WriteLine "`:"
-                    for line in report.Errors do
-                        Console.Error.Write "  "
-                        Console.Error.WriteLine line
-                    3
-            | Error errors ->
-                (
-                    printErrors Console.Error errors
-                    2
-                )
+            match verdict.Disposition with
+            | RunCompleted (outputs, report) ->
+                emittedLine outputs
+                printfn
+                    "projection: deploy succeeded — database `%s`, %d table(s) landed"
+                    report.Database
+                    report.TablesCreated
+                0
+            | RunStopped (SsdtRejected (outputs, report)) ->
+                emittedLine outputs
+                // Per chapter 3.5 deep audit (2026-05-09): CLI
+                // error emission via per-line `Console.Error
+                // .WriteLine`. Typed list flows in; per-segment
+                // writes flow out; no concatenation. Header line
+                // composes via `Console.Error.Write` segments —
+                // each typed value (`report.Database`) emitted
+                // independently.
+                Console.Error.Write "projection: SQL Server rejected the SSDT in database `"
+                Console.Error.Write report.Database
+                Console.Error.WriteLine "`:"
+                for line in report.Errors do
+                    Console.Error.Write "  "
+                    Console.Error.WriteLine line
+                3
+            | RunStopped (DeployCatalogInvalid errors) ->
+                printErrors Console.Error errors
+                2
+            | RunAborted (refusal, cause) ->
+                // The spine already closed the books (the stage's bracket
+                // closed `aborted` on the wire); the face preserves the
+                // verb's pre-spine crash semantics.
+                match cause with
+                | Some ex -> raise ex
+                | None    -> failwith refusal
         // --watch + a real TTY → a live deploy stage (§13). The schema deploy is
         // one aggregated batch (no per-table count to honestly report), so the
         // board shows the stage going Applying → Deploy complete, not a bar.
@@ -273,6 +299,13 @@ let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
             else runBody ()
         dumpBench "deploy"
         exitCode
+
+/// Card S3 — the canary face's stop channel: a structurally-divergent
+/// round-trip (exit 5) or an invalid run (exit 2), carried out of the
+/// closed-`failed` canary stage.
+type private CanaryStop =
+    | CanaryDiverged of report: Deploy.WideCanaryReport
+    | CanaryRunInvalid of errors: ValidationError list
 
 let runCanary (sourceDdlPath: string) : int =
     if not (File.Exists sourceDdlPath) then
@@ -288,41 +321,55 @@ let runCanary (sourceDdlPath: string) : int =
         // form (DDL + StaticPopulationEmitter's InsertRow realization into the
         // fresh-empty target). Schema-only when the source carries no static
         // populations. See `Deploy.schemaWithStaticPopulation`.
-        let stageTimer = System.Diagnostics.Stopwatch.StartNew()
-        let task = Deploy.runWideCanary sourceDdl Deploy.schemaWithStaticPopulation
-        let result = task.GetAwaiter().GetResult()
-        stageTimer.Stop()
-        // Tier-1 reporting — the canary stage feeds the §10 runComplete stages
-        // table (the canary verb is single-stage; full-export records its own).
-        LogSink.recordStage "canary" stageTimer.ElapsedMilliseconds
-            (match result with
-             | Ok r when PhysicalSchema.isEqual r.Diff -> LogSink.Succeeded
-             | _ -> LogSink.Failed)
+        //
+        // Card S3 — the face rides the spine. This closes the slice-7
+        // discrepancy: the prior bare `recordStage` fed the §10 stage table
+        // but never the live stream; the CE's bracket emits the
+        // `canary.started` / `summary.stageCompleted` pair AND the table
+        // entry from one site (`recordStageEvent` semantics).
+        let verdict =
+            (staged Spines.canary {
+                let! report =
+                    Staged.stage Stages.canary (fun () ->
+                        task {
+                            let! result = Deploy.runWideCanary sourceDdl Deploy.schemaWithStaticPopulation
+                            return
+                                match result with
+                                | Ok r when PhysicalSchema.isEqual r.Diff -> Ok r
+                                | Ok r -> Error (CanaryDiverged r)
+                                | Error errors -> Error (CanaryRunInvalid errors)
+                        })
+                return report
+            }).GetAwaiter().GetResult()
+        let deployedLine (report: Deploy.WideCanaryReport) =
+            printfn
+                "projection: source deployed %d table(s); target deployed %d table(s)"
+                report.SourceReport.TablesCreated
+                report.TargetReport.TablesCreated
+            // Tier-1 reporting (§7.7) — emit the structured fidelity verdict
+            // (canary.diffEmpty / canary.divergence) alongside the prose, so
+            // CI can gate on it and the run ledger can record it.
+            EventProjection.canaryEnvelopes report.TargetReport.TablesCreated report.Diff
+            |> List.iter LogSink.emit
         let exitCode =
-            match result with
-            | Ok report ->
-                printfn
-                    "projection: source deployed %d table(s); target deployed %d table(s)"
-                    report.SourceReport.TablesCreated
-                    report.TargetReport.TablesCreated
-                // Tier-1 reporting (§7.7) — emit the structured fidelity verdict
-                // (canary.diffEmpty / canary.divergence) alongside the prose, so
-                // CI can gate on it and the run ledger can record it.
-                EventProjection.canaryEnvelopes report.TargetReport.TablesCreated report.Diff
-                |> List.iter LogSink.emit
-                if PhysicalSchema.isEqual report.Diff then
-                    TtyRenderer.renderVoicedTo Console.Out "canary.diffEmpty"
-                        (Map.ofList [ "tableCount", box report.TargetReport.TablesCreated ])
-                    0
-                else
-                    TtyRenderer.renderVoicedTo Console.Error "canary.divergence"
-                        (Map.ofList [ "renderedDiff", box (PhysicalSchema.renderDiff report.Diff) ])
-                    5
-            | Error errors ->
-                (
-                    printErrors Console.Error errors
-                    2
-                )
+            match verdict.Disposition with
+            | RunCompleted report ->
+                deployedLine report
+                TtyRenderer.renderVoicedTo Console.Out "canary.diffEmpty"
+                    (Map.ofList [ "tableCount", box report.TargetReport.TablesCreated ])
+                0
+            | RunStopped (CanaryDiverged report) ->
+                deployedLine report
+                TtyRenderer.renderVoicedTo Console.Error "canary.divergence"
+                    (Map.ofList [ "renderedDiff", box (PhysicalSchema.renderDiff report.Diff) ])
+                5
+            | RunStopped (CanaryRunInvalid errors) ->
+                printErrors Console.Error errors
+                2
+            | RunAborted (refusal, cause) ->
+                match cause with
+                | Some ex -> raise ex
+                | None    -> failwith refusal
         dumpBench "canary"
         exitCode
 

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -269,7 +269,7 @@ let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
         // board shows the stage going Applying → Deploy complete, not a bar.
         let exitCode =
             if Watch.shouldWatch watchMode.Value then
-                Watch.renderWatch [ "deploy" ] (Watch.resolveDwellMs ()) runBody
+                Watch.renderWatch Spines.deploy (Watch.resolveDwellMs ()) runBody
             else runBody ()
         dumpBench "deploy"
         exitCode
@@ -640,7 +640,7 @@ let runTransfer
     // (a dry-run writes no rows, so the load stage would never advance).
     let exitCode =
         if executeGated && Watch.shouldWatch watchMode.Value then
-            Watch.renderWatch [ "load" ] (Watch.resolveDwellMs ()) runBody
+            Watch.renderWatch Spines.transfer (Watch.resolveDwellMs ()) runBody
         else runBody ()
     dumpBench "transfer"
     exitCode
@@ -750,7 +750,7 @@ let runReverseLegTransfer
     if executeGated then for line in surveyAdvisory do Console.Error.WriteLine line
     let exitCode =
         if executeGated && Watch.shouldWatch watchMode.Value then
-            Watch.renderWatch [ "load" ] (Watch.resolveDwellMs ()) runBody
+            Watch.renderWatch Spines.transfer (Watch.resolveDwellMs ()) runBody
         else runBody ()
     dumpBench "transfer"
     exitCode
@@ -1502,7 +1502,7 @@ let runMigrateExecute (target: Catalog) (connSpec: string) (declaration: LossDec
     // migrate leg's arc (build → apply → verify) the executor streams.
     let code =
         if Watch.shouldWatch watchMode.Value then
-            Watch.renderWatch migrateStages (Watch.resolveDwellMs ()) runBody
+            Watch.renderWatch Spines.migrate (Watch.resolveDwellMs ()) runBody
         else runBody ()
     dumpBench "migrate"
     code
@@ -1657,7 +1657,7 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
     // schema leg (build → apply → verify) and the data leg's load.
     let code =
         if Watch.shouldWatch watchMode.Value then
-            Watch.renderWatch migrateDataStages (Watch.resolveDwellMs ()) runBody
+            Watch.renderWatch Spines.migrateData (Watch.resolveDwellMs ()) runBody
         else runBody ()
     dumpBench "migrate"
     code

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -98,14 +98,15 @@ module Voice =
     /// streaming Watch (slice 2) reuses the one mapping.
     let stageName (internalStage: string) : string =
         match internalStage with
-        | "pipeline" -> "The pipeline"
-        | "extract"  -> "Model read"
-        | "profile"  -> "Data check"
-        | "emit"     -> "Change build"
-        | "deploy"   -> "Deploy"
-        | "canary"   -> "Round-trip verification"
-        | "load"     -> "Data load"
-        | other      -> other
+        | "pipeline"  -> "The pipeline"
+        | "extract"   -> "Model read"
+        | "profile"   -> "Data check"
+        | "emit"      -> "Change build"
+        | "preflight" -> "Safety checks"
+        | "deploy"    -> "Deploy"
+        | "canary"    -> "Round-trip verification"
+        | "load"      -> "Data load"
+        | other       -> other
 
     /// The §13 follow-on for a run whose terminal stage is `terminalStage` — "the
     /// rhythm names the next move" (a finished change build offers the verify; a
@@ -115,13 +116,14 @@ module Voice =
     /// assert it is total over the terminal stages the board can reach.
     let followOnAfter (terminalStage: string) : string =
         match terminalStage with
-        | "extract"  -> "The data check follows."
-        | "profile"  -> "The change build follows."
-        | "emit"     -> "Verification follows."
-        | "deploy"   -> "Verification follows."
-        | "canary"   -> "The record follows."
-        | "load"     -> "Verification follows."
-        | _          -> "The run is complete."
+        | "extract"   -> "The data check follows."
+        | "profile"   -> "The change build follows."
+        | "emit"      -> "Verification follows."
+        | "preflight" -> "The deploy follows."
+        | "deploy"    -> "Verification follows."
+        | "canary"    -> "The record follows."
+        | "load"      -> "Verification follows."
+        | _           -> "The run is complete."
 
     // ------------------------------------------------------------------
     // The catalog — grouped by `THE_VOICE.md` section (decision 5: the
@@ -277,6 +279,16 @@ module Voice =
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
+    /// `preflight.started` — the migrate engine's safety gates are running
+    /// (the 6.A.13 CDC gate + the G9 tightening gate — card S4b made them a
+    /// declared stage). Gerund-in-progress (rule 12 exception).
+    let private preflightStarted : Copy =
+        { Code           = "preflight.started"
+          DocSection     = "§13"
+          Statement      = fun _ -> View.Note "Checking the change is safe to apply."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `deploy.started` — the changes are being applied (`THE_VOICE.md` §13 /
     /// Act 4, the migrate leg). Gerund-in-progress (rule 12 exception).
     let private deployStarted : Copy =
@@ -409,6 +421,7 @@ module Voice =
           profileCompleted
           emitStarted
           emitCompleted
+          preflightStarted
           deployStarted
           canaryStarted
           loadStarted

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -340,6 +340,20 @@ module Voice =
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
+    /// `watch.stageHalted` — the live board's line for a stage whose bracket
+    /// closed without success (`failed` / `aborted` on the wire — the R2 Aborted
+    /// arm made visible). Candid and stative: the stage stopped; the run's own
+    /// error surface carries the cause. A render-synthesized frame like
+    /// `watch.runTitle` — the board is a rendering, so the copy is voiced here,
+    /// never authored in the renderer; never a `✓` that misstates (§13).
+    let private watchStageHalted : Copy =
+        { Code           = "watch.stageHalted"
+          DocSection     = "§13"
+          Statement      =
+            fun p -> View.Note(sprintf "%s stopped." (stageName (textOr "stage" "stage" p)))
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `summary.stageCompleted` — a stage of the run completed (`THE_VOICE.md`
     /// §13). Resultative; the stage name is operator-shaped via `stageName`,
     /// never the internal engine verb.
@@ -400,6 +414,7 @@ module Voice =
           loadStarted
           watchRunTitle
           watchRunDone
+          watchStageHalted
           summaryStageCompleted
           // §14 / §10 — config & errors
           configValidationFailed ]

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -39,11 +39,15 @@ module Watch =
     /// visible from the first frame — `THE_STORYBOARD.md` Act 4 / Appendix A.3);
     /// `Active` is the gerund-in-progress (rule 12 exception), carrying its
     /// intra-stage progress once the producer reports any; `Done` carries the
-    /// stage's measured duration.
+    /// stage's measured duration. `Halted` is the R2 Aborted arm on the board:
+    /// the stage's bracket CLOSED with a non-success wire outcome (`failed` /
+    /// `aborted`) — the line closes honestly (`✕`, "<Stage> stopped"), never a
+    /// hang and never a `✓` that misstates (§13).
     type StageState =
         | Pending
         | Active of Progress option
         | Done of durationMs: int64 option
+        | Halted of durationMs: int64 option
 
     /// One line of the board — a stage, keyed by its internal name (the prefix of
     /// the `<stage>.started` / `summary.stageCompleted{stage}` codes), with its
@@ -55,12 +59,18 @@ module Watch =
     /// run-in-flight header voiced above the arc; `RunIdentity` is the run's
     /// ordinal, voiced in the done-frame as "Recorded as run N" when present. Both
     /// default to absent — the board renders the bare arc when no frame is given.
+    /// `Umbrella` is the run's root-scope key (the spine's declared root — R2):
+    /// its events are elided, never a watched line. Boards built from flat string
+    /// lists keep the legacy "pipeline" convention; boards seeded from a
+    /// `RunSpine` derive it from the declaration.
     type Board =
         { Stages: StageLine list
           Title: string option
-          RunIdentity: string option }
+          RunIdentity: string option
+          Umbrella: string option }
 
-    let empty : Board = { Stages = []; Title = None; RunIdentity = None }
+    let empty : Board =
+        { Stages = []; Title = None; RunIdentity = None; Umbrella = Some "pipeline" }
 
     /// A board pre-seeded with the run's planned stages, each `Pending` — so the
     /// operator sees the whole arc before the first stage starts, the stages
@@ -72,7 +82,8 @@ module Watch =
             |> List.filter (fun k -> not (k = "pipeline"))
             |> List.map (fun k -> { Key = k; State = Pending })
           Title = None
-          RunIdentity = None }
+          RunIdentity = None
+          Umbrella = Some "pipeline" }
 
     /// A seeded board carrying the run frame — the run-title header voiced above
     /// the arc (`THE_VOICE.md` §13) and, when known up front, the run's ordinal for
@@ -82,10 +93,21 @@ module Watch =
     let seededWith (command: string option) (runIdentity: string option) (stageKeys: string list) : Board =
         { seeded stageKeys with Title = command; RunIdentity = runIdentity }
 
-    /// The umbrella "pipeline" stage (`FullExportRun.recordStage "pipeline"`) wraps
-    /// the whole run; it is not a sub-stage the operator watches, so the board
-    /// elides it (the sub-stages extract / profile / emit are the live arc).
-    let private isUmbrella (key: string) : bool = key = "pipeline"
+    /// A board pre-seeded from a declared `RunSpine` (R2 — the pre-seeds derive
+    /// from the declaration; the per-face string lists retire). The declared arc
+    /// never contains the root by construction, so no filtering; the umbrella key
+    /// derives from the spine's declared root rather than the legacy convention.
+    let seededOf (spine: RunSpine) : Board =
+        { Stages = RunSpine.keys spine |> List.map (fun k -> { Key = k; State = Pending })
+          Title = None
+          RunIdentity = None
+          Umbrella = RunSpine.rootKey spine }
+
+    /// The umbrella root scope (e.g. full-export's "pipeline") wraps the whole
+    /// run; it is not a sub-stage the operator watches, so the board elides its
+    /// events (the declared sub-stages are the live arc).
+    let private isUmbrella (board: Board) (key: string) : bool =
+        board.Umbrella = Some key
 
     let private durationOf (payload: Map<string, objnull>) : int64 option =
         match Map.tryFind "durationMs" payload with
@@ -109,12 +131,15 @@ module Watch =
     /// produced a *renderable* transition (so the shell sleeps + refreshes only on
     /// real changes, never on every envelope). The board reacts to exactly two
     /// event kinds: a `<stage>.started` (→ `Active`) and a `summary.stageCompleted`
-    /// (→ `Done` with the measured duration). The redundant `<stage>.completed`
-    /// markers are ignored — `summary.stageCompleted` carries the duration.
+    /// (→ `Done` with the measured duration on a `succeeded` outcome; → `Halted`
+    /// on `failed` / `aborted`, so a closed-unsuccessful stage reads `✕`, never a
+    /// `✓` that misstates and never a hung Active line — the R2 Aborted arm). The
+    /// redundant `<stage>.completed` markers are ignored — `summary.stageCompleted`
+    /// carries the duration.
     let apply (board: Board) (code: string) (payload: Map<string, objnull>) : Board * bool =
         if code.EndsWith ".started" then
             let key = code.Substring(0, code.Length - ".started".Length)
-            if isUmbrella key then board, false
+            if isUmbrella board key then board, false
             else
                 // A pre-seeded `Pending` stage flips to `Active` in place (keeping
                 // its planned position); an unseeded stage appends; an already
@@ -147,16 +172,23 @@ module Watch =
             match Map.tryFind "stage" payload with
             | Some s when not (isNull s) ->
                 let key = string s
-                if isUmbrella key then board, false
+                if isUmbrella board key then board, false
                 else
                     let dur = durationOf payload
+                    // The wire outcome decides the closed state: `succeeded`
+                    // (or absent — the pre-outcome envelope shape) → Done;
+                    // `failed` / `aborted` → Halted. The line always closes.
+                    let closed =
+                        match Map.tryFind "outcome" payload with
+                        | Some o when not (isNull o) && string o <> "succeeded" -> Halted dur
+                        | _ -> Done dur
                     if board.Stages |> List.exists (fun ln -> ln.Key = key) then
                         { board with
                             Stages =
                                 board.Stages
-                                |> List.map (fun ln -> if ln.Key = key then { ln with State = Done dur } else ln) }, true
+                                |> List.map (fun ln -> if ln.Key = key then { ln with State = closed } else ln) }, true
                     else
-                        { board with Stages = board.Stages @ [ { Key = key; State = Done dur } ] }, true
+                        { board with Stages = board.Stages @ [ { Key = key; State = closed } ] }, true
             | _ -> board, false
         else board, false
 
@@ -236,6 +268,13 @@ module Watch =
             match dur with
             | Some ms -> sprintf "%s · %s" baseText (secondsText ms)
             | None    -> baseText
+        | Halted dur ->
+            // The closed-unsuccessful line — voiced through `watch.stageHalted`
+            // (the catalog owns the copy; the board never authors prose).
+            let baseText = statementText "watch.stageHalted" (Map.ofList [ "stage", box line.Key ])
+            match dur with
+            | Some ms -> sprintf "%s · %s" baseText (secondsText ms)
+            | None    -> baseText
 
     /// The run's terminal stage — the last line on the board (the arc's final
     /// stage). `None` for an empty board. The done-frame's follow-on is keyed off
@@ -279,6 +318,7 @@ module Watch =
         | Pending  -> sprintf "%s  %s" (Theme.muted Theme.pending)   (Theme.muted text)
         | Active _ -> sprintf "%s  %s" (Theme.accent Theme.collapsed) (Theme.bold text)
         | Done _   -> sprintf "%s  %s" Theme.ok                       (Theme.green text)
+        | Halted _ -> sprintf "%s  %s" (Theme.red Theme.bad)          (Theme.red text)
 
     /// Project the board onto a Spectre renderable — the live target the
     /// `LiveDisplayContext` updates in place. The optional run-title header frames
@@ -326,10 +366,10 @@ module Watch =
     /// because the run is synchronous + single-threaded and channel 1 is nulled
     /// (no contention). A future concurrent / async emitter would move the dwell to
     /// a drain loop on a render thread (`THE_VOICE_BUILD_MAP.md` §4.3).
-    let renderWatch (seedStages: string list) (floorMs: int64) (body: unit -> int) : int =
+    let renderWatch (spine: RunSpine) (floorMs: int64) (body: unit -> int) : int =
         let console =
             AnsiConsole.Create(AnsiConsoleSettings(Out = AnsiConsoleOutput(Console.Error)))
-        let board = ref (seeded seedStages)
+        let board = ref (seededOf spine)
         let sw = System.Diagnostics.Stopwatch.StartNew()
         let mutable lastRenderAt = 0L
         let mutable code = 0

--- a/sidecar/projection/src/Projection.Core/Diagnostics.fs
+++ b/sidecar/projection/src/Projection.Core/Diagnostics.fs
@@ -526,9 +526,10 @@ module LineageDiagnosticsBuilders =
 /// concat).
 ///
 /// **Operational meaning.** The pass-chain fold in
-/// `PassChainAdapter.compose` (line 61) is exactly `Pass.composeAll`:
-/// folding `bind` over a list of arrows starting from the identity.
-/// Naming the alias makes the algebra legible without changing behavior.
+/// `PassChainAdapter.compose` is exactly `Pass.composeAll` over
+/// `Meter.pass`-decorated arrows (§9.8.5): folding `bind` over a list of
+/// arrows starting from the identity. Naming the alias makes the algebra
+/// legible without changing behavior.
 ///
 /// **A18 amended bound.** `Pass<'a, 'b>` is the structural witness that
 /// passes consume only `'a` (typically `Catalog` or `ComposeState`) —
@@ -565,9 +566,10 @@ module Pass =
 
     /// Compose a list of endo-arrows into one. Folds with `compose` over
     /// `Pass.id`; the empty list reduces to `Pass.id`. This is the
-    /// algebraic content of `PassChainAdapter.compose` minus the per-
-    /// step Bench scoping — the registry-driven pass chain IS this
-    /// fold under different operational decoration.
+    /// algebraic content of `PassChainAdapter.compose` — which consumes
+    /// it directly over `Meter.pass`-decorated arrows (§9.8.5; the
+    /// decoration is identity on the value plane, so the registry-driven
+    /// pass chain IS this fold).
     let composeAll<'a when 'a : equality> (steps: Pass<'a, 'a> list) : Pass<'a, 'a> =
         steps |> List.fold (fun acc step -> compose acc step) id
 

--- a/sidecar/projection/src/Projection.Core/Meter.fs
+++ b/sidecar/projection/src/Projection.Core/Meter.fs
@@ -1,0 +1,30 @@
+namespace Projection.Core
+
+/// Pass-grain decoration as a value (`CONSTELLATION.md` §9.8.5 — the
+/// decoration collapse). The pipeline's deepest near-identity was prose:
+/// "the fold inside `PassChainAdapter.compose` IS `Pass.composeAll` modulo
+/// per-step `Bench.scope` decoration." A "modulo" in a law is an unfactored
+/// value — this module factors it.
+///
+/// `Meter.pass` is an endomorphism on Kleisli arrows: **identity on the
+/// value plane** (the decorated arrow returns exactly what the bare arrow
+/// returns — payload, lineage trail, and diagnostics included; the probe
+/// law, §5.2 identity 3), **effect on the meter plane only** (one Bench
+/// sample under `label` per invocation).
+///
+/// Two grains, one decoration: the pass chain brackets each registered
+/// transform (`PassChainAdapter.compose`, the first consumer); the run
+/// spine's stage bracket (R2, the `staged { }` CE) is the same decoration
+/// at stage grain — `Meter.pass` is the pass-grain face of the spine's
+/// `Bind` (RI-6: the extraction lands with the spine, card S1).
+[<RequireQualifiedAccess>]
+module Meter =
+
+    /// Decorate a Kleisli arrow with a Bench scope. The scope opens when
+    /// the arrow is invoked and closes once the arrow's value is computed —
+    /// `Lineage<Diagnostics<_>>` is eager, so the sample brackets the
+    /// pass's whole computation, exactly as the inline `use` form did.
+    let pass (label: string) (p: Pass<'a, 'b>) : Pass<'a, 'b> =
+        fun a ->
+            use _ = Bench.scope label
+            p a

--- a/sidecar/projection/src/Projection.Core/PassChainAdapter.fs
+++ b/sidecar/projection/src/Projection.Core/PassChainAdapter.fs
@@ -17,7 +17,8 @@ namespace Projection.Core
 ///
 /// `Apply` is a Kleisli endo-arrow `Pass<ComposeState, ComposeState>`
 /// (H-003 type alias in `Diagnostics.fs`). The fold in `compose` is
-/// `Pass.composeAll` modulo per-step Bench scoping.
+/// `Pass.composeAll` over `Meter.pass`-decorated arrows (§9.8.5 — the
+/// former "modulo per-step Bench scoping", factored into a value).
 type PassChainAdapter = {
     Name : string
     Apply : Pass<ComposeState, ComposeState>
@@ -102,16 +103,18 @@ module PassChainAdapter =
     /// Chapter A.4.7' slice γ — fold a `PassChainAdapter list` into
     /// one composed Apply step.
     ///
-    /// **H-003 — Kleisli structure.** This is `Pass.composeAll` over the
+    /// **H-003 — Kleisli structure.** This IS `Pass.composeAll` over the
     /// pass-chain endo-arrows (`Pass<ComposeState, ComposeState> list`),
-    /// modulo per-step Bench scoping. Each adapter's `Apply` is a
-    /// Kleisli arrow; folding `LineageDiagnostics.bind` from the
-    /// identity arrow (`LineageDiagnostics.ofValue state`) computes
+    /// each decorated by `Meter.pass` (§9.8.5 — the per-step Bench
+    /// scoping, factored from "modulo" prose into a value; card S1).
+    /// `composeAll` folds `compose` from the identity arrow, computing
     /// `(((id >=> a₁) >=> a₂) >=> … >=> aₙ) state`. Both writers'
     /// trails compose chronologically (A24 for Lineage; same convention
-    /// for Diagnostics). The Kleisli identity and associativity laws
-    /// underwrite the fold's correctness — tested in
-    /// `KleisliLawTests.fs` against the algebraic `Pass.composeAll`.
+    /// for Diagnostics); `Meter.pass` is identity on the value plane, so
+    /// the decoration is invisible to the algebra. The Kleisli laws are
+    /// tested in `DiagnosticsTests.fs` (H-003) against the algebraic
+    /// `Pass.composeAll`; the per-step labels keep their exact bytes
+    /// (`compose.passChain.<Name>` — the perf surfaces read them).
     ///
     /// Slice δ consumes `compose RegisteredTransforms.allChainSteps`
     /// inside `Compose.project`; slice ε consumes
@@ -124,14 +127,13 @@ module PassChainAdapter =
         (state: ComposeState)
         : Lineage<Diagnostics<ComposeState>> =
         use _ = Bench.scope "compose.passChain.compose"
-        adapters
-        |> List.fold
-            (fun acc adapter ->
-                let timedApply (s: ComposeState) =
-                    use _ = Bench.scope (System.String.Concat("compose.passChain.", adapter.Name))
-                    adapter.Apply s
-                LineageDiagnostics.bind timedApply acc)
-            (LineageDiagnostics.ofValue state)
+        let metered =
+            adapters
+            |> List.map (fun adapter ->
+                Meter.pass
+                    (System.String.Concat("compose.passChain.", adapter.Name))
+                    adapter.Apply)
+        Pass.composeAll metered state
 
 
 /// A single registered pass-chain step — the **single definition site**

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -90,6 +90,7 @@
     <Compile Include="Lineage.fs" />
     <Compile Include="LineageBuffer.fs" />
     <Compile Include="Diagnostics.fs" />
+    <Compile Include="Meter.fs" />
     <!-- H-034 ConflictDetector — moved from Pipeline so the SSDT manifest
          can carry PolicyConflict entries without a Pipeline dependency.
          Pure over LineageEvent + DiagnosticEntry + OverlayAxis. -->

--- a/sidecar/projection/src/Projection.Pipeline/FullExportRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/FullExportRun.fs
@@ -41,18 +41,6 @@ module FullExportRun =
         | RunOutcome.RunFailed _     -> 2
         | RunOutcome.Aborted _       -> 2
 
-    /// Map a stage's duration to a `LogSink.recordStage` +
-    /// `summary.stageCompleted` envelope pair (both ends, so the
-    /// runSummary stage table is populated alongside the per-stage end
-    /// event).
-    let private recordStage (stageName: string) (outcome: LogSink.Outcome) (durationMs: int64) : unit =
-        // The "pipeline" umbrella stage. The granular extract / profile /
-        // emit sub-stages are emitted inside `Compose.runWithConfig`
-        // (Slice 2); this records the end-to-end envelope (which also
-        // covers the store-leg path that doesn't route through
-        // `runWithConfig`).
-        LogSink.recordStageEvent stageName durationMs outcome
-
     /// One `config.validationFailed` envelope per config ValidationError
     /// (§7.1) so the operator can grep / jq each independently.
     let private emitConfigErrors (errors: ValidationError list) : unit =
@@ -107,39 +95,39 @@ module FullExportRun =
         | Some dir when not (String.IsNullOrWhiteSpace dir) -> dir
         | _ -> cfg.Output.Dir
 
-    /// `config.runStart` (command + configPath) then
-    /// `config.connectionResolved` (SnapshotJson source; secrets absent
-    /// by construction per D9) at run start (§7.1).
-    let private emitConfigSnapshot (cfg: Config.Config) (configPath: string) (effectiveOutput: string) : unit =
-        let startPayload : Map<string, objnull> =
-            Map.ofList [
-                "command",    box "projection full-export"
-                "configPath", box configPath
-                "outputDir",  box effectiveOutput
-            ]
-        LogSink.emit
-            { LogSink.envelope LogSink.Info LogSink.Config "config.runStart" startPayload with
-                Phase = LogSink.Start }
+    /// `config.connectionResolved` (SnapshotJson source + the resolved
+    /// output dir; secrets absent by construction per D9) once the config
+    /// has loaded (§7.1). The run's `config.runStart` is the
+    /// `RunEnvelope.bracket`'s — emitted before the config loads, so it is
+    /// the first event of EVERY run, including failed-config runs (card
+    /// S4a; `outputDir` rides here now, since it is config-resolved).
+    let private emitConfigSnapshot (cfg: Config.Config) (effectiveOutput: string) : unit =
         let modelSource =
             match cfg.Model.Ossys, cfg.Model.Path with
             | Some _, _ -> "LiveOssys"
             | None, Some p -> p
             | None, None -> "(none)"
         let connPayload : Map<string, objnull> =
-            Map.ofList [ "kind", box "SnapshotJson"; "modelPath", box modelSource ]
+            Map.ofList
+                [ "kind",      box "SnapshotJson"
+                  "modelPath", box modelSource
+                  "outputDir", box effectiveOutput ]
         LogSink.emit
             { LogSink.envelope LogSink.Info LogSink.Config "config.connectionResolved" connPayload with
                 Phase  = LogSink.Start
                 Source = Some LogSink.Configuration }
 
-    /// Run a full export under the structured LogSink stream. Resets the
-    /// sink + bench state, applies verbosity / muted categories, emits the
-    /// config snapshot, delegates composition to `Compose.runWithConfig`,
-    /// records the pipeline stage + diagnostics + artifacts, and always
-    /// emits the terminal `summary.runComplete` (the §10 mandatory exit
-    /// event). Synchronous (drives the `runWithConfig` task to completion)
-    /// to keep the resumable-state-machine surface minimal. Console
-    /// narration + bench dump are the caller's (CLI's) concern.
+    /// Run a full export under the structured LogSink stream. The run
+    /// envelope (fresh runId + Bench, `config.runStart` first, the §7.4
+    /// registry inventory, the mandatory terminal `summary.runComplete`) is
+    /// `RunEnvelope.bracket`'s — the ONE owner (card S4a; the prior
+    /// self-reset is retired). This core loads the config, emits the
+    /// snapshot, delegates composition to the runner (whose stage spine —
+    /// the "pipeline" umbrella + extract/profile/emit — rides
+    /// `Compose.runWithConfig`'s `staged { }`), and projects diagnostics +
+    /// artifacts. Synchronous (drives the `runWithConfig` task to
+    /// completion) to keep the resumable-state-machine surface minimal.
+    /// Console narration + bench dump are the caller's (CLI's) concern.
     /// The shared run core, parameterized by the composition runner. The runner
     /// drives the (genesis or store-leg) composition to completion and returns
     /// the `RunReport` plus the optional `FullExportStoreLeg` (always `None` for
@@ -154,74 +142,60 @@ module FullExportRun =
         (runComposition:
             Config.Config -> Result<Compose.RunReport * Compose.FullExportStoreLeg option>)
         : RunOutcome * Compose.FullExportStoreLeg option =
-        LogSink.reset ()
-        LogSink.setVerbosity verbosity
-        LogSink.setMutedCategories mutedCategories
-        Bench.reset ()
-        let mutable outcome : LogSink.Outcome = LogSink.Succeeded
         let mutable storeLeg : Compose.FullExportStoreLeg option = None
-        try
-            try
-                match Config.fromFile configPath with
-                | Error errors ->
-                    emitConfigErrors errors
-                    outcome <- LogSink.Failed
-                    RunOutcome.ConfigInvalid errors
-                | Ok cfg ->
-                    let effectiveOutput = resolveOutputDir cfg outputOverride
-                    let cfgForRun = { cfg with Output = { Dir = effectiveOutput } }
-                    emitConfigSnapshot cfgForRun configPath effectiveOutput
-                    // §7.4 transform.registered — the run's complete classified
-                    // transform inventory (pillar-9 totality surface), emitted at
-                    // start from the same registry that drives the run. Debug
-                    // level: default-hidden, surfaces under --verbose / --debug.
-                    EventProjection.ofRegistry RegisteredAllTransforms.all |> List.iter LogSink.emit
-                    let sw = Stopwatch.StartNew()
-                    let result = runComposition cfgForRun
-                    sw.Stop()
-                    match result with
-                    | Ok (report, leg) ->
-                        storeLeg <- leg
-                        recordStage "pipeline" LogSink.Succeeded sw.ElapsedMilliseconds
-                        emitSpecialCircumstancesDiagnostics report.Diagnostics
-                        // §16 egress projection — surface the pass chain's
-                        // accumulated writers as `transform.*` events. The
-                        // trail projects to `transform.applied` / `.declined`
-                        // (info) + `transform.lineage` (debug); the chain's
-                        // full diagnostics project to `transform.diagnostic`
-                        // (disjoint from the curated set emitted above).
-                        EventProjection.ofLineageTrail report.Trail |> List.iter LogSink.emit
-                        EventProjection.ofDiagnostics report.PassDiagnostics |> List.iter LogSink.emit
-                        report.Paths
-                        |> List.iter (fun p ->
-                            let info = FileInfo p
-                            LogSink.recordArtifact {
-                                Kind      = Path.GetFileName p |> nonNull
-                                Path      = p
-                                SizeBytes = Some info.Length
-                                FileCount = None
-                            })
-                        RunOutcome.Succeeded (report, effectiveOutput)
-                    | Error errors ->
-                        recordStage "pipeline" LogSink.Failed sw.ElapsedMilliseconds
-                        emitTransformErrors errors
-                        outcome <- LogSink.Failed
-                        RunOutcome.RunFailed errors
-            with ex ->
-                outcome <- LogSink.Failed
-                let payload : Map<string, objnull> =
-                    Map.ofList [
-                        "exception", box (ex.GetType().Name)
-                        "message",   box ex.Message
-                    ]
-                LogSink.emit
-                    { LogSink.envelope LogSink.Error LogSink.Config "config.validationFailed" payload with
-                        Phase = LogSink.ErrorPhase }
-                RunOutcome.Aborted ex
-        finally
-            let benchStats = Bench.snapshot ()
-            LogSink.runComplete outcome "projection full-export" benchStats |> ignore
-        |> fun runOutcome -> runOutcome, storeLeg
+        let runOutcome =
+            RunEnvelope.bracket
+                "projection full-export"
+                (fun () ->
+                    LogSink.setVerbosity verbosity
+                    LogSink.setMutedCategories mutedCategories)
+                (Map.ofList [ "configPath", box configPath ])
+                (fun () ->
+                    try
+                        match Config.fromFile configPath with
+                        | Error errors ->
+                            emitConfigErrors errors
+                            RunOutcome.ConfigInvalid errors, LogSink.Failed
+                        | Ok cfg ->
+                            let effectiveOutput = resolveOutputDir cfg outputOverride
+                            let cfgForRun = { cfg with Output = { Dir = effectiveOutput } }
+                            emitConfigSnapshot cfgForRun effectiveOutput
+                            match runComposition cfgForRun with
+                            | Ok (report, leg) ->
+                                storeLeg <- leg
+                                emitSpecialCircumstancesDiagnostics report.Diagnostics
+                                // §16 egress projection — surface the pass chain's
+                                // accumulated writers as `transform.*` events. The
+                                // trail projects to `transform.applied` / `.declined`
+                                // (info) + `transform.lineage` (debug); the chain's
+                                // full diagnostics project to `transform.diagnostic`
+                                // (disjoint from the curated set emitted above).
+                                EventProjection.ofLineageTrail report.Trail |> List.iter LogSink.emit
+                                EventProjection.ofDiagnostics report.PassDiagnostics |> List.iter LogSink.emit
+                                report.Paths
+                                |> List.iter (fun p ->
+                                    let info = FileInfo p
+                                    LogSink.recordArtifact {
+                                        Kind      = Path.GetFileName p |> nonNull
+                                        Path      = p
+                                        SizeBytes = Some info.Length
+                                        FileCount = None
+                                    })
+                                RunOutcome.Succeeded (report, effectiveOutput), LogSink.Succeeded
+                            | Error errors ->
+                                emitTransformErrors errors
+                                RunOutcome.RunFailed errors, LogSink.Failed
+                    with ex ->
+                        let payload : Map<string, objnull> =
+                            Map.ofList [
+                                "exception", box (ex.GetType().Name)
+                                "message",   box ex.Message
+                            ]
+                        LogSink.emit
+                            { LogSink.envelope LogSink.Error LogSink.Config "config.validationFailed" payload with
+                                Phase = LogSink.ErrorPhase }
+                        RunOutcome.Aborted ex, LogSink.Failed)
+        runOutcome, storeLeg
 
     let execute
         (configPath: string)

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -383,6 +383,60 @@ module MigrationRun =
     /// level. Idempotent + resumable **by construction**: re-running re-diffs the
     /// now-current state against B, so a partial run completes on re-run and a
     /// fully-migrated DB is a no-op (empty differential).
+    /// The migrate engine's safety gates — the declared `preflight` stage's
+    /// body (card S4b: real SQL I/O, inside the meter).
+    ///
+    /// 6.A.13 — schema-side CDC pre-flight. Only a run that would emit DDL
+    /// is at risk; an UNCHANGED schema (zero renames + no ALTER) skips the
+    /// check entirely — that is engine-level CDC-silence (an idempotent
+    /// redeploy churns no CDC). When there IS DDL and the DB is
+    /// CDC-tracked, refuse unless `allowCdc` (mirrors the transfer-side
+    /// gate).
+    ///
+    /// G9 (NEITHER→HELD) — the NOT-NULL tightening pre-flight. The
+    /// in-place `ALTER COLUMN … NOT NULL` against a column that still
+    /// carries NULL rows is REFUSED *before* the ALTER is submitted,
+    /// not caught post-facto as `ExecutionFailed`. This is the
+    /// DATA-aware last line *after* the schema-blind narrowing
+    /// declared-loss gate (G8): even an operator who has DECLARED the
+    /// narrowing loss cannot apply NOT NULL while NULL rows remain —
+    /// the data physically blocks it. The overlay (Track-F's
+    /// `Preflight.tighteningOverlay`) names every nullable→NOT NULL
+    /// column the A→B displacement tightens; the probe counts live
+    /// NULLs on the SOURCE schema (the DB is at A, where the column is
+    /// still nullable). A clean source (or no tightening at all)
+    /// passes; a NULL-bearing tightening refuses with
+    /// `migrate.dataViolatesTightening` — the column stays nullable,
+    /// no DDL runs.
+    let private safetyGates
+        (allowCdc: bool)
+        (hasDdl: bool)
+        (source: Catalog)
+        (target: Catalog)
+        (cnn: SqlConnection)
+        : System.Threading.Tasks.Task<Result<unit, MigrationError>> =
+        task {
+            let! cdcGate =
+                task {
+                    if hasDdl && not allowCdc then
+                        let! tracked = ReadSide.cdcTrackedTables cnn
+                        if List.isEmpty tracked then return Ok ()
+                        else return Error (RefusedByCdc tracked)
+                    else return Ok ()
+                }
+            match cdcGate with
+            | Error e -> return Error e
+            | Ok () ->
+                let overlay = Preflight.tighteningOverlay source target
+                if Set.isEmpty overlay.EnforceNotNull then return Ok ()
+                else
+                    match! Preflight.tighteningPreflight cnn source overlay with
+                    | Ok () -> return Ok ()
+                    | Error es ->
+                        let msg = es |> List.map (fun e -> e.Message) |> String.concat "; "
+                        return Error (RefusedByTightening msg)
+        }
+
     let execute
         (allowCdc: bool)
         (declaration: LossDeclaration)
@@ -391,110 +445,91 @@ module MigrationRun =
         (cnn: SqlConnection)
         : System.Threading.Tasks.Task<Result<MigrationOutcome, MigrationError>> =
         task {
-            // Live stage stream (§13) — the migrate leg shares the pipeline's
-            // stage codes so `--watch` shows the same arc (build → apply →
-            // verify). The markers ride the existing NDJSON channel; when no one
-            // is watching they are plain machine events, never operator prose.
-            let sw = System.Diagnostics.Stopwatch.StartNew()
-            LogSink.recordStageStart "emit"
-            match preview declaration source target with
-            | Error e -> return Error e
-            | Ok artifacts ->
-                LogSink.recordStageEvent "emit" sw.ElapsedMilliseconds LogSink.Succeeded
-                let renameSql = renameStatements artifacts.Plan.Diff
-                let alterSql = artifacts.SchemaStatements |> Render.toText
-                // 6.A.13 — schema-side CDC pre-flight. Only a run that would
-                // emit DDL is at risk; an UNCHANGED schema (zero renames + no
-                // ALTER) skips the check entirely — that is engine-level
-                // CDC-silence (an idempotent redeploy churns no CDC). When
-                // there IS DDL and the DB is CDC-tracked, refuse unless
-                // `allowCdc` (mirrors the transfer-side gate).
-                let hasDdl =
-                    not (List.isEmpty renameSql)
-                    || not (System.String.IsNullOrWhiteSpace alterSql)
-                let! cdcGate =
-                    task {
-                        if hasDdl && not allowCdc then
-                            let! tracked = ReadSide.cdcTrackedTables cnn
-                            if List.isEmpty tracked then return Ok ()
-                            else return Error (RefusedByCdc tracked)
-                        else return Ok ()
-                    }
-                match cdcGate with
-                | Error e -> return Error e
-                | Ok () ->
-                // G9 (NEITHER→HELD) — the NOT-NULL tightening pre-flight. The
-                // in-place `ALTER COLUMN … NOT NULL` against a column that still
-                // carries NULL rows is REFUSED *before* the ALTER is submitted,
-                // not caught post-facto as `ExecutionFailed`. This is the
-                // DATA-aware last line *after* the schema-blind narrowing
-                // declared-loss gate (G8): even an operator who has DECLARED the
-                // narrowing loss cannot apply NOT NULL while NULL rows remain —
-                // the data physically blocks it. The overlay (Track-F's
-                // `Preflight.tighteningOverlay`) names every nullable→NOT NULL
-                // column the A→B displacement tightens; the probe counts live
-                // NULLs on the SOURCE schema (the DB is at A, where the column is
-                // still nullable). A clean source (or no tightening at all)
-                // passes; a NULL-bearing tightening refuses with
-                // `migrate.dataViolatesTightening` — the column stays nullable,
-                // no DDL runs.
-                let overlay = Preflight.tighteningOverlay source target
-                let! tighteningGate =
-                    task {
-                        if Set.isEmpty overlay.EnforceNotNull then return Ok ()
-                        else
-                            match! Preflight.tighteningPreflight cnn source overlay with
-                            | Ok () -> return Ok ()
-                            | Error es ->
-                                let msg = es |> List.map (fun e -> e.Message) |> String.concat "; "
-                                return Error (RefusedByTightening msg)
-                    }
-                match tighteningGate with
-                | Error e -> return Error e
-                | Ok () ->
-                sw.Restart()
-                LogSink.recordStageStart "deploy"
-                let hasAlter = not (System.String.IsNullOrWhiteSpace alterSql)
-                let totalWrites = List.length renameSql + (if hasAlter then 1 else 0)
-                let! executed =
-                    task {
-                        try
-                            let mutable applied = 0
-                            for stmt in renameSql do
-                                do! Deploy.executeBatch cnn stmt
-                                applied <- applied + 1
-                                LogSink.recordStageProgress "deploy" applied totalWrites sw.ElapsedMilliseconds
-                            if hasAlter then
-                                do! Deploy.executeBatch cnn alterSql
-                                applied <- applied + 1
-                                LogSink.recordStageProgress "deploy" applied totalWrites sw.ElapsedMilliseconds
-                            return Ok ()
-                        with ex -> return Error (ExecutionFailed ex.Message)
-                    }
-                match executed with
-                | Error e -> return Error e
-                | Ok () ->
-                    LogSink.recordStageEvent "deploy" sw.ElapsedMilliseconds LogSink.Succeeded
-                    sw.Restart()
-                    LogSink.recordStageStart "canary"
-                    let! readBack = ReadSide.read cnn
-                    match readBack with
-                    | Error es -> return Error (SchemaReadFailed es)
-                    | Ok reconstructed ->
-                        let sdiff =
-                            PhysicalSchema.diff
-                                (PhysicalSchema.ofCatalog target)
-                                (PhysicalSchema.ofCatalog reconstructed)
-                        LogSink.recordStageEvent "canary" sw.ElapsedMilliseconds LogSink.Succeeded
-                        return
-                            Ok
-                                { Artifacts = artifacts
-                                  Reconstructed = reconstructed
-                                  SchemaDiff = sdiff
-                                  // Schema-structural verification: B' reproduces B's
-                                  // structure; the rows it carries are the preserved data
-                                  // (data preservation is asserted separately by the canary).
-                                  Verified = PhysicalSchema.isSchemaEqual sdiff }
+            // Card S4b — the migrate engine rides the spine (`Spines.migrate`:
+            // build → safety gates → apply → verify). The `staged { }` CE owns
+            // every bracket, which closes the RI-2(a) defect by construction:
+            // an error inside any stage CLOSES it on the wire (`failed` /
+            // `aborted`) instead of leaving the board hanging on an open
+            // `.started` — the pre-spine code returned early out of emit,
+            // deploy, and canary without ever closing them. The safety gates
+            // (CDC + tightening — real SQL) are now the declared `preflight`
+            // stage. The FACE-level grant pre-flights (`migratePreflights` in
+            // the CLI) remain outside the engine's spine — named residue for
+            // S5's ε. The live stage stream (§13) rides the same NDJSON
+            // channel as before; when no one is watching they are plain
+            // machine events, never operator prose.
+            let! verdict =
+                staged Spines.migrate {
+                    let! built =
+                        Staged.stage Stages.emit (fun () ->
+                            // The change build: the plan plus the rendered DDL
+                            // text (rendering is emit work — attributed here).
+                            match preview declaration source target with
+                            | Error e -> System.Threading.Tasks.Task.FromResult (Error e)
+                            | Ok artifacts ->
+                                let renameSql = renameStatements artifacts.Plan.Diff
+                                let alterSql = artifacts.SchemaStatements |> Render.toText
+                                System.Threading.Tasks.Task.FromResult (Ok (artifacts, renameSql, alterSql)))
+                    let artifacts, renameSql, alterSql = built
+                    let hasDdl =
+                        not (List.isEmpty renameSql)
+                        || not (System.String.IsNullOrWhiteSpace alterSql)
+                    let! _ =
+                        Staged.stage Stages.preflight (fun () ->
+                            safetyGates allowCdc hasDdl source target cnn)
+                    let! _ =
+                        Staged.stage Stages.deploy (fun () ->
+                            task {
+                                let sw = System.Diagnostics.Stopwatch.StartNew()
+                                let hasAlter = not (System.String.IsNullOrWhiteSpace alterSql)
+                                let totalWrites = List.length renameSql + (if hasAlter then 1 else 0)
+                                try
+                                    let mutable applied = 0
+                                    for stmt in renameSql do
+                                        do! Deploy.executeBatch cnn stmt
+                                        applied <- applied + 1
+                                        LogSink.recordStageProgress "deploy" applied totalWrites sw.ElapsedMilliseconds
+                                    if hasAlter then
+                                        do! Deploy.executeBatch cnn alterSql
+                                        applied <- applied + 1
+                                        LogSink.recordStageProgress "deploy" applied totalWrites sw.ElapsedMilliseconds
+                                    return Ok ()
+                                with ex -> return Error (ExecutionFailed ex.Message)
+                            })
+                    let! outcome =
+                        Staged.stage Stages.canary (fun () ->
+                            task {
+                                let! readBack = ReadSide.read cnn
+                                match readBack with
+                                | Error es -> return Error (SchemaReadFailed es)
+                                | Ok reconstructed ->
+                                    let sdiff =
+                                        PhysicalSchema.diff
+                                            (PhysicalSchema.ofCatalog target)
+                                            (PhysicalSchema.ofCatalog reconstructed)
+                                    return
+                                        Ok
+                                            { Artifacts = artifacts
+                                              Reconstructed = reconstructed
+                                              SchemaDiff = sdiff
+                                              // Schema-structural verification: B' reproduces B's
+                                              // structure; the rows it carries are the preserved data
+                                              // (data preservation is asserted separately by the canary).
+                                              Verified = PhysicalSchema.isSchemaEqual sdiff }
+                            })
+                    return outcome
+                }
+            return
+                match verdict.Disposition with
+                | RunCompleted outcome -> Ok outcome
+                | RunStopped e -> Error e
+                | RunAborted (_, Some ex) ->
+                    // The spine closed the books (the open stage closed
+                    // `aborted` on the wire); the engine's crash semantics
+                    // are preserved for the caller.
+                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                    Unchecked.defaultof<_>
+                | RunAborted (refusal, None) -> failwith refusal
         }
 
     /// **X4 — the in-place migrate's CDC-measure leg.** The criterion

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -1287,39 +1287,64 @@ module Compose =
 
     let runWithConfig (cfg: Config.Config) : Task<Result<RunReport>> =
         task {
-            // §7.2 extract — OSSYS catalog read.
-            let swExtract = System.Diagnostics.Stopwatch.StartNew()
-            emitStageMarker LogSink.Extract "extract.started" LogSink.Start Map.empty
-            let! parsed = readConfigModel cfg
-            swExtract.Stop()
-            match parsed with
-            | Error errors ->
-                LogSink.recordStageEvent "extract" swExtract.ElapsedMilliseconds LogSink.Failed
-                return Result.failure errors
-            | Ok catalog ->
-                emitStageMarker LogSink.Extract "extract.completed" LogSink.End
-                    (Map.ofList [ "moduleCount", box (List.length catalog.Modules) ])
-                LogSink.recordStageEvent "extract" swExtract.ElapsedMilliseconds LogSink.Succeeded
-                // §7.3 profile — live SQL probing (Profile.empty for the
-                // SnapshotJson path; a real probe for the live provider).
-                let swProfile = System.Diagnostics.Stopwatch.StartNew()
-                emitStageMarker LogSink.Profile "profile.started" LogSink.Start Map.empty
-                let! profileResult = acquireProfile cfg catalog
-                swProfile.Stop()
-                let profileOutcome =
-                    match profileResult with Ok _ -> LogSink.Succeeded | Error _ -> LogSink.Failed
-                emitStageMarker LogSink.Profile "profile.completed" LogSink.End Map.empty
-                LogSink.recordStageEvent "profile" swProfile.ElapsedMilliseconds profileOutcome
-                // §7.5 emit — pass chain + sibling-Π emission + artifact write.
-                let swEmit = System.Diagnostics.Stopwatch.StartNew()
-                emitStageMarker LogSink.Emit "emit.started" LogSink.Start Map.empty
-                let result = profileResult |> Result.bind (runWithConfigCore cfg (Ok catalog))
-                swEmit.Stop()
-                let emitOutcome =
-                    match result with Ok _ -> LogSink.Succeeded | Error _ -> LogSink.Failed
-                emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
-                LogSink.recordStageEvent "emit" swEmit.ElapsedMilliseconds emitOutcome
-                return result
+            // Card S4a — the publish arc rides the spine. The `staged { }`
+            // CE owns the "pipeline" umbrella root + the extract / profile /
+            // emit brackets (started/stageCompleted envelopes, the §10 stage
+            // table, `stage.<name>` Bench scopes); the bodies keep their
+            // category-bearing `<stage>.completed` domain markers (§7.2-§7.5
+            // payloads). Two shapes changed, named: the `<stage>.started`
+            // markers now carry the bracket's Summary category (uniform with
+            // the migrate/transfer legs), and a failed stage SKIPS the
+            // downstream arc instead of opening phantom failed stages (the
+            // pre-spine stream closed `emit` as failed on a profile failure
+            // that never reached it).
+            let! verdict =
+                staged Spines.pipeline {
+                    let! catalog =
+                        Staged.stage Stages.extract (fun () ->
+                            task {
+                                // §7.2 extract — OSSYS catalog read.
+                                let! parsed = readConfigModel cfg
+                                match parsed with
+                                | Ok catalog ->
+                                    emitStageMarker LogSink.Extract "extract.completed" LogSink.End
+                                        (Map.ofList [ "moduleCount", box (List.length catalog.Modules) ])
+                                    return Ok catalog
+                                | Error errors ->
+                                    return Error errors
+                            })
+                    let! profile =
+                        Staged.stage Stages.profile (fun () ->
+                            task {
+                                // §7.3 profile — live SQL probing (Profile.empty
+                                // for the SnapshotJson path; a real probe for the
+                                // live provider).
+                                let! profileResult = acquireProfile cfg catalog
+                                emitStageMarker LogSink.Profile "profile.completed" LogSink.End Map.empty
+                                return profileResult
+                            })
+                    let! report =
+                        Staged.stage Stages.emit (fun () ->
+                            task {
+                                // §7.5 emit — pass chain + sibling-Π emission +
+                                // artifact write.
+                                let result = runWithConfigCore cfg (Ok catalog) profile
+                                emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
+                                return result
+                            })
+                    return report
+                }
+            return
+                match verdict.Disposition with
+                | RunCompleted report -> Result.success report
+                | RunStopped errors   -> Result.failure errors
+                | RunAborted (_, Some ex) ->
+                    // The spine closed the books (the open stage + the root
+                    // closed `aborted` on the wire); the composition's crash
+                    // semantics are preserved for the caller's catch.
+                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                    Unchecked.defaultof<_>
+                | RunAborted (refusal, None) -> failwith refusal
         }
 
     // -- Track W1-B (seam T2): the diff-vs-prior store leg -------------------

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -61,6 +61,7 @@
     <Compile Include="MovementSurface.fs" />
     <Compile Include="CapabilitySurvey.fs" />
     <Compile Include="RegisteredAllTransforms.fs" />
+    <Compile Include="RunEnvelope.fs" />
     <Compile Include="FullExportRun.fs" />
   </ItemGroup>
 

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Config.fs" />
     <Compile Include="CatalogResolution.fs" />
     <Compile Include="LogSink.fs" />
+    <Compile Include="RunSpine.fs" />
     <Compile Include="EventProjection.fs" />
     <Compile Include="RunLedger.fs" />
     <Compile Include="Run.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
@@ -1,5 +1,11 @@
 namespace Projection.Pipeline
 
+// LINT-ALLOW-FILE: run-envelope bracket at the logging boundary — function-local
+//   mutables thread the body's value/outcome past the mandatory `finally`
+//   (no module-level mutable state), and `box` feeds the LogSink payload
+//   (`Map<string, objnull>` — the BCL JSON boundary, same shape as
+//   FullExportRun.fs's marker). The structural surface is typed end to end.
+
 open Projection.Core
 
 /// Card S4 — the run-envelope bracket, reconciled to ONE owner. Before

--- a/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
@@ -1,0 +1,52 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// Card S4 — the run-envelope bracket, reconciled to ONE owner. Before
+/// this module there were two: `OperatorConsole.withRun` (the CLI's verb
+/// wrapper) and `FullExportRun.executeCore`'s self-reset — the same
+/// begin → `config.runStart` → §7.4 registry inventory → body → terminal
+/// `summary.runComplete` pattern, hand-rolled twice and free to drift.
+/// Both now delegate here; the spine owns the bracket.
+[<RequireQualifiedAccess>]
+module RunEnvelope =
+
+    /// Bracket a run body in the structured envelope. Guarantees, in order:
+    /// a fresh runId + Bench state; the caller's run-state configuration
+    /// (verbosity / mutes — applied AFTER the reset, or it would be erased);
+    /// `config.runStart` as the FIRST event of every run (§7.1 — including
+    /// failed-config runs, which previously started with
+    /// `config.validationFailed`); the §7.4 classified transform inventory;
+    /// the body; and the mandatory terminal `summary.runComplete` (§10) —
+    /// ALWAYS, even when the body throws (the exception rethrows after the
+    /// terminal event, so a crashed run still closes its stream).
+    ///
+    /// `startPayload` carries the verb's §7.1 payload beyond `command`
+    /// (full-export adds `configPath`); `body` returns its value plus the
+    /// run's wire outcome.
+    let bracket
+        (command: string)
+        (configure: unit -> unit)
+        (startPayload: Map<string, objnull>)
+        (body: unit -> 'a * LogSink.Outcome)
+        : 'a =
+        LogSink.beginRun () |> ignore
+        Bench.reset ()
+        configure ()
+        LogSink.emit
+            { LogSink.envelope LogSink.Info LogSink.Config "config.runStart"
+                (Map.add "command" (box command : objnull) startPayload) with
+                Phase = LogSink.Start }
+        // §7.4 — every run publishes its classified transform inventory
+        // (the registry that drives the pass chain). Debug level: hidden
+        // unless --verbose / --debug.
+        EventProjection.ofRegistry RegisteredAllTransforms.all |> List.iter LogSink.emit
+        let mutable outcome = LogSink.Failed
+        let mutable value = Unchecked.defaultof<'a>
+        try
+            let v, oc = body ()
+            outcome <- oc
+            value <- v
+        finally
+            LogSink.runComplete outcome command (Bench.snapshot ()) |> ignore
+        value

--- a/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
@@ -372,33 +372,53 @@ module StagedBuilderEntry =
     /// between stages is syntactically impossible.
     let staged (spine: RunSpine) : StagedBuilder = StagedBuilder spine
 
+/// The canonical stage names — the declare-once site at the stage-name
+/// grain. The spines compose from these, and the faces reference the same
+/// values at their `Staged.stage` calls, so a face cannot drift from its
+/// declaration by retyping a string.
+[<RequireQualifiedAccess>]
+module Stages =
+
+    let private name (s: string) : StageName =
+        StageName.create s |> Result.value
+
+    /// The full-export umbrella root (never a watched sub-stage).
+    let pipeline : StageName = name "pipeline"
+    let extract  : StageName = name "extract"
+    let profile  : StageName = name "profile"
+    let emit     : StageName = name "emit"
+    let deploy   : StageName = name "deploy"
+    let canary   : StageName = name "canary"
+    let load     : StageName = name "load"
+
 /// The declared spines — one definition site per run face's arc (the
 /// per-face display string lists retire onto these; the Watch pre-seeds
 /// derive via `RunSpine.keys`).
 [<RequireQualifiedAccess>]
 module Spines =
 
-    let private name (s: string) : StageName =
-        StageName.create s |> Result.value
-
     /// `full-export`: the "pipeline" umbrella over extract → profile → emit.
     let pipeline : RunSpine =
-        RunSpine.createWithRoot (name "pipeline") [ name "extract"; name "profile"; name "emit" ]
+        RunSpine.createWithRoot Stages.pipeline [ Stages.extract; Stages.profile; Stages.emit ]
         |> Result.value
 
     /// The in-place migrate leg: build → apply → verify.
     let migrate : RunSpine =
-        RunSpine.create [ name "emit"; name "deploy"; name "canary" ] |> Result.value
+        RunSpine.create [ Stages.emit; Stages.deploy; Stages.canary ] |> Result.value
 
     /// The cross-substrate migrate: the schema leg, then the data load.
     let migrateData : RunSpine =
-        RunSpine.create [ name "emit"; name "deploy"; name "canary"; name "load" ] |> Result.value
+        RunSpine.create [ Stages.emit; Stages.deploy; Stages.canary; Stages.load ] |> Result.value
 
     /// The standalone deploy verb's single-stage arc.
     let deploy : RunSpine =
-        RunSpine.create [ name "deploy" ] |> Result.value
+        RunSpine.create [ Stages.deploy ] |> Result.value
+
+    /// The wide-canary verb's single-stage arc.
+    let canary : RunSpine =
+        RunSpine.create [ Stages.canary ] |> Result.value
 
     /// The data-transfer verbs' single-stage arc (the load leg streams its
     /// own per-table progress inside the one stage).
     let transfer : RunSpine =
-        RunSpine.create [ name "load" ] |> Result.value
+        RunSpine.create [ Stages.load ] |> Result.value

--- a/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
@@ -1,0 +1,85 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// R2 — the stage spine (`CONSTELLATION.md` §9.3; CONSTELLATION_BACKLOG
+/// stage 2, card S1). Stage identity today is a string-prefix convention
+/// over event codes (`<stage>.started` / `summary.stageCompleted{stage}`,
+/// parsed by the Watch board) plus per-face display lists. The spine types
+/// promote that convention to the type plane: a `StageName` is constructed
+/// once, validly, or not at all; a `RunSpine` is the declared stage arc of
+/// one run face — what the Watch pre-seeds from, and what the `staged { }`
+/// CE (card S2) holds the run accountable to (`declared ⇔
+/// executed∪aborted`).
+///
+/// The smart ctor is the contract (the house derive-macro): `private` case
+/// + `[<RequireQualifiedAccess>]` companion makes an invalid stage name
+/// unrepresentable downstream.
+type StageName = private StageName of string
+
+[<RequireQualifiedAccess>]
+module StageName =
+
+    /// Non-blank, dot-free. Stage names key the wire codes
+    /// (`<stage>.started`; the `stage` payload of `summary.stageCompleted`
+    /// / `summary.stageProgress`) where `.` is the code-namespace
+    /// separator — a dotted stage name would collide with the prefix
+    /// convention the Watch board parses (`Watch.apply`).
+    let create (name: string) : Result<StageName> =
+        let blankErrors =
+            Validation.nonBlank "stage.name.empty" "Stage name must be provided." name
+        let dottedErrors =
+            if not (System.String.IsNullOrWhiteSpace name) && name.Contains "." then
+                [ ValidationError.create
+                    "stage.name.dotted"
+                    "Stage name must not contain '.' — the envelope-code namespace separator." ]
+            else []
+        match blankErrors @ dottedErrors with
+        | [] -> Result.success (StageName name)
+        | es -> Result.failure es
+
+    /// The wire key — the `<stage>` of `<stage>.started` and the `stage`
+    /// payload value of the summary events.
+    let value (StageName n) : string = n
+
+/// The declared stage arc of one run face — distinct, non-empty, in
+/// execution order. The Watch board pre-seeds `Pending` lines from it so
+/// the whole arc is visible from the first frame; the `staged { }` CE
+/// asserts `declared ⇔ executed∪aborted` at run end (an open stage at run
+/// end becomes a named `Aborted`, never a board hang).
+type RunSpine = private { Declared : StageName list }
+
+[<RequireQualifiedAccess>]
+module RunSpine =
+
+    let create (stages: StageName list) : Result<RunSpine> =
+        let emptyErrors =
+            Validation.nonEmpty
+                "spine.stages.empty"
+                "A run spine must declare at least one stage."
+                stages
+        let duplicateErrors =
+            stages
+            |> Validation.duplicateKeyErrors
+                "spine.stages.duplicateKey"
+                (sprintf "Run spine declares stage '%s' more than once; declared stages are distinct.")
+                StageName.value
+        match emptyErrors @ duplicateErrors with
+        | [] -> Result.success { Declared = stages }
+        | es -> Result.failure es
+
+    /// The declared stages, in execution order.
+    let declared (spine: RunSpine) : StageName list = spine.Declared
+
+/// The spine-level outcome of one declared stage. RI-2's correction is the
+/// third arm: **aborted-at-stage is a real outcome** — a stage opened and
+/// never closed because the run died inside it (e.g. `MigrationRun.execute`
+/// opens "emit" and errors out before the close). The law admits it by
+/// name rather than letting the board hang on an Active line. `Skipped`
+/// is the declared-but-legitimately-not-run arm (a named reason, e.g. a
+/// store leg absent from this invocation) — distinct from `Aborted`, which
+/// is always a failure of the run to reach the stage's close.
+type StagedOutcome =
+    | Completed of durationMs: int64
+    | Aborted of refusal: string
+    | Skipped of reason: string

--- a/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
@@ -383,13 +383,16 @@ module Stages =
         StageName.create s |> Result.value
 
     /// The full-export umbrella root (never a watched sub-stage).
-    let pipeline : StageName = name "pipeline"
-    let extract  : StageName = name "extract"
-    let profile  : StageName = name "profile"
-    let emit     : StageName = name "emit"
-    let deploy   : StageName = name "deploy"
-    let canary   : StageName = name "canary"
-    let load     : StageName = name "load"
+    let pipeline  : StageName = name "pipeline"
+    let extract   : StageName = name "extract"
+    let profile   : StageName = name "profile"
+    let emit      : StageName = name "emit"
+    /// The migrate engine's safety gates (the 6.A.13 CDC gate + the G9
+    /// tightening gate) — real SQL I/O, declared and metered (card S4b).
+    let preflight : StageName = name "preflight"
+    let deploy    : StageName = name "deploy"
+    let canary    : StageName = name "canary"
+    let load      : StageName = name "load"
 
 /// The declared spines — one definition site per run face's arc (the
 /// per-face display string lists retire onto these; the Watch pre-seeds
@@ -402,13 +405,15 @@ module Spines =
         RunSpine.createWithRoot Stages.pipeline [ Stages.extract; Stages.profile; Stages.emit ]
         |> Result.value
 
-    /// The in-place migrate leg: build → apply → verify.
+    /// The in-place migrate leg: build → safety gates → apply → verify.
     let migrate : RunSpine =
-        RunSpine.create [ Stages.emit; Stages.deploy; Stages.canary ] |> Result.value
+        RunSpine.create [ Stages.emit; Stages.preflight; Stages.deploy; Stages.canary ] |> Result.value
 
     /// The cross-substrate migrate: the schema leg, then the data load.
     let migrateData : RunSpine =
-        RunSpine.create [ Stages.emit; Stages.deploy; Stages.canary; Stages.load ] |> Result.value
+        RunSpine.create
+            [ Stages.emit; Stages.preflight; Stages.deploy; Stages.canary; Stages.load ]
+        |> Result.value
 
     /// The standalone deploy verb's single-stage arc.
     let deploy : RunSpine =

--- a/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
@@ -1,16 +1,22 @@
 namespace Projection.Pipeline
 
+// LINT-ALLOW-FILE: refusal / skip-reason strings at the spine's accounting
+//   boundary compose via sprintf (the Catalog.create validation-message
+//   precedent); the structural surface is the typed StageName / RunSpine /
+//   StagedOutcome algebra.
+
+open System.Diagnostics
+open System.Threading.Tasks
 open Projection.Core
 
 /// R2 — the stage spine (`CONSTELLATION.md` §9.3; CONSTELLATION_BACKLOG
-/// stage 2, card S1). Stage identity today is a string-prefix convention
+/// stage 2, cards S1/S2). Stage identity today is a string-prefix convention
 /// over event codes (`<stage>.started` / `summary.stageCompleted{stage}`,
 /// parsed by the Watch board) plus per-face display lists. The spine types
 /// promote that convention to the type plane: a `StageName` is constructed
 /// once, validly, or not at all; a `RunSpine` is the declared stage arc of
 /// one run face — what the Watch pre-seeds from, and what the `staged { }`
-/// CE (card S2) holds the run accountable to (`declared ⇔
-/// executed∪aborted`).
+/// CE holds the run accountable to (`declared ⇔ executed∪aborted`).
 ///
 /// The smart ctor is the contract (the house derive-macro): `private` case
 /// + `[<RequireQualifiedAccess>]` companion makes an invalid stage name
@@ -43,16 +49,20 @@ module StageName =
     let value (StageName n) : string = n
 
 /// The declared stage arc of one run face — distinct, non-empty, in
-/// execution order. The Watch board pre-seeds `Pending` lines from it so
-/// the whole arc is visible from the first frame; the `staged { }` CE
-/// asserts `declared ⇔ executed∪aborted` at run end (an open stage at run
-/// end becomes a named `Aborted`, never a board hang).
-type RunSpine = private { Declared : StageName list }
+/// execution order, with an optional umbrella **root** (the spine's root
+/// scope — `FullExportRun`'s "pipeline" stage, which wraps the whole run
+/// and is never a sub-stage the operator watches). Nesting is one level,
+/// by declaration: the root brackets the run; the declared stages are the
+/// arc inside it. The Watch board pre-seeds `Pending` lines from the
+/// declared arc; the `staged { }` CE asserts `declared ⇔ executed∪aborted`
+/// at run end (an open stage at run end becomes a named `Aborted`, never a
+/// board hang).
+type RunSpine = private { Root : StageName option; Declared : StageName list }
 
 [<RequireQualifiedAccess>]
 module RunSpine =
 
-    let create (stages: StageName list) : Result<RunSpine> =
+    let private stageErrors (stages: StageName list) : ValidationError list =
         let emptyErrors =
             Validation.nonEmpty
                 "spine.stages.empty"
@@ -64,22 +74,331 @@ module RunSpine =
                 "spine.stages.duplicateKey"
                 (sprintf "Run spine declares stage '%s' more than once; declared stages are distinct.")
                 StageName.value
-        match emptyErrors @ duplicateErrors with
-        | [] -> Result.success { Declared = stages }
+        emptyErrors @ duplicateErrors
+
+    /// A rootless spine — the declared arc alone (migrate, deploy, …).
+    let create (stages: StageName list) : Result<RunSpine> =
+        match stageErrors stages with
+        | [] -> Result.success { Root = None; Declared = stages }
         | es -> Result.failure es
 
-    /// The declared stages, in execution order.
+    /// A spine with an umbrella root scope (full-export's "pipeline"). The
+    /// root brackets the whole run — it is not a declared sub-stage, so it
+    /// must not also appear in the arc.
+    let createWithRoot (root: StageName) (stages: StageName list) : Result<RunSpine> =
+        let rootErrors =
+            if stages |> List.exists (fun s -> s = root) then
+                [ ValidationError.create
+                    "spine.root.declared"
+                    "The umbrella root must not also be a declared sub-stage; nesting is one level, by declaration." ]
+            else []
+        match stageErrors stages @ rootErrors with
+        | [] -> Result.success { Root = Some root; Declared = stages }
+        | es -> Result.failure es
+
+    /// The declared stages, in execution order (the root is not among them).
     let declared (spine: RunSpine) : StageName list = spine.Declared
+
+    /// The declared arc as wire keys — what the Watch board pre-seeds from
+    /// (the per-face string lists retire onto this projection).
+    let keys (spine: RunSpine) : string list =
+        spine.Declared |> List.map StageName.value
+
+    /// The umbrella root scope, when declared.
+    let root (spine: RunSpine) : StageName option = spine.Root
+
+    /// The root's wire key — what the board elides (the umbrella is not a
+    /// line the operator watches).
+    let rootKey (spine: RunSpine) : string option =
+        spine.Root |> Option.map StageName.value
 
 /// The spine-level outcome of one declared stage. RI-2's correction is the
 /// third arm: **aborted-at-stage is a real outcome** — a stage opened and
 /// never closed because the run died inside it (e.g. `MigrationRun.execute`
 /// opens "emit" and errors out before the close). The law admits it by
 /// name rather than letting the board hang on an Active line. `Skipped`
-/// is the declared-but-legitimately-not-run arm (a named reason, e.g. a
-/// store leg absent from this invocation) — distinct from `Aborted`, which
-/// is always a failure of the run to reach the stage's close.
+/// is the declared-but-legitimately-not-run arm (a named reason — explicit
+/// via `Staged.skip`, or downstream of a stop/abort) — distinct from
+/// `Aborted`, which is always a failure of the run to reach the stage's
+/// close. `Completed` is bracket-plane: the stage ran to its close — the
+/// wire outcome (`succeeded` / `failed`) rides the envelope, not this arm.
 type StagedOutcome =
     | Completed of durationMs: int64
     | Aborted of refusal: string
     | Skipped of reason: string
+
+// ---------------------------------------------------------------------------
+// The `staged { }` CE (card S2) — the writer-fidelity graduation, applied to
+// time. Inside the CE, a stage crossing is structural: the Bind brackets
+// `Bench.scope "stage.<name>"`, the `<stage>.started` envelope, and the
+// `summary.stageCompleted` close (which the live Watch board folds) — and the
+// builder's `Run` closes the books: `declared ⇔ executed∪aborted`, every
+// declared stage accounted for by name, a missed or extra stage a named
+// refusal at run end, never a render glitch.
+// ---------------------------------------------------------------------------
+
+/// How the staged run ended, on the value plane. `RunStopped` is a stage
+/// body returning `Error` (the stage CLOSED — wire outcome `failed` — and
+/// the downstream arc was skipped); `RunAborted` is an exception or a spine
+/// refusal (undeclared / re-entered / unvisited stage), always named.
+type StagedDisposition<'a, 'e> =
+    | RunCompleted of value: 'a
+    | RunStopped of error: 'e
+    | RunAborted of refusal: string * cause: exn option
+
+/// The closed books of one staged run: every declared stage's outcome, in
+/// declared order, total by construction — plus the root bracket's outcome
+/// when the spine declares an umbrella.
+type StagedVerdict<'a, 'e> =
+    { Root        : (StageName * StagedOutcome) option
+      Outcomes    : (StageName * StagedOutcome) list
+      Disposition : StagedDisposition<'a, 'e> }
+
+/// The per-step flow inside the CE — internal; faces see `StagedVerdict`.
+type internal StagedStep<'a, 'e> =
+    | Flowing of value: 'a
+    | StoppedBy of error: 'e
+    | AbortedBy of refusal: string * cause: exn option
+
+/// The run-scoped accounting ledger. Mutable by design and confined to one
+/// `Run` invocation (the run is synchronous + sequential — the LogSink
+/// boundary precedent): a continuation that throws must not lose the books
+/// already written.
+type internal SpineLedger() =
+    let visited = ResizeArray<StageName * StagedOutcome>()  // LINT-ALLOW: run-scoped accumulator; read out as an immutable list at close
+    member _.Visit(name: StageName, outcome: StagedOutcome) : unit =
+        visited.Add((name, outcome))
+    member _.HasVisited(name: StageName) : bool =
+        visited |> Seq.exists (fun (n, _) -> n = name)
+    member _.Visited : (StageName * StagedOutcome) list =
+        List.ofSeq visited
+
+type internal SpineContext =
+    { Spine : RunSpine
+      Ledger : SpineLedger }
+
+/// One staged computation — a program over the spine context. Constructed
+/// only by `Staged.stage` / `Staged.skip` / the builder, so every stage
+/// crossing is bracketed by construction.
+type Staged<'a, 'e> = internal Staged of (SpineContext -> Task<StagedStep<'a, 'e>>)
+
+[<RequireQualifiedAccess>]
+module Staged =
+
+    let internal run (Staged f) = f
+
+    let private benchLabel (key: string) : string = "stage." + key
+
+    let private abortRefusal (key: string) (ex: exn) : string =
+        sprintf "spine.stage.aborted: '%s' threw %s: %s" key (ex.GetType().Name) ex.Message
+
+    /// A declared stage: the bracket opens (`<stage>.started`, the Bench
+    /// scope), the body runs, the bracket closes (`summary.stageCompleted`
+    /// + the §10 stage-table entry — wire outcome `succeeded` on `Ok`,
+    /// `failed` on `Error`, `aborted` on an exception, so the board's line
+    /// always closes). An undeclared or re-entered stage refuses by name
+    /// without opening a bracket (no phantom wire events).
+    let stage (name: StageName) (body: unit -> Task<Result<'a, 'e>>) : Staged<'a, 'e> =
+        Staged (fun ctx ->
+            task {
+                let key = StageName.value name
+                if not (RunSpine.declared ctx.Spine |> List.contains name) then
+                    return AbortedBy (sprintf "spine.stage.undeclared: '%s' ran outside the declared spine" key, None)
+                elif ctx.Ledger.HasVisited name then
+                    return AbortedBy (sprintf "spine.stage.reentered: '%s' ran twice in one run" key, None)
+                else
+                    LogSink.recordStageStart key
+                    let sw = Stopwatch.StartNew()
+                    use _ = Bench.scope (benchLabel key)
+                    try
+                        let! result = body ()
+                        sw.Stop()
+                        match result with
+                        | Ok value ->
+                            LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Succeeded
+                            ctx.Ledger.Visit(name, Completed sw.ElapsedMilliseconds)
+                            return Flowing value
+                        | Error e ->
+                            LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Failed
+                            ctx.Ledger.Visit(name, Completed sw.ElapsedMilliseconds)
+                            return StoppedBy e
+                    with ex ->
+                        sw.Stop()
+                        // The Aborted arm is first-class: the bracket CLOSES
+                        // (outcome `aborted` on the wire — the board line goes
+                        // Halted, never hangs) and the refusal is named.
+                        LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Aborted
+                        ctx.Ledger.Visit(name, StagedOutcome.Aborted (abortRefusal key ex))
+                        return AbortedBy (abortRefusal key ex, Some ex)
+            })
+
+    /// A declared stage explicitly not run this invocation, with its named
+    /// reason. Ledger-only: no wire events (the stage never started; the
+    /// board line honestly stays Pending), but the books stay total.
+    let skip (name: StageName) (reason: string) : Staged<unit, 'e> =
+        Staged (fun ctx ->
+            task {
+                let key = StageName.value name
+                if not (RunSpine.declared ctx.Spine |> List.contains name) then
+                    return AbortedBy (sprintf "spine.stage.undeclared: '%s' skipped outside the declared spine" key, None)
+                elif ctx.Ledger.HasVisited name then
+                    return AbortedBy (sprintf "spine.stage.reentered: '%s' visited twice in one run" key, None)
+                else
+                    ctx.Ledger.Visit(name, StagedOutcome.Skipped reason)
+                    return Flowing ()
+            })
+
+/// Internal close — the books, balanced. Pure over the ledger snapshot.
+module internal StagedClose =
+
+    /// Total outcomes in DECLARED order: every declared stage appears
+    /// exactly once — visited stages with their recorded outcome, unvisited
+    /// stages as `Skipped` with the run-shaped reason.
+    let private totalOutcomes
+        (spine: RunSpine)
+        (visited: (StageName * StagedOutcome) list)
+        (skipReason: string)
+        : (StageName * StagedOutcome) list =
+        let byName = visited |> List.map (fun (n, o) -> StageName.value n, o) |> Map.ofList
+        RunSpine.declared spine
+        |> List.map (fun n ->
+            match Map.tryFind (StageName.value n) byName with
+            | Some o -> n, o
+            | None   -> n, Skipped skipReason)
+
+    let close
+        (spine: RunSpine)
+        (visited: (StageName * StagedOutcome) list)
+        (step: StagedStep<'a, 'e>)
+        : StagedVerdict<'a, 'e> =
+        let lastVisitedKey =
+            visited |> List.tryLast |> Option.map (fst >> StageName.value)
+        match step with
+        | Flowing value ->
+            let unvisited =
+                let byName = visited |> List.map (fst >> StageName.value) |> Set.ofList
+                RunSpine.declared spine
+                |> List.filter (fun n -> not (Set.contains (StageName.value n) byName))
+            if List.isEmpty unvisited then
+                { Root        = None
+                  Outcomes    = totalOutcomes spine visited "unreachable"
+                  Disposition = RunCompleted value }
+            else
+                // The law's teeth: a declared stage neither run nor skipped
+                // is a named refusal at run end, not a silent pass.
+                let names = unvisited |> List.map StageName.value |> String.concat ", "
+                { Root        = None
+                  Outcomes    = totalOutcomes spine visited "unvisited at run end — the close refused"
+                  Disposition = RunAborted (sprintf "spine.stages.unvisited: %s" names, None) }
+        | StoppedBy error ->
+            let reason =
+                match lastVisitedKey with
+                | Some k -> sprintf "run stopped at '%s'" k
+                | None   -> "run stopped before any stage"
+            { Root        = None
+              Outcomes    = totalOutcomes spine visited reason
+              Disposition = RunStopped error }
+        | AbortedBy (refusal, cause) ->
+            { Root        = None
+              Outcomes    = totalOutcomes spine visited (sprintf "run aborted: %s" refusal)
+              Disposition = RunAborted (refusal, cause) }
+
+    /// Guard the program run so a continuation that throws (between stage
+    /// brackets) still closes the books by name.
+    let guarded (m: Staged<'a, 'e>) (ctx: SpineContext) : Task<StagedStep<'a, 'e>> =
+        task {
+            try
+                return! Staged.run m ctx
+            with ex ->
+                return AbortedBy (sprintf "spine.run.threw: %s: %s" (ex.GetType().Name) ex.Message, Some ex)
+        }
+
+/// The `staged spine { … }` builder. Member set mirrors the house CE
+/// precedent (`LineageDiagnosticsBuilder`): Bind sequences stages (a
+/// stopped or aborted flow short-circuits the rest — downstream declared
+/// stages close as `Skipped`, by name); `Run` brackets the optional
+/// umbrella root and closes the books. The CE expression evaluates to a
+/// hot `Task<StagedVerdict<_,_>>`, like `task { }` itself.
+type StagedBuilder(spine: RunSpine) =
+
+    member _.Bind(m: Staged<'a, 'e>, f: 'a -> Staged<'b, 'e>) : Staged<'b, 'e> =
+        Staged (fun ctx ->
+            task {
+                let! step = Staged.run m ctx
+                match step with
+                | Flowing a          -> return! Staged.run (f a) ctx
+                | StoppedBy e        -> return StoppedBy e
+                | AbortedBy (r, c)   -> return AbortedBy (r, c)
+            })
+
+    member _.Return(x: 'a) : Staged<'a, 'e> =
+        Staged (fun _ -> Task.FromResult (Flowing x))
+
+    member _.ReturnFrom(m: Staged<'a, 'e>) : Staged<'a, 'e> = m
+
+    member _.Delay(f: unit -> Staged<'a, 'e>) : Staged<'a, 'e> =
+        Staged (fun ctx -> Staged.run (f ()) ctx)
+
+    member _.Run(m: Staged<'a, 'e>) : Task<StagedVerdict<'a, 'e>> =
+        task {
+            let ctx = { Spine = spine; Ledger = SpineLedger() }
+            match RunSpine.root spine with
+            | None ->
+                let! step = StagedClose.guarded m ctx
+                return StagedClose.close spine ctx.Ledger.Visited step
+            | Some rootName ->
+                // The umbrella root scope — one level of nesting, by
+                // declaration. The root's bracket encloses the whole arc;
+                // its wire outcome mirrors the disposition.
+                let rootKey = StageName.value rootName
+                LogSink.recordStageStart rootKey
+                let sw = Stopwatch.StartNew()
+                use _ = Bench.scope ("stage." + rootKey)
+                let! step = StagedClose.guarded m ctx
+                sw.Stop()
+                let verdict = StagedClose.close spine ctx.Ledger.Visited step
+                let wireOutcome, rootOutcome =
+                    match verdict.Disposition with
+                    | RunCompleted _      -> LogSink.Succeeded, Completed sw.ElapsedMilliseconds
+                    | RunStopped _        -> LogSink.Failed,    Completed sw.ElapsedMilliseconds
+                    | RunAborted (r, _)   -> LogSink.Aborted,   StagedOutcome.Aborted r
+                LogSink.recordStageEvent rootKey sw.ElapsedMilliseconds wireOutcome
+                return { verdict with Root = Some (rootName, rootOutcome) }
+        }
+
+[<AutoOpen>]
+module StagedBuilderEntry =
+    /// The `staged spine { … }` CE entry point — inside it, unmetered work
+    /// between stages is syntactically impossible.
+    let staged (spine: RunSpine) : StagedBuilder = StagedBuilder spine
+
+/// The declared spines — one definition site per run face's arc (the
+/// per-face display string lists retire onto these; the Watch pre-seeds
+/// derive via `RunSpine.keys`).
+[<RequireQualifiedAccess>]
+module Spines =
+
+    let private name (s: string) : StageName =
+        StageName.create s |> Result.value
+
+    /// `full-export`: the "pipeline" umbrella over extract → profile → emit.
+    let pipeline : RunSpine =
+        RunSpine.createWithRoot (name "pipeline") [ name "extract"; name "profile"; name "emit" ]
+        |> Result.value
+
+    /// The in-place migrate leg: build → apply → verify.
+    let migrate : RunSpine =
+        RunSpine.create [ name "emit"; name "deploy"; name "canary" ] |> Result.value
+
+    /// The cross-substrate migrate: the schema leg, then the data load.
+    let migrateData : RunSpine =
+        RunSpine.create [ name "emit"; name "deploy"; name "canary"; name "load" ] |> Result.value
+
+    /// The standalone deploy verb's single-stage arc.
+    let deploy : RunSpine =
+        RunSpine.create [ name "deploy" ] |> Result.value
+
+    /// The data-transfer verbs' single-stage arc (the load leg streams its
+    /// own per-table progress inside the one stage).
+    let transfer : RunSpine =
+        RunSpine.create [ name "load" ] |> Result.value

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -286,8 +286,11 @@ module Transfer =
             // re-point against captures made by their (earlier-ordered)
             // targets.
             let remap = PackedSurrogateRemap.create ()
-            let mutable writeSkips : (SsKey * UnresolvedReference) list = []
-            let mutable laneDescents : LaneDescent list = []
+            // ref cells (not `let mutable`): the load body is the staged CE's
+            // stage thunk (card S4c), and F# closures cannot capture mutable
+            // locals.
+            let writeSkips : (SsKey * UnresolvedReference) list ref = ref []
+            let laneDescents : LaneDescent list ref = ref []
 
             // Phase 1 excludes the deferred (cycle) FK columns from the re-point:
             // they are inserted as NULL, and their targets' captures are not
@@ -307,82 +310,102 @@ module Transfer =
             // when no one is watching.
             let loadTotal = List.length plan.Loads
             let loadSw = System.Diagnostics.Stopwatch.StartNew()
-            let mutable loaded = 0
-            LogSink.recordStageStart "load"
-            for load in plan.Loads do
-                if not (List.isEmpty load.Rows) then
-                    match Catalog.tryFindKind load.Kind catalog with
-                    | None      -> ()
-                    | Some kind ->
-                        let remapped = repoint load.DeferredFkColumns kind load.Rows
-                        writeSkips <- writeSkips @ (remapped.Skipped |> List.map (fun u -> load.Kind, u))
-                        match load.Disposition with
-                        | IdentityDisposition.AssignedBySink ->
-                            match kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity) with
-                            | Some _ when not (Set.contains load.Kind fkTargetKinds) ->
-                                // No FK anywhere targets this kind, so its minted
-                                // surrogates have no consumer: skip capture and
-                                // bulk-insert with the identity column excluded —
-                                // the Sink mints, nothing needs the mapping. (A
-                                // cycle member is always FK-targeted by its cycle
-                                // predecessor, so this lane never carries
-                                // deferred columns.)
-                                do! Bulk.copyRowsSinkMinted sink kind.Physical
-                                        (toCellRowsExcludingIdentity kind load.DeferredFkColumns remapped.Rows)
-                            | Some idAttr ->
-                                let! descents =
-                                    captureChunks sink kind idAttr load.DeferredFkColumns load.Kind remap
-                                        CaptureLane.StagedMergeOutput []
-                                        (remapped.Rows |> List.chunkBySize CaptureChunkSize)
-                                laneDescents <- laneDescents @ descents
-                            | None ->
-                                // ofKind only returns AssignedBySink for an IDENTITY PK, so this is
-                                // unreachable; fall back to the bulk path rather than drop the rows.
+            let loaded = ref 0
+            // Card S4c — the load bracket is the `staged { }` CE's
+            // (`Spines.transfer`): an exception mid-load now CLOSES the stage
+            // `aborted` on the wire (the board line goes Halted) instead of
+            // leaving an open `.started`; the per-table progress events are
+            // unchanged.
+            let loadBody () : Task<Result<unit, ValidationError list>> =
+              task {
+                for load in plan.Loads do
+                    if not (List.isEmpty load.Rows) then
+                        match Catalog.tryFindKind load.Kind catalog with
+                        | None      -> ()
+                        | Some kind ->
+                            let remapped = repoint load.DeferredFkColumns kind load.Rows
+                            writeSkips.Value <- writeSkips.Value @ (remapped.Skipped |> List.map (fun u -> load.Kind, u))
+                            match load.Disposition with
+                            | IdentityDisposition.AssignedBySink ->
+                                match kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity) with
+                                | Some _ when not (Set.contains load.Kind fkTargetKinds) ->
+                                    // No FK anywhere targets this kind, so its minted
+                                    // surrogates have no consumer: skip capture and
+                                    // bulk-insert with the identity column excluded —
+                                    // the Sink mints, nothing needs the mapping. (A
+                                    // cycle member is always FK-targeted by its cycle
+                                    // predecessor, so this lane never carries
+                                    // deferred columns.)
+                                    do! Bulk.copyRowsSinkMinted sink kind.Physical
+                                            (toCellRowsExcludingIdentity kind load.DeferredFkColumns remapped.Rows)
+                                | Some idAttr ->
+                                    let! descents =
+                                        captureChunks sink kind idAttr load.DeferredFkColumns load.Kind remap
+                                            CaptureLane.StagedMergeOutput []
+                                            (remapped.Rows |> List.chunkBySize CaptureChunkSize)
+                                    laneDescents.Value <- laneDescents.Value @ descents
+                                | None ->
+                                    // ofKind only returns AssignedBySink for an IDENTITY PK, so this is
+                                    // unreachable; fall back to the bulk path rather than drop the rows.
+                                    do! Bulk.copyRows sink kind.Physical (toCellRows kind load.DeferredFkColumns remapped.Rows)
+                            | _ ->
                                 do! Bulk.copyRows sink kind.Physical (toCellRows kind load.DeferredFkColumns remapped.Rows)
-                        | _ ->
-                            do! Bulk.copyRows sink kind.Physical (toCellRows kind load.DeferredFkColumns remapped.Rows)
-                loaded <- loaded + 1
-                LogSink.recordStageProgress "load" loaded loadTotal loadSw.ElapsedMilliseconds
+                    loaded.Value <- loaded.Value + 1
+                    LogSink.recordStageProgress "load" loaded.Value loadTotal loadSw.ElapsedMilliseconds
 
-            // Phase 2 — re-point the cycle-deferred FK columns against the
-            // COMPLETED remap. For an `AssignedBySink` kind the WHERE keys on
-            // the ASSIGNED PK (the sink replaced the source PK at insert; the
-            // captured remap supplies the translation — the 6.A.2 lift,
-            // operator-authorized 2026-06-10). A deferred FK value with no
-            // captured target is a NAMED phase-2 erasure: the row stands (it
-            // was inserted in phase 1 with the column NULL) but the reference
-            // is lost — surfaced in `SkippedReferences`, never silent. A row
-            // whose own PK has no capture was dropped (and named) in phase 1;
-            // it has no sink row to update, so it is passed over here.
-            for load in plan.Loads do
-                if not (Set.isEmpty load.DeferredFkColumns) && not (List.isEmpty load.Rows) then
-                    match Catalog.tryFindKind load.Kind catalog with
-                    | None      -> ()
-                    | Some kind ->
-                        let remapped2 = repoint Set.empty kind load.Rows
-                        writeSkips <-
-                            writeSkips
-                            @ (remapped2.Skipped
-                               |> List.filter (fun u -> Set.contains u.Column load.DeferredFkColumns)
-                               |> List.map (fun u -> load.Kind, u))
-                        let rowsForUpdate =
-                            match load.Disposition, kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity) with
-                            | IdentityDisposition.AssignedBySink, Some idAttr ->
-                                remapped2.Rows
-                                |> List.choose (fun row ->
-                                    match Map.tryFind idAttr.Name row.Values with
-                                    | Some srcVal when srcVal <> "" ->
-                                        PackedSurrogateRemap.tryFind remap load.Kind srcVal
-                                        |> Option.map (fun assigned ->
-                                            { row with Values = Map.add idAttr.Name assigned row.Values })
-                                    | _ -> None)
-                            | _ -> remapped2.Rows
-                        let updates = rowsForUpdate |> List.choose (phase2UpdateSql kind load.DeferredFkColumns)
-                        if not (List.isEmpty updates) then
-                            do! Deploy.executeBatch sink (String.concat "\n" updates)
+                // Phase 2 — re-point the cycle-deferred FK columns against the
+                // COMPLETED remap. For an `AssignedBySink` kind the WHERE keys on
+                // the ASSIGNED PK (the sink replaced the source PK at insert; the
+                // captured remap supplies the translation — the 6.A.2 lift,
+                // operator-authorized 2026-06-10). A deferred FK value with no
+                // captured target is a NAMED phase-2 erasure: the row stands (it
+                // was inserted in phase 1 with the column NULL) but the reference
+                // is lost — surfaced in `SkippedReferences`, never silent. A row
+                // whose own PK has no capture was dropped (and named) in phase 1;
+                // it has no sink row to update, so it is passed over here.
+                for load in plan.Loads do
+                    if not (Set.isEmpty load.DeferredFkColumns) && not (List.isEmpty load.Rows) then
+                        match Catalog.tryFindKind load.Kind catalog with
+                        | None      -> ()
+                        | Some kind ->
+                            let remapped2 = repoint Set.empty kind load.Rows
+                            writeSkips.Value <-
+                                writeSkips.Value
+                                @ (remapped2.Skipped
+                                   |> List.filter (fun u -> Set.contains u.Column load.DeferredFkColumns)
+                                   |> List.map (fun u -> load.Kind, u))
+                            let rowsForUpdate =
+                                match load.Disposition, kind.Attributes |> List.tryFind (fun a -> a.IsPrimaryKey && a.IsIdentity) with
+                                | IdentityDisposition.AssignedBySink, Some idAttr ->
+                                    remapped2.Rows
+                                    |> List.choose (fun row ->
+                                        match Map.tryFind idAttr.Name row.Values with
+                                        | Some srcVal when srcVal <> "" ->
+                                            PackedSurrogateRemap.tryFind remap load.Kind srcVal
+                                            |> Option.map (fun assigned ->
+                                                { row with Values = Map.add idAttr.Name assigned row.Values })
+                                        | _ -> None)
+                                | _ -> remapped2.Rows
+                            let updates = rowsForUpdate |> List.choose (phase2UpdateSql kind load.DeferredFkColumns)
+                            if not (List.isEmpty updates) then
+                                do! Deploy.executeBatch sink (String.concat "\n" updates)
 
-            LogSink.recordStageEvent "load" loadSw.ElapsedMilliseconds LogSink.Succeeded
-            return writeSkips, laneDescents
+                return Ok ()
+              }
+            let! verdict =
+                staged Spines.transfer {
+                    do! Staged.stage Stages.load loadBody
+                    return ()
+                }
+            match verdict.Disposition with
+            | RunCompleted () -> return writeSkips.Value, laneDescents.Value
+            | RunStopped _ ->
+                // The body never returns Error; total match, named.
+                return invalidOp "writePlan: the load body cannot stop"
+            | RunAborted (_, Some ex) ->
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                return Unchecked.defaultof<_>
+            | RunAborted (refusal, None) -> return failwith refusal
         }
 
     // -- D10 / G10 (Wave 3) — the wipe-and-load + resumable write envelopes ---
@@ -1265,13 +1288,31 @@ module Transfer =
             }
 
         task {
-            LogSink.recordStageStart "load"
-            match! phase1 plan.Loads 0 Map.empty [] [] with
-            | Error es -> return Result.failure es
-            | Ok (totals, skips, descents) ->
-                let! phase2Skips = phase2 plan.Loads []
-                LogSink.recordStageEvent "load" loadSw.ElapsedMilliseconds LogSink.Succeeded
-                return Result.success (totals, skips @ phase2Skips, descents)
+            // Card S4c — the load bracket is the `staged { }` CE's
+            // (`Spines.transfer`): a phase-1 refusal (e.g. the resume
+            // source-drift refusal) now CLOSES the stage `failed` on the wire —
+            // the pre-spine code returned early, leaving the board hanging on
+            // an open `.started` — and an exception closes it `aborted`.
+            let! verdict =
+                staged Spines.transfer {
+                    let! outcome =
+                        Staged.stage Stages.load (fun () ->
+                            task {
+                                match! phase1 plan.Loads 0 Map.empty [] [] with
+                                | Error es -> return Error es
+                                | Ok (totals, skips, descents) ->
+                                    let! phase2Skips = phase2 plan.Loads []
+                                    return Ok (totals, skips @ phase2Skips, descents)
+                            })
+                    return outcome
+                }
+            match verdict.Disposition with
+            | RunCompleted value -> return Result.success value
+            | RunStopped es -> return Result.failure es
+            | RunAborted (_, Some ex) ->
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                return Unchecked.defaultof<_>
+            | RunAborted (refusal, None) -> return failwith refusal
         }
 
     /// **The streaming realization** — bounded memory for the estate-scale

--- a/sidecar/projection/tests/Projection.Tests/DiagnosticsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DiagnosticsTests.fs
@@ -541,6 +541,27 @@ let ``H-003 Kleisli: composeAll [f; g; h] threads chronologically`` () =
     Assert.Equal<DiagnosticEntry list>([d1; d2; d3], LineageDiagnostics.entries result)
 
 // ---------------------------------------------------------------------------
+// §9.8.5 (card S1): Meter.pass — the decoration collapse. The Bench
+// decoration is an endomorphism on Kleisli arrows that is IDENTITY on the
+// value plane (payload + both writers' trails); its only effect is a meter
+// sample. With this law, `PassChainAdapter.compose` = `Pass.composeAll`
+// over decorated arrows is exactly the undecorated algebra's result.
+// ---------------------------------------------------------------------------
+
+[<Property>]
+let ``Meter.pass p ≡ p on the value plane — decoration is invisible to the algebra`` (x: int) =
+    let p = wrapPass (dualEvent customerKey) (entry "p" DiagnosticSeverity.Info "c" "m") 7
+    byValueAndBothTrails (Meter.pass "test.meter.pass" p x) (p x)
+
+[<Property>]
+let ``Meter.pass distributes over composition — metered chains compose like bare chains`` (x: int) =
+    let f = wrapPass (dualEvent customerKey) (entry "f" DiagnosticSeverity.Info "c1" "m1") 1
+    let g = wrapPass (dualEvent orderKey)    (entry "g" DiagnosticSeverity.Info "c2" "m2") 2
+    let metered = Pass.composeAll [ Meter.pass "test.meter.f" f; Meter.pass "test.meter.g" g ]
+    let bare    = Pass.composeAll [ f; g ]
+    byValueAndBothTrails (metered x) (bare x)
+
+// ---------------------------------------------------------------------------
 // H-008: DiagnosticLattice — subsumption + minimal reduction.
 // ---------------------------------------------------------------------------
 

--- a/sidecar/projection/tests/Projection.Tests/FullExportCliTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportCliTests.fs
@@ -336,6 +336,54 @@ let ``slice 7: eventCounts.info >= 3 on happy path (runStart + connectionResolve
         File.Delete configPath
         File.Delete modelPath
 
+[<Fact>]
+let ``S5: wall(run) − Σ wall(stage) ≤ ε — the publish run's stage account, honestly bounded`` () =
+    // R2's additivity law (T14 on the time plane), asserted on the REAL run
+    // at two levels of nesting. ε's residue, enumerated:
+    //   level 1 (umbrella − children): the staged CE's plumbing only — no
+    //     I/O between brackets by construction (card S4a).
+    //   level 2 (run wall − umbrella): config load + model-path resolution
+    //     (before the root opens), artifact recording + diagnostics
+    //     projection + transform-event egress + envelope serialization
+    //     (after it closes). No SQL and no network on this fixture.
+    // The bounds are generous for CI scheduling noise: this witness catches
+    // STRUCTURAL unaccounted work (the pre-spine migratePreflights class,
+    // seconds of unmetered I/O), not micro-jitter. The migrate run's
+    // face-level grant pre-flights remain named, unbounded residue — they
+    // run real SQL before the engine's spine opens (DECISIONS 2026-06-12,
+    // S4).
+    let modelPath = writeTempJson v1MinimalFixture
+    let outDir = tempOutputDir ()
+    let configPath = writeTempConfig modelPath outDir
+    try
+        let _, text = runFullExportInProcess configPath None
+        let lines = parseLines text
+        let first = List.head lines
+        let last = List.last lines
+        let stages = prop (prop last "payload") "stages"
+        let stageDur (name: string) : int64 =
+            [ for i in 0 .. stages.GetArrayLength() - 1 -> stages.[i] ]
+            |> List.tryPick (fun s ->
+                if getStr (prop s "stage") = name then Some ((prop s "durationMs").GetInt64()) else None)
+            |> Option.defaultValue 0L
+        let umbrella = stageDur "pipeline"
+        let childSum = stageDur "extract" + stageDur "profile" + stageDur "emit"
+        // level 1 — the umbrella covers its children; the gap is CE plumbing.
+        Assert.True(umbrella + 3L >= childSum, sprintf "umbrella %dms must cover children %dms" umbrella childSum)
+        Assert.True(umbrella - childSum <= 500L, sprintf "nesting ε=%dms exceeds the named 500ms bound" (umbrella - childSum))
+        // level 2 — the run wall covers the umbrella; the gap is the named residue.
+        let tsOf (e: JsonElement) =
+            DateTime.Parse(getStr (prop e "ts"), null, System.Globalization.DateTimeStyles.RoundtripKind)
+        let runWallMs = int64 (tsOf last - tsOf first).TotalMilliseconds
+        Assert.True(runWallMs + 3L >= umbrella, sprintf "run wall %dms must cover the umbrella %dms" runWallMs umbrella)
+        Assert.True(
+            runWallMs - umbrella <= 3000L,
+            sprintf "run-level ε=%dms — unaccounted run work grew past the named residue" (runWallMs - umbrella))
+    finally
+        safeRm outDir
+        File.Delete configPath
+        File.Delete modelPath
+
 // ----------------------------------------------------------------------
 // AC-X3 — the publication bundle is reachable from the `full-export` CLI
 // surface (the `--lifecycle-store` routing the CLI's `runFullExport` does).

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="BenchTests.fs" />
     <Compile Include="LogSinkTests.fs" />
     <Compile Include="LogSinkSubscriberTests.fs" />
+    <Compile Include="RunSpineTests.fs" />
     <Compile Include="RunLedgerTests.fs" />
     <Compile Include="RunTests.fs" />
     <Compile Include="SourceTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="LogSinkTests.fs" />
     <Compile Include="LogSinkSubscriberTests.fs" />
     <Compile Include="RunSpineTests.fs" />
+    <Compile Include="StagedTests.fs" />
     <Compile Include="RunLedgerTests.fs" />
     <Compile Include="RunTests.fs" />
     <Compile Include="SourceTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RunSpineTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunSpineTests.fs
@@ -1,0 +1,47 @@
+module Projection.Tests.RunSpineTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+/// Card S1 (CONSTELLATION_BACKLOG stage 2) — the spine types' smart ctors.
+/// The contract under test: an invalid stage name or spine is
+/// unrepresentable (the house derive-macro), so the `staged { }` CE (S2)
+/// and the Watch pre-seed never meet a blank, dotted, duplicated, or empty
+/// arc at runtime.
+
+let private stage (n: string) : StageName =
+    StageName.create n |> Result.value
+
+[<Fact>]
+let ``S1: StageName.create — non-blank, dot-free; the wire-code prefix convention is protected at construction`` () =
+    // The happy path round-trips to the wire key.
+    Assert.Equal("deploy", StageName.create "deploy" |> Result.value |> StageName.value)
+    // Blank refuses by name.
+    Assert.Equal<string list>(
+        [ "stage.name.empty" ],
+        StageName.create "   " |> Result.errors |> List.map (fun e -> e.Code))
+    // A dotted name would collide with the envelope-code namespace
+    // (`<stage>.started`); refused by name.
+    Assert.Equal<string list>(
+        [ "stage.name.dotted" ],
+        StageName.create "deploy.schema" |> Result.errors |> List.map (fun e -> e.Code))
+
+[<Fact>]
+let ``S1: RunSpine.create — declared stages are distinct, non-empty, order-preserved`` () =
+    // Order is the execution order — preserved exactly.
+    let spine = RunSpine.create [ stage "emit"; stage "deploy"; stage "canary" ] |> Result.value
+    Assert.Equal<string list>(
+        [ "emit"; "deploy"; "canary" ],
+        RunSpine.declared spine |> List.map StageName.value)
+    // Empty refuses by name.
+    Assert.Equal<string list>(
+        [ "spine.stages.empty" ],
+        RunSpine.create [] |> Result.errors |> List.map (fun e -> e.Code))
+    // A duplicated stage refuses by name (declared ⇔ executed needs a
+    // well-defined declaration side).
+    Assert.Equal<string list>(
+        [ "spine.stages.duplicateKey" ],
+        RunSpine.create [ stage "emit"; stage "emit" ]
+        |> Result.errors
+        |> List.map (fun e -> e.Code))

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -261,6 +261,45 @@ let ``R2: the stage bracket meters — Bench carries one stage-labelled sample p
     Assert.Contains("stage.canary", labels)
 
 // ---------------------------------------------------------------------------
+// additivity (card S5) — T14 on the time plane, honestly
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``R2: wall(root) − Σ wall(stage) ≤ ε — T14 on the time plane (the spine's nesting is tight)`` () =
+    // The CE's own nesting: the root bracket encloses exactly the declared
+    // children plus the builder's plumbing (binds, ledger appends, envelope
+    // emission — no I/O between brackets by construction). The sleeps make
+    // the children's wall dominate; ε is the plumbing, bounded generously
+    // for CI scheduling noise. The +2ms slack absorbs independent stopwatch
+    // rounding. (The RUN-level account — config, artifacts, face gates —
+    // is the FullExportCliTests S5 witness; its residue is enumerated
+    // there.)
+    let rootSpine =
+        RunSpine.createWithRoot (stage "pipeline") [ stage "extract"; stage "emit" ]
+        |> Result.value
+    let sleepStage (ms: int) : unit -> Task<Result<unit, string>> =
+        fun () ->
+            task {
+                do! Task.Delay ms
+                return Ok ()
+            }
+    let verdict, _ =
+        runCaptured (fun () ->
+            staged rootSpine {
+                do! Staged.stage (stage "extract") (sleepStage 60)
+                do! Staged.stage (stage "emit") (sleepStage 60)
+                return ()
+            })
+    let childSum =
+        verdict.Outcomes
+        |> List.sumBy (fun (_, o) -> match o with Completed ms -> ms | _ -> 0L)
+    match verdict.Root with
+    | Some (_, Completed rootMs) ->
+        Assert.True(rootMs + 2L >= childSum, sprintf "the root (%dms) must cover its children (%dms)" rootMs childSum)
+        Assert.True(rootMs - childSum <= 250L, sprintf "nesting ε=%dms exceeds the named 250ms bound" (rootMs - childSum))
+    | other -> Assert.Fail(sprintf "expected the root bracket completed, got %A" other)
+
+// ---------------------------------------------------------------------------
 // the run-envelope bracket (card S4a) — ONE owner, both callers
 // ---------------------------------------------------------------------------
 

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -272,4 +272,5 @@ let ``S2: the declared spines carry the per-face arcs the string lists carried``
     Assert.Equal<string list>([ "emit"; "deploy"; "canary" ], RunSpine.keys Spines.migrate)
     Assert.Equal<string list>([ "emit"; "deploy"; "canary"; "load" ], RunSpine.keys Spines.migrateData)
     Assert.Equal<string list>([ "deploy" ], RunSpine.keys Spines.deploy)
+    Assert.Equal<string list>([ "canary" ], RunSpine.keys Spines.canary)
     Assert.Equal<string list>([ "load" ], RunSpine.keys Spines.transfer)

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -1,0 +1,275 @@
+[<Xunit.Collection("Global-MutableState")>]
+module Projection.Tests.StagedTests
+
+// Card S2 (CONSTELLATION_BACKLOG stage 2) — the `staged { }` CE and the R2
+// law: `declared ⇔ executed∪aborted`. The registry pattern's fifth instance
+// (after registered⇔executed, code⇔copy, expressible⇔reachable, and the
+// codec): the spine declares the arc; the CE brackets every crossing
+// (`<stage>.started` / `summary.stageCompleted` / `Bench.scope "stage.<name>"`);
+// the Run closure balances the books — every declared stage accounted for by
+// name, a missed or extra stage a named refusal at run end, the Aborted arm
+// first-class (an open stage at run end closes `aborted`, never a board hang).
+//
+// Lives in the Global-MutableState collection: the CE writes the LogSink +
+// Bench process state, like every emitting surface.
+
+open System.Threading.Tasks
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Cli
+
+let private stage (n: string) : StageName =
+    StageName.create n |> Result.value
+
+let private spine3 : RunSpine =
+    RunSpine.create [ stage "extract"; stage "deploy"; stage "canary" ] |> Result.value
+
+let private ok (v: 'a) : unit -> Task<Result<'a, string>> =
+    fun () -> Task.FromResult (Ok v)
+
+let private err (e: string) : unit -> Task<Result<'a, string>> =
+    fun () -> Task.FromResult (Error e : Result<'a, string>)
+
+/// Run a staged program with the LogSink captured: returns the verdict plus
+/// the envelopes channel 1 would have written, in stream order (via the
+/// subscriber — the exact feed the live Watch board consumes).
+let private runCaptured (program: unit -> Task<StagedVerdict<'a, 'e>>) : StagedVerdict<'a, 'e> * LogSink.Envelope list =
+    let captured = ResizeArray<LogSink.Envelope>()
+    LogSink.reset ()
+    LogSink.addSubscriber captured.Add
+    try
+        let verdict =
+            LogSink.withWriter (new System.IO.StringWriter()) (fun () ->
+                (program ()).GetAwaiter().GetResult())
+        verdict, List.ofSeq captured
+    finally
+        LogSink.clearSubscribers ()
+
+let private codesOf (envs: LogSink.Envelope list) : string list =
+    envs
+    |> List.filter (fun e -> e.Code.EndsWith ".started" || e.Code = "summary.stageCompleted")
+    |> List.map (fun e ->
+        if e.Code = "summary.stageCompleted" then
+            sprintf "completed:%O" (Map.find "stage" e.Payload)
+        else e.Code)
+
+let private outcomePayloadOf (stageKey: string) (envs: LogSink.Envelope list) : string =
+    envs
+    |> List.pick (fun e ->
+        if e.Code = "summary.stageCompleted"
+           && string (Map.find "stage" e.Payload) = stageKey
+        then Some (string (Map.find "outcome" e.Payload))
+        else None)
+
+// ---------------------------------------------------------------------------
+// the law — declared ⇔ executed∪aborted
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``R2: declared ⇔ executed∪aborted — every declared stage accounted, in declared order`` () =
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                let! b = Staged.stage (stage "deploy") (ok (a + 1))
+                let! c = Staged.stage (stage "canary") (ok (b + 1))
+                return c
+            })
+    match verdict.Disposition with
+    | RunCompleted 3 -> ()
+    | other -> Assert.Fail(sprintf "expected RunCompleted 3, got %A" other)
+    // The books: total over the declaration, in declared order, all bracket-closed.
+    Assert.Equal<string list>(
+        [ "extract"; "deploy"; "canary" ],
+        verdict.Outcomes |> List.map (fst >> StageName.value))
+    Assert.True(verdict.Outcomes |> List.forall (fun (_, o) -> match o with Completed _ -> true | _ -> false))
+    // The wire: started + completed per stage, in execution order, all succeeded.
+    Assert.Equal<string list>(
+        [ "extract.started"; "completed:extract"
+          "deploy.started";  "completed:deploy"
+          "canary.started";  "completed:canary" ],
+        codesOf envs)
+    Assert.Equal("succeeded", outcomePayloadOf "deploy" envs)
+
+[<Fact>]
+let ``R2: a stage body's Error closes the stage failed and skips the downstream arc by name`` () =
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! _ = Staged.stage (stage "extract") (ok 1)
+                let! _ = Staged.stage (stage "deploy") (err "no grant")
+                let! c = Staged.stage (stage "canary") (ok 3)
+                return c
+            })
+    match verdict.Disposition with
+    | RunStopped "no grant" -> ()
+    | other -> Assert.Fail(sprintf "expected RunStopped, got %A" other)
+    // deploy CLOSED (bracket plane) with the failed wire outcome; canary never opened.
+    Assert.Equal("failed", outcomePayloadOf "deploy" envs)
+    Assert.False(envs |> List.exists (fun e -> e.Code = "canary.started"))
+    match verdict.Outcomes with
+    | [ (_, Completed _); (_, Completed _); (_, Skipped reason) ] ->
+        Assert.Equal("run stopped at 'deploy'", reason)
+    | other -> Assert.Fail(sprintf "expected Completed/Completed/Skipped, got %A" other)
+
+[<Fact>]
+let ``R2: the Aborted arm — an exception closes the open stage aborted, never a board hang`` () =
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! _ = Staged.stage (stage "extract") (ok 1)
+                let! _ =
+                    Staged.stage (stage "deploy") (fun () ->
+                        task {
+                            failwith "connection lost"
+                            return (Ok 2 : Result<int, string>)
+                        })
+                let! c = Staged.stage (stage "canary") (ok 3)
+                return c
+            })
+    match verdict.Disposition with
+    | RunAborted (refusal, Some _) -> Assert.Contains("spine.stage.aborted: 'deploy'", refusal)
+    | other -> Assert.Fail(sprintf "expected RunAborted with its cause, got %A" other)
+    // The bracket CLOSED on the wire — outcome `aborted` — so the live board's
+    // line goes Halted instead of hanging Active forever.
+    Assert.Equal("aborted", outcomePayloadOf "deploy" envs)
+    match verdict.Outcomes with
+    | [ (_, Completed _); (_, StagedOutcome.Aborted r); (_, Skipped _) ] ->
+        Assert.Contains("connection lost", r)
+    | other -> Assert.Fail(sprintf "expected Completed/Aborted/Skipped, got %A" other)
+    // The display half of the law: folding the same envelope stream the live
+    // board consumes yields a Halted line — closed, honest, no hang.
+    let board =
+        envs |> List.fold (fun b e -> Watch.applyEnvelope b e |> fst) (Watch.seededOf spine3)
+    match board.Stages |> List.tryFind (fun s -> s.Key = "deploy") with
+    | Some { State = Watch.Halted _ } -> ()
+    | other -> Assert.Fail(sprintf "expected the deploy line Halted, got %A" other)
+    Assert.False(Watch.isTerminal board)
+
+[<Fact>]
+let ``R2: an undeclared stage refuses by name without opening a bracket`` () =
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! _ = Staged.stage (stage "extract") (ok 1)
+                let! x = Staged.stage (stage "verify") (ok 2)
+                return x
+            })
+    match verdict.Disposition with
+    | RunAborted (refusal, None) -> Assert.Contains("spine.stage.undeclared: 'verify'", refusal)
+    | other -> Assert.Fail(sprintf "expected the undeclared refusal, got %A" other)
+    // No phantom wire events for the undeclared stage.
+    Assert.False(envs |> List.exists (fun e -> e.Code = "verify.started"))
+
+[<Fact>]
+let ``R2: a re-entered stage refuses by name`` () =
+    let verdict, _ =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! _ = Staged.stage (stage "extract") (ok 1)
+                let! x = Staged.stage (stage "extract") (ok 2)
+                return x
+            })
+    match verdict.Disposition with
+    | RunAborted (refusal, None) -> Assert.Contains("spine.stage.reentered: 'extract'", refusal)
+    | other -> Assert.Fail(sprintf "expected the re-entry refusal, got %A" other)
+
+[<Fact>]
+let ``R2: an unvisited declared stage at completion is a named refusal, not a silent pass`` () =
+    let verdict, _ =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                return a
+            })
+    match verdict.Disposition with
+    | RunAborted (refusal, None) ->
+        Assert.Contains("spine.stages.unvisited", refusal)
+        Assert.Contains("deploy", refusal)
+        Assert.Contains("canary", refusal)
+    | other -> Assert.Fail(sprintf "expected the unvisited refusal, got %A" other)
+
+[<Fact>]
+let ``R2: an explicit skip keeps the books total with its named reason`` () =
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                do! Staged.skip (stage "deploy") "no sink configured this run"
+                let! c = Staged.stage (stage "canary") (ok (a + 2))
+                return c
+            })
+    match verdict.Disposition with
+    | RunCompleted 3 -> ()
+    | other -> Assert.Fail(sprintf "expected RunCompleted, got %A" other)
+    match verdict.Outcomes with
+    | [ (_, Completed _); (_, Skipped reason); (_, Completed _) ] ->
+        Assert.Equal("no sink configured this run", reason)
+    | other -> Assert.Fail(sprintf "expected the skip in the books, got %A" other)
+    // Ledger-only: a skipped stage never starts on the wire.
+    Assert.False(envs |> List.exists (fun e -> e.Code = "deploy.started"))
+
+[<Fact>]
+let ``R2: the umbrella root brackets the run — one level of nesting, by declaration`` () =
+    let rootSpine =
+        RunSpine.createWithRoot (stage "pipeline") [ stage "extract"; stage "emit" ]
+        |> Result.value
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged rootSpine {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                let! b = Staged.stage (stage "emit") (ok (a + 1))
+                return b
+            })
+    // The root's bracket encloses the whole arc on the wire.
+    Assert.Equal<string list>(
+        [ "pipeline.started"
+          "extract.started"; "completed:extract"
+          "emit.started";    "completed:emit"
+          "completed:pipeline" ],
+        codesOf envs)
+    // The root rides the verdict beside the declared books, never among them.
+    match verdict.Root with
+    | Some (r, Completed _) -> Assert.Equal("pipeline", StageName.value r)
+    | other -> Assert.Fail(sprintf "expected the root bracket completed, got %A" other)
+    Assert.Equal<string list>(
+        [ "extract"; "emit" ],
+        verdict.Outcomes |> List.map (fst >> StageName.value))
+    // The board elides the root: seeded from the spine, no root line appears.
+    let board =
+        envs |> List.fold (fun b e -> Watch.applyEnvelope b e |> fst) (Watch.seededOf rootSpine)
+    Assert.Equal<string list>([ "extract"; "emit" ], board.Stages |> List.map (fun s -> s.Key))
+    Assert.True(Watch.isTerminal board)
+
+[<Fact>]
+let ``R2: the stage bracket meters — Bench carries one stage-labelled sample per crossing`` () =
+    // Safe in the Global-MutableState collection: every Bench.reset caller in
+    // the pure pool serializes here.
+    Bench.reset ()
+    let _ =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                let! _ = Staged.stage (stage "deploy") (ok 2)
+                let! c = Staged.stage (stage "canary") (ok (a + 2))
+                return c
+            })
+    let labels = Bench.snapshot () |> List.map (fun s -> s.Label)
+    Assert.Contains("stage.extract", labels)
+    Assert.Contains("stage.deploy", labels)
+    Assert.Contains("stage.canary", labels)
+
+// ---------------------------------------------------------------------------
+// the declared spines — the retired string lists, pinned at their one
+// definition site
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``S2: the declared spines carry the per-face arcs the string lists carried`` () =
+    Assert.Equal<string list>([ "extract"; "profile"; "emit" ], RunSpine.keys Spines.pipeline)
+    Assert.Equal(Some "pipeline", RunSpine.rootKey Spines.pipeline)
+    Assert.Equal<string list>([ "emit"; "deploy"; "canary" ], RunSpine.keys Spines.migrate)
+    Assert.Equal<string list>([ "emit"; "deploy"; "canary"; "load" ], RunSpine.keys Spines.migrateData)
+    Assert.Equal<string list>([ "deploy" ], RunSpine.keys Spines.deploy)
+    Assert.Equal<string list>([ "load" ], RunSpine.keys Spines.transfer)

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -261,6 +261,53 @@ let ``R2: the stage bracket meters — Bench carries one stage-labelled sample p
     Assert.Contains("stage.canary", labels)
 
 // ---------------------------------------------------------------------------
+// the run-envelope bracket (card S4a) — ONE owner, both callers
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``S4a: RunEnvelope.bracket — runStart is the first event and runComplete the terminal one, with the verb's payload`` () =
+    let captured = ResizeArray<LogSink.Envelope>()
+    LogSink.reset ()
+    LogSink.addSubscriber captured.Add
+    try
+        let value =
+            LogSink.withWriter (new System.IO.StringWriter()) (fun () ->
+                RunEnvelope.bracket "projection test-verb"
+                    ignore
+                    (Map.ofList [ "configPath", box "cfg.json" ])
+                    (fun () -> 41 + 1, LogSink.Succeeded))
+        Assert.Equal(42, value)
+        let envs = List.ofSeq captured
+        let first = List.head envs
+        Assert.Equal("config.runStart", first.Code)
+        Assert.Equal(box "projection test-verb", Map.find "command" first.Payload)
+        Assert.Equal(box "cfg.json", Map.find "configPath" first.Payload)
+        Assert.Equal("summary.runComplete", (List.last envs).Code)
+    finally
+        LogSink.clearSubscribers ()
+
+[<Fact>]
+let ``S4a: RunEnvelope.bracket — a crashed body still closes its stream with the §10 terminal event`` () =
+    let captured = ResizeArray<LogSink.Envelope>()
+    LogSink.reset ()
+    LogSink.addSubscriber captured.Add
+    try
+        let thrown =
+            try
+                LogSink.withWriter (new System.IO.StringWriter()) (fun () ->
+                    RunEnvelope.bracket "projection test-verb" ignore Map.empty
+                        (fun () -> failwith "boom" : int * LogSink.Outcome))
+                |> ignore
+                false
+            with _ -> true
+        Assert.True(thrown, "the body's exception must propagate after the terminal event")
+        let last = List.last (List.ofSeq captured)
+        Assert.Equal("summary.runComplete", last.Code)
+        Assert.Equal(box "failed", Map.find "outcome" last.Payload)
+    finally
+        LogSink.clearSubscribers ()
+
+// ---------------------------------------------------------------------------
 // the declared spines — the retired string lists, pinned at their one
 // definition site
 // ---------------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -316,8 +316,10 @@ let ``S4a: RunEnvelope.bracket — a crashed body still closes its stream with t
 let ``S2: the declared spines carry the per-face arcs the string lists carried`` () =
     Assert.Equal<string list>([ "extract"; "profile"; "emit" ], RunSpine.keys Spines.pipeline)
     Assert.Equal(Some "pipeline", RunSpine.rootKey Spines.pipeline)
-    Assert.Equal<string list>([ "emit"; "deploy"; "canary" ], RunSpine.keys Spines.migrate)
-    Assert.Equal<string list>([ "emit"; "deploy"; "canary"; "load" ], RunSpine.keys Spines.migrateData)
+    Assert.Equal<string list>([ "emit"; "preflight"; "deploy"; "canary" ], RunSpine.keys Spines.migrate)
+    Assert.Equal<string list>(
+        [ "emit"; "preflight"; "deploy"; "canary"; "load" ],
+        RunSpine.keys Spines.migrateData)
     Assert.Equal<string list>([ "deploy" ], RunSpine.keys Spines.deploy)
     Assert.Equal<string list>([ "canary" ], RunSpine.keys Spines.canary)
     Assert.Equal<string list>([ "load" ], RunSpine.keys Spines.transfer)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -23,7 +23,7 @@ let private inScopeCodes : Set<string> =
           "profile.started"; "profile.completed"
           "emit.started"; "emit.completed"
           "deploy.started"; "canary.started"; "load.started"
-          "watch.runTitle"; "watch.runDone"
+          "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           "summary.stageCompleted"
           "config.validationFailed" ]
 
@@ -43,10 +43,11 @@ let private knownEmittableCodes : Set<string> =
           // data-transfer leg's load stage
           "deploy.started"; "canary.started"; "load.started"
           // the live Watch board's render-synthesized frame codes (§13) — the
-          // run-title header + the terminal done-frame. Not LogSink envelopes: the
-          // board is a *rendering* of the run, so its frame copy is voiced through
-          // the catalog (one register) and consumed at render, never emitted.
-          "watch.runTitle"; "watch.runDone"
+          // run-title header, the terminal done-frame, and the halted stage line
+          // (the R2 Aborted arm). Not LogSink envelopes: the board is a
+          // *rendering* of the run, so its frame copy is voiced through the
+          // catalog (one register) and consumed at render, never emitted.
+          "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           // round-trip verification verdict
           "canary.diffEmpty"; "canary.divergence"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -22,7 +22,7 @@ let private inScopeCodes : Set<string> =
           "extract.started"; "extract.completed"
           "profile.started"; "profile.completed"
           "emit.started"; "emit.completed"
-          "deploy.started"; "canary.started"; "load.started"
+          "preflight.started"; "deploy.started"; "canary.started"; "load.started"
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           "summary.stageCompleted"
           "config.validationFailed" ]
@@ -41,7 +41,7 @@ let private knownEmittableCodes : Set<string> =
           "emit.started"; "emit.completed"
           // the migrate leg's live stage stream (build → apply → verify) + the
           // data-transfer leg's load stage
-          "deploy.started"; "canary.started"; "load.started"
+          "preflight.started"; "deploy.started"; "canary.started"; "load.started"
           // the live Watch board's render-synthesized frame codes (§13) — the
           // run-title header, the terminal done-frame, and the halted stage line
           // (the R2 Aborted arm). Not LogSink envelopes: the board is a
@@ -180,7 +180,7 @@ let ``Voice register: the error frames clear the banned list`` () =
 let ``Voice stageName: every emitted internal stage maps to an operator name`` () =
     // The stages `LogSink.recordStageEvent` emits today (Pipeline + FullExportRun
     // + the migrate leg's deploy / canary phases).
-    let emittedStages = [ "pipeline"; "extract"; "profile"; "emit"; "deploy"; "canary"; "load" ]
+    let emittedStages = [ "pipeline"; "extract"; "profile"; "emit"; "preflight"; "deploy"; "canary"; "load" ]
     for s in emittedStages do
         Assert.NotEqual<string>(s, Voice.stageName s)   // never the internal verb
 

--- a/sidecar/projection/tests/Projection.Tests/WatchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchTests.fs
@@ -68,6 +68,55 @@ let ``Watch board: stageCompleted flips the line to Done with its duration`` () 
     | other -> Assert.Fail(sprintf "expected extract Done 1200, got %A" other)
 
 [<Fact>]
+let ``Watch board: a stageCompleted with a failed or aborted outcome goes Halted, never a misstating Done`` () =
+    // The R2 Aborted arm on the board: the line CLOSES (no hang) and reads
+    // halted (no `✓` for a stage that did not succeed).
+    let close outcome =
+        let board, _ = Watch.apply Watch.empty "deploy.started" Map.empty
+        Watch.apply board "summary.stageCompleted"
+            (payload [ "stage", box "deploy"; "durationMs", box 700L; "outcome", box outcome ])
+    match close "aborted" with
+    | { Stages = [ { Key = "deploy"; State = Watch.Halted(Some 700L) } ] }, true -> ()
+    | other -> Assert.Fail(sprintf "expected deploy Halted on aborted, got %A" other)
+    match close "failed" with
+    | { Stages = [ { State = Watch.Halted(Some 700L) } ] }, true -> ()
+    | other -> Assert.Fail(sprintf "expected deploy Halted on failed, got %A" other)
+    match close "succeeded" with
+    | { Stages = [ { State = Watch.Done(Some 700L) } ] }, true -> ()
+    | other -> Assert.Fail(sprintf "expected deploy Done on succeeded, got %A" other)
+
+[<Fact>]
+let ``Watch board: a halted stage blocks the done-frame — the arc did not land`` () =
+    let board = Watch.seeded [ "deploy"; "canary" ]
+    let started, _ = Watch.apply board "deploy.started" Map.empty
+    let halted, _ =
+        Watch.apply started "summary.stageCompleted"
+            (payload [ "stage", box "deploy"; "durationMs", box 1L; "outcome", box "aborted" ])
+    Assert.False(Watch.isTerminal halted)
+    Assert.True((Watch.doneFrameText halted).IsNone)
+
+[<Fact>]
+let ``Watch line: a halted stage voices the stop — candid, never a checkmark phrase`` () =
+    let text = Watch.lineText { Key = "deploy"; State = Watch.Halted(Some 1200L) }
+    Assert.Contains("Deploy stopped", text)
+    Assert.Contains("1.2s", text)
+    Assert.DoesNotContain("complete", text)
+
+[<Fact>]
+let ``Watch board: seededOf derives the arc and the umbrella from the declared spine`` () =
+    // R2 — the pre-seeds derive from the declaration (the per-face string
+    // lists retired onto `Spines`).
+    let board = Watch.seededOf Projection.Pipeline.Spines.pipeline
+    Assert.Equal<string list>(
+        [ "extract"; "profile"; "emit" ],
+        board.Stages |> List.map (fun s -> s.Key))
+    Assert.True(board.Stages |> List.forall (fun s -> s.State = Watch.Pending))
+    // The spine's declared root is the elided umbrella.
+    let afterRootStart, changed = Watch.apply board "pipeline.started" Map.empty
+    Assert.False changed
+    Assert.Equal(3, List.length afterRootStart.Stages)
+
+[<Fact>]
 let ``Watch board: the pipeline umbrella stage is elided`` () =
     let board, changed =
         Watch.apply Watch.empty "summary.stageCompleted" (payload [ "stage", box "pipeline"; "durationMs", box 5L ])
@@ -123,7 +172,9 @@ let ``Watch line: every stage line clears the twelve-rule banned list`` () =
           Watch.lineText { Key = "deploy";  State = Watch.Active(Some { Done = 142; Total = 300; ElapsedMs = 4000L }) }
           Watch.lineText { Key = "extract"; State = Watch.Done(Some 1200L) }
           Watch.lineText { Key = "profile"; State = Watch.Done None }
-          Watch.lineText { Key = "emit";    State = Watch.Done(Some 800L) } ]
+          Watch.lineText { Key = "emit";    State = Watch.Done(Some 800L) }
+          Watch.lineText { Key = "deploy";  State = Watch.Halted(Some 700L) }
+          Watch.lineText { Key = "canary";  State = Watch.Halted None } ]
     for line in lines do
         let lowered = line.ToLowerInvariant()
         for b in banned do


### PR DESCRIPTION
## Summary

This PR implements the structural leg of the stage spine (CONSTELLATION §9.3, backlog stage 2), introducing the `staged { }` computation expression and the R2 law that ensures `declared ⇔ executed∪aborted` — every declared stage is accounted for by name at run end, with the Aborted arm as a first-class outcome.

## Key Changes

**Core Types & Validation (S1)**
- Added `StageName` private smart constructor with validation (non-blank, dot-free to protect wire-code prefix convention)
- Added `RunSpine` with optional umbrella root scope and declared stages (distinct, non-empty, in execution order)
- Added `StagedOutcome` enum: `Completed of durationMs | Aborted of refusal | Skipped of reason` (RI-2 third arm)
- Extracted `Meter.pass` as a value (pass-grain decoration, identity on value plane) in new `Meter.fs`

**Computation Expression (S2)**
- Implemented `staged spine { }` CE in `RunSpine.fs` with:
  - `Bind` that brackets each stage crossing: `Bench.scope "stage.<name>"`, `<stage>.started` envelope, and `summary.stageCompleted` close
  - `Run` closure that balances the books: validates all declared stages are accounted for, names any missed/extra/re-entered stages as refusals
  - Proper handling of exceptions (closes bracket as `aborted` on wire, never leaves hanging)
  - Skipping of downstream stages when a stage body returns `Error` or an exception occurs

**Run Envelope Bracket (S4)**
- Added `RunEnvelope.fs` to consolidate the run-envelope bracket (previously hand-rolled in two places)
- Guarantees fresh runId + Bench state, `config.runStart` envelope, registry inventory, body execution, and terminal `summary.runComplete`

**Face Integration (S3, S4b, S4c)**
- Updated `RunFaces.fs` deploy face to use `staged Spines.deploy` CE
- Updated `MigrationRun.fs` to wrap execution in `staged Spines.migrate` with `preflight` stage for CDC + tightening gates
- Updated `TransferRun.fs` load path to use `staged Spines.transfer` CE (converted mutable locals to ref cells for closure capture)
- Updated `Pipeline.fs` `Compose.runWithConfig` to use `staged Spines.pipeline` CE with umbrella root

**Watch Board Integration**
- Added `Halted` state to `Watch.StageState` for stages that closed with non-success outcome (`failed`/`aborted`)
- Updated `Watch.applyEnvelope` to transition to `Halted` instead of `Done` when outcome is not `succeeded`
- Added `Umbrella` field to `Watch.Board` for the spine's root scope (elided from display)

**Voice & Display**
- Added "Safety checks" stage name mapping for `preflight` stage
- Updated stage-name mappings to align with new spine structure

## Notable Implementation Details

- The law is enforced structurally: invalid stage names/spines are unrepresentable (private ctors + `[<RequireQualifiedAccess>]`)
- The Aborted arm closes the wire bracket with outcome `aborted`, ensuring the board line goes `Halted` (closed and honest) rather than hanging `Active`
- Stage duration is measured at the bracket plane; `Completed` carries the duration but the wire outcome (`succeeded`/`failed`) rides the envelope
- Nesting is one level by declaration: the root brackets the run; declared stages are the arc inside it
- The CE is synchronous + sequential; mutable state is confined to one `Run` invocation (LogSink boundary precedent)

## Tests

- Added `RunSpineTests.fs` with smart constructor validation tests
- Added `StagedTests.fs` with comprehensive R2 law verification (declared ⇔ executed∪aborted, exception handling, skipping)
- Added `WatchTests.fs` test for

https://claude.ai/code/session_0167Hiptm1BnXjmunQDXWLHq