### PR TITLE
Voice migration, face 1: full-export --load — headers retired, verdict voiced

### DIFF
--- a/sidecar/projection/CLAUDE.md
+++ b/sidecar/projection/CLAUDE.md
@@ -115,7 +115,11 @@ within their first session. Everything not on this list, this file only points t
    failing the 100k-row scale tests after several full Docker-pool runs on one warm
    container — the instance's memory pool degrades with accumulated load; it is the
    container, not the code. Restart, re-run the failed class focused, and only then suspect
-   a regression.
+   a regression. *Root cause found 2026-06-12 (L/R session): per-run databases were never
+   dropped on the warm container (209 counted after one session) — `withBootstrappedDatabase`
+   now reaps on exit, so accumulation is structural-fixed; the restart remedy stays for
+   long-lived containers predating the fix. A fourth signature from the same family:
+   **a batch of pre-login-handshake failures** across warm-container suites — same remedy.*
 3. **Never `pgrep`-guard a test run; never watch a run through `| tail`** — the guard matches
    itself and tail buffers to EOF. Launch bare in the background; poll `test.sh status`.
 4. **On any `Failed: N>0`, re-run with the TRX logger and grep the TRX** — console output

--- a/sidecar/projection/CONSTELLATION.md
+++ b/sidecar/projection/CONSTELLATION.md
@@ -904,7 +904,7 @@ Each promotion follows the corpus's protocol: the feature-surface row, the trigg
 | CE builder for the spine | precedented — the lineage/diagnostics builders are canonical | R2: metering graduates from discipline to syntax | `StagedBuilder`, Pipeline/CLI |
 | private-DU proof tokens | precedented — `ArtifactByKind` is the worked example | R3 admission; R5 parallel safety | `Verified<_>`, `ParallelSafe<_>` |
 | `[<Struct>]` records | consciously deferred; trigger = "allocation pressure on a hot pass" | trigger **fired** by the measured row-carrier priors | `RowQuantum` only |
-| units of measure | deferred at H-013; trigger = mixed quantities in one expression | trigger **fires** at `Run.diff` (ms × counts, one surface) | the delta surface only; hot accumulators stay raw |
+| units of measure | deferred at H-013; trigger = mixed quantities in one expression | trigger **fires** at `Run.diff` (ms × counts, one surface) — **landed 2026-06-12 with card R1d** (`[<Measure>] ms`, `Run.fs`) | the delta surface only; hot accumulators stay raw |
 | `ReadOnlySpan<byte>` / `ValueTask` | already precedented (`PhysicalSchema.fs:345`; `Retry.fs:110`) | — | hashing/codec/retry boundaries, unchanged |
 | record-of-functions contracts | house-preferred over interfaces and object expressions | R3's two existing consumers + the harness third | `LedgerSpec`, Core |
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -542,32 +542,41 @@ machinery (a single full-state quantum has no partial sums; the no-op IS the res
 
 ### Stage 4 — the Run, completed and wired (R1, reframed per RI-1)
 
-**R1a · Complete the aggregate.** Add to the existing `Run.Run`: `Ledgers : LedgerRef list`
-(journal file digests + episode coordinates) and `Bench : Bench.Run option`. Keep the
-shipped ULID + `InputDigest` factoring (the thesis's content-addressed-RunId design is
-withdrawn). Codec discipline per the house (totality over the new fields). S. Deps: none
-(better after L1 for `LedgerRef` naming). Rollback: additive fields.
+**R1a · Complete the aggregate — DONE 2026-06-12.** `Run.Run` gained `Ledgers : LedgerRef
+list` (JournalRef digest / EpisodeRef coordinate — the run-side name for the R3 instances)
+and `Bench : Bench.Run option`; ULID + `InputDigest` factoring kept. Codec totality
+hand-built (Bench.Stats is an F# list — STJ deserialize foreclosed); pre-R1a files load
+with `[]`/`None`. *Witness shipped:* the populated round-trip law (+1).
 
-**R1b · Wire capture into the envelope — census corrected per RI-11.** `withRun` calls
-`Run.capture`+`Run.save` under the existing `PROJECTION_LEDGER_DIR` (not a second env var);
-the orphan verbs move under `withRun` — **~21 of 27 faces run bare today**, not ~11, so the
-card scopes by the law: every envelope-*emitting* verb moves; pure read-only verbs that mint
-no envelopes may stay outside, each named in the commit. The `runReadiness` orphan
-`beginRun` (`RunFaces.fs:930`) is fixed. *Witness:* `` `every verb's run is capturable: no
-orphan RunIds` ``. M–L. Deps: R1a; after S4 if sequenced late (the spine changes what
-`withRun` brackets — do R1b after S4 to wire once). Rollback: env-gated.
+**R1b · Wire capture into the envelope — DONE 2026-06-12.** Capture landed at the ONE
+bracket owner (`RunEnvelope.bracket` — the "after S4, to wire once" clause realized
+literally): under `PROJECTION_LEDGER_DIR` every bracketed run persists `run.json` (events +
+bench snapshot; crashed bodies included). The emitting orphans moved under `withRun`
+(transfer, reverse-leg, migrate, migrate --with-data, synth-load); `runReadiness`'s orphan
+`beginRun` RETIRED (the face brackets directly — no ledger append for the query, per its
+documented contract); the envelope-free faces stay bare, each named in the commit.
+InputDigest stays `""` at the bracket grain, named (per-face threading is consumer
+territory). *Witness shipped:* `` `R1b: every bracketed verb's run is capturable — no
+orphan RunIds` ``.
 
-**R1c · Bench keyed by run.** `BenchSink` filename = RunId (wall-clock moves inside the
-value — `BenchSink.fs`'s reified boundary relocated, not deleted); `perf-gate.sh` discovery
-updated from mtime-glob to newest-run. S. Deps: R1a. Rollback: dual-write one release.
+**R1c · Bench keyed by run — DONE 2026-06-12.** `BenchSink.runPath` (bench/<tag>/<runId>.json;
+`defaultPath` retired; ULID keeps the chronological `ls | sort` walk); wall-clock lives only
+inside the value (`CapturedAtUtc`). `perf-gate.sh` discovery = lexical max over ULID-shaped
+names; legacy-only directories fall back to mtime WITH a logged warning. Baseline NOT
+re-recorded (no floor moved).
 
-**R1d · The projections.** `inspect <runId>` (D5 — the store already resolves; the verb
-renders) and `diff <runA> <runB>` (`Run.diff` with the UoM delta surface; the harness's
-before/after becomes its restriction to KeyLabels). M. Deps: R1a–c. Rollback: read-only verbs.
+**R1d · The projections — DONE 2026-06-12.** `projection inspect <runId>` renders the
+stored aggregate; `inspect <a> <b>` renders `Run.diff` — the §7 UoM promotion FIRED here,
+scoped to the delta surface (`[<Measure>] ms`); the keyLabels restriction is the harness's
+before/after shape. *Deviation, named:* the card's `diff <runA> <runB>` verb name is held
+by the shipped catalog-refs diff — the run-grain projection lands under `inspect` (one noun
+per surface). `Run.storeDir` = the one reader resolution rule (RUNS_DIR else LEDGER_DIR).
 
-**R1e · The law.** `` `R1: live view ≡ projection of the stored Run` `` — the Watch board
-reconstructed from `Run.Events` equals the board the live subscriber built; `readiness`
-gauges over `RunHistory`. S. Deps: R1b, S2 (the spine makes board-reconstruction total).
+**R1e · The law — DONE 2026-06-12.** `` `R1: live view ≡ projection of the stored Run` ``:
+`Watch.boardOfStored` folds the persisted NDJSON trail through the SAME `apply` the live
+subscriber feeds — witnessed equal on a mixed run (Halted + ledger-only Skip arms; the S2
+spine makes the reconstruction total). `RunHistory.readiness` already existed; its
+equivalence to the ledger projection is now witnessed (two stores, one gauge).
 
 ### Stage 5 — the row quantum (R4, gated; corrected per RI-4)
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -686,11 +686,20 @@ Bucket-B convention witness (+1); the leveled ≡ sequential equivalence ran GAT
 **P2 · Production leveled data deploy.** The canary-only wiring promoted to the CLI deploy
 path behind the existing parallelism resolution stack. *Witness:* operator-reality canary +
 perf-gate (baseline re-record only if the floor moves, with its DECISIONS amendment). S.
-Deps: P1 (met), and a Stage-0/1 measurement showing the win at operator scale. *Gate state
-(2026-06-12):* segment-level evidence is registered — the 20-table microbench shows
-sequential 782ms → parallel(4) 411ms (1.90×) — but the OPERATOR-SCALE before/after through
-the production face (6.25k×150, the perf-gate envelope) has not been run; the gate stands
-half-met, do not wire on the microbench alone.
+Deps: P1 (met), and a Stage-0/1 measurement showing the win at operator scale — **gate MET
+2026-06-12**: the declared `leveled-deploy-150x42` scenario (150 independent static kinds ×
+42 rows = the operator envelope, through the REAL composer + leveled plan + the existing
+`resolveParallelism` stack, paired legs on one container) replicated **2.59× / 2.65× /
+2.85×** across three runs (sequential ~2.0–2.1s → leveled-parallel ~0.74–0.79s at
+parallelism 4). One command re-runs it: `perf-harness.sh run leveled-deploy`. *What the
+wiring slice must decide (named so it isn't re-derived):* the two candidate faces are
+`runDeploy → runFromCatalogWith → runEphemeral` (deploys `aggregateSsdt`'s fused
+schema+seeds single batch — splitting schema-vs-data there must keep the deploy FAITHFUL to
+the published bundle, never a re-composition that can diverge from it) and the full-export
+load leg (`Compose.runWithConfigAndLoad` takes an injected `SqlConnection -> string -> Task`
+executor — `executeBatchParallel` needs the connection STRING for per-segment opens, so the
+executor seam needs re-threading). Witnesses stay as carded: operator-reality canary +
+perf-gate, baseline re-record only if the floor moves, with its DECISIONS amendment.
 
 **P3 · Schema-side levels.** `statementsWith` gains a leveled grouping (inline-FK fact makes
 level-by-level the only safe shape — RI-5); deploy through `ParallelSafe`. **Trigger-held:**

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -671,15 +671,26 @@ container, back-to-back with the BEFORE) — see PERF_HARNESS §5 Q-arc results.
 
 ### Stage 6 — licensed parallelism (R5, corrected per RI-5)
 
-**P1 · `ParallelSafe`, minted by `levels`.** The token + `executeBatchParallel` re-signed to
-demand it + `ComprehensiveCanaryTests` updated as the first consumer; the `Deploy.fs:436`
-stale docstring retired. *Witness:* the leveled ≡ sequential equivalence already in the
-canary, now type-guarded. S. Deps: none.
+**P1 · `ParallelSafe`, minted by `levels` — DONE 2026-06-12.** The proof token landed in
+Core beside its one mint (`TopologicalOrder.levels`, re-typed `→ ParallelSafe<SsKey> list`);
+`map`/`choose` are the structure-preserving carriers, so the token rides the composer's
+rendering (`LeveledDeploymentText` carries `ParallelSafe<string>` per level — the cross-kind
+`String.Concat` and its LINT-ALLOW retired). `executeBatchParallel` RE-SIGNED to demand the
+token (miswiring is a compile error; segment bytes + bench labels unchanged — per-member
+split ≡ split-of-concat over GO-terminated members); the stale `Deploy.fs` status note
+retired (RI-5). The primitive tests mint through the REAL prover. The manifest's
+`DeploymentBatches` wire shape kept via the read-only `members` view. *Witnesses:* the
+Bucket-B convention witness (+1); the leveled ≡ sequential equivalence ran GATE-OPEN
+(comprehensive canary 1/1, 4m17s, empty PhysicalSchema diff).
 
 **P2 · Production leveled data deploy.** The canary-only wiring promoted to the CLI deploy
 path behind the existing parallelism resolution stack. *Witness:* operator-reality canary +
 perf-gate (baseline re-record only if the floor moves, with its DECISIONS amendment). S.
-Deps: P1, and a Stage-0/1 measurement showing the win at operator scale.
+Deps: P1 (met), and a Stage-0/1 measurement showing the win at operator scale. *Gate state
+(2026-06-12):* segment-level evidence is registered — the 20-table microbench shows
+sequential 782ms → parallel(4) 411ms (1.90×) — but the OPERATOR-SCALE before/after through
+the production face (6.25k×150, the perf-gate envelope) has not been run; the gate stands
+half-met, do not wire on the microbench alone.
 
 **P3 · Schema-side levels.** `statementsWith` gains a leveled grouping (inline-FK fact makes
 level-by-level the only safe shape — RI-5); deploy through `ParallelSafe`. **Trigger-held:**

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -502,29 +502,43 @@ gates into a declared arc, R1b-adjacent territory). S. Deps: S4.
 
 ### Stage 3 — the ledger contract (R3, corrected per RI-3)
 
-**L1 · `LedgerSpec`, corrected.** Core, pure: `Genesis/Apply/FingerprintOf` **plus the
-admission split** — `WriteAdmit` (external-witness-capable; mints `Verified<_>`) and
-`ResumeAdmit` (recomputation vs stored fingerprint). `Ledger.replay`/`resumePoint` over
-verified entries. *Witness:* the FsCheck FTC property over a constructed-valid generator. M.
-Deps: none (F4 recommended first). Rollback: revert; instances not yet cut over.
+**L1 · `LedgerSpec`, corrected — DONE 2026-06-12.** Core, pure (`Ledger.fs`):
+`Genesis/Apply/FingerprintOf` **plus the admission split** — `Ledger.writeAdmit`
+(external-witness-capable; mints the private-ctor `Verified<_>` token) and
+`Ledger.resumeAdmit` (recomputed-vs-stored fingerprint; the recomputation is the instance's
+I/O — Core compares values and returns a typed `LedgerDrift` on disagreement).
+`Ledger.replay` (the FTC fold) / `resumePoint` (first absent position — an index, not a
+prefix) over verified entries. *Witness shipped:* the FsCheck FTC property + the partial-sum
+step law + crash-at-k + seven siblings (`LedgerTests.fs`, +9 pure pool).
 
-**L2 · The journal instance.** `CaptureJournal` re-expressed on the contract; the effectful
-remap fold adapted at the instance (the spec stays pure); resume path of
-`writePlanStreaming` re-routed through `Ledger.resumePoint`. *Witness:* `` `R3: crash at
-chunk k resumes at k; drift refuses by name` `` + the streaming ≡ materialized equivalence
-canary, unchanged. M. Deps: L1, F4. Rollback: the old inline path is one commit back; the
-equivalence canary guards both.
+**L2 · The journal instance — DONE 2026-06-12.** `CaptureJournal` re-expressed on the
+contract (`fingerprintOf`/`toEntry`/`spec`); the effectful remap fold adapted at the
+instance (Apply feeds pairs into the SHARED in-flight remap it is handed — Genesis is the
+live accumulator). *Shape correction at the cut:* the card's "re-routed through
+`Ledger.resumePoint`" landed as **`Ledger.resumeAdmit` per chunk** — the journal's resume is
+per-chunk admission against the `(kind, chunkIx)` last-write-wins index, not a single point;
+`resumePoint` carries the kind's chain-form law in the witnesses. WriteAdmit is named as
+POSITIONAL (the append sits after the chunk's atomic commit point — ceremony refused).
+`digestOf` untouched — **F1-hex stays armed** (§6 item 13). Drift maps the typed
+`LedgerDrift` onto the same `transfer.resume.sourceDrift` (code+message bytes unchanged;
+recorded/recomputed fingerprints added as metadata). *Witnesses shipped:* +3 pure-pool
+instance laws; the four Docker ReverseLegStreaming witnesses green unchanged.
 
-**L3 · The episode instance, honestly.** The snapshot-chain instance: `WriteAdmit` = the
-B′≡B witness (`recordVerified` re-expressed as the `Verified` mint); `ResumeAdmit` = ordinal
-monotonicity (named as such — the contract does NOT pretend to re-verify B′≡B at load); the
-FTC fold remains the *verification property*, not the recovery path. The store keeps full
-snapshots — converting to stored-diffs is **refused** (§6). *Witness:* `LifecycleStoreTests`
-green, unchanged. S. Deps: L1. Rollback: revert.
+**L3 · The episode instance, honestly — DONE 2026-06-12.** `recordVerified` re-expressed as
+the grain's WriteAdmit (`Ledger.writeAdmit` mints `Verified<MigrationOutcome>` on B′≡B;
+refusal shape unchanged, AC-P8 trio held); `ResumeAdmit` = ordinal monotonicity, named as
+such at both seats (`EpisodicLifecycle.append`, `LifecycleStore.buildLifecycle`) — the
+contract does NOT pretend to re-verify B′≡B at load; `reconstructLatestSchema` named as the
+*verification property*, not the recovery path (the snapshot dual). The store keeps full
+snapshots — stored-diffs stays **refused** (§6). *Witness:* the lifecycle-store +
+MigrationRun suites green, unchanged (zero new tests, by design).
 
-**L4 · G10 onto the contract.** The progress table as the trivial single-quantum instance —
-retired as a separate mechanism, honest that it exercises nothing (RI-3). *Witness:* the
-resumable-transfer Docker test, unchanged. S. Deps: L2.
+**L4 · G10 onto the contract — DONE 2026-06-12.** The progress table named as the DEGENERATE
+single-quantum instance (entry = the whole run; fingerprint = `planMarker` recomputed per
+run, equality realized as SQL set-membership; WriteAdmit positional at `markComplete`) —
+retired as a separate ledger mechanism, honest that it exercises nothing of the replay
+machinery (a single full-state quantum has no partial sums; the no-op IS the resume).
+*Witness:* AC-G10 Docker test green, unchanged.
 
 ### Stage 4 — the Run, completed and wired (R1, reframed per RI-1)
 

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21694,3 +21694,74 @@ stage skips the downstream arc (no more phantom failed `emit` after a
 failed `profile`); migrate runs gain `preflight` started/completed
 pairs and stage-table entries. The pinned FullExportCliTests slice-7
 trio held without amendment.
+
+## 2026-06-12 — The ledger contract and the Run land (cards L1–L4, R1a–R1e); the UoM gate fires
+
+The R3 + R1 legs of the constellation backlog are CLOSED, on the
+admission-split correction (RI-3) and the complete-don't-rebuild
+reframe (RI-1). The disciplines that outlive the diffs:
+
+**L — one contract, three honest instances.** `LedgerSpec`
+(Genesis/Apply/FingerprintOf, Core, pure) + the proof-token
+`Verified<_>` whose only mints are the two admission arms: `writeAdmit`
+(the external witness, checked at the one moment it is checkable) and
+`resumeAdmit` (recomputed-vs-stored fingerprint; Core compares values,
+the recomputation stays the instance's I/O). The journal instance
+adapts the EFFECTFUL remap fold (Genesis = the run's shared in-flight
+accumulator); the episode instance says plainly that load-time
+verification is chain structure (ordinal monotonicity), never a
+re-verification of B′≡B; the G10 marker is the degenerate
+single-quantum instance, retired as a separate mechanism. Two
+refusals, named: a ceremonial writeAdmit at the journal's append
+(control flow already proves the witness), and the card's
+resumePoint-in-the-walk (the journal resumes per chunk against a
+last-write-wins index; resumePoint keeps the chain-form law).
+F1-hex stays armed — `digestOf` untouched.
+
+**R1 — the aggregate completed, capture wired ONCE.** `Run.Run` gains
+`Ledgers : LedgerRef list` + `Bench : Bench.Run option` (codec
+hand-built: Bench.Stats is an F# list, STJ deserialize foreclosed).
+Capture lives at the single bracket owner (`RunEnvelope.bracket`):
+under `PROJECTION_LEDGER_DIR` every bracketed run persists run.json —
+crashed bodies included, no orphan RunIds. The envelope-emitting
+orphans moved under `withRun` (transfer, reverse-leg, migrate ×2,
+synth-load); `runReadiness`'s orphan beginRun retired by bracketing
+the face directly (no ledger append for the query — its documented
+contract). Bench snapshots key by RunId (`BenchSink.runPath`;
+perf-gate discovery off mtime, legacy fallback logged). `inspect
+<runId> [<runId>]` renders the store and the `Run.diff` delta surface —
+where the §9.7 units-of-measure promotion FIRED, scoped as gated
+(`[<Measure>] ms`; a bench millisecond cannot add to a transform
+count). R1e's law holds witnessed: the board reconstructed from a
+stored run's envelope trail equals the live board (mixed run — Halted
++ ledger-only Skip), and readiness over RunHistory equals the ledger
+projection.
+
+## 2026-06-12 — The test pools pay for work, not ceremony; §4 rule 2's third signature is root-caused
+
+Operator-directed optimization, measurement-first. Three findings with
+teeth:
+
+1. **The ~3.4s flat per-test floor was the DROP.** SINGLE_USER WITH
+   ROLLBACK IMMEDIATE killing the body's idle pooled per-DB session:
+   3051ms measured; 51ms with the pool evicted first. One incision at
+   `ContainerFixtureSupport.withEphemeralDatabase` (+ three inline
+   sites). LiveProfilerIntegrationTests: median 3.46s → 0.43s.
+2. **The warm container was dying of leaked databases.**
+   `withBootstrappedDatabase` never dropped (209 user DBs after one
+   session) — the root cause of rule 2's third signature. It reaps on
+   exit now; a full fast run adds zero databases. `runEphemeral`
+   deliberately unchanged (the deploy-to-docker flow leaves an
+   inspectable database by design).
+3. **The pool split now follows the attribute, not the filename.** The
+   substring split had broken BOTH ways: six Docker-collection tests
+   ran inside the parallel fast pool (one cold-starting an isolated
+   container there), and six pure AxiomTests whose names embed Docker
+   class names ran inside the serial docker pool. Set-diff proves the
+   exact 6↔6 swap, nothing dropped. Plus: build skipped when the test
+   DLL is newer than every input (~100ms scan vs ~10s no-op MSBuild);
+   every passing pool prints its five slowest.
+
+The pools: fast 58–71s → **31s**; docker 925s → **383s** (229/0). The
+remaining docker wall is dominated by the two 100k sustained-envelope
+measurements (71s) — witnesses, not overhead; they stay.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21791,3 +21791,28 @@ empty PhysicalSchema diff).
 operator-scale before/after through the production face has NOT been
 run; P2 stays open and must not wire on the microbench alone. P3 stays
 trigger-held on harness evidence of schema-deploy as a bottleneck.
+
+## 2026-06-12 — P2's gate is MET: leveled-parallel wins 2.6–2.9× at the operator envelope (wiring owed, design constraint named)
+
+The declared `leveled-deploy-150x42` harness scenario (150 independent
+static kinds × 42 rows — the perf-gate canary's table count and
+volume; independent lookups ARE the static-seed topology) ran the
+paired comparison through the REAL path: `composeRenderedLeveled` →
+`ParallelSafe` levels → `executeBatchParallel` under the existing
+`resolveParallelism` stack, against today's production shape (the
+aggregated sequential batch). Three runs, one warm container,
+back-to-back legs: **2.85× / 2.59× / 2.65×** (sequential ~2.0–2.1s →
+parallel ~0.74–0.79s at parallelism 4). The scenario landed DECLARED
+(H7: `all` + the PERF-SCENARIO registry + the gated fact; totality
+test green), and `StaticCatalogFixtures` gained the N-kind form
+(`staticCatalogOfKinds`) rather than a fifth hand-rolled instance —
+`staticCatalog` now delegates, key shapes byte-identical.
+
+The WIRING is deliberately left to its own slice, with the design
+constraint recorded on the card so it is not re-derived: `runEphemeral`
+deploys `aggregateSsdt`'s fused schema+seeds, so a schema-vs-data split
+there must stay FAITHFUL to the published bundle; the full-export load
+leg injects a `SqlConnection -> string -> Task` executor, while
+`executeBatchParallel` needs the connection STRING for per-segment
+opens — the seam needs re-threading. Witnesses for the wire stay as
+carded (operator-reality canary + perf-gate).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21765,3 +21765,29 @@ teeth:
 The pools: fast 58–71s → **31s**; docker 925s → **383s** (229/0). The
 remaining docker wall is dominated by the two 100k sustained-envelope
 measurements (71s) — witnesses, not overhead; they stay.
+
+## 2026-06-12 — P1 lands: ParallelSafe, minted by levels (the comment-borne MUST becomes a type)
+
+The R5 proof-token (RI-5 corrected): `ParallelSafe<'a>` (private ctor,
+Core, beside its one mint — `TopologicalOrder.levels`, re-typed to
+return `ParallelSafe<SsKey> list`). `map`/`choose` are the
+structure-preserving carriers: per-member projection and per-member
+dropping cannot merge groups or smuggle a dependent member in, so the
+independence proof rides the composer's rendering to
+`Deploy.executeBatchParallel`, which now DEMANDS the token — the
+docstring MUST died, the type lives. Equivalences held by
+construction: per-member batch-split ≡ split-of-concatenation
+(GO-terminated members), so segment bytes and the bench label series
+are unchanged; the manifest's `DeploymentBatches` keeps its wire shape
+through the read-only `members` view. The primitive's tests mint
+through the real prover (n independent kinds → one level → per-member
+map), not a fixture backdoor. The leveled ≡ sequential equivalence ran
+GATE-OPEN per §4 rule 12 (the comprehensive canary soft-skips in the
+docker pool by design — its verdict was confirmed at 1/1, 4m17s,
+empty PhysicalSchema diff).
+
+**P2's gate, honestly:** the 20-table microbench registers 1.90×
+(782ms → 411ms at parallelism 4) — segment-level evidence only. The
+operator-scale before/after through the production face has NOT been
+run; P2 stays open and must not wire on the microbench alone. P3 stays
+trigger-held on harness evidence of schema-deploy as a bottleneck.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,96 @@
+# Handoff addendum — 2026-06-12, generation 6 CLOSE (the contract leg is CLOSED: L1→L4 + R1a→R1e; the Voice lane advanced; the pools pay for work)
+
+To the next agent.
+
+The books balance. What you inherit, in order of weight:
+
+**1. The ledger contract is LIVE (L1→L4) on the RI-3 admission split.**
+`LedgerSpec` + the `Verified<_>` proof token in Core (`Ledger.fs`);
+`writeAdmit` (external witness — B′≡B at `recordVerified`; the
+journal's commit-point position) vs `resumeAdmit` (recomputed-vs-stored
+fingerprint; drift is typed, mapped onto the unchanged
+`transfer.resume.sourceDrift`). The journal instance adapts the
+effectful remap fold (Genesis = the shared in-flight accumulator); the
+episode instance names load-time verification as chain structure,
+honestly; G10 is the degenerate single-quantum instance, retired as a
+second mechanism. Two card corrections are named in the backlog (L2's
+resumePoint→resumeAdmit-per-chunk; the positional WriteAdmit). F1-hex
+stays ARMED — `digestOf` was never touched.
+
+**2. The Run is COMPLETE and WIRED (R1a→R1e).** Capture lives at the
+ONE bracket owner (`RunEnvelope.bracket`, the "wire once" clause
+realized literally): under `PROJECTION_LEDGER_DIR`, every bracketed
+run persists its aggregate — crashed bodies included, no orphan
+RunIds. Transfer/reverse-leg/migrate/migrate-with-data/synth-load
+moved under `withRun`; `runReadiness`'s orphan beginRun is retired
+(face-bracketed, no ledger append per its contract); bench keys by
+RunId; `projection inspect <runId> [<runId>]` renders the store and
+the `Run.diff` delta surface — where the §9.7 UoM promotion FIRED
+(`[<Measure>] ms`, scoped exactly as gated). R1e's law is witnessed:
+stored-trail board ≡ live board (mixed run), readiness over RunHistory
+≡ the ledger projection. The card's `diff <a> <b>` name collided with
+the shipped refs-diff verb — landed under `inspect`, named.
+
+**3. The pools pay for work, not ceremony — and §4 rule 2's third
+signature has a ROOT CAUSE.** The flat ~3.4s ephemeral-test floor was
+the DROP killing the idle pooled per-DB session (3051ms measured; 51ms
+evicted) — `ClearPool` lands before every drop. The warm container was
+dying of LEAKED databases (`withBootstrappedDatabase` never dropped;
+209 counted) — it reaps now; a full fast run adds zero. The pool split
+follows the Collection ATTRIBUTE, not the filename — the substring
+trap had broken both ways (six Docker tests in the parallel fast pool;
+six pure AxiomTests in the serial docker pool; set-diff proved the
+6↔6 swap, nothing dropped). Build skips when the test DLL is newer
+than every input. **fast: 58–71s → 31s; docker: 925s → 383s (229/0);
+every passing pool prints its five slowest.** `runEphemeral` is
+deliberately unchanged (deploy-to-docker leaves an inspectable DB by
+design). The remaining docker wall is ~71s of 100k sustained-envelope
+MEASUREMENT — witnesses, not overhead.
+
+**4. The Voice lane advanced in parallel (a worktree subagent,
+reviewed against the register before merging).** Seven faces voiced
+(full-export --load, deploy's SSDT-rejection worked example, the
+canary pair, drift, the migrate stop channel with
+`Voice.migrationStopDetail` as a typed projection, eject,
+verify-data); 21 codes, catalog 20→41, both totality registries per
+commit, exits byte-identical, NDJSON untouched. RunFaces raw-print
+census 148 → 80; the remaining faces (transfer narration — wants a
+TransferReport→Surface design, not flat templates; explain/suggest —
+View/Surface documents; migrate success verdicts) are deferred with
+named reasons in the lane's commits.
+
+**Witness state at close:** pure pool 31s green at every commit
+(3115/0 at the head under the corrected split — six axiom tests came
+HOME to the fast pool, six Docker tests went home to docker); full
+Docker pool 229/0 (383s) at the head; the inherited witnesses were
+re-run at open per the law (pure 3078/0/211 exact; Docker 229/0 at
+925s pre-fix; readside-rowstream 869ms/165ms — inside generation 4's
+band, four hosts deep). One infra flake en route, named and §4-filed:
+a 27-failure pre-login-handshake batch (rule 2's fourth signature;
+restart → focused re-run green → full green).
+
+**Traps from this session:** (a) `Assert`-era F# files can shadow
+`System.DateTime` — qualify it in new test literals (two FS0003s cost
+minutes). (b) The paren-`use` eviction form trips FS0792 inside a task
+CE's `finally` — use let-bind + explicit Dispose. (c) Editing test.sh
+while a pool RUNS risks corrupting the in-flight bash — stage to /tmp,
+swap after the verdict.
+
+**Your queue, by the backlog's graph:** P1→P2 (licensed parallelism —
+`ParallelSafe` minted by `levels`; P3 stays trigger-held on harness
+evidence), the Voice lane's named remainder, and the §6 armed items
+with their wake conditions (F1-hex still waits on a third
+persistence-coupled digest or a digestOf touch). J5 — a writable UAT
+connection — still trumps everything.
+
+Hold the spine; balance the books; keep the patient breathing; re-run
+the witnesses you inherit before you stand on them — mine are one
+command each: `scripts/test.sh fast` (31s), `scripts/test.sh docker`
+(383s, 229/0), `perf-harness.sh run readside-rowstream` (the Q-arc's
+band).
+
+— Generation 6, the contract-keeper, 2026-06-12
+
 # Handoff addendum — 2026-06-12, generation 5 CLOSE (the S-track is CLOSED: the spine is held, S1→S5)
 
 To the next agent.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,28 @@
+# Handoff addendum — 2026-06-12, generation 6 SECOND POSTSCRIPT (P2's gate is MET: 2.6–2.9× at the operator envelope; the wiring slice is yours)
+
+The half-met gate in the postscript below is now FULLY MET. The
+declared `leveled-deploy-150x42` scenario (H7-disciplined: in `all`,
+the registry, the gated fact; `StaticCatalogFixtures` gained the
+N-kind form rather than a fifth instance) ran the paired comparison at
+the operator envelope through the REAL path — `composeRenderedLeveled`
+→ `ParallelSafe` → `executeBatchParallel` under `resolveParallelism` —
+and replicated **2.85× / 2.59× / 2.65×** (sequential ~2.0–2.1s →
+parallel ~0.74–0.79s, parallelism 4). One command:
+`perf-harness.sh run leveled-deploy`.
+
+**What remains of P2 is the WIRE, deliberately left whole for a fresh
+session** — the design constraints are on the card so you don't
+re-derive them: (a) `runDeploy → runEphemeral` deploys `aggregateSsdt`'s
+FUSED schema+seeds — a schema-vs-data split there must stay faithful to
+the published bundle, never a re-composition that can diverge; (b) the
+full-export load leg injects a `SqlConnection -> string -> Task`
+executor while `executeBatchParallel` needs the connection STRING for
+per-segment opens — re-thread the seam. Witnesses as carded:
+operator-reality canary + perf-gate (baseline re-record only if a
+floor legitimately moves, with its DECISIONS amendment).
+
+— Generation 6, the contract-keeper (second postscript), 2026-06-12
+
 # Handoff addendum — 2026-06-12, generation 6 POSTSCRIPT (P1 is CUT: ParallelSafe is minted by levels; P2's gate is half-met, named)
 
 A continuation after the letter below — read it as that letter's coda.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,32 @@
+# Handoff addendum — 2026-06-12, generation 6 POSTSCRIPT (P1 is CUT: ParallelSafe is minted by levels; P2's gate is half-met, named)
+
+A continuation after the letter below — read it as that letter's coda.
+
+**P1 is DONE.** `ParallelSafe<'a>` lives in Core beside its one mint
+(`TopologicalOrder.levels`); `map`/`choose` carry the proof through
+the composer (the cross-kind `String.Concat` + LINT-ALLOW retired);
+`Deploy.executeBatchParallel` DEMANDS the token — miswiring is now a
+compile error; the stale "canary continues using sequential" status
+note is retired (RI-5). Segment bytes, bench labels, and the
+manifest's wire shape are all unchanged by construction. The leveled ≡
+sequential equivalence ran GATE-OPEN
+(`PROJECTION_RUN_COMPREHENSIVE_CANARY=1`, 1/1 at 4m17s — remember §4
+rule 12: that canary soft-skips in the docker pool; open the gate when
+its verdict matters). Pure pool 3116/0 (31s) at the commit.
+
+**P2 is NOT cut, deliberately.** Its gate demands an operator-scale
+measurement through the production face; what exists is segment-level
+evidence (the 20-table microbench: 782ms → 411ms, 1.90× at
+parallelism 4 — printed by the ExecuteBatchParallelTests bench, now in
+the docker pool's standing output). Run the operator-envelope
+before/after (6.25k×150 through the CLI deploy path) BEFORE wiring;
+the backlog card carries this gate state. P3 stays trigger-held.
+
+The queue from here: P2 behind its measurement, the Voice lane's named
+remainder, the §6 armed items. J5 still trumps everything.
+
+— Generation 6, the contract-keeper (postscript), 2026-06-12
+
 # Handoff addendum — 2026-06-12, generation 6 CLOSE (the contract leg is CLOSED: L1→L4 + R1a→R1e; the Voice lane advanced; the pools pay for work)
 
 To the next agent.

--- a/sidecar/projection/scripts/perf-gate.sh
+++ b/sidecar/projection/scripts/perf-gate.sh
@@ -188,7 +188,18 @@ run_canary() {
     fi
 
     local snapshot
-    snapshot="$(ls -1t "$ROOT/bench/canary"/*.json 2>/dev/null | head -n1 || true)"
+    # R1c — snapshots are keyed by RunId (ULID, lexically time-ordered), so
+    # the newest RUN is the lexically-greatest ULID name; file mtime no
+    # longer decides (a re-touched old file cannot masquerade as the latest
+    # run). Legacy timestamped names are excluded from selection; if ONLY
+    # legacy files exist the gate falls back to mtime-newest and says so.
+    snapshot="$(ls -1 "$ROOT/bench/canary" 2>/dev/null | grep -E '^[0-9A-HJKMNP-TV-Z]{26}\.json$' | LC_ALL=C sort | tail -n1 || true)"
+    if [[ -n "$snapshot" ]]; then
+        snapshot="$ROOT/bench/canary/$snapshot"
+    else
+        snapshot="$(ls -1t "$ROOT/bench/canary"/*.json 2>/dev/null | head -n1 || true)"
+        [[ -n "$snapshot" ]] && log "WARN: no RunId-keyed snapshot found; falling back to mtime-newest over legacy names"
+    fi
 
     if [[ -z "$snapshot" ]]; then
         log "FATAL: no canary bench snapshot found under $ROOT/bench/canary/"

--- a/sidecar/projection/scripts/test.sh
+++ b/sidecar/projection/scripts/test.sh
@@ -81,13 +81,29 @@ log()  { printf '\033[36m[test]\033[0m %s\n' "$1"; }
 err()  { printf '\033[31m[test]\033[0m %s\n' "$1" >&2; }
 
 # Derive the Docker-collection test classes from the source markers, so the
-# pool split stays correct as classes are added/removed. One file = one class
-# (the module/type name matches the file name by convention); the ephemeral
-# container fixture is infra, not a test class.
+# pool split stays correct as classes are added/removed.
+#
+# 2026-06-12 — derived from the DECLARATION the attribute decorates, not the
+# file basename. The one-file-one-class convention broke silently: a file can
+# carry several classes, and a class named differently from its file
+# (ReverseLegCdcNormTests in ReverseLegScaleTests.fs;
+# LogicalNameRoundtripIntegration in LogicalNameRoundtripTests.fs; the two
+# RunWithConfig* classes in RunWithConfigProfileTests.fs) LEAKED into the
+# pure pool — ~25s of Docker-collection SQL tests, including an isolated-
+# container cold start, ran inside the parallel fast loop. The awk walks each
+# `[<Collection("Docker-SqlServer")>]` to the module/type it decorates, so
+# the attribute IS the pool membership — by construction, not by filename.
 docker_classes() {
-    grep -rl 'Collection("Docker-SqlServer")' "$TESTS_DIR"/*.fs 2>/dev/null \
-        | xargs -n1 basename \
-        | sed 's/\.fs$//' \
+    awk '
+        /CollectionDefinition/ { next }
+        /Collection\("Docker-SqlServer"\)/ { armed=1; next }
+        armed && /^(module|type) / {
+            name = $2
+            sub(/\(.*/, "", name)        # type X(fixture: ...) -> X
+            print name
+            armed = 0
+        }
+    ' "$TESTS_DIR"/*.fs 2>/dev/null \
         | grep -v '^EphemeralContainerFixture$' \
         | sort -u
 }
@@ -126,9 +142,29 @@ warm_autodetect() {
     fi
 }
 
+# The test DLL is current when it is newer than EVERY build input (sources,
+# project files, props/targets, restore assets). The scan costs ~100 ms and
+# replaces a ~10 s no-op MSBuild walk in the steady-state loop — the build
+# runs only when something actually changed. TEST_FORCE_BUILD=1 overrides.
+build_is_current() {
+    local dll="$TESTS_DIR/bin/$CONFIG/net9.0/Projection.Tests.dll"
+    [[ -f "$dll" ]] || return 1
+    local newer
+    newer="$(find "$ROOT/src" "$ROOT/tests" "$ROOT/global.json" \
+                \( -name '*.fs' -o -name '*.fsproj' -o -name '*.props' \
+                   -o -name '*.targets' -o -name 'project.assets.json' \
+                   -o -name 'global.json' \) \
+                -not -path '*/bin/*' -newer "$dll" -print -quit 2>/dev/null)"
+    [[ -z "$newer" ]]
+}
+
 build_once() {
     if [[ "${TEST_NO_BUILD:-0}" == "1" ]]; then
         log "skipping build (TEST_NO_BUILD=1)"
+        return 0
+    fi
+    if [[ "${TEST_FORCE_BUILD:-0}" != "1" ]] && build_is_current; then
+        log "build current — skipping (every input older than the test DLL; TEST_FORCE_BUILD=1 overrides)"
         return 0
     fi
     log "building Projection.Tests ($CONFIG)..."
@@ -156,6 +192,20 @@ build_once() {
 #   parallel pure pool never piles onto the serial Docker pool + SQL
 #   container and OOM-kills the host on this 4-core / no-swap box.
 # Extract failed-test names from a TRX (the test-failure capture protocol).
+# The five slowest tests of a finished pool, from the TRX — keeps the cost
+# surface in the operator's attention so the pools stay fast (the same
+# motive as the bench table, applied to the test plane).
+slowest_of() {
+    local trx="$1"
+    [[ -f "$trx" ]] || return 0
+    log "slowest:"
+    grep -oE 'testName="[^"]+" [^>]*duration="[0-9:.]+"' "$trx" 2>/dev/null \
+        | sed -E 's/^testName="([^"]+)".*duration="([0-9:.]+)".*$/\2 \1/' \
+        | sort -r | head -n 5 \
+        | sed -E 's/^([0-9:.]+) (Projection\.Tests\.)?(.*)$/    \1  \3/' \
+        | cut -c1-110
+}
+
 failed_names_of() {
     local trx="$1"
     # testName and outcome sit on the SAME UnitTestResult line; a -B1 context
@@ -217,6 +267,7 @@ run_pool() {
     else
         echo "PASSED exit=0 duration=$((t1 - t0))s" > "$status"
         log "$label pool passed ($((t1 - t0))s)"
+        slowest_of "$trx"
     fi
     return "$code"
 }

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -54,7 +54,9 @@ let verboseMode = ref false
 let dumpBench (tag: string) : unit =
     let stats = Bench.snapshot ()
     if not (List.isEmpty stats) then
-        let path = BenchSink.defaultPath (Directory.GetCurrentDirectory()) tag
+        // R1c — keyed by the run: the snapshot file and the captured Run
+        // aggregate share the RunId address.
+        let path = BenchSink.runPath (Directory.GetCurrentDirectory()) tag (LogSink.runId ())
         try BenchSink.persistJson path tag stats
         with ex -> eprintfn "  WARNING: failed to persist bench snapshot: %s" ex.Message
         // Calm by default (REPORTING_HORIZON polish) — the table is depth,

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -139,7 +139,13 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     | PlanAction.PreviewSchema (model, modelOssys, conn, decl) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat -> runProjectLivePreview shapedCat conn decl))
     | PlanAction.Transfer (src, sink, opts, execute) ->
-        runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables surveyAdvisory
+        // R1b — the envelope-emitting faces move under `withRun` (the law:
+        // a verb that mints envelopes runs bracketed; RI-11's census). The
+        // transfer/migrate/synthetic engines emit the staged spines' stage
+        // events, so their streams now open with `config.runStart` and
+        // close with the §10 terminal — and the run is capturable.
+        withRun "projection transfer" (fun () ->
+            runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables surveyAdvisory)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE
@@ -149,11 +155,14 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // contracts (ReadSide synthesizes attribute SsKeys, which would never
         // align — the original residual's premise, now honored structurally).
         needCatalog modelOssys model (fun cat ->
-            runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables surveyAdvisory)
+            withRun "projection reverse-leg" (fun () ->
+                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables surveyAdvisory))
     | PlanAction.MigrateWithData (model, modelOssys, sink, src, opts) ->
-        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat -> runMigrateWithData shapedCat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Store opts.Env))
+        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
+            withRun "projection migrate --with-data" (fun () ->
+                runMigrateWithData shapedCat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Store opts.Env)))
     | PlanAction.SynthesizeAndLoad (model, modelOssys, profile, conn, opts, execute) ->
-        runSyntheticLoad model modelOssys profile conn opts execute
+        withRun "projection synth-load" (fun () -> runSyntheticLoad model modelOssys profile conn opts execute)
     | PlanAction.CaptureProfile (conn, out) -> runCaptureProfile conn out
     | PlanAction.PublishAndLoad (c, conn, store, env) ->
         let run () = runFullExportLoad c conn None store env
@@ -162,7 +171,9 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         if Watch.shouldWatch watchMode.Value then Watch.renderWatch Spines.pipeline (Watch.resolveDwellMs ()) run
         else run ()
     | PlanAction.Migrate (model, modelOssys, conn, opts) ->
-        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat -> runMigrateExecute shapedCat conn opts.Declaration opts.AllowCdc opts.Store opts.Env))
+        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
+            withRun "projection migrate" (fun () ->
+                runMigrateExecute shapedCat conn opts.Declaration opts.AllowCdc opts.Store opts.Env)))
     // check --------------------------------------------------------------
     | PlanAction.CheckCanary (ddl, false) -> withRun "projection check" (fun () -> runCanary ddl)
     | PlanAction.CheckCanary (ddl, true)  -> withRun "projection check --cdc-silence" (fun () -> runCanaryCdcSilence ddl)

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -38,6 +38,7 @@ let private usageLines : string list =
         "                       | migrate --to <b> ( --from <a> | --from empty | --store <s> ) [--allow-drops] )"
         "    projection seal ( --store <path> | approve <version> --approver <name> ... )"
         "    projection report <flow>        the on-prem migration-team change bundle"
+        "    projection inspect <runId> [<runId>]  a stored run, or what moved between two runs"
         "    projection init                 scaffold a projection.json"
         "    projection setup [--conn <ref>] read back what is configured (history, writes, board);"
         "                                    --conn also probes a target (reachable + ALTER grant)"
@@ -344,6 +345,8 @@ let main argv =
         0
     | [||] -> runList ()
     | [| "init" |] -> runInit ()
+    | [| "inspect"; runId |] -> runInspect runId None
+    | [| "inspect"; runA; runB |] -> runInspect runA (Some runB)
     | [| "setup" |] -> runSetup None
     | [| "setup"; "--conn"; ref |] -> runSetup (Some ref)
     | [| "survey" |] -> runSurvey ()

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -964,16 +964,23 @@ let runDrift (toPath: string) (connSpec: string) : int =
 let runEject (storePath: string) : int =
     match EjectRun.fromStore storePath with
     | Error msg ->
-        Console.Error.WriteLine (sprintf "projection eject: %s" msg)
+        // §14 — the finding leads; the raw store error is the located cause.
+        TtyRenderer.renderVoicedTo Console.Error "eject.storeUnreadable"
+            (Map.ofList [ "cause", box msg ])
         2
     | Ok pkg ->
-        printfn "projection eject: timeline %s — %d episode(s) preserved (append-forever), %d refactorlog reference(s)"
-            (Timeline.name pkg.Timeline) (List.length pkg.Episodes) (List.length pkg.RefactorLogRefs)
+        // §13 resultative — the package line, voiced; the timeline beneath.
+        TtyRenderer.renderVoicedTo Console.Out "eject.packaged"
+            (Map.ofList
+                [ "timeline",         box (Timeline.name pkg.Timeline)
+                  "episodeCount",     box (List.length pkg.Episodes)
+                  "refactorLogCount", box (List.length pkg.RefactorLogRefs) ])
         if EjectRun.isFaithful pkg then
-            printfn "Verified. The reconstruction reproduces the frozen state from genesis to freeze."
+            // §6 — the freeze's self-verification, asserted.
+            TtyRenderer.renderVoicedTo Console.Out "eject.verified" Map.empty
             0
         else
-            Console.Error.WriteLine "The package is not verified: the reconstruction does not reproduce the frozen state."
+            TtyRenderer.renderVoicedTo Console.Error "eject.unverified" Map.empty
             5
 
 /// Tier-4 reporting — `readiness`. Read the cross-run ledger

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -316,14 +316,18 @@ type private CanaryStop =
 
 let runCanary (sourceDdlPath: string) : int =
     if not (File.Exists sourceDdlPath) then
-        die 1 (sprintf "projection: source DDL not found: %s" sourceDdlPath)
+        // §14 — concrete and located; the path is the substantiation.
+        TtyRenderer.renderVoicedTo Console.Error "canary.sourceMissing"
+            (Map.ofList [ "path", box sourceDdlPath ])
+        1
     elif not (Deploy.Docker.isAvailable ()) then
-        die
-            4
-            "projection: Docker daemon not reachable. Set DOCKER_HOST or start the daemon to run `canary`."
+        TtyRenderer.renderVoicedTo Console.Error "docker.unavailable"
+            (Map.ofList [ "purpose", box "round-trip verification" ])
+        4
     else
         let sourceDdl = File.ReadAllText sourceDdlPath
-        printfn "projection: spinning up ephemeral SQL Server for the wide canary..."
+        TtyRenderer.renderVoicedTo Console.Out "container.starting"
+            (Map.ofList [ "purpose", box "round-trip verification" ])
         // E4 — the production canary deploys the canonical schema-then-data
         // form (DDL + StaticPopulationEmitter's InsertRow realization into the
         // fresh-empty target). Schema-only when the source carries no static
@@ -349,10 +353,11 @@ let runCanary (sourceDdlPath: string) : int =
                 return report
             }).GetAwaiter().GetResult()
         let deployedLine (report: Deploy.WideCanaryReport) =
-            printfn
-                "projection: source deployed %d table(s); target deployed %d table(s)"
-                report.SourceReport.TablesCreated
-                report.TargetReport.TablesCreated
+            // §13 resultative — both sides of the round-trip are in place.
+            TtyRenderer.renderVoicedTo Console.Out "canary.deployed"
+                (Map.ofList
+                    [ "sourceTables", box report.SourceReport.TablesCreated
+                      "targetTables", box report.TargetReport.TablesCreated ])
             // Tier-1 reporting (§7.7) — emit the structured fidelity verdict
             // (canary.diffEmpty / canary.divergence) alongside the prose, so
             // CI can gate on it and the run ledger can record it.
@@ -389,11 +394,13 @@ let runCanary (sourceDdlPath: string) : int =
 /// the canary itself, not a harness.
 let runCanaryCdcSilence (sourceDdlPath: string) : int =
     if not (File.Exists sourceDdlPath) then
-        die 1 (sprintf "projection: source DDL not found: %s" sourceDdlPath)
+        TtyRenderer.renderVoicedTo Console.Error "canary.sourceMissing"
+            (Map.ofList [ "path", box sourceDdlPath ])
+        1
     elif not (Deploy.Docker.isAvailable ()) then
-        die
-            4
-            "projection: Docker daemon not reachable. Set DOCKER_HOST or start the daemon to run `canary`."
+        TtyRenderer.renderVoicedTo Console.Error "docker.unavailable"
+            (Map.ofList [ "purpose", box "CDC-silence verification" ])
+        4
     else
         let sourceDdl = File.ReadAllText sourceDdlPath
         let enableCdc cnn (cat: Catalog) =
@@ -413,7 +420,8 @@ let runCanaryCdcSilence (sourceDdlPath: string) : int =
                 let! _ = MigrationRun.execute true DeclareNone cat cat cnn
                 return ()
             }
-        printfn "projection: spinning up ephemeral SQL Server for the CDC-silence canary..."
+        TtyRenderer.renderVoicedTo Console.Out "container.starting"
+            (Map.ofList [ "purpose", box "CDC-silence verification" ])
         let work =
             Deploy.runWideCanaryWithCdcSilence
                 (fun cnn -> Deploy.executeBatch cnn sourceDdl)
@@ -424,19 +432,21 @@ let runCanaryCdcSilence (sourceDdlPath: string) : int =
         let exitCode =
             match result with
             | Ok (report, cdcDelta) ->
-                printfn
-                    "projection: source deployed %d table(s); target deployed %d table(s)"
-                    report.SourceReport.TablesCreated
-                    report.TargetReport.TablesCreated
+                TtyRenderer.renderVoicedTo Console.Out "canary.deployed"
+                    (Map.ofList
+                        [ "sourceTables", box report.SourceReport.TablesCreated
+                          "targetTables", box report.TargetReport.TablesCreated ])
                 let schemaOk = PhysicalSchema.isEqual report.Diff
                 if not schemaOk then
                     TtyRenderer.renderVoicedTo Console.Error "canary.divergence"
                         (Map.ofList [ "renderedDiff", box (PhysicalSchema.renderDiff report.Diff) ])
                 if cdcDelta <> 0 then
-                    eprintfn "The redeploy was not idempotent: %d row(s) captured where none were expected." cdcDelta
+                    // §6 — the silence proof failed; the finding carries its measure.
+                    TtyRenderer.renderVoicedTo Console.Error "canary.cdcCaptured"
+                        (Map.ofList [ "capturedRows", box cdcDelta ])
                 if schemaOk && cdcDelta = 0 then
                     // §6 CDC-silence proof — the deepest fidelity finding, said plain.
-                    printfn "Confirmed idempotent: zero rows captured, zero schema changes issued."
+                    TtyRenderer.renderVoicedTo Console.Out "canary.cdcSilent" Map.empty
                     0
                 else 5
             | Error errors ->

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -1241,22 +1241,25 @@ let runPolicyDiff (configAPath: string) (configBPath: string) : int =
 /// never a silent plan. The `--execute` leg (against a live deployed DB) is
 /// `MigrationRun.execute`; this surface previews what it would do.
 
-/// A `MigrationError` as a plain located cause — the operator reads the finding,
-/// never a raw DU dump (`THE_VOICE.md` §10). The full statement-first migrate
-/// surfaces land in Waves 2–3; this Wave-0 translation only banishes the `%A`.
-let migrationErrorDetail (e: MigrationError) : string =
-    match e with
-    | DiffFailed _              -> "the changes could not be computed"
-    | RefusedByViolations v     -> sprintf "%d removal(s) are not yet approved" (List.length v)
-    | RefusedBySchemaErrors es  -> sprintf "%d change(s) cannot be expressed as a single ALTER" (List.length es)
-    | EmitFailed _              -> "the changes could not be built"
-    | SchemaReadFailed _        -> "the deployed schema could not be read"
-    | ExecutionFailed msg       -> sprintf "the migration could not be applied — %s" msg
-    | RefusedByTightening msg   -> sprintf "a column tightening would fail against existing data — %s" msg
-    | VerificationFailed _      -> "the round-trip did not match the model"
-    | DataTransferFailed _      -> "the data load did not complete"
-    | RefusedByCdc t            -> sprintf "the schema change would run against a CDC-tracked database (%d table(s))" (List.length t)
-    | StoreReadFailed msg       -> sprintf "the run history could not be read — %s" msg
+/// The §10 inexpressible-change verdict, voiced (`migrate.inexpressible`): the
+/// statement carries the count; each refusing entry is demoted into the
+/// disclosure beneath, its code beside its cause. The newline join is data
+/// marshalling into the envelope payload, not prose.
+let private renderInexpressible (entries: DiagnosticEntry list) : unit =
+    TtyRenderer.renderVoicedTo Console.Error "migrate.inexpressible"
+        (Map.ofList
+            [ "entryCount", box (List.length entries)
+              "entries",
+              box (entries
+                   |> List.map (fun e -> sprintf "%s (%s)" e.Message e.Code)
+                   |> String.concat "\n") ])
+
+/// The §10 stop for a `MigrationError` the gates do not own, voiced
+/// (`migrate.stopped`): the statement frames the stop; the plain located cause
+/// is `Voice.migrationStopDetail` (the catalog's typed projection over the DU).
+let private renderMigrateStopped (e: MigrationError) : unit =
+    TtyRenderer.renderVoicedTo Console.Error "migrate.stopped"
+        (Map.ofList [ "cause", box (Voice.migrationStopDetail e) ])
 
 /// The migrate preview as a §6/§9 minimality Surface — the smallest faithful
 /// change, said plain (statement first, the per-move breakdown beneath), never
@@ -1302,12 +1305,10 @@ let reportPreviewOutcome (header: string) (result: Result<MigrationArtifacts, Mi
             renderUndeclaredDropGate violations
             9
         | Error (RefusedBySchemaErrors entries) ->
-            Console.Error.WriteLine "projection migrate: these change(s) cannot be expressed as a single ALTER:"
-            for e in entries do
-                Console.Error.WriteLine (sprintf "    [%s] %s" e.Code e.Message)
+            renderInexpressible entries
             9
         | Error other ->
-            Console.Error.WriteLine (sprintf "The migration did not complete: %s." (migrationErrorDetail other))
+            renderMigrateStopped other
             2
         | Ok artifacts ->
             printfn "%s" header
@@ -1326,11 +1327,9 @@ let runMigratePreview (fromPath: string) (toPath: string) (declaration: LossDecl
     let a, b = loaded.GetAwaiter().GetResult()
     match a, b with
     | Error errors, _ ->
-        Console.Error.WriteLine (sprintf "projection migrate: could not read --from %s:" fromPath)
         printErrors Console.Error errors
         6
     | _, Error errors ->
-        Console.Error.WriteLine (sprintf "projection migrate: could not read --to %s:" toPath)
         printErrors Console.Error errors
         6
     | Ok source, Ok target ->
@@ -1348,7 +1347,6 @@ let runMigrateFromStore (storePath: string) (toPath: string) (declaration: LossD
     let bRead = (Compose.read toPath).GetAwaiter().GetResult()
     match bRead with
     | Error errors ->
-        Console.Error.WriteLine (sprintf "projection migrate: could not read --to %s:" toPath)
         printErrors Console.Error errors
         6
     | Ok target ->
@@ -1392,23 +1390,29 @@ let reportMigrationError (e: MigrationError) : int =
         renderUndeclaredDropGate violations
         9
     | RefusedBySchemaErrors entries ->
-        Console.Error.WriteLine "projection migrate: these change(s) cannot be expressed:"
-        for e in entries do Console.Error.WriteLine (sprintf "    [%s] %s" e.Code e.Message)
+        renderInexpressible entries
         9
     | RefusedByCdc tracked ->
-        Console.Error.WriteLine (
-            sprintf "projection migrate: schema DDL against a CDC-tracked database (%d table(s)). Pass --allow-cdc to proceed." (List.length tracked))
+        // §5 CDC gate — the consent surface (consequence as meaning + the one
+        // lever), keyed by the closed GateLabel DU; the tracked count and the
+        // --allow-cdc lever ride in the located detail. Exit 9 unchanged.
+        TtyRenderer.renderGate "projection migrate"
+            (Preflight.refusalOf
+                [ ValidationError.create "migrate.cdcTrackedSink"
+                    (sprintf "%d table(s) are CDC-tracked; --allow-cdc accepts the capture." (List.length tracked)) ])
         9
     | RefusedByTightening msg ->
-        Console.Error.WriteLine (
-            sprintf "projection migrate: a column tightening (NULL → NOT NULL) would fail against existing NULL data; no DDL ran. %s" msg)
+        // §5 data-compat gate — the same surface the pre-flight probe renders.
+        TtyRenderer.renderGate "projection migrate"
+            (Preflight.refusalOf [ ValidationError.create "migrate.dataViolatesTightening" msg ])
         9
     | SchemaReadFailed es ->
-        Console.Error.WriteLine "The deployed schema could not be read."
+        // The §10 schema-read frame states the finding; the located causes
+        // ride beneath (the raw header line is retired).
         printErrors Console.Error es
         6
     | other ->
-        Console.Error.WriteLine (sprintf "The migration did not complete: %s." (migrationErrorDetail other))
+        renderMigrateStopped other
         2
 
 /// The A1 connection + A2 permission pre-flights against a sink connection,
@@ -1490,7 +1494,6 @@ let runMigrateExecute (target: Catalog) (connSpec: string) (declaration: LossDec
         task {
             match TransferSpec.parseConnectionSpec connSpec with
             | Error es ->
-                Console.Error.WriteLine "projection migrate: --conn argument error:"
                 printErrors Console.Error es
                 return 2
             | Ok connRef ->
@@ -1498,7 +1501,6 @@ let runMigrateExecute (target: Catalog) (connSpec: string) (declaration: LossDec
                     { Environment = parseEnvironment "migrate-sink" None; Role = SubstrateRole.Sink; ConnectionRef = connRef }
                 match! ConnectionResolver.openSubstrate sub with
                 | Error es ->
-                    Console.Error.WriteLine "projection migrate: could not open --conn:"
                     printErrors Console.Error es
                     return 3
                 | Ok cnn ->
@@ -1529,7 +1531,6 @@ let runMigrateExecute (target: Catalog) (connSpec: string) (declaration: LossDec
                                         let timeline = Timeline.create (Projection.Core.Environment.name env)
                                         match timeline with
                                         | Error es ->
-                                            Console.Error.WriteLine "projection migrate: --lifecycle-store timeline name error:"
                                             printErrors Console.Error es
                                             return 2
                                         | Ok tl ->
@@ -1609,7 +1610,6 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
             else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
     let specErrors = (parsedReconciles |> List.collect collectErrs) @ collectErrs parsedUserMap
     if not (List.isEmpty specErrors) then
-        Console.Error.WriteLine "projection migrate: --reconcile / --user-map argument error:"
         printErrors Console.Error specErrors
         dumpBench "migrate"
         2
@@ -1620,11 +1620,9 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
         task {
             match TransferSpec.parseConnectionSpec sinkSpec, TransferSpec.parseConnectionSpec sourceSpec with
             | Error es, _ ->
-                Console.Error.WriteLine "projection migrate: --sink-conn argument error:"
                 printErrors Console.Error es
                 return 2
             | _, Error es ->
-                Console.Error.WriteLine "projection migrate: --source-conn argument error:"
                 printErrors Console.Error es
                 return 2
             | Ok sinkRef, Ok sourceRef ->
@@ -1632,14 +1630,12 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
                 let sourceSub : Substrate = { Environment = parseEnvironment "migrate-source" None; Role = SubstrateRole.Source; ConnectionRef = sourceRef }
                 match! ConnectionResolver.openSubstrate sinkSub with
                 | Error es ->
-                    Console.Error.WriteLine "projection migrate: could not open --sink-conn:"
                     printErrors Console.Error es
                     return 3
                 | Ok sink ->
                     use sink = sink
                     match! ConnectionResolver.openSubstrate sourceSub with
                     | Error es ->
-                        Console.Error.WriteLine "projection migrate: could not open --source-conn:"
                         printErrors Console.Error es
                         return 3
                     | Ok dataSource ->
@@ -1675,7 +1671,6 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
                                       // pre-write gate composes first.
                                       match TransferSpec.resolveAllReconciliation target reconcileEntries userMapEntries with
                                       | Error es ->
-                                          Console.Error.WriteLine "projection migrate: --reconcile / --user-map could not be resolved against contract B:"
                                           printErrors Console.Error es
                                           return 2
                                       | Ok reconciliation ->
@@ -1690,7 +1685,6 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
                                             let env = parseEnvironment "DEV" envLabel
                                             match Timeline.create (Projection.Core.Environment.name env) with
                                             | Error es ->
-                                                Console.Error.WriteLine "projection migrate: --lifecycle-store timeline name error:"
                                                 printErrors Console.Error es
                                                 return 2
                                             | Ok tl ->
@@ -1749,7 +1743,6 @@ let runProjectLivePreview (target: Catalog) (connSpec: string) (declaration: Los
         task {
             match TransferSpec.parseConnectionSpec connSpec with
             | Error es ->
-                Console.Error.WriteLine "projection project: connection reference error:"
                 printErrors Console.Error es
                 return 6
             | Ok connRef ->
@@ -1757,7 +1750,6 @@ let runProjectLivePreview (target: Catalog) (connSpec: string) (declaration: Los
                     { Environment = parseEnvironment "preview" None; Role = SubstrateRole.Sink; ConnectionRef = connRef }
                 match! ConnectionResolver.openSubstrate sub with
                 | Error es ->
-                    Console.Error.WriteLine "projection project: could not open the destination:"
                     printErrors Console.Error es
                     return 3
                 | Ok cnn ->

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -101,21 +101,22 @@ let runFullExportLoad
     (storePath: string option)
     (envLabel: string option)
     : int =
+    // The error face is the voiced §10/§14 surface alone (`printErrors` →
+    // `Voice.errorsSurface`): the statement is the catalog's frame for the
+    // primary code, the located causes ride beneath. No command-prefixed
+    // header — the frame already names the finding and the next move.
     match TransferSpec.parseConnectionSpec connSpec with
     | Error es ->
-        Console.Error.WriteLine "projection full-export --load: --conn argument error:"
         printErrors Console.Error es
         2
     | Ok connRef ->
         match ConnectionResolver.resolve "Sink" connRef with
         | Error es ->
-            Console.Error.WriteLine "projection full-export --load: connection error:"
             printErrors Console.Error es
             6
         | Ok connStr ->
             match Config.fromFile configPath with
             | Error es ->
-                Console.Error.WriteLine "projection full-export --load: config error:"
                 printErrors Console.Error es
                 6
             | Ok cfg0 ->
@@ -126,7 +127,6 @@ let runFullExportLoad
                 let env = parseEnvironment "DEV" envLabel
                 match Timeline.create (Projection.Core.Environment.name env) with
                 | Error es ->
-                    Console.Error.WriteLine "projection full-export --load: --env timeline name error:"
                     printErrors Console.Error es
                     2
                 | Ok tl ->
@@ -140,13 +140,20 @@ let runFullExportLoad
                     let code =
                         match work.GetAwaiter().GetResult() with
                         | Ok (report, legOpt, cdcDelta) ->
-                            printfn "%d artifact(s) published; seed loaded (%d row(s) captured)."
-                                report.Paths.Length cdcDelta
+                            // §4/§6 — the publish-and-load verdict, voiced by code
+                            // (`load.completed`): statement first, the CDC measure
+                            // as the grounding evidence beneath.
+                            TtyRenderer.renderVoicedTo Console.Out "load.completed"
+                                (Map.ofList
+                                    [ "artifactCount", box report.Paths.Length
+                                      "capturedRows",  box cdcDelta ])
                             legOpt
                             |> Option.iter (fun leg ->
-                                printfn "  this run recorded — episode %d on timeline %s."
-                                    (EpisodicLifecycle.episodes leg.Chain |> List.length)
-                                    (Timeline.name (EpisodicLifecycle.timeline leg.Chain)))
+                                // §13 — the durable record, stated plainly.
+                                TtyRenderer.renderVoicedTo Console.Out "episode.recorded"
+                                    (Map.ofList
+                                        [ "episodeCount", box (EpisodicLifecycle.episodes leg.Chain |> List.length)
+                                          "timeline",     box (Timeline.name (EpisodicLifecycle.timeline leg.Chain)) ]))
                             0
                         | Error es ->
                             printErrors Console.Error es

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -966,27 +966,33 @@ let runReadiness () : int =
         eprintfn "projection: no run ledger configured. Set PROJECTION_LEDGER_DIR to accumulate run history."
         4
     | Some dir ->
-        let records = RunLedger.read dir
-        let r = RunLedger.readiness records
-        let recent =
-            records |> List.choose (fun e -> e.Canary) |> List.rev |> List.truncate 16 |> List.rev
-        // Human channel — the themed cutover board (color on a TTY, plain piped).
-        TtyRenderer.renderReadinessBoard r recent (RunLedger.ledgerPath dir)
-        // Machine channel — one structured summary.readiness event (CI gates
-        // on `eligible`).
-        LogSink.beginRun () |> ignore
-        LogSink.emit
-            { LogSink.envelope LogSink.Info LogSink.Summary "summary.readiness"
-                (Map.ofList [
-                    "totalRuns",        box r.TotalRuns
-                    "canaryRuns",       box r.CanaryRuns
-                    "consecutiveGreen", box r.ConsecutiveGreen
-                    "threshold",        box r.Threshold
-                    "lastCanary",       (match r.LastCanary with Some c -> box c | None -> null)
-                    "recentCanaries",   box recent
-                    "eligible",         box r.Eligible ]) with
-                Phase = LogSink.End }
-        0
+        // R1b — the orphan `beginRun` is retired: the run-envelope bracket
+        // (the ONE owner, S4) brackets the readiness query directly, so
+        // `summary.readiness` rides a CONFORMING stream (runStart first,
+        // §10 terminal always) and the run is capturable. Bracketed here
+        // rather than via `withRun` to honor the documented contract above:
+        // no ledger append for the query itself.
+        RunEnvelope.bracket "projection check ready" ignore Map.empty (fun () ->
+            let records = RunLedger.read dir
+            let r = RunLedger.readiness records
+            let recent =
+                records |> List.choose (fun e -> e.Canary) |> List.rev |> List.truncate 16 |> List.rev
+            // Human channel — the themed cutover board (color on a TTY, plain piped).
+            TtyRenderer.renderReadinessBoard r recent (RunLedger.ledgerPath dir)
+            // Machine channel — one structured summary.readiness event (CI gates
+            // on `eligible`).
+            LogSink.emit
+                { LogSink.envelope LogSink.Info LogSink.Summary "summary.readiness"
+                    (Map.ofList [
+                        "totalRuns",        box r.TotalRuns
+                        "canaryRuns",       box r.CanaryRuns
+                        "consecutiveGreen", box r.ConsecutiveGreen
+                        "threshold",        box r.Threshold
+                        "lastCanary",       (match r.LastCanary with Some c -> box c | None -> null)
+                        "recentCanaries",   box recent
+                        "eligible",         box r.Eligible ]) with
+                    Phase = LogSink.End }
+            0, LogSink.Succeeded)
 
 /// Live-probe a target for the setup readback:
 /// `(ref, reachable, grants)` where `grants` pairs each planned write action

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -235,12 +235,14 @@ type private DeployStop =
 
 let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
     if not (Deploy.Docker.isAvailable ()) then
-        die
-            4
-            "projection: Docker daemon not reachable. Set DOCKER_HOST or start the daemon to run `deploy`."
+        // §14 required-and-missing, voiced by code (`docker.unavailable`).
+        TtyRenderer.renderVoicedTo Console.Error "docker.unavailable"
+            (Map.ofList [ "purpose", box "deploy" ])
+        4
     else
         let runBody () =
-            printfn "projection: spinning up an ephemeral SQL Server container..."
+            TtyRenderer.renderVoicedTo Console.Out "container.starting"
+                (Map.ofList [ "purpose", box "deploy" ])
             // Card S3 — the face rides the spine: the `staged { }` CE owns the
             // deploy stage's bracket (started/completed envelopes + the §10
             // stage table + `Bench.scope "stage.deploy"`); the face maps the
@@ -260,32 +262,30 @@ let runDeploy (shaping: Config.Config) (catalog: Catalog) : int =
                     return landed
                 }).GetAwaiter().GetResult()
             let emittedLine (outputs: Compose.Outputs) =
-                printfn
-                    "projection: emitted %d SSDT bundle entries (JSON + distributions: typed JsonNode)"
-                    (Map.count outputs.SsdtBundle)
+                // §13 resultative stage line, voiced by code.
+                TtyRenderer.renderVoicedTo Console.Out "deploy.bundleEmitted"
+                    (Map.ofList [ "entryCount", box (Map.count outputs.SsdtBundle) ])
             match verdict.Disposition with
             | RunCompleted (outputs, report) ->
                 emittedLine outputs
-                printfn
-                    "projection: deploy succeeded — database `%s`, %d table(s) landed"
-                    report.Database
-                    report.TablesCreated
+                // §3 — the deploy verdict, voiced (`deploy.completed`); the
+                // ephemeral database name is the substantiation.
+                TtyRenderer.renderVoicedTo Console.Out "deploy.completed"
+                    (Map.ofList
+                        [ "database",   box report.Database
+                          "tableCount", box report.TablesCreated ])
                 0
             | RunStopped (SsdtRejected (outputs, report)) ->
                 emittedLine outputs
-                // Per chapter 3.5 deep audit (2026-05-09): CLI
-                // error emission via per-line `Console.Error
-                // .WriteLine`. Typed list flows in; per-segment
-                // writes flow out; no concatenation. Header line
-                // composes via `Console.Error.Write` segments —
-                // each typed value (`report.Database`) emitted
-                // independently.
-                Console.Error.Write "projection: SQL Server rejected the SSDT in database `"
-                Console.Error.Write report.Database
-                Console.Error.WriteLine "`:"
-                for line in report.Errors do
-                    Console.Error.Write "  "
-                    Console.Error.WriteLine line
+                // §10 — the rejection verdict, voiced (`deploy.ssdtRejected`):
+                // the statement is the register's finding; the server's own
+                // error lines are demoted into the disclosure beneath, the
+                // exact shape `canary.divergence` set. The newline join is
+                // data marshalling into the envelope payload, not prose.
+                TtyRenderer.renderVoicedTo Console.Error "deploy.ssdtRejected"
+                    (Map.ofList
+                        [ "database",     box report.Database
+                          "serverErrors", box (String.concat "\n" report.Errors) ])
                 3
             | RunStopped (DeployCatalogInvalid errors) ->
                 printErrors Console.Error errors

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -827,29 +827,39 @@ let runReverseLegTransfer
 // contract is read from the before deployment via `ReadSide.read`.
 // ---------------------------------------------------------------------------
 
+/// The §6 data-fidelity verdict pair, voiced (`verifyData.matched` /
+/// `verifyData.diverged`): the statement leads; the per-table deltas are
+/// demoted into counted disclosures beneath. The newline joins are data
+/// marshalling into the envelope payload, not prose — the catalog owns the
+/// framing and the disclosure headlines.
 let narrateIntegrityReport (report: IntegrityReport) : unit =
     if DataIntegrityChecker.isClean report then
-        printfn "Verified. The data matches across both deployments."
+        TtyRenderer.renderVoicedTo Console.Out "verifyData.matched" Map.empty
     else
-        printfn "The data diverges between the two deployments. The differences are shown below."
-        if not (List.isEmpty report.RowCountDeltas) then
-            printfn ""
-            printfn "Row counts (%d differ):" report.RowCountDeltas.Length
-            for d in report.RowCountDeltas do
-                printfn "  %-40s before=%d after=%d (change=%+d)"
-                    (SsKey.rootOriginal d.Kind) d.Before d.After (d.After - d.Before)
-        if not (List.isEmpty report.NullCountDeltas) then
-            printfn ""
-            printfn "Null counts (%d differ):" report.NullCountDeltas.Length
-            for d in report.NullCountDeltas do
-                printfn "  %-40s %-30s before=%d after=%d (change=%+d)"
-                    (SsKey.rootOriginal d.Kind) (SsKey.rootOriginal d.Attribute)
-                    d.Before d.After (d.After - d.Before)
-        if not (List.isEmpty report.Warnings) then
-            printfn ""
-            printfn "Schema differences between the two deployments (%d):" report.Warnings.Length
-            for w in report.Warnings do
-                printfn "  %s  (%s)" w.Message w.Code
+        let joined (lines: string list) = lines |> String.concat "\n"
+        let payload : Voice.Payload =
+            [ if not (List.isEmpty report.RowCountDeltas) then
+                "rowDeltas",
+                box (report.RowCountDeltas
+                     |> List.map (fun d ->
+                         sprintf "%-40s before=%d after=%d (change=%+d)"
+                             (SsKey.rootOriginal d.Kind) d.Before d.After (d.After - d.Before))
+                     |> joined)
+              if not (List.isEmpty report.NullCountDeltas) then
+                "nullDeltas",
+                box (report.NullCountDeltas
+                     |> List.map (fun d ->
+                         sprintf "%-40s %-30s before=%d after=%d (change=%+d)"
+                             (SsKey.rootOriginal d.Kind) (SsKey.rootOriginal d.Attribute)
+                             d.Before d.After (d.After - d.Before))
+                     |> joined)
+              if not (List.isEmpty report.Warnings) then
+                "schemaWarnings",
+                box (report.Warnings
+                     |> List.map (fun w -> sprintf "%s (%s)" w.Message w.Code)
+                     |> joined) ]
+            |> Map.ofList
+        TtyRenderer.renderVoicedTo Console.Out "verifyData.diverged" payload
 
 let runVerifyData (beforeSpec: string) (afterSpec: string) : int =
     let collect = function Ok _ -> [] | Error es -> es
@@ -857,7 +867,8 @@ let runVerifyData (beforeSpec: string) (afterSpec: string) : int =
     let parsedAfter  = TransferSpec.parseConnectionSpec afterSpec
     let specErrors = collect parsedBefore @ collect parsedAfter
     if not (List.isEmpty specErrors) then
-        Console.Error.WriteLine "projection verify-data: argument error:"
+        // The voiced §10/§14 error surface is the whole error face — no
+        // command-prefixed header; exits unchanged.
         printErrors Console.Error specErrors
         dumpBench "verify-data"
         2
@@ -869,7 +880,6 @@ let runVerifyData (beforeSpec: string) (afterSpec: string) : int =
     let afterStrR  = ConnectionResolver.resolve "After"  afterRef
     let connErrors = collect beforeStrR @ collect afterStrR
     if not (List.isEmpty connErrors) then
-        Console.Error.WriteLine "projection verify-data: connection error:"
         printErrors Console.Error connErrors
         dumpBench "verify-data"
         6

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -907,17 +907,19 @@ let runVerifyData (beforeSpec: string) (afterSpec: string) : int =
 /// is rendered). This is the deployed-vs-model check `verify-data`
 /// (deployed-vs-deployed) structurally cannot perform.
 let runDrift (toPath: string) (connSpec: string) : int =
+    // The error face is the voiced §10/§14 surface alone — no command-prefixed
+    // headers: the catalog's frame for the primary code is the statement
+    // (malformed reference / unresolved secret / model failed to load /
+    // deployed schema unreadable), the located causes ride beneath.
     let collect = function Ok _ -> [] | Error es -> es
     let parsedConn = TransferSpec.parseConnectionSpec connSpec
     if not (List.isEmpty (collect parsedConn)) then
-        Console.Error.WriteLine "projection drift: --conn argument error:"
         printErrors Console.Error (collect parsedConn)
         dumpBench "drift"
         2
     else
     let connStrR = ConnectionResolver.resolve "Deployed" (Result.value parsedConn)
     if not (List.isEmpty (collect connStrR)) then
-        Console.Error.WriteLine "projection drift: connection error:"
         printErrors Console.Error (collect connStrR)
         dumpBench "drift"
         6
@@ -927,7 +929,6 @@ let runDrift (toPath: string) (connSpec: string) : int =
             let! modelR = Compose.read toPath
             match modelR with
             | Error es ->
-                Console.Error.WriteLine (sprintf "projection drift: could not read --to %s:" toPath)
                 printErrors Console.Error es
                 return 6
             | Ok model ->
@@ -935,16 +936,19 @@ let runDrift (toPath: string) (connSpec: string) : int =
                 do! cnn.OpenAsync()
                 match! DriftRun.detect model cnn with
                 | Error es ->
-                    Console.Error.WriteLine "projection drift: could not read the deployed schema:"
                     printErrors Console.Error es
                     return 3
                 | Ok diff ->
                     if PhysicalSchema.isEqual diff then
-                        printfn "Verified. The deployed schema matches the model."
+                        // §6 — the no-drift verdict, voiced (`drift.none`).
+                        TtyRenderer.renderVoicedTo Console.Out "drift.none" Map.empty
                         return 0
                     else
-                        eprintfn "The deployed schema diverges from the model. The difference is shown below."
-                        eprintfn "%s" (PhysicalSchema.renderDiff diff)
+                        // §5 drift gate — the finding leads; the rendered
+                        // difference is demoted into the disclosure beneath;
+                        // the surface ends on the operator's levers.
+                        TtyRenderer.renderVoicedTo Console.Error "drift.diverged"
+                            (Map.ofList [ "renderedDiff", box (PhysicalSchema.renderDiff diff) ])
                         return 5
         }
     let code = work.GetAwaiter().GetResult()

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -1079,6 +1079,79 @@ let runSetup (connRef: string option) : int =
     TtyRenderer.renderAnswer false View.defaultDepth view
     0
 
+/// R1d — `projection inspect <runId> [<runId>]`: the stored Run aggregate,
+/// rendered (D5 — the store already resolves; this verb renders). One id
+/// answers "what was this run?"; two ids answer "what moved between these
+/// runs?" through `Run.diff` (the UoM delta surface; the harness's
+/// before/after protocol is its restriction to a key-label set).
+/// Read-only and envelope-free — stays outside the bracket per the R1b law.
+/// NOTE: the card named this verb `diff <runA> <runB>`; that name is held
+/// by the shipped catalog-refs diff, so the run-grain projection lands
+/// under `inspect` — one noun per surface, the collision named here.
+let runInspect (idA: string) (idB: string option) : int =
+    match Run.storeDir () with
+    | None ->
+        eprintfn "No run store is configured. Set PROJECTION_LEDGER_DIR to capture runs, then inspect by run id."
+        4
+    | Some dir ->
+        let load (id: string) : Run.Run option = Run.load dir id
+        match idB with
+        | None ->
+            match load idA with
+            | None ->
+                eprintfn "Run %s is not in the store at %s." idA dir
+                1
+            | Some r ->
+                printfn "Run %s — %s" r.RunId r.Command
+                printfn "  at %s — %s%s" r.Ts r.Outcome (match r.Canary with Some c -> sprintf " (canary %s)" c | None -> "")
+                printfn "  transforms: %d registered, %d applied, %d declined" r.Registered r.Applied r.Declined
+                printfn "  events: %d   artifacts: %s"
+                    (List.length r.Events)
+                    (if Map.isEmpty r.Artifacts then "none" else r.Artifacts |> Map.toList |> List.map fst |> String.concat ", ")
+                (match r.Ledgers with
+                 | [] -> ()
+                 | ledgers ->
+                     printfn "  ledgers extended:"
+                     for l in ledgers do
+                         match l with
+                         | Run.JournalRef d -> printfn "    journal %s" d
+                         | Run.EpisodeRef (t, o) -> printfn "    episode %s ordinal %d" t o)
+                (match r.Bench with
+                 | None -> ()
+                 | Some b ->
+                     let top = b.Stats |> List.sortByDescending (fun s -> s.TotalMs) |> List.truncate 5
+                     if not (List.isEmpty top) then
+                         printfn "  slowest labels:"
+                         for s in top do printfn "    %-44s %6d ms" s.Label s.TotalMs)
+                0
+        | Some idB ->
+            match load idA, load idB with
+            | None, _ ->
+                eprintfn "Run %s is not in the store at %s." idA dir
+                1
+            | _, None ->
+                eprintfn "Run %s is not in the store at %s." idB dir
+                1
+            | Some a, Some b ->
+                let d = Run.diff None a b
+                printfn "Runs %s → %s" (fst d.RunIds) (snd d.RunIds)
+                printfn "  commands: %s → %s" (fst d.Commands) (snd d.Commands)
+                printfn "  outcomes: %s → %s%s" (fst d.Outcomes) (snd d.Outcomes)
+                    (match d.Canaries with
+                     | Some ca, Some cb -> sprintf " (canary %s → %s)" ca cb
+                     | _ -> "")
+                printfn "  transform deltas: %+d registered, %+d applied, %+d declined   events: %+d"
+                    d.Registered d.Applied d.Declined d.Events
+                let moved = d.BenchDeltas |> List.filter (fun bd -> bd.DeltaMs <> 0L<Run.ms>) |> List.truncate 10
+                if List.isEmpty moved then
+                    printfn "  wall times: no label moved."
+                else
+                    printfn "  wall-time movement (largest first):"
+                    for bd in moved do
+                        let fmt (v: int64<Run.ms> option) = match v with Some x -> sprintf "%d" (int64 x) | None -> "—"
+                        printfn "    %-44s %s → %s ms (%+d)" bd.Label (fmt bd.BeforeMs) (fmt bd.AfterMs) (int64 bd.DeltaMs)
+                0
+
 /// `diff <refA> <refB>` — change, rendered essence-first (INSTRUMENT slice 1,
 /// the first surface of the instrument). Resolves both refs through `Ref`
 /// (file / `@runId` / `json:` / `live:`) and renders the catalog change: the

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -573,6 +573,44 @@ module Voice =
                 @ (match text "code" p with Some c -> [ View.Field("code", c, View.Neutral) ] | None -> [])
           Action         = fun _ -> Some(View.Action "Correct the configuration and rerun.") }
 
+    /// `migrate.inexpressible` — the schema emitter refused changes it cannot
+    /// express as a single ALTER (`THE_VOICE.md` §10): the statement carries the
+    /// count and states that the database is unchanged; each refusing change is
+    /// demoted into the disclosure beneath, its code beside its cause.
+    let private migrateInexpressible : Copy =
+        { Code           = "migrate.inexpressible"
+          DocSection     = "§10"
+          Statement      =
+            fun p ->
+                match text "entryCount" p with
+                | Some n -> View.Hero(View.Bad, sprintf "%s change(s) cannot be expressed as a single ALTER. The database is unchanged." (humane n))
+                | None   -> View.Hero(View.Bad, "A change cannot be expressed as a single ALTER. The database is unchanged.")
+          Substantiation =
+            fun p ->
+                match text "entries" p with
+                | Some es ->
+                    let lines =
+                        es.Split '\n'
+                        |> Array.toList
+                        |> List.filter (fun l -> l.Trim() <> "")
+                    [ View.Disclosure("the changes", View.Bad, lines |> List.map View.Note) ]
+                | None -> []
+          Action         = fun _ -> None }
+
+    /// `migrate.stopped` — a migration stop outside the §5 gate vocabulary
+    /// (`THE_VOICE.md` §10 real failure): the run stopped; the plain located
+    /// cause (the `migrationStopDetail` projection) rides beneath.
+    let private migrateStopped : Copy =
+        { Code           = "migrate.stopped"
+          DocSection     = "§10"
+          Statement      = fun _ -> View.Hero(View.Bad, "The migration did not complete. The cause is shown below.")
+          Substantiation =
+            fun p ->
+                match text "cause" p with
+                | Some c -> [ View.Field("cause", c, View.Neutral) ]
+                | None   -> []
+          Action         = fun _ -> None }
+
     /// `canary.sourceMissing` — the round-trip verification's source DDL file is
     /// absent (`THE_VOICE.md` §14 set-but-invalid: concrete and located — the
     /// path rides beneath the plain statement).
@@ -647,7 +685,9 @@ module Voice =
           // §14 / §10 — config & errors
           configValidationFailed
           canarySourceMissing
-          dockerUnavailable ]
+          dockerUnavailable
+          migrateInexpressible
+          migrateStopped ]
 
     /// Look a code's copy up. `None` when the code is not yet voiced — the
     /// totality test guarantees every in-scope LIVE code IS voiced, so a `None`
@@ -719,6 +759,11 @@ module Voice =
             // §14 set-but-invalid: the --env label cannot name a timeline.
             View.Hero(View.Bad, "The environment label cannot name a timeline. Correct the --env label and rerun."),
             Some(View.Action "Correct the --env label and rerun.")
+        elif code.StartsWith "transfer.reconcile." || code.StartsWith "transfer.userMap." then
+            // §14 set-but-invalid — a reconciliation argument the run cannot
+            // use; the located cause (the spec / the file) is the substantiation.
+            View.Hero(View.Bad, "A reconciliation argument is invalid. Correct the --reconcile / --user-map value and rerun."),
+            Some(View.Action "Correct the --reconcile / --user-map value and rerun.")
         elif code.StartsWith "adapter.osm." || code.StartsWith "model." then
             // §10 invalid input — the model could not be loaded; the located
             // detail (path / line / field) is the substantiation beneath.
@@ -829,3 +874,32 @@ module Voice =
                   View.Field("detail", refusal.Error.Message, View.Neutral)
                   View.Field("exit", string refusal.ExitCode, View.Neutral) ]) ]
           Action         = action }
+
+    // ------------------------------------------------------------------
+    // The migrate stop channel — §10 (mechanism 1: a typed projection over
+    // the closed `MigrationError` DU, the run-stop sibling of the §5 gate
+    // projection). The face routes the gate-shaped arms (violations /
+    // CDC-tracked / tightening) through `gateSurface`; the inexpressible
+    // refusal speaks through `migrate.inexpressible`; every remaining arm
+    // states its plain located cause through `migrate.stopped`.
+    // ------------------------------------------------------------------
+
+    /// The plain located cause for a `MigrationError` (`THE_VOICE.md` §10) —
+    /// the finding in operator words, never a raw DU dump. Total over the
+    /// closed DU by exhaustive match. (Moved from `RunFaces.
+    /// migrationErrorDetail`, 2026-06-12 register migration — the catalog owns
+    /// the copy; the face passes the projection as the `migrate.stopped`
+    /// payload's located cause.)
+    let migrationStopDetail (e: MigrationError) : string =
+        match e with
+        | DiffFailed _              -> "the changes could not be computed"
+        | RefusedByViolations v     -> sprintf "%d removal(s) are not yet approved" (List.length v)
+        | RefusedBySchemaErrors es  -> sprintf "%d change(s) cannot be expressed as a single ALTER" (List.length es)
+        | EmitFailed _              -> "the changes could not be built"
+        | SchemaReadFailed _        -> "the deployed schema could not be read"
+        | ExecutionFailed msg       -> sprintf "the migration could not be applied — %s" msg
+        | RefusedByTightening msg   -> sprintf "a column tightening would fail against existing data — %s" msg
+        | VerificationFailed _      -> "the round-trip did not match the model"
+        | DataTransferFailed _      -> "the data load did not complete"
+        | RefusedByCdc t            -> sprintf "the schema change would run against a CDC-tracked database (%d table(s))" (List.length t)
+        | StoreReadFailed msg       -> sprintf "the run history could not be read — %s" msg

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -184,9 +184,47 @@ module Voice =
                 | None    -> []
           Action         = fun _ -> None }
 
+    /// `load.completed` — the publish-and-load verdict (`THE_VOICE.md` §4 data
+    /// plane / §6 minimality): the bundle is published and the idempotent seed is
+    /// loaded, the data movement grounded in its measure (the CDC capture count =
+    /// rows captured, rule 8). A face-verdict code rendered by the run face
+    /// (`renderVoicedTo`), the sibling of `canary.diffEmpty`.
+    let private loadCompleted : Copy =
+        { Code           = "load.completed"
+          DocSection     = "§6"
+          Statement      =
+            fun p ->
+                match text "capturedRows" p with
+                | Some n -> View.Hero(View.Ok, sprintf "The bundle is published and the seed is loaded — %s rows captured." (humane n))
+                | None   -> View.Hero(View.Ok, "The bundle is published and the seed is loaded.")
+          Substantiation =
+            fun p ->
+                (match text "artifactCount" p with
+                 | Some n -> [ View.Field("artifacts", sprintf "%s published" (humane n), View.Neutral) ]
+                 | None   -> [])
+                @ (match text "capturedRows" p with
+                   | Some n -> [ View.Field("evidence", sprintf "CDC capture count = %s — the measured data movement" (humane n), View.Neutral) ]
+                   | None   -> [])
+          Action         = fun _ -> None }
+
     // §13 — lifecycle & the live run (Watch). Stage names are what they do for the
     //       operator, never the engine verb. The gerund names a live activity in
     //       progress (rule 12 exception); a completed stage is resultative.
+
+    /// `episode.recorded` — the run's durable record (`THE_VOICE.md` §13 — "This
+    /// run recorded to the history."). Stative and agentless: the record is a
+    /// state, named with its episode ordinal and timeline when present.
+    let private episodeRecorded : Copy =
+        { Code           = "episode.recorded"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "episodeCount" p, text "timeline" p with
+                | Some n, Some tl ->
+                    View.Note(sprintf "This run recorded to the history — episode %s on timeline %s." (humane n) tl)
+                | _ -> View.Note "This run recorded to the history."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
 
     /// `config.runStart` — the run opens by reading its configuration
     /// (`THE_VOICE.md` §13 / Act 1 Reading). A gerund-in-progress (rule 12
@@ -412,7 +450,9 @@ module Voice =
           canaryDiffEmpty
           canaryDivergence
           summaryRunComplete
+          loadCompleted
           // §13 — lifecycle / Watch (the spine + the per-stage stream)
+          episodeRecorded
           configRunStart
           configConnectionResolved
           extractStarted
@@ -487,6 +527,21 @@ module Voice =
             // gate.intent code, not a Preflight.GateLabel variant).
             View.Hero(View.Warn, "A live write requires PROJECTION_ALLOW_EXECUTE=1 in the environment."),
             Some(View.Action "Set PROJECTION_ALLOW_EXECUTE=1, then re-run.")
+        elif code.StartsWith "transfer.connection.spec" then
+            // §14 set-but-invalid: the reference's *shape* is wrong — an argument
+            // finding, never a reachability claim (the prior routing borrowed the
+            // unreachable frame for parse failures, which overstated the probe).
+            View.Hero(View.Bad, "The connection reference is malformed — the expected shape is env:NAME or file:PATH. Correct it and rerun."),
+            Some(View.Action "Correct the connection reference and rerun.")
+        elif code.StartsWith "transfer.connection.ref" then
+            // §14 required-and-missing: the reference is well-formed but the
+            // secret it points to (the env var / the file) is absent or empty.
+            View.Hero(View.Bad, "The connection reference does not resolve to a connection string. Provide the secret it points to, then retry."),
+            Some(View.Action "Provide the connection secret, then retry.")
+        elif code.StartsWith "timeline.name" then
+            // §14 set-but-invalid: the --env label cannot name a timeline.
+            View.Hero(View.Bad, "The environment label cannot name a timeline. Correct the --env label and rerun."),
+            Some(View.Action "Correct the --env label and rerun.")
         elif code.Contains "connection" then
             View.Hero(View.Warn, "The target is unreachable. Check the connection and retry."),
             Some(View.Action "Check the connection and retry.")

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -277,6 +277,30 @@ module Voice =
                 | None   -> []
           Action         = fun _ -> None }
 
+    /// `drift.none` — the deployed-vs-model check found no divergence
+    /// (`THE_VOICE.md` §6 commuting square, the drift lens). Asserted; the
+    /// residual evidence beneath.
+    let private driftNone : Copy =
+        { Code           = "drift.none"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Ok, "Verified. The deployed schema matches the model.")
+          Substantiation = fun _ -> [ View.Field("evidence", "deployed ⊖ model residual empty", View.Neutral) ]
+          Action         = fun _ -> None }
+
+    /// `drift.diverged` — the deployed schema differs from the model
+    /// (`THE_VOICE.md` §5 drift gate / §10): a watchful finding, the rendered
+    /// difference demoted into the disclosure, ending on the operator's levers.
+    let private driftDiverged : Copy =
+        { Code           = "drift.diverged"
+          DocSection     = "§5"
+          Statement      = fun _ -> View.Hero(View.Warn, "The deployed schema diverges from the model. The difference is shown below.")
+          Substantiation =
+            fun p ->
+                match text "renderedDiff" p with
+                | Some d -> [ View.Disclosure("the difference", View.Warn, [ View.Note d ]) ]
+                | None   -> []
+          Action         = fun _ -> Some(View.Action "Remediate the server, or update the model, then re-run the check.") }
+
     // §13 — lifecycle & the live run (Watch). Stage names are what they do for the
     //       operator, never the engine verb. The gerund names a live activity in
     //       progress (rule 12 exception); a completed stage is resultative.
@@ -597,6 +621,8 @@ module Voice =
           deploySsdtRejected
           canaryCdcSilent
           canaryCdcCaptured
+          driftNone
+          driftDiverged
           // §13 — lifecycle / Watch (the spine + the per-stage stream)
           episodeRecorded
           containerStarting
@@ -693,6 +719,16 @@ module Voice =
             // §14 set-but-invalid: the --env label cannot name a timeline.
             View.Hero(View.Bad, "The environment label cannot name a timeline. Correct the --env label and rerun."),
             Some(View.Action "Correct the --env label and rerun.")
+        elif code.StartsWith "adapter.osm." || code.StartsWith "model." then
+            // §10 invalid input — the model could not be loaded; the located
+            // detail (path / line / field) is the substantiation beneath.
+            View.Hero(View.Bad, "The model failed to load. Correct it and rerun."),
+            Some(View.Action "Correct the model and rerun.")
+        elif code.StartsWith "readside." then
+            // §10 — the deployed schema could not be read (the same finding the
+            // §5 SchemaReadFailed gate states).
+            View.Hero(View.Bad, "The deployed schema could not be read. Check the connection and retry."),
+            Some(View.Action "Check the connection and retry.")
         elif code.Contains "connection" then
             View.Hero(View.Warn, "The target is unreachable. Check the connection and retry."),
             Some(View.Action "Check the connection and retry.")

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -348,6 +348,27 @@ module Voice =
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
+    /// `eject.packaged` — the provenance package is assembled (`THE_VOICE.md`
+    /// §13, resultative; §7 P-7): every episode preserved, the rename records
+    /// carried; the timeline named beneath. ("append-forever" and "refactorlog"
+    /// stay off the surface — §2.1: the operator's words are the history and
+    /// the record.)
+    let private ejectPackaged : Copy =
+        { Code           = "eject.packaged"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "episodeCount" p, text "refactorLogCount" p with
+                | Some n, Some r ->
+                    View.Note(sprintf "Provenance package assembled — %s episodes preserved, %s rename records carried." (humane n) (humane r))
+                | _ -> View.Note "Provenance package assembled — every episode preserved."
+          Substantiation =
+            fun p ->
+                match text "timeline" p with
+                | Some tl -> [ View.Field("timeline", tl, View.Neutral) ]
+                | None    -> []
+          Action         = fun _ -> None }
+
     /// `episode.recorded` — the run's durable record (`THE_VOICE.md` §13 — "This
     /// run recorded to the history."). Stative and agentless: the record is a
     /// state, named with its episode ordinal and timeline when present.
@@ -573,6 +594,27 @@ module Voice =
                 @ (match text "code" p with Some c -> [ View.Field("code", c, View.Neutral) ] | None -> [])
           Action         = fun _ -> Some(View.Action "Correct the configuration and rerun.") }
 
+    /// `eject.verified` — the freeze's self-verification passed (`THE_VOICE.md`
+    /// §6 / §7 P-7): the reconstruction from genesis reproduces the frozen
+    /// state. Asserted; the replay evidence beneath.
+    let private ejectVerified : Copy =
+        { Code           = "eject.verified"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Ok, "Verified. The reconstruction reproduces the frozen state from genesis to freeze.")
+          Substantiation = fun _ -> [ View.Field("evidence", "replay from genesis = the frozen state", View.Neutral) ]
+          Action         = fun _ -> None }
+
+    /// `eject.unverified` — the freeze's self-verification failed
+    /// (`THE_VOICE.md` §6 / §10): the reconstruction diverges from the frozen
+    /// state, so the package is unverified. Honest without exception — the
+    /// finding is stated plainly; no lever exists beyond investigation.
+    let private ejectUnverified : Copy =
+        { Code           = "eject.unverified"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Bad, "The reconstruction does not reproduce the frozen state. The package is unverified.")
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `migrate.inexpressible` — the schema emitter refused changes it cannot
     /// express as a single ALTER (`THE_VOICE.md` §10): the statement carries the
     /// count and states that the database is unchanged; each refusing change is
@@ -610,6 +652,20 @@ module Voice =
                 | Some c -> [ View.Field("cause", c, View.Neutral) ]
                 | None   -> []
           Action         = fun _ -> None }
+
+    /// `eject.storeUnreadable` — the durable run history could not be loaded for
+    /// the freeze (`THE_VOICE.md` §14 set-but-invalid / §10): the plain finding
+    /// with the located cause beneath, never a raw store error on the lead.
+    let private ejectStoreUnreadable : Copy =
+        { Code           = "eject.storeUnreadable"
+          DocSection     = "§14"
+          Statement      = fun _ -> View.Hero(View.Bad, "The run history could not be read. Check the --store path and retry.")
+          Substantiation =
+            fun p ->
+                match text "cause" p with
+                | Some c -> [ View.Field("cause", c, View.Neutral) ]
+                | None   -> []
+          Action         = fun _ -> Some(View.Action "Check the --store path and retry.") }
 
     /// `canary.sourceMissing` — the round-trip verification's source DDL file is
     /// absent (`THE_VOICE.md` §14 set-but-invalid: concrete and located — the
@@ -661,8 +717,11 @@ module Voice =
           canaryCdcCaptured
           driftNone
           driftDiverged
+          ejectVerified
+          ejectUnverified
           // §13 — lifecycle / Watch (the spine + the per-stage stream)
           episodeRecorded
+          ejectPackaged
           containerStarting
           deployBundleEmitted
           canaryDeployed
@@ -687,7 +746,8 @@ module Voice =
           canarySourceMissing
           dockerUnavailable
           migrateInexpressible
-          migrateStopped ]
+          migrateStopped
+          ejectStoreUnreadable ]
 
     /// Look a code's copy up. `None` when the code is not yet voiced — the
     /// totality test guarantees every in-scope LIVE code IS voiced, so a `None`

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -594,6 +594,41 @@ module Voice =
                 @ (match text "code" p with Some c -> [ View.Field("code", c, View.Neutral) ] | None -> [])
           Action         = fun _ -> Some(View.Action "Correct the configuration and rerun.") }
 
+    /// `verifyData.matched` — the post-deploy data-integrity check passed
+    /// (`THE_VOICE.md` §6, the data-fidelity complement of the structural
+    /// round-trip): asserted, with the compared measures as the evidence.
+    let private verifyDataMatched : Copy =
+        { Code           = "verifyData.matched"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Ok, "Verified. The data matches across both deployments.")
+          Substantiation = fun _ -> [ View.Field("evidence", "per-table row counts and per-column null counts equal", View.Neutral) ]
+          Action         = fun _ -> None }
+
+    /// `verifyData.diverged` — the data differs between the two deployments
+    /// (`THE_VOICE.md` §6 / §10): the finding leads; the per-table deltas are
+    /// demoted into disclosures (row counts · null counts · schema differences),
+    /// each counted on its headline; the surface ends on the move.
+    let private verifyDataDiverged : Copy =
+        { Code           = "verifyData.diverged"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Bad, "The data diverges between the two deployments. The differences are shown below.")
+          Substantiation =
+            fun p ->
+                let detailLines (v: string) =
+                    v.Split '\n' |> Array.toList |> List.filter (fun l -> l.Trim() <> "")
+                let block (key: string) (label: string) (status: View.Status) =
+                    match text key p with
+                    | Some v ->
+                        let lines = detailLines v
+                        [ View.Disclosure(
+                            sprintf "%s — %s differ" label (humane (string (List.length lines))),
+                            status, lines |> List.map View.Note) ]
+                    | None -> []
+                block "rowDeltas" "row counts" View.Bad
+                @ block "nullDeltas" "null counts" View.Bad
+                @ block "schemaWarnings" "schema differences" View.Warn
+          Action         = fun _ -> Some(View.Action "Investigate the listed tables, then re-run the check.") }
+
     /// `eject.verified` — the freeze's self-verification passed (`THE_VOICE.md`
     /// §6 / §7 P-7): the reconstruction from genesis reproduces the frozen
     /// state. Asserted; the replay evidence beneath.
@@ -717,6 +752,8 @@ module Voice =
           canaryCdcCaptured
           driftNone
           driftDiverged
+          verifyDataMatched
+          verifyDataDiverged
           ejectVerified
           ejectUnverified
           // §13 — lifecycle / Watch (the spine + the per-stage stream)

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -207,9 +207,79 @@ module Voice =
                    | None   -> [])
           Action         = fun _ -> None }
 
+    /// `deploy.completed` — the deploy verdict (`THE_VOICE.md` §3): the change
+    /// build landed in SQL Server. Resultative and agentless; the ephemeral
+    /// database name is the substantiation, never the lead.
+    let private deployCompleted : Copy =
+        { Code           = "deploy.completed"
+          DocSection     = "§3"
+          Statement      =
+            fun p ->
+                match text "tableCount" p with
+                | Some n -> View.Hero(View.Ok, sprintf "Deploy complete — %s tables created." (humane n))
+                | None   -> View.Hero(View.Ok, "Deploy complete.")
+          Substantiation =
+            fun p ->
+                match text "database" p with
+                | Some db -> [ View.Field("database", db, View.Neutral) ]
+                | None    -> []
+          Action         = fun _ -> None }
+
+    /// `deploy.ssdtRejected` — SQL Server rejected the emitted SSDT
+    /// (`THE_VOICE.md` §10): the statement is the plain finding; the server's
+    /// own messages are demoted into a disclosure (the substantiation), exactly
+    /// as `canary.divergence` demotes the rendered diff. The database name rides
+    /// beneath; the move ends the surface.
+    let private deploySsdtRejected : Copy =
+        { Code           = "deploy.ssdtRejected"
+          DocSection     = "§10"
+          Statement      = fun _ -> View.Hero(View.Bad, "SQL Server rejected the change build. The server's findings are shown below.")
+          Substantiation =
+            fun p ->
+                (match text "database" p with
+                 | Some db -> [ View.Field("database", db, View.Neutral) ]
+                 | None    -> [])
+                @ (match text "serverErrors" p with
+                   | Some es ->
+                       let lines =
+                           es.Split '\n'
+                           |> Array.toList
+                           |> List.filter (fun l -> l.Trim() <> "")
+                       [ View.Disclosure("the server's findings", View.Bad, lines |> List.map View.Note) ]
+                   | None -> [])
+          Action         = fun _ -> Some(View.Action "Resolve the findings, then redeploy.") }
+
     // §13 — lifecycle & the live run (Watch). Stage names are what they do for the
     //       operator, never the engine verb. The gerund names a live activity in
     //       progress (rule 12 exception); a completed stage is resultative.
+
+    /// `container.starting` — an ephemeral SQL Server container is coming up for
+    /// a run that needs one (`THE_VOICE.md` §13). Gerund-in-progress (rule 12
+    /// exception); `purpose` names which face the container serves.
+    let private containerStarting : Copy =
+        { Code           = "container.starting"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "purpose" p with
+                | Some purpose -> View.Note(sprintf "Starting an ephemeral SQL Server container for the %s." purpose)
+                | None         -> View.Note "Starting an ephemeral SQL Server container."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
+    /// `deploy.bundleEmitted` — the change build is complete and its SSDT bundle
+    /// is in hand (`THE_VOICE.md` §13, resultative). The entry count grounds the
+    /// line; the emitter internals (the JSON node machinery) stay off the surface.
+    let private deployBundleEmitted : Copy =
+        { Code           = "deploy.bundleEmitted"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "entryCount" p with
+                | Some n -> View.Note(sprintf "Change build complete — %s SSDT bundle entries." (humane n))
+                | None   -> View.Note "Change build complete."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
 
     /// `episode.recorded` — the run's durable record (`THE_VOICE.md` §13 — "This
     /// run recorded to the history."). Stative and agentless: the record is a
@@ -436,6 +506,21 @@ module Voice =
                 @ (match text "code" p with Some c -> [ View.Field("code", c, View.Neutral) ] | None -> [])
           Action         = fun _ -> Some(View.Action "Correct the configuration and rerun.") }
 
+    /// `docker.unavailable` — a face that needs an ephemeral SQL Server cannot
+    /// reach the Docker daemon (`THE_VOICE.md` §14 required-and-missing): the
+    /// requirement and how to provide it, stated without scolding. `purpose`
+    /// names the face the daemon is required for.
+    let private dockerUnavailable : Copy =
+        { Code           = "docker.unavailable"
+          DocSection     = "§14"
+          Statement      =
+            fun p ->
+                View.Hero(View.Warn,
+                    sprintf "A reachable Docker daemon is required for the %s. Start the daemon or set DOCKER_HOST, then retry."
+                        (textOr "purpose" "run" p))
+          Substantiation = fun _ -> []
+          Action         = fun _ -> Some(View.Action "Start the Docker daemon or set DOCKER_HOST, then retry.") }
+
     // ------------------------------------------------------------------
     // The harvest — `all` gathers every declared copy into one catalog.
     // The `code ⇔ copy` totality test reads this (the sibling of the
@@ -451,8 +536,12 @@ module Voice =
           canaryDivergence
           summaryRunComplete
           loadCompleted
+          deployCompleted
+          deploySsdtRejected
           // §13 — lifecycle / Watch (the spine + the per-stage stream)
           episodeRecorded
+          containerStarting
+          deployBundleEmitted
           configRunStart
           configConnectionResolved
           extractStarted
@@ -470,7 +559,8 @@ module Voice =
           watchStageHalted
           summaryStageCompleted
           // §14 / §10 — config & errors
-          configValidationFailed ]
+          configValidationFailed
+          dockerUnavailable ]
 
     /// Look a code's copy up. `None` when the code is not yet voiced — the
     /// totality test guarantees every in-scope LIVE code IS voiced, so a `None`

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -249,9 +249,52 @@ module Voice =
                    | None -> [])
           Action         = fun _ -> Some(View.Action "Resolve the findings, then redeploy.") }
 
+    /// `canary.cdcSilent` — the CDC-silence proof (`THE_VOICE.md` §6): the
+    /// deepest fidelity finding, said plain and grounded in both its zeros.
+    let private canaryCdcSilent : Copy =
+        { Code           = "canary.cdcSilent"
+          DocSection     = "§6"
+          Statement      = fun _ -> View.Hero(View.Ok, "Confirmed idempotent: zero rows captured, zero schema changes issued.")
+          Substantiation = fun _ -> [ View.Field("evidence", "CDC capture count = 0 · zero ALTER statements", View.Neutral) ]
+          Action         = fun _ -> None }
+
+    /// `canary.cdcCaptured` — the CDC-silence proof failed (`THE_VOICE.md` §6 /
+    /// §10): the redeploy touched rows where the proof requires silence. The
+    /// finding is asserted with its measure; the capture detail is in the run's
+    /// events. Ends on the verdict — no single lever exists for this finding.
+    let private canaryCdcCaptured : Copy =
+        { Code           = "canary.cdcCaptured"
+          DocSection     = "§6"
+          Statement      =
+            fun p ->
+                match text "capturedRows" p with
+                | Some n -> View.Hero(View.Bad, sprintf "The redeploy was not idempotent — %s rows captured where zero were expected." (humane n))
+                | None   -> View.Hero(View.Bad, "The redeploy was not idempotent — rows were captured where zero were expected.")
+          Substantiation =
+            fun p ->
+                match text "capturedRows" p with
+                | Some n -> [ View.Field("evidence", sprintf "CDC capture count = %s" (humane n), View.Neutral) ]
+                | None   -> []
+          Action         = fun _ -> None }
+
     // §13 — lifecycle & the live run (Watch). Stage names are what they do for the
     //       operator, never the engine verb. The gerund names a live activity in
     //       progress (rule 12 exception); a completed stage is resultative.
+
+    /// `canary.deployed` — both sides of the round-trip verification are in
+    /// place (`THE_VOICE.md` §13, resultative): the source schema and the
+    /// engine's own emission, each deployed to its ephemeral database.
+    let private canaryDeployed : Copy =
+        { Code           = "canary.deployed"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "sourceTables" p, text "targetTables" p with
+                | Some s, Some t ->
+                    View.Note(sprintf "Both sides deployed — source %s tables, target %s tables." (humane s) (humane t))
+                | _ -> View.Note "Both sides deployed."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
 
     /// `container.starting` — an ephemeral SQL Server container is coming up for
     /// a run that needs one (`THE_VOICE.md` §13). Gerund-in-progress (rule 12
@@ -506,6 +549,20 @@ module Voice =
                 @ (match text "code" p with Some c -> [ View.Field("code", c, View.Neutral) ] | None -> [])
           Action         = fun _ -> Some(View.Action "Correct the configuration and rerun.") }
 
+    /// `canary.sourceMissing` — the round-trip verification's source DDL file is
+    /// absent (`THE_VOICE.md` §14 set-but-invalid: concrete and located — the
+    /// path rides beneath the plain statement).
+    let private canarySourceMissing : Copy =
+        { Code           = "canary.sourceMissing"
+          DocSection     = "§14"
+          Statement      = fun _ -> View.Hero(View.Bad, "The source DDL file was not found. Check the path and rerun.")
+          Substantiation =
+            fun p ->
+                match text "path" p with
+                | Some path -> [ View.Field("path", path, View.Neutral) ]
+                | None      -> []
+          Action         = fun _ -> Some(View.Action "Check the path and rerun.") }
+
     /// `docker.unavailable` — a face that needs an ephemeral SQL Server cannot
     /// reach the Docker daemon (`THE_VOICE.md` §14 required-and-missing): the
     /// requirement and how to provide it, stated without scolding. `purpose`
@@ -538,10 +595,13 @@ module Voice =
           loadCompleted
           deployCompleted
           deploySsdtRejected
+          canaryCdcSilent
+          canaryCdcCaptured
           // §13 — lifecycle / Watch (the spine + the per-stage stream)
           episodeRecorded
           containerStarting
           deployBundleEmitted
+          canaryDeployed
           configRunStart
           configConnectionResolved
           extractStarted
@@ -560,6 +620,7 @@ module Voice =
           summaryStageCompleted
           // §14 / §10 — config & errors
           configValidationFailed
+          canarySourceMissing
           dockerUnavailable ]
 
     /// Look a code's copy up. `None` when the code is not yet voiced — the

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -196,6 +196,50 @@ module Watch =
     let applyEnvelope (board: Board) (env: LogSink.Envelope) : Board * bool =
         apply board env.Code env.Payload
 
+    /// R1e — reconstruct the board from a STORED run's serialized envelopes
+    /// (`Run.Events`, the NDJSON lines `Run.capture` persists): each line
+    /// parses to its (code, payload) and folds through the SAME `apply` the
+    /// live subscriber feeds. The R1 law is that this projection equals the
+    /// board the live run built — the stored Run is a faithful source for
+    /// the view, not a lossy echo. Unparseable lines fold as no-ops (the
+    /// board reacts to the stage codes only; foreign lines carry none).
+    let boardOfStored (seed: Board) (events: string list) : Board =
+        let parseLine (line: string) : (string * Map<string, objnull>) option =
+            try
+                use doc = System.Text.Json.JsonDocument.Parse line
+                let root = doc.RootElement
+                match root.TryGetProperty "code" with
+                | true, c when c.ValueKind = System.Text.Json.JsonValueKind.String ->
+                    let code = match c.GetString() with null -> "" | s -> s
+                    let payload =
+                        match root.TryGetProperty "payload" with
+                        | true, p when p.ValueKind = System.Text.Json.JsonValueKind.Object ->
+                            [ for prop in p.EnumerateObject() ->
+                                let v : objnull =
+                                    match prop.Value.ValueKind with
+                                    | System.Text.Json.JsonValueKind.Number ->
+                                        (match prop.Value.TryGetInt64() with
+                                         | true, l -> box l
+                                         | _ -> box (prop.Value.GetDouble()))
+                                    | System.Text.Json.JsonValueKind.String ->
+                                        (match prop.Value.GetString() with null -> box "" | s -> box s)
+                                    | System.Text.Json.JsonValueKind.True -> box true
+                                    | System.Text.Json.JsonValueKind.False -> box false
+                                    | _ -> box (prop.Value.GetRawText())
+                                prop.Name, v ]
+                            |> Map.ofList
+                        | _ -> Map.empty
+                    Some (code, payload)
+                | _ -> None
+            with _ -> None
+        events
+        |> List.fold
+            (fun board line ->
+                match parseLine line with
+                | Some (code, payload) -> fst (apply board code payload)
+                | None -> board)
+            seed
+
     // -- the dwell floor (pure; clock-injected) --------------------------------
 
     /// The minimum interval a frame stays on screen before the next is shown

--- a/sidecar/projection/src/Projection.Core/Episode.fs
+++ b/sidecar/projection/src/Projection.Core/Episode.fs
@@ -180,6 +180,13 @@ module EpisodicLifecycle =
     /// Append the next episode, enforcing L3-L2 (monotonic history) on the
     /// schema-plane `Version` ordinal — the same rule `Lifecycle.append` holds.
     /// A non-monotone append fails rather than silently reordering.
+    ///
+    /// This check IS the episode grain's **ResumeAdmit** (R3 / RI-3, card
+    /// L3): re-run over every edge when the store reloads a chain, it
+    /// verifies chain STRUCTURE — ordinal monotonicity — and nothing more.
+    /// The grain's write witness (B'≡B, `MigrationRun.recordVerified`)
+    /// cannot be re-verified at load (no B' exists to re-deploy), and this
+    /// contract does not pretend to.
     let append (episode: Episode) (lifecycle: EpisodicLifecycle) : Result<EpisodicLifecycle> =
         let (EpisodicLifecycle data) = lifecycle
         let lastOrdinal = Version.ordinal (Episode.version (List.last data.Episodes))
@@ -207,6 +214,13 @@ module EpisodicLifecycle =
     /// reconstructing the latest schema from genesis + the per-edge deltas. The
     /// chain-level round-trip law: the reconstruction agrees with the stored
     /// latest schema modulo the diff's captured surface.
+    ///
+    /// On the ledger contract (R3, card L3) this fold is the snapshot
+    /// chain's **verification property, not its recovery path** — each
+    /// episode carries FULL state, so recovery reads the stored latest
+    /// snapshot directly; the FTC fold earns its keep by AGREEING with it.
+    /// (The dual of the journal grain, whose entries are partial sums and
+    /// whose replay IS recovery.)
     let reconstructLatestSchema (lifecycle: EpisodicLifecycle) : Result<Catalog, EmitError> =
         let (EpisodicLifecycle data) = lifecycle
         let genesisSchema = (List.head data.Episodes).Schema

--- a/sidecar/projection/src/Projection.Core/Ledger.fs
+++ b/sidecar/projection/src/Projection.Core/Ledger.fs
@@ -1,0 +1,124 @@
+namespace Projection.Core
+
+/// The ledger contract — R3 (`CONSTELLATION.md` §9.2, corrected per
+/// `CONSTELLATION_BACKLOG.md` RI-3). The engine's two durable ledgers — the
+/// capture journal (a partial-sum ledger of chunk quanta) and the episode
+/// store (a snapshot chain with derivable displacements) — converged on one
+/// discipline independently: append-only, admission-guarded, FTC-related.
+/// This file names that discipline once, in Core, pure: the instances adapt
+/// at the boundary (the journal's effectful remap fold, the store's JSON
+/// home) while the chain algebra and the admission split live here.
+///
+/// **The admission split (RI-3).** One `FingerprintOf : 'entry -> 'fp`
+/// cannot honestly cover both grains, because the two ledgers verify
+/// DIFFERENT things at different times:
+///   - `WriteAdmit` — at write time, an entry may demand an **external
+///     witness** (the episode grain's B′≡B round-trip; the journal grain's
+///     completed sink statement). The witness is checked once, when it is
+///     checkable, and the `Verified<_>` token records that it held.
+///   - `ResumeAdmit` — at resume time, the external witness is gone (no
+///     B′ to re-deploy; no completed write to observe). What CAN be checked
+///     is the stored fingerprint against a **recomputation from the live
+///     source** — equality admits, disagreement is drift, and drift refuses
+///     by name (`transfer.resume.sourceDrift`'s shape, generalized), never
+///     a silent re-run over changed data.
+/// A snapshot-chain instance whose resume check is ordinal monotonicity
+/// (the episode store) says so honestly — it verifies chain STRUCTURE, not
+/// the write witness (see `LifecycleStore`, card L3).
+type LedgerEntry<'entry, 'fp> =
+    {
+        /// The entry's position in the chain (chunk index; episode ordinal).
+        Position    : int
+        /// The fingerprint recorded AT WRITE TIME — what `ResumeAdmit`
+        /// recomputes against. For the journal: first/last source PK + raw
+        /// count. For the episode store: the monotone coordinate ordinal.
+        Fingerprint : 'fp
+        Entry       : 'entry
+    }
+
+/// A ledger entry that passed its grain's admission check. Minted ONLY by
+/// `Ledger.writeAdmit` / `Ledger.resumeAdmit` — the private constructor is
+/// the admission law (the `ArtifactByKind` proof-token idiom): a
+/// `Verified<'entry>` cannot exist unless an admission arm held when it
+/// was constructed. `Ledger.replay` folds over verified entries only, so
+/// an unadmitted entry structurally cannot reach the partial sums.
+type Verified<'entry> = private Verified of 'entry
+
+/// A recorded fingerprint disagreeing with its recomputation — the named
+/// drift at one position. Core keeps this typed and instance-neutral; each
+/// instance maps it onto its own named refusal (the journal:
+/// `transfer.resume.sourceDrift`).
+type LedgerDrift<'fp> =
+    {
+        Position   : int
+        Recorded   : 'fp
+        Recomputed : 'fp
+    }
+
+/// The pure chain algebra of one ledger grain — record-of-functions, per
+/// the house preference for data over dispatch. `Apply` is ⊕ at this
+/// grain; `Genesis` its unit; `FingerprintOf` what write-time stamps and
+/// resume-time recomputes. The journal (chunk grain), the episode store
+/// (episode grain), and the G10 progress marker (the degenerate
+/// single-entry grain) are its instances.
+type LedgerSpec<'state, 'entry, 'fp when 'fp : equality> =
+    {
+        Genesis       : 'state
+        Apply         : 'state -> 'entry -> 'state
+        FingerprintOf : 'entry -> 'fp
+    }
+
+[<RequireQualifiedAccess>]
+module Verified =
+
+    /// Read the admitted entry out of its token.
+    let value (Verified entry) : 'entry = entry
+
+[<RequireQualifiedAccess>]
+module Ledger =
+
+    /// Stamp a new entry into chain form at write time: the position and
+    /// the spec's fingerprint, recorded beside the entry so resume can
+    /// recompute against it.
+    let entryOf (spec: LedgerSpec<'s, 'e, 'fp>) (position: int) (entry: 'e) : LedgerEntry<'e, 'fp> =
+        { Position = position; Fingerprint = spec.FingerprintOf entry; Entry = entry }
+
+    /// **WriteAdmit** — the external-witness arm. The grain's verifier
+    /// decides (`'err` stays the grain's own error algebra); a passing
+    /// witness mints the token. The witness is the part that cannot be
+    /// re-run later — B′≡B needs the deployed B′; the journal's commit
+    /// point needs the write to have happened — which is exactly why the
+    /// token exists: it carries "the witness held" forward in the type.
+    let writeAdmit (witness: 'entry -> Result<unit, 'err>) (entry: 'entry) : Result<Verified<'entry>, 'err> =
+        match witness entry with
+        | Ok () -> Ok (Verified entry)
+        | Error e -> Error e
+
+    /// **ResumeAdmit** — the recomputation arm. The caller recomputes the
+    /// fingerprint **from the live source** (that recomputation is the
+    /// instance's I/O and happens at the boundary; Core compares values).
+    /// Equality admits the recorded entry; disagreement is the named
+    /// drift — never a silent re-run.
+    let resumeAdmit (recomputed: 'fp) (recorded: LedgerEntry<'e, 'fp>) : Result<Verified<'e>, LedgerDrift<'fp>> =
+        if recomputed = recorded.Fingerprint then
+            Ok (Verified recorded.Entry)
+        else
+            Error { Position = recorded.Position; Recorded = recorded.Fingerprint; Recomputed = recomputed }
+
+    /// The FTC at this grain (`CONSTELLATION.md` §5.1): fold ⊕ over
+    /// verified entries from genesis — the partial sums reconstruct the
+    /// state. Total over its input by construction: only admitted entries
+    /// can appear in the list.
+    let replay (spec: LedgerSpec<'s, 'e, 'fp>) (entries: Verified<'e> list) : 's =
+        entries |> List.fold (fun state (Verified entry) -> spec.Apply state entry) spec.Genesis
+
+    /// Resume = the first position absent from the chain. A gapless chain
+    /// 0..k−1 resumes at k; a gap resumes at the gap (the chain is an
+    /// index, not a prefix — a last-write-wins journal may hold positions
+    /// past a crash hole, and those entries still admit individually via
+    /// `resumeAdmit` when the live walk reaches them).
+    let resumePoint (recorded: LedgerEntry<'e, 'fp> list) : int =
+        let positions = recorded |> List.map (fun r -> r.Position) |> Set.ofList
+        let rec firstAbsent candidate =
+            if Set.contains candidate positions then firstAbsent (candidate + 1) else candidate
+        firstAbsent 0

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Compile Include="Result.fs" />
+    <Compile Include="Ledger.fs" />
     <Compile Include="Message.fs" />
     <Compile Include="Bench.fs" />
     <Compile Include="PinnedWriting.fs" />

--- a/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
+++ b/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
@@ -136,6 +136,42 @@ type TopologicalOrder = {
     Diagnostics  : string list
 }
 
+/// R5 / card P1 — a group whose members may execute CONCURRENTLY. The
+/// proof-token idiom (`ArtifactByKind`'s move, applied to parallelism):
+/// the private constructor is the safety law — a value of this type
+/// cannot exist unless the independence proof ran at construction. The
+/// ONLY production mint is `TopologicalOrder.levels` (the Kahn-style
+/// level assignment: within a level, no member depends on another).
+/// The comment-borne "callers MUST deploy levels in order; within a
+/// single level segments are independent" contract becomes this type:
+/// the MUST dies, the type lives.
+///
+/// `map` / `choose` are the structure-preserving carriers: per-member
+/// projection (kind → that kind's rendered script) and per-member
+/// dropping can never merge groups or smuggle a dependent member in —
+/// so the token survives the composer's rendering pipeline honestly.
+type ParallelSafe<'a> = private ParallelSafe of 'a list
+
+[<RequireQualifiedAccess>]
+module ParallelSafe =
+
+    /// The group's members, for consumers that render or count — the
+    /// read-only view (a manifest listing, a level walk). Reading never
+    /// forges; only construction is guarded.
+    let members (ParallelSafe xs) : 'a list = xs
+
+    /// Per-member projection. Structure-preserving: one image per
+    /// member, no merging, no reordering across groups.
+    let map (f: 'a -> 'b) (ParallelSafe xs) : ParallelSafe<'b> =
+        ParallelSafe (List.map f xs)
+
+    /// Per-member projection that may drop members. Dropping a member
+    /// never breaks the independence of those that remain.
+    let choose (f: 'a -> 'b option) (ParallelSafe xs) : ParallelSafe<'b> =
+        ParallelSafe (List.choose f xs)
+
+    let isEmpty (ParallelSafe xs) : bool = List.isEmpty xs
+
 [<RequireQualifiedAccess>]
 module TopologicalOrder =
 
@@ -235,7 +271,12 @@ module TopologicalOrder =
                 else None)
             |> Set.ofList
 
-    let levels (t: TopologicalOrder) : SsKey list list =
+    /// Kahn-style level assignment — and the MINT of `ParallelSafe`
+    /// (card P1): each returned group's members sit at one dependency
+    /// depth, so no member depends on another and the group may deploy
+    /// concurrently. Levels themselves stay ordered (level k+1 may
+    /// depend on level k); only WITHIN a group is parallelism licensed.
+    let levels (t: TopologicalOrder) : ParallelSafe<SsKey> list =
         let parentsOf =
             t.Edges
             |> List.groupBy fst
@@ -259,7 +300,8 @@ module TopologicalOrder =
         |> List.groupBy snd
         |> List.sortBy fst
         |> List.map (fun (_, pairs) ->
-            pairs |> List.map fst |> List.sort)
+            // The mint: one dependency depth = one concurrent-safe group.
+            ParallelSafe (pairs |> List.map fst |> List.sort))
 
 
 /// H-037 — result of schema island detection. Each inner list is one

--- a/sidecar/projection/src/Projection.Pipeline/BenchSink.fs
+++ b/sidecar/projection/src/Projection.Pipeline/BenchSink.fs
@@ -20,14 +20,6 @@ open Projection.Core
 [<RequireQualifiedAccess>]
 module BenchSink =
 
-    /// Filename timestamp format: `yyyyMMddTHHmmssZ` keeps lexically
-    /// sortable, fixed-width filenames so a future bench-tracker
-    /// script can `ls bench/<tag>/` and walk runs in chronological
-    /// order without parsing dates. The trailing `Z` advertises UTC
-    /// (the timestamp itself is `DateTime.UtcNow`).
-    [<Literal>]
-    let private TimestampFormat : string = "yyyyMMddTHHmmssZ"
-
     let private jsonOptions : JsonSerializerOptions =
         let o = JsonSerializerOptions(WriteIndented = true)
         o.Converters.Add(JsonStringEnumConverter())
@@ -62,10 +54,6 @@ module BenchSink =
         let json = JsonSerializer.Serialize(run, jsonOptions)
         File.WriteAllText(path, json)
 
-    /// Compose a default `bench/<tag>/<utc-iso>.json` path under
-    /// `rootDir`. The UTC timestamp in `yyyyMMddTHHmmssZ` form keeps
-    /// filenames sortable. Used by the CLI to choose where to drop
-    /// each run's JSON.
     /// Subdirectory under `rootDir` collecting bench snapshots.
     [<Literal>]
     let private BenchSubdirectory : string = "bench"
@@ -74,7 +62,14 @@ module BenchSink =
     [<Literal>]
     let private SnapshotExtension : string = ".json"
 
-    let defaultPath (rootDir: string) (tag: string) : string =
-        let timestamp = DateTime.UtcNow.ToString(TimestampFormat)  // LINT-ALLOW: reified non-determinism boundary at file-sink layer
-        Path.Combine(rootDir, BenchSubdirectory, tag, timestamp + SnapshotExtension)  // LINT-ALLOW: terminal filesystem path; timestamp is already vetted typed format
+    /// Compose the per-run `bench/<tag>/<runId>.json` path under `rootDir`
+    /// (R1c — the snapshot is keyed by the RUN that produced it, so a
+    /// stored `Run` and its bench file share an address). A ULID is
+    /// lexically time-ordered, so `ls | sort` still walks runs
+    /// chronologically — the property the retired timestamp filename
+    /// carried. The wall-clock now lives only INSIDE the value
+    /// (`persistJson`'s `CapturedAtUtc`) — the reified non-determinism
+    /// boundary relocated, not deleted.
+    let runPath (rootDir: string) (tag: string) (runId: string) : string =
+        Path.Combine(rootDir, BenchSubdirectory, tag, runId + SnapshotExtension)  // LINT-ALLOW: terminal filesystem path; runId is the LogSink-minted ULID
 

--- a/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
@@ -76,6 +76,46 @@ module CaptureJournal =
     /// Append one completed chunk. The write is flushed on close, so a
     /// crash AFTER the append never re-executes the chunk and a crash
     /// DURING the chunk never journals it — the chunk's sink statement
-    /// (one MERGE / one bulk batch) is the atomic commit point.
+    /// (one MERGE / one bulk batch) is the atomic commit point. This
+    /// positioning IS the grain's WriteAdmit (R3 / RI-3): the completed
+    /// sink statement is the external witness, proven by control flow —
+    /// a ceremonial `Ledger.writeAdmit` here would assert nothing the
+    /// append's position does not already.
     let append (journal: CaptureJournal) (record: ChunkRecord) : unit =
         File.AppendAllText(journal.FilePath, JsonSerializer.Serialize record + "\n")
+
+    // -- L2: the journal grain on the ledger contract (R3 / RI-3) ------------
+
+    /// The chunk's SOURCE fingerprint — what `Ledger.resumeAdmit` compares
+    /// against the live stream's recomputation (first/last source PK + raw
+    /// count; deterministic because `ReadSide` orders by PK). The persisted
+    /// bytes are unchanged by this card: the `ChunkRecord` NDJSON line IS
+    /// the stored fingerprint, so existing journals resume across the
+    /// contract cutover (the RI-7 byte-stability discipline).
+    let fingerprintOf (record: ChunkRecord) : string * string * int =
+        record.FirstPk, record.LastPk, record.RawCount
+
+    /// A journaled record in chain form: position = the chunk index within
+    /// its kind. The one NDJSON file is a per-kind FAMILY of chains —
+    /// `load`'s `(kind, chunkIx)` last-write-wins index — so the contract
+    /// instance is per kind, and `Ledger.resumePoint` over one kind's
+    /// entries is where its crashed run resumes.
+    let toEntry (record: ChunkRecord) : LedgerEntry<ChunkRecord, string * string * int> =
+        { Position = record.ChunkIx; Fingerprint = fingerprintOf record; Entry = record }
+
+    /// The journal grain's `LedgerSpec` instance for one kind — the
+    /// EFFECTFUL REMAP FOLD, ADAPTED AT THE INSTANCE (RI-3): the contract
+    /// record stays pure data; this instance's `Apply` feeds the journaled
+    /// `(source → assigned)` pairs into the accumulator it is handed and
+    /// returns the same value. `Genesis` is the run's SHARED in-flight
+    /// remap (FKs cross kinds, so the run owns ONE accumulator; replay
+    /// folds into it, never beside it).
+    let spec (kind: SsKey) (remap: PackedSurrogateRemap) : LedgerSpec<PackedSurrogateRemap, ChunkRecord, string * string * int> =
+        { Genesis = remap
+          Apply =
+            fun acc record ->
+                record.Pairs
+                |> Array.iter (fun pair ->
+                    if pair.Length = 2 then PackedSurrogateRemap.capture kind pair[0] pair[1] acc)
+                acc
+          FingerprintOf = fingerprintOf }

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -869,11 +869,23 @@ module Deploy =
 
     /// Bootstrap a fresh per-run database, deploy `seedSql` to it,
     /// then invoke `body` with an open `SqlConnection`. Disposes the
-    /// connection on exit; the per-run database is left for the
-    /// container's cleanup. Chapter 5.0 slice γ — the OSSYS extraction
-    /// canary's orchestration primitive: caller seeds the database with
-    /// the synthetic OSSYS schema, then runs the rowsets-SQL extraction
-    /// against the seeded source.
+    /// connection AND reaps the per-run database on exit (best-effort).
+    /// Chapter 5.0 slice γ — the OSSYS extraction canary's orchestration
+    /// primitive: caller seeds the database with the synthetic OSSYS
+    /// schema, then runs the rowsets-SQL extraction against the seeded
+    /// source.
+    ///
+    /// **Why the reap (2026-06-12).** The original "left for the
+    /// container's cleanup" was correct only for true ephemeral
+    /// containers. Under the warm dev-loop container the per-run
+    /// databases ACCUMULATED for the instance's lifetime — 209 counted
+    /// after one session's runs — and that accumulation is the
+    /// degradation behind the warm container's
+    /// `insufficient system memory in resource pool 'default'` failures
+    /// (CLAUDE.md §4 rule 2's third signature, root-caused). The drop is
+    /// cheap (~50 ms) because the per-DB pool is evicted first — an idle
+    /// pooled session makes SINGLE_USER WITH ROLLBACK IMMEDIATE cost
+    /// ~3 s (measured) while an evicted one costs ~50 ms.
     ///
     /// The body's `SqlConnection` is open against the bootstrapped
     /// per-run database. The body is responsible for any exception
@@ -891,10 +903,25 @@ module Deploy =
                         let dbName = uniqueDatabaseName DatabaseNameGenerator.guidBased databaseLabel
                         do! createDatabase masterConn dbName
                         let perDbConn = buildPerDbConnectionString masterConn dbName
-                        use cnn = new SqlConnection(perDbConn)
-                        do! cnn.OpenAsync()
-                        do! executeBatch cnn seedSql
-                        return! body cnn
+                        try
+                            use cnn = new SqlConnection(perDbConn)
+                            do! cnn.OpenAsync()
+                            do! executeBatch cnn seedSql
+                            return! body cnn
+                        finally
+                            try
+                                let cnnEvict = new SqlConnection(perDbConn)
+                                SqlConnection.ClearPool cnnEvict
+                                cnnEvict.Dispose()
+                                use cnnDrop = new SqlConnection(masterConn)
+                                cnnDrop.OpenAsync().GetAwaiter().GetResult()
+                                executeBatch cnnDrop
+                                    (System.String.Concat(
+                                        "ALTER DATABASE ", Render.quote dbName,
+                                        " SET SINGLE_USER WITH ROLLBACK IMMEDIATE; ",
+                                        "DROP DATABASE ", Render.quote dbName, ";"))
+                                |> fun t -> t.GetAwaiter().GetResult()
+                            with _ -> ()
                     })
         }
 

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -410,30 +410,24 @@ module Deploy =
                     return detected
         }
 
-    /// **Parallel-segment realization of a SQL text batch** (slice
-    /// A.4.7'-prelude.perf-sweep-5 primitive; integration deferred per
-    /// preflight). Splits via `BatchSplitter` then dispatches segments
-    /// across `parallelism` concurrent SqlConnections gated by a
-    /// SemaphoreSlim. Each segment runs on its own freshly-opened
-    /// connection; `SqlConnection`'s internal pooling (keyed on the
-    /// connection string) makes the per-segment new/Open/Dispose cheap
-    /// on warm pools.
+    /// **Parallel realization of one concurrent-safe group** (slice
+    /// A.4.7'-prelude.perf-sweep-5 primitive; card P1 re-signs it to
+    /// DEMAND the proof). Each member is batch-split via `BatchSplitter`
+    /// and the segments dispatch across `parallelism` concurrent
+    /// SqlConnections gated by a SemaphoreSlim. Each segment runs on its
+    /// own freshly-opened connection; `SqlConnection`'s internal pooling
+    /// (keyed on the connection string) makes the per-segment
+    /// new/Open/Dispose cheap on warm pools.
     ///
-    /// **CALLER CONTRACT — segment-ordering independence.** The caller
-    /// MUST guarantee that all segments in `sql` are mutually
-    /// independent. Violating this contract produces nondeterministic
-    /// failures (FK constraints; Phase-1/Phase-2 sequencing; etc.).
-    /// True for: a topological-level group of independent kinds at a
-    /// single phase. FALSE for: full schema DDL (FK target → FK source);
-    /// full data deploy (Phase-1 MERGEs are topologically ordered;
-    /// Phase-2 UPDATEs reference Phase-1 rows).
-    ///
-    /// **Status — landed without integration.** The composer-side
-    /// refactor to emit parallel-safe topological-level groups is
-    /// deferred to a dedicated architectural slice. This primitive
-    /// ships as a ready tool with the preflight contract documented;
-    /// the canary continues using sequential `executeBatch` until the
-    /// composer exposes safe groups.
+    /// **The independence contract is the argument's TYPE** (card P1 /
+    /// R5): `ParallelSafe<string>` cannot exist unless
+    /// `TopologicalOrder.levels` proved the group's members mutually
+    /// independent — the comment-borne MUST this docstring used to
+    /// carry is structural now. (Its 2026-05-era "the canary continues
+    /// using sequential executeBatch until the composer exposes safe
+    /// groups" status note was stale — the comprehensive canary has
+    /// deployed leveled data through this primitive since perf-sweep-6 —
+    /// and is retired with the re-signing, RI-5.)
     /// Cap the requested parallelism against the connection string's
     /// `Max Pool Size` (slice A.4.7'-prelude.defensive-hardening).
     /// Defensive against Azure SQL Database tier connection caps
@@ -466,12 +460,18 @@ module Deploy =
 
     let executeBatchParallel
             (connectionString: string)
-            (sql: string)
+            (level: ParallelSafe<string>)
             (parallelism: int)
             : Task<unit> =
         task {
             use _ = Bench.scope "deploy.executeBatchParallel"
-            let segments = BatchSplitter.splitWithLoudFallback "deploy.executeBatchParallel" sql
+            // Per-member split then flatten ≡ split-of-concatenation (every
+            // member is GO-terminated), so the segment bytes and the bench
+            // label series are unchanged by the re-signing.
+            let segments =
+                ParallelSafe.members level
+                |> List.toArray
+                |> Array.collect (BatchSplitter.splitWithLoudFallback "deploy.executeBatchParallel")
             let cappedParallelism = capParallelismToPool connectionString parallelism
             Bench.recordSample "deploy.executeBatchParallel.segments" (int64 segments.Length)
             Bench.recordSample "deploy.executeBatchParallel.parallelism" (int64 cappedParallelism)

--- a/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
@@ -210,7 +210,11 @@ module LifecycleStore =
                         Ok (Episode.create coordinate schema Profile.empty (optStr el "refactorLogRef") data)
 
     /// Reconstruct the chain from a non-empty episode list, enforcing the
-    /// monotone-history invariant via `EpisodicLifecycle.append`.
+    /// monotone-history invariant via `EpisodicLifecycle.append` — the
+    /// episode grain's ResumeAdmit (R3 / RI-3), run over every loaded edge:
+    /// chain structure is verified at load; the B'≡B write witness is not
+    /// re-verifiable here and is not pretended to be (see
+    /// `MigrationRun.recordVerified`, the grain's WriteAdmit).
     let private buildLifecycle (timeline: Timeline) (episodes: Episode list) : Result<EpisodicLifecycle, string> =
         match episodes with
         | [] -> Error "lifecycle has no episodes (a lifecycle opens at genesis)"

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -277,12 +277,25 @@ module MigrationRun =
         (data: DataObservation)
         (outcome: MigrationOutcome)
         : Result<EpisodicLifecycle, MigrationRecordError> =
-        if not outcome.Verified then
-            Error (NonMonotonic "refusing to record an unverified migration outcome (B' did not reproduce B)")
-        else
+        // L3 — the episode grain's WriteAdmit (R3 / RI-3): the B'≡B
+        // round-trip is the external witness, checked HERE — the one moment
+        // it is checkable — and the `Verified<_>` token carries that the
+        // witness held. The grain's ResumeAdmit is ordinal monotonicity
+        // (`EpisodicLifecycle.append`, re-run at load by the store's
+        // `buildLifecycle`) — named as such, honestly: the store cannot
+        // re-verify B'≡B at load, because no B' exists to re-deploy.
+        let admitted =
+            Ledger.writeAdmit
+                (fun (o: MigrationOutcome) ->
+                    if o.Verified then Ok ()
+                    else Error (NonMonotonic "refusing to record an unverified migration outcome (B' did not reproduce B)"))
+                outcome
+        match admitted with
+        | Error e -> Error e
+        | Ok token ->
             match nextCoordinate path environment at with
             | Error e -> Error e
-            | Ok coordinate -> record path timeline coordinate refactorLogRef data outcome.Artifacts
+            | Ok coordinate -> record path timeline coordinate refactorLogRef data (Verified.value token).Artifacts
 
     // -- the live-execute leg (direct execution against a deployed DB) --------
 

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -452,7 +452,9 @@ module Preflight =
             9, UnmappedIdentities
         elif code = "migrate.dataViolatesTightening" then
             9, DataViolatesTightening
-        elif code = "transfer.cdcTrackedSink" then
+        elif code = "transfer.cdcTrackedSink" || code = "migrate.cdcTrackedSink" then
+            // The same axis under both namespaces — the migrate verb's
+            // RefusedByCdc routes through the gate surface under its own name.
             9, CdcTrackedSink
         elif code = "migrate.schemaReadFailed" then
             6, SchemaReadFailed

--- a/sidecar/projection/src/Projection.Pipeline/Run.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Run.fs
@@ -23,6 +23,17 @@ open System.Security.Cryptography
 /// projection (`toLedgerEntry`), so the run *subsumes* the ledger row.
 module Run =
 
+    /// R1a — a reference to a durable ledger the run touched. The run
+    /// aggregate carries WHERE its ledgers live, never their content: the
+    /// capture journal by its digest (the digest IS the filename,
+    /// `transfer-<digest16>.ndjson` — RI-7), the episode by its timeline
+    /// coordinate. `LedgerRef` is the run-side name for the R3 contract's
+    /// instances (L1–L4): a stored run can answer "which chains did this
+    /// run extend?" offline.
+    type LedgerRef =
+        | JournalRef of digest: string
+        | EpisodeRef of timeline: string * ordinal: int
+
     type Run = {
         RunId       : string
         Ts          : string
@@ -42,6 +53,13 @@ module Run =
         /// makes a `runId` resolve to *artifacts* (so diff / migrate / explain
         /// can operate offline from a stored run), not just events.
         Artifacts   : Map<string, string>
+        /// R1a — the ledgers this run extended (journal digests + episode
+        /// coordinates). Empty for runs that touched no chain.
+        Ledgers     : LedgerRef list
+        /// R1a — the run's measurement snapshot, when one was captured
+        /// (R1c keys the BenchSink file by RunId; this carries the value
+        /// on the aggregate so `diff <runA> <runB>` can compare offline).
+        Bench       : Projection.Core.Bench.Run option
     }
 
     /// Content-address the run by its inputs. Two runs with the same config +
@@ -72,6 +90,42 @@ module Run =
         let art = JsonObject()
         for KeyValue(k, v) in r.Artifacts do art.[k] <- JsonValue.Create v
         o.["artifacts"] <- art
+        // R1a — codec totality over the completed aggregate: every field
+        // on the record round-trips (the load(save run) = run predicate).
+        let ledgers = JsonArray()
+        for l in r.Ledgers do
+            let lo = JsonObject()
+            (match l with
+             | JournalRef digest ->
+                 lo.["kind"]   <- JsonValue.Create "journal"
+                 lo.["digest"] <- JsonValue.Create digest
+             | EpisodeRef (timeline, ordinal) ->
+                 lo.["kind"]     <- JsonValue.Create "episode"
+                 lo.["timeline"] <- JsonValue.Create timeline
+                 lo.["ordinal"]  <- JsonValue.Create ordinal)
+            ledgers.Add lo
+        o.["ledgers"] <- ledgers
+        (match r.Bench with
+         | None -> ()
+         | Some b ->
+             let bo = JsonObject()
+             bo.["capturedAtUtc"] <- JsonValue.Create (b.CapturedAtUtc.ToString("o"))
+             bo.["tag"] <- JsonValue.Create b.Tag
+             let sa = JsonArray()
+             for s in b.Stats do
+                 let so = JsonObject()
+                 so.["label"]   <- JsonValue.Create s.Label
+                 so.["count"]   <- JsonValue.Create s.Count
+                 so.["totalMs"] <- JsonValue.Create s.TotalMs
+                 so.["minMs"]   <- JsonValue.Create s.MinMs
+                 so.["maxMs"]   <- JsonValue.Create s.MaxMs
+                 so.["meanMs"]  <- JsonValue.Create s.MeanMs
+                 so.["p50Ms"]   <- JsonValue.Create s.P50Ms
+                 so.["p95Ms"]   <- JsonValue.Create s.P95Ms
+                 so.["p99Ms"]   <- JsonValue.Create s.P99Ms
+                 sa.Add so
+             bo.["stats"] <- sa
+             o.["bench"] <- bo)
         o.ToJsonString(JsonSerializerOptions(WriteIndented = true))
 
     let private parse (json: string) : Run option =
@@ -97,11 +151,56 @@ module Run =
                 if root.TryGetProperty("artifacts", &v) && v.ValueKind = JsonValueKind.Object
                 then [ for p in v.EnumerateObject() -> (p.Name, nz (p.Value.GetString())) ] |> Map.ofList
                 else Map.empty
+            // R1a — total over the new fields; a pre-R1a run.json (no
+            // 'ledgers' / 'bench') loads with the empty/None defaults.
+            let estr (el: JsonElement) (name: string) =
+                let mutable v = Unchecked.defaultof<JsonElement>
+                if el.TryGetProperty(name, &v) && v.ValueKind = JsonValueKind.String then nz (v.GetString()) else ""
+            let ledgers =
+                let mutable v = Unchecked.defaultof<JsonElement>
+                if root.TryGetProperty("ledgers", &v) && v.ValueKind = JsonValueKind.Array then
+                    [ for el in v.EnumerateArray() do
+                        match estr el "kind" with
+                        | "journal" -> yield JournalRef (estr el "digest")
+                        | "episode" ->
+                            let mutable ov = Unchecked.defaultof<JsonElement>
+                            let ordinal = if el.TryGetProperty("ordinal", &ov) && ov.ValueKind = JsonValueKind.Number then ov.GetInt32() else 0
+                            yield EpisodeRef (estr el "timeline", ordinal)
+                        | _ -> () ]
+                else []
+            let bench =
+                let mutable v = Unchecked.defaultof<JsonElement>
+                if root.TryGetProperty("bench", &v) && v.ValueKind = JsonValueKind.Object then
+                    let stats =
+                        let mutable sv = Unchecked.defaultof<JsonElement>
+                        if v.TryGetProperty("stats", &sv) && sv.ValueKind = JsonValueKind.Array then
+                            [ for el in sv.EnumerateArray() do
+                                let i64 (name: string) =
+                                    let mutable nv = Unchecked.defaultof<JsonElement>
+                                    if el.TryGetProperty(name, &nv) && nv.ValueKind = JsonValueKind.Number then nv.GetInt64() else 0L
+                                let f (name: string) =
+                                    let mutable nv = Unchecked.defaultof<JsonElement>
+                                    if el.TryGetProperty(name, &nv) && nv.ValueKind = JsonValueKind.Number then nv.GetDouble() else 0.0
+                                let c =
+                                    let mutable nv = Unchecked.defaultof<JsonElement>
+                                    if el.TryGetProperty("count", &nv) && nv.ValueKind = JsonValueKind.Number then nv.GetInt32() else 0
+                                ({ Label = estr el "label"; Count = c
+                                   TotalMs = i64 "totalMs"; MinMs = i64 "minMs"; MaxMs = i64 "maxMs"
+                                   MeanMs = f "meanMs"
+                                   P50Ms = i64 "p50Ms"; P95Ms = i64 "p95Ms"; P99Ms = i64 "p99Ms" } : Projection.Core.Bench.Stats) ]
+                        else []
+                    let capturedAt =
+                        match DateTime.TryParse(estr v "capturedAtUtc", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind) with
+                        | true, dt -> dt
+                        | _ -> DateTime.MinValue
+                    Some ({ CapturedAtUtc = capturedAt; Tag = estr v "tag"; Stats = stats } : Projection.Core.Bench.Run)
+                else None
             Some {
                 RunId = str "runId"; Ts = str "ts"; Command = str "command"
                 InputDigest = str "inputDigest"; Outcome = str "outcome"; Canary = canary
                 Registered = i "registered"; Applied = i "applied"; Declined = i "declined"
                 Events = events; Artifacts = artifacts
+                Ledgers = ledgers; Bench = bench
             }
         with _ -> None
 
@@ -165,4 +264,8 @@ module Run =
           Applied     = applied
           Declined    = declined
           Events      = LogSink.serializedEnvelopes ()
-          Artifacts   = artifacts }
+          Artifacts   = artifacts
+          // R1a — additive defaults at capture; R1b/R1c thread the real
+          // ledger refs + bench snapshot when the envelope wires them.
+          Ledgers     = []
+          Bench       = None }

--- a/sidecar/projection/src/Projection.Pipeline/Run.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Run.fs
@@ -232,6 +232,84 @@ module Run =
             |> Array.toList
         else []
 
+    /// R1d — where runs are stored, one resolution rule for every reader:
+    /// `PROJECTION_RUNS_DIR` when set (the explicit override), else
+    /// `PROJECTION_LEDGER_DIR` (where the R1b bracket capture persists).
+    let storeDir () : string option =
+        match configuredDir () with
+        | Some d -> Some d
+        | None -> RunLedger.configuredDir ()
+
+    // R1d — the run-vs-run delta surface. The §7 units-of-measure
+    // promotion FIRES here, scoped to this surface exactly as gated
+    // (CONSTELLATION §9.7): the trigger was mixed quantities — counts
+    // beside milliseconds — in one expression; the measure keeps a
+    // bench millisecond from ever adding to a transform count.
+    [<Measure>]
+    type ms
+
+    /// One label's wall-time movement between two runs. `None` = the
+    /// label is absent from that side (a stage that ran only once).
+    type BenchDelta =
+        {
+            Label    : string
+            BeforeMs : int64<ms> option
+            AfterMs  : int64<ms> option
+            /// after − before, an absent side counting 0.
+            DeltaMs  : int64<ms>
+        }
+
+    /// The run-vs-run projection: verdict movement + count deltas (b − a)
+    /// + the per-label bench deltas.
+    type RunDiff =
+        {
+            RunIds      : string * string
+            Commands    : string * string
+            Outcomes    : string * string
+            Canaries    : string option * string option
+            Registered  : int
+            Applied     : int
+            Declined    : int
+            Events      : int
+            BenchDeltas : BenchDelta list
+        }
+
+    let private benchTotals (r: Run) : Map<string, int64<ms>> =
+        match r.Bench with
+        | None -> Map.empty
+        | Some b -> b.Stats |> List.map (fun s -> s.Label, s.TotalMs * 1L<ms>) |> Map.ofList
+
+    /// R1d — diff two stored runs. `keyLabels` is the restriction the
+    /// harness's before/after protocol is an instance of: `Some labels`
+    /// compares exactly those; `None` compares every label present on
+    /// either side. Labels sort by |delta| descending — the biggest
+    /// movement leads.
+    let diff (keyLabels: Set<string> option) (a: Run) (b: Run) : RunDiff =
+        let ta, tb = benchTotals a, benchTotals b
+        let labels =
+            Set.union (ta |> Map.toSeq |> Seq.map fst |> Set.ofSeq) (tb |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+            |> fun all -> match keyLabels with Some ks -> Set.intersect all ks | None -> all
+        let deltas =
+            labels
+            |> Set.toList
+            |> List.map (fun label ->
+                let before = Map.tryFind label ta
+                let after = Map.tryFind label tb
+                { Label = label
+                  BeforeMs = before
+                  AfterMs = after
+                  DeltaMs = (defaultArg after 0L<ms>) - (defaultArg before 0L<ms>) })
+            |> List.sortByDescending (fun d -> abs (int64 d.DeltaMs))
+        { RunIds = a.RunId, b.RunId
+          Commands = a.Command, b.Command
+          Outcomes = a.Outcome, b.Outcome
+          Canaries = a.Canary, b.Canary
+          Registered = b.Registered - a.Registered
+          Applied = b.Applied - a.Applied
+          Declined = b.Declined - a.Declined
+          Events = List.length b.Events - List.length a.Events
+          BenchDeltas = deltas }
+
     /// Project the run onto its ledger index row — the run subsumes the
     /// `RunLedger.LedgerRecord` (one source, the ledger is a derived view).
     let toLedgerEntry (r: Run) : RunLedger.LedgerRecord =

--- a/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunEnvelope.fs
@@ -55,4 +55,26 @@ module RunEnvelope =
             value <- v
         finally
             LogSink.runComplete outcome command (Bench.snapshot ()) |> ignore
+            // R1b — wired ONCE, at the single bracket owner (the card's
+            // "after S4, to wire once" clause): under PROJECTION_LEDGER_DIR
+            // the completed aggregate persists beside the ledger NDJSON —
+            // run.json keyed by runId, events including the terminal §10
+            // close, the bench snapshot on the value (R1a) — so no bracketed
+            // run leaves an orphan RunId, crashed bodies included. Opt-in
+            // (the env var), and a capture failure never masks the body's
+            // outcome. InputDigest stays "" at the bracket grain — the
+            // bracket cannot see config/catalog content; per-face threading
+            // is R1d-consumer territory, not faked here.
+            match RunLedger.configuredDir () with
+            | Some dir ->
+                (try
+                    let bench : Bench.Run =
+                        { CapturedAtUtc = System.DateTime.UtcNow  // LINT-ALLOW: reified non-determinism boundary at the envelope sink (BenchSink's pattern)
+                          Tag = command
+                          Stats = Bench.snapshot () }
+                    let code = match outcome with LogSink.Succeeded -> 0 | _ -> 1
+                    Run.save dir { Run.capture command code "" Map.empty with Bench = Some bench }
+                 with ex ->
+                    eprintfn "  WARNING: failed to persist the run aggregate: %s" ex.Message)
+            | None -> ()
         value

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -453,6 +453,20 @@ module Transfer =
 
     /// The durable phase-marker table — records which transfers completed, so a
     /// re-run of an already-finished transfer is a no-op (idempotent).
+    ///
+    /// L4 — G10 on the ledger contract (R3 / RI-3): this is the DEGENERATE
+    /// single-quantum instance, retired as a separate ledger mechanism. One
+    /// entry ("the whole run"), fingerprint = the plan signature
+    /// (`planMarker`, recomputed from the live plan on every run — the
+    /// grain's ResumeAdmit, with equality realized as the SQL set-membership
+    /// `isMarked` answers), WriteAdmit positional at `markComplete` (after
+    /// `writePlan`, the same control-flow witness as the journal's append).
+    /// It exercises NOTHING of the contract's replay machinery, honestly: a
+    /// single full-state quantum has no partial sums to rebuild — the sink's
+    /// rows ARE the state, and the admitted re-run's no-op IS the resume.
+    /// The streaming realization's chunk-grain journal (`CaptureJournal`) is
+    /// the non-degenerate sibling; the two stay distinct REALIZATIONS of one
+    /// contract, not two mechanisms.
     let private progressTableSql : string =
         "IF OBJECT_ID('dbo.__projection_transfer_progress') IS NULL \
            CREATE TABLE dbo.__projection_transfer_progress \

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -1032,12 +1032,21 @@ module Transfer =
     // -- The streaming realization (bounded memory + chunk resume) -----------
 
     /// The named refusal for a resume whose source changed under the journal.
-    let private sourceDriftRefusal (kind: SsKey) (chunkIx: int) : ValidationError =
-        ValidationError.create
+    /// L2: the typed `LedgerDrift` (the contract's ResumeAdmit disagreement)
+    /// maps onto the SAME named refusal — code and message bytes unchanged;
+    /// the recorded/recomputed fingerprints ride as metadata (candor gained,
+    /// nothing moved).
+    let private sourceDriftRefusal (kind: SsKey) (drift: LedgerDrift<string * string * int>) : ValidationError =
+        let render (firstPk: string, lastPk: string, rawCount: int) =
+            sprintf "firstPk=%s lastPk=%s rawCount=%d" firstPk lastPk rawCount
+        ValidationError.createWithMetadata
             "transfer.resume.sourceDrift"
             (sprintf
                 "Kind %s chunk %d does not match its journaled fingerprint; the source changed since the journaled run. Refusing to resume over drifted data — clear the journal (or run WipeAndLoad) to reload from scratch."
-                (SsKey.rootOriginal kind) chunkIx)
+                (SsKey.rootOriginal kind) drift.Position)
+            (Map.ofList
+                [ "recordedFingerprint", Some (render drift.Recorded)
+                  "recomputedFingerprint", Some (render drift.Recomputed) ])
 
     /// Per-kind phase-1 streaming totals (rows pulled from the source;
     /// rows that reached the sink — journal-skipped chunks count what the
@@ -1111,13 +1120,19 @@ module Transfer =
                         | true, record -> Some record
                         | false, _ -> None)
                 match journaled with
-                | Some record when record.FirstPk = firstPk && record.LastPk = lastPk && record.RawCount = rawCount ->
-                    record.Pairs
-                    |> Array.iter (fun pair ->
-                        if pair.Length = 2 then PackedSurrogateRemap.capture load.Kind pair[0] pair[1] remap)
-                    return Result.success (record.WrittenCount, [], [], lane)
-                | Some _ ->
-                    return Result.failureOf (sourceDriftRefusal load.Kind chunkIx)
+                | Some record ->
+                    // L2 — the journal grain's ResumeAdmit (R3 / RI-3): the
+                    // live source slice recomputes the fingerprint; admission
+                    // replays the journaled pairs into the shared remap
+                    // through the instance's spec (the effectful fold,
+                    // adapted at the instance); disagreement is the SAME
+                    // named drift refusal as before, never a silent re-run.
+                    match Ledger.resumeAdmit (firstPk, lastPk, rawCount) (CaptureJournal.toEntry record) with
+                    | Ok admitted ->
+                        Ledger.replay (CaptureJournal.spec load.Kind remap) [ admitted ] |> ignore
+                        return Result.success ((Verified.value admitted).WrittenCount, [], [], lane)
+                    | Error drift ->
+                        return Result.failureOf (sourceDriftRefusal load.Kind drift)
                 | None ->
                     let remapped = repoint basis load.DeferredFkColumns kind chunkRaw
                     let skips = remapped.Skipped |> List.map (fun u -> load.Kind, u)

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -330,22 +330,25 @@ module DataEmissionComposer =
                     |> System.String.Concat  // LINT-ALLOW: terminal global Phase-1-then-Phase-2 concatenation across all kinds in topological order (chapter 4.1.B slice ι); each segment is the per-kind ScriptDom-rendered RenderedPhase1 / RenderedPhase2 string already terminated by `;\nGO\n`; BCL `String.Concat(IEnumerable<string>)` is the right primitive at this terminal-text boundary; preserves the global cycle-correct deploy order that per-kind Rendered cannot express
                 Ok allText
 
-    /// Per-level rendered text for parallel-safe deployment. Each
-    /// `string` in `Phase1Levels` / `Phase2Levels` concatenates the
-    /// rendered SQL for every kind at one topological level; the
-    /// list itself is level-ordered (level 0 first).
+    /// Per-level rendered scripts for parallel-safe deployment. Each
+    /// `ParallelSafe<string>` group carries one kind's rendered SQL per
+    /// member, at one topological level; the lists are level-ordered
+    /// (level 0 first).
     ///
-    /// **Realization contract:** callers MUST deploy `Phase1Levels`
-    /// in order, then `Phase2Levels` in order. Within a single level
-    /// string, segments are mutually FK-independent — callers MAY
-    /// dispatch via `Deploy.executeBatchParallel` for within-level
-    /// parallelism. Empty levels are dropped from the output (a
-    /// level whose kinds have empty `RenderedPhase1` or
+    /// **Realization contract (card P1 — the half the type now
+    /// carries):** WITHIN-group independence is the token itself —
+    /// `ParallelSafe` is minted only by `TopologicalOrder.levels` and
+    /// rides here through per-member `choose` (kind → that kind's
+    /// rendered script), so `Deploy.executeBatchParallel` can demand it.
+    /// What stays the caller's duty, stated: deploy `Phase1Levels` in
+    /// order, then `Phase2Levels` in order — LEVELS are sequential;
+    /// only members within one level are concurrent. Empty levels are
+    /// dropped (a level whose kinds have empty `RenderedPhase1` /
     /// `RenderedPhase2` doesn't appear). Slice
     /// A.4.7'-prelude.perf-sweep-6 (composer-levels) cash-out.
     type LeveledDeploymentText = {
-        Phase1Levels : string list
-        Phase2Levels : string list
+        Phase1Levels : ParallelSafe<string> list
+        Phase2Levels : ParallelSafe<string> list
     }
 
     /// Level-aware sibling of `composeRenderedFull` — returns the
@@ -379,22 +382,29 @@ module DataEmissionComposer =
             | Ok artifact ->
                 let map = ArtifactByKind.toMap artifact
                 let levels = TopologicalOrder.levels topo
-                let textForLevel
+                // Card P1 — the token rides the rendering: per-member
+                // `choose` (kind → that kind's rendered script) preserves
+                // the group structure `levels` proved, so the cross-kind
+                // concatenation (and its LINT-ALLOW) is retired — the
+                // members stay distinct and `executeBatchParallel` splits
+                // per member.
+                let scriptsForLevel
                     (selector: DataInsertScript -> string)
-                    (levelKeys: SsKey list)
-                    : string =
-                    levelKeys
-                    |> List.choose (fun k ->
-                        Map.tryFind k map |> Option.map selector)
-                    |> System.String.Concat  // LINT-ALLOW: terminal cross-kind concatenation within a single topological level (slice A.4.7'-prelude.perf-sweep-6); each segment is a ScriptDom-rendered string already terminated by `;\nGO\n`; within-level kinds are SsKey-sorted via `TopologicalOrder.levels`; parallel-safety is the load-bearing contract for `Deploy.executeBatchParallel` consumers
-                let nonEmpty = List.filter (fun (s: string) -> s.Length > 0)
+                    (level: ParallelSafe<SsKey>)
+                    : ParallelSafe<string> =
+                    level
+                    |> ParallelSafe.choose (fun k ->
+                        Map.tryFind k map
+                        |> Option.map selector
+                        |> Option.filter (fun s -> s.Length > 0))
+                let nonEmpty = List.filter (ParallelSafe.isEmpty >> not)
                 let phase1 =
                     levels
-                    |> List.map (textForLevel (fun s -> s.RenderedPhase1))
+                    |> List.map (scriptsForLevel (fun s -> s.RenderedPhase1))
                     |> nonEmpty
                 let phase2 =
                     levels
-                    |> List.map (textForLevel (fun s -> s.RenderedPhase2))
+                    |> List.map (scriptsForLevel (fun s -> s.RenderedPhase2))
                     |> nonEmpty
                 Bench.recordSample "compose.data.composeRenderedLeveled.phase1Levels" (int64 phase1.Length)
                 Bench.recordSample "compose.data.composeRenderedLeveled.phase2Levels" (int64 phase2.Length)

--- a/sidecar/projection/src/Projection.Targets.SSDT/ManifestEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ManifestEmitter.fs
@@ -674,8 +674,10 @@ module ManifestEmitter =
                                        StdDev = moments.StdDev })))
             |> List.sortBy (fun cp -> cp.Schema, cp.Table, cp.Column)
         let deploymentBatches =
+            // P1 — `levels` now mints `ParallelSafe`; the manifest LISTS the
+            // groups (read-only view), so its wire shape is unchanged.
             topology
-            |> Option.map TopologicalOrder.levels
+            |> Option.map (TopologicalOrder.levels >> List.map ParallelSafe.members)
             |> Option.defaultValue []
         {
             Tables = entries

--- a/sidecar/projection/tests/Projection.Tests/BenchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/BenchTests.fs
@@ -164,11 +164,11 @@ let ``Bench: iterMap projects values and records one sample per element`` () =
     Assert.Equal(4, entry.Count)
 
 [<Fact>]
-let ``BenchSink: defaultPath produces a sortable timestamped path under bench/<tag>/`` () =
-    let path = BenchSink.defaultPath "/tmp/example" "wide-canary-enterprise"
+let ``R1c: BenchSink.runPath keys the snapshot by RunId under bench/<tag>/`` () =
+    // The run and its bench file share an address; a ULID filename keeps
+    // the chronological `ls | sort` walk the retired timestamp gave.
+    let path = BenchSink.runPath "/tmp/example" "wide-canary-enterprise" "01KTY80SV6X3P9423RJ15ZABKB"
     Assert.Contains("bench", path)
     Assert.Contains("wide-canary-enterprise", path)
     Assert.EndsWith(".json", path)
-    // Filename is yyyyMMddTHHmmssZ.json — sortable.
-    let filename = Path.GetFileName path
-    Assert.Matches(@"^\d{8}T\d{6}Z\.json$", filename)
+    Assert.Equal("01KTY80SV6X3P9423RJ15ZABKB.json", Path.GetFileName path)

--- a/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
@@ -3,6 +3,7 @@ module Projection.Tests.CaptureJournalTests
 open System
 open System.IO
 open Xunit
+open Projection.Core
 open Projection.Pipeline
 
 // CONSTELLATION_BACKLOG card F4 / plane N5: the chunk-resume journal was
@@ -130,3 +131,59 @@ let ``load: a corrupt (non-JSON) line throws — the resume surface is not silen
         CaptureJournal.append j (chunk "OS_USER" 0 "1" "5" 5 [||])
         File.AppendAllText(CaptureJournal.filePath j, "this-is-not-json\n")
         Assert.ThrowsAny<exn>(fun () -> CaptureJournal.load j |> ignore) |> ignore)
+
+// -- L2: the journal grain on the ledger contract (R3 / RI-3) --------------
+// The contract instance over REAL journal records: the chain form, the
+// resume point, drift detection, and the effectful remap fold adapted at
+// the instance. The operator-facing named refusal
+// (transfer.resume.sourceDrift) and the no-duplicates equivalence ride the
+// Docker ReverseLegStreaming witnesses, unchanged.
+
+let private testKind : SsKey =
+    SsKey.synthesized "OS_TEST_CJ" "User"
+    |> function Ok k -> k | Error e -> failwithf "fixture: %A" e
+
+[<Fact>]
+let ``R3: crash at chunk k resumes at k — the journaled kind's chain through Ledger.resumePoint`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "5" 5 [||])
+        CaptureJournal.append j (chunk "OS_USER" 1 "6" "10" 5 [||])
+        CaptureJournal.append j (chunk "OS_USER" 2 "11" "15" 5 [||])
+        CaptureJournal.append j (chunk "OS_ORDER" 0 "1" "3" 3 [||])
+        let userChain =
+            CaptureJournal.load j
+            |> Seq.filter (fun kv -> fst kv.Key = "OS_USER")
+            |> Seq.map (fun kv -> CaptureJournal.toEntry kv.Value)
+            |> List.ofSeq
+        Assert.Equal(3, Ledger.resumePoint userChain))
+
+[<Fact>]
+let ``R3: drift refuses by name — the live slice's recomputed fingerprint disagrees at the chunk`` () =
+    let recorded = CaptureJournal.toEntry (chunk "OS_USER" 4 "201" "250" 50 [||])
+    match Ledger.resumeAdmit ("201", "250", 49) recorded with
+    | Ok _ -> failwith "a drifted source slice must never silently admit"
+    | Error drift ->
+        Assert.Equal(4, drift.Position)
+        Assert.Equal(("201", "250", 50), drift.Recorded)
+        Assert.Equal(("201", "250", 49), drift.Recomputed)
+
+[<Fact>]
+let ``R3: journaled pairs rebuild the remap through replay — the effectful fold adapted at the instance`` () =
+    let remap = PackedSurrogateRemap.create ()
+    let records =
+        [ chunk "OS_USER" 0 "1" "2" 2 [| [| "1"; "9001" |]; [| "2"; "9002" |] |]
+          chunk "OS_USER" 1 "3" "4" 2 [| [| "3"; "9003" |] |] ]
+    let admitted =
+        records
+        |> List.map (fun r ->
+            match Ledger.resumeAdmit (CaptureJournal.fingerprintOf r) (CaptureJournal.toEntry r) with
+            | Ok token -> token
+            | Error drift -> failwithf "fixture: unexpected drift at %d" drift.Position)
+    let replayed = Ledger.replay (CaptureJournal.spec testKind remap) admitted
+    // Apply folds INTO the shared accumulator (Genesis), never beside it.
+    Assert.Same(remap, replayed)
+    Assert.Equal(Some "9001", PackedSurrogateRemap.tryFind remap testKind "1")
+    Assert.Equal(Some "9002", PackedSurrogateRemap.tryFind remap testKind "2")
+    Assert.Equal(Some "9003", PackedSurrogateRemap.tryFind remap testKind "3")
+    Assert.Equal(None, PackedSurrogateRemap.tryFind remap testKind "4")

--- a/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
@@ -546,8 +546,8 @@ module ComprehensiveCanaryTests =
     /// independent per `TopologicalOrder.levels`'s invariant).
     type private LeveledDeploymentPlan = {
         Schema       : string
-        Phase1Levels : string list
-        Phase2Levels : string list
+        Phase1Levels : ParallelSafe<string> list
+        Phase2Levels : ParallelSafe<string> list
     }
 
     /// Sibling of `composeEmission` for leveled deployment. Fires the
@@ -573,12 +573,14 @@ module ComprehensiveCanaryTests =
                 UserRemapContext.empty
         match dataResult with
         | Ok leveled ->
+            let levelBytes (levels: ParallelSafe<string> list) =
+                levels |> List.sumBy (ParallelSafe.members >> List.sumBy (fun s -> s.Length))
             printfn
                 "Data emission leveled: %d Phase-1 levels, %d Phase-2 levels (%d + %d bytes)"
                 leveled.Phase1Levels.Length
                 leveled.Phase2Levels.Length
-                (leveled.Phase1Levels |> List.sumBy (fun s -> s.Length))
-                (leveled.Phase2Levels |> List.sumBy (fun s -> s.Length))
+                (levelBytes leveled.Phase1Levels)
+                (levelBytes leveled.Phase2Levels)
             { Schema       = schemaText
               Phase1Levels = leveled.Phase1Levels
               Phase2Levels = leveled.Phase2Levels }
@@ -1034,14 +1036,15 @@ module ComprehensiveCanaryTests =
                     printfn "Target-deploy parallelism resolved to %d" parallelism
                     // Phase A: schema (sequential — FK-ordered DDL).
                     do! Deploy.executeBatch cnn leveledPlan.Schema
-                    // Phase B: data Phase-1 levels (parallel within level).
-                    for levelText in leveledPlan.Phase1Levels do
-                        if levelText.Length > 0 then
-                            do! Deploy.executeBatchParallel perDbConn levelText parallelism
+                    // Phase B: data Phase-1 levels (parallel within level —
+                    // the ParallelSafe token IS the within-level proof, P1).
+                    for level in leveledPlan.Phase1Levels do
+                        if not (ParallelSafe.isEmpty level) then
+                            do! Deploy.executeBatchParallel perDbConn level parallelism
                     // Phase C: data Phase-2 levels (parallel within level).
-                    for levelText in leveledPlan.Phase2Levels do
-                        if levelText.Length > 0 then
-                            do! Deploy.executeBatchParallel perDbConn levelText parallelism
+                    for level in leveledPlan.Phase2Levels do
+                        if not (ParallelSafe.isEmpty level) then
+                            do! Deploy.executeBatchParallel perDbConn level parallelism
                     return! ReadSide.read cnn
                 })
                 |> fun t -> t.GetAwaiter().GetResult()

--- a/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
@@ -1107,7 +1107,7 @@ module ComprehensiveCanaryTests =
                         | d -> findRoot d.Parent
                     findRoot (System.IO.DirectoryInfo(System.IO.Directory.GetCurrentDirectory()))
                 | v -> v
-            let path = BenchSink.defaultPath benchRoot "canary"
+            let path = BenchSink.runPath benchRoot "canary" (LogSink.runId ())
             BenchSink.persistJson path "comprehensiveOperatorReality" stats
             printfn "Bench snapshot persisted: %s" path
 

--- a/sidecar/projection/tests/Projection.Tests/EphemeralContainerFixture.fs
+++ b/sidecar/projection/tests/Projection.Tests/EphemeralContainerFixture.fs
@@ -46,6 +46,17 @@ module ContainerFixtureSupport =
                 return! body cnnPerDb perDbConn
             finally
                 try
+                    // Evict the per-DB connection POOL before the drop: the
+                    // body's `use` returned its physical connection to the
+                    // pool still OPEN, and a SINGLE_USER WITH ROLLBACK
+                    // IMMEDIATE that must KILL that idle session costs ~3.0s
+                    // per drop (measured 2026-06-12: 3051ms with one idle
+                    // session vs 51ms with none — the flat ~3.4s per-test
+                    // floor the docker pool's TRX showed). ClearPool closes
+                    // it client-side, so the drop pays the cheap path.
+                    let cnnEvict = new SqlConnection(perDbConn)
+                    SqlConnection.ClearPool cnnEvict
+                    cnnEvict.Dispose()
                     use cnnDrop = new SqlConnection(masterConn)
                     cnnDrop.OpenAsync().GetAwaiter().GetResult()
                     let q = Render.quote dbName

--- a/sidecar/projection/tests/Projection.Tests/ExecuteBatchParallelTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ExecuteBatchParallelTests.fs
@@ -126,6 +126,12 @@ module ExecuteBatchParallelTests =
                         finally
                             // Best-effort drop.
                             try
+                                // Pool evicted first: an idle pooled per-DB
+                                // session makes the SINGLE_USER ROLLBACK kill
+                                // cost ~3s; evicted, ~50ms (2026-06-12).
+                                let cnnEvict = new SqlConnection(perDbConn)
+                                SqlConnection.ClearPool cnnEvict
+                                cnnEvict.Dispose()
                                 use cnnDrop = new SqlConnection(masterConn)
                                 cnnDrop.OpenAsync().GetAwaiter().GetResult()
                                 let q = Render.quote dbName
@@ -185,6 +191,12 @@ module ExecuteBatchParallelTests =
                             return threw
                         finally
                             try
+                                // Pool evicted first: an idle pooled per-DB
+                                // session makes the SINGLE_USER ROLLBACK kill
+                                // cost ~3s; evicted, ~50ms (2026-06-12).
+                                let cnnEvict = new SqlConnection(perDbConn)
+                                SqlConnection.ClearPool cnnEvict
+                                cnnEvict.Dispose()
                                 use cnnDrop = new SqlConnection(masterConn)
                                 cnnDrop.OpenAsync().GetAwaiter().GetResult()
                                 let q = Render.quote dbName
@@ -266,6 +278,12 @@ module ExecuteBatchParallelTests =
                         // ---- Teardown both DBs (best-effort).
                         for db in [ dbSeq; dbPar ] do
                             try
+                                // Pool evicted first: an idle pooled per-DB
+                                // session makes the SINGLE_USER ROLLBACK kill
+                                // cost ~3s; evicted, ~50ms (2026-06-12).
+                                let cnnEvict = new SqlConnection(Deploy.ConnectionString.buildPerDb masterConn db)
+                                SqlConnection.ClearPool cnnEvict
+                                cnnEvict.Dispose()
                                 use cnnDrop = new SqlConnection(masterConn)
                                 cnnDrop.OpenAsync().GetAwaiter().GetResult()
                                 let q = Render.quote db

--- a/sidecar/projection/tests/Projection.Tests/ExecuteBatchParallelTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ExecuteBatchParallelTests.fs
@@ -49,22 +49,42 @@ module ExecuteBatchParallelTests =
             sb.AppendLine "GO" |> ignore
         sb.ToString()
 
-    /// Build N independent INSERT batches (one INSERT-per-table,
-    /// separated by GO) — each is a self-contained segment with no
-    /// cross-table dependency.
-    let private buildIndependentInsertBatches (n: int) (rowsPerTable: int) : string =
+    /// One table's self-contained INSERT batch (GO-terminated) — the
+    /// per-member script shape the token carries.
+    let private insertBatchFor (rowsPerTable: int) (i: int) : string =
         let sb = System.Text.StringBuilder()
-        for i in 0 .. n - 1 do
+        sb.AppendLine(
+            sprintf
+                "INSERT INTO [dbo].[T%d] ([Id], [Label]) VALUES"
+                i) |> ignore
+        for r in 0 .. rowsPerTable - 1 do
+            let sep = if r = rowsPerTable - 1 then ";" else ","
             sb.AppendLine(
-                sprintf
-                    "INSERT INTO [dbo].[T%d] ([Id], [Label]) VALUES"
-                    i) |> ignore
-            for r in 0 .. rowsPerTable - 1 do
-                let sep = if r = rowsPerTable - 1 then ";" else ","
-                sb.AppendLine(
-                    sprintf "    (%d, N'row-%d-%d')%s" r i r sep) |> ignore
-            sb.AppendLine "GO" |> ignore
+                sprintf "    (%d, N'row-%d-%d')%s" r i r sep) |> ignore
+        sb.AppendLine "GO" |> ignore
         sb.ToString()
+
+    /// Build N independent INSERT batches as ONE text (GO-separated) —
+    /// the sequential `executeBatch` leg's shape.
+    let private buildIndependentInsertBatches (n: int) (rowsPerTable: int) : string =
+        [ for i in 0 .. n - 1 -> insertBatchFor rowsPerTable i ]
+        |> String.concat ""
+
+    /// Mint the test's concurrent-safe group through the REAL prover
+    /// (card P1 — `ParallelSafe` has no other producer): n independent
+    /// kinds (no edges) form exactly one level under
+    /// `TopologicalOrder.levels`; the per-table batches ride the token
+    /// via per-member `map`, the same carrier production scripts use.
+    let private mintIndependentBatches (n: int) (batchFor: int -> string) : ParallelSafe<string> =
+        let keys =
+            [ for i in 0 .. n - 1 ->
+                SsKey.synthesized "OS_TEST_EBP" (sprintf "T%02d" i)
+                |> function Ok k -> k | Error e -> failwithf "fixture: %A" e ]
+        let order = { TopologicalOrder.empty with Order = keys }
+        let indexOf = keys |> List.mapi (fun i k -> k, i) |> Map.ofList
+        match TopologicalOrder.levels order with
+        | [ level ] -> level |> ParallelSafe.map (fun k -> batchFor indexOf.[k])
+        | other -> failwithf "fixture: expected ONE level over independent kinds, got %d" (List.length other)
 
     let private countRows (cnn: SqlConnection) (table: string) : Task<int> =
         task {
@@ -108,8 +128,9 @@ module ExecuteBatchParallelTests =
                                 do! cnn.OpenAsync()
                                 do! Deploy.executeBatch cnn (buildIndependentSchemaDdl 5)
                             }
-                            // Parallel insert dispatch.
-                            let inserts = buildIndependentInsertBatches 5 3
+                            // Parallel insert dispatch — the group minted
+                            // through the prover (P1).
+                            let inserts = mintIndependentBatches 5 (insertBatchFor 3)
                             do! Deploy.executeBatchParallel perDbConn inserts 3
                             // Verify rows landed.
                             use cnn = new SqlConnection(perDbConn)
@@ -182,11 +203,13 @@ module ExecuteBatchParallelTests =
                             // missing table. We don't deploy any schema;
                             // both should fail. Either way, the await
                             // must surface an exception.
-                            let badSql =
-                                "SELECT 1;\nGO\nINSERT INTO [dbo].[DoesNotExist] ([X]) VALUES (1);\nGO"
+                            let badLevel =
+                                mintIndependentBatches 2 (fun i ->
+                                    if i = 0 then "SELECT 1;\nGO\n"
+                                    else "INSERT INTO [dbo].[DoesNotExist] ([X]) VALUES (1);\nGO\n")
                             let mutable threw = false
                             try
-                                do! Deploy.executeBatchParallel perDbConn badSql 2
+                                do! Deploy.executeBatchParallel perDbConn badLevel 2
                             with _ -> threw <- true
                             return threw
                         finally
@@ -271,7 +294,7 @@ module ExecuteBatchParallelTests =
                             do! Deploy.executeBatch cnn schema
                         }
                         let sw = System.Diagnostics.Stopwatch.StartNew()
-                        do! Deploy.executeBatchParallel connPar inserts 4
+                        do! Deploy.executeBatchParallel connPar (mintIndependentBatches n (insertBatchFor rowsPerTable)) 4
                         sw.Stop()
                         let parMs = sw.ElapsedMilliseconds
 

--- a/sidecar/projection/tests/Projection.Tests/GeneratorScaleTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/GeneratorScaleTests.fs
@@ -256,7 +256,7 @@ let ``Operator-reality canary: 6.25k rows × 150 tables, variegated, round-trips
                         | d -> findRoot d.Parent
                     findRoot (System.IO.DirectoryInfo(System.IO.Directory.GetCurrentDirectory()))
                 | v -> v
-            let path = BenchSink.defaultPath benchRoot "canary"
+            let path = BenchSink.runPath benchRoot "canary" (LogSink.runId ())
             BenchSink.persistJson path "operatorReality" stats
             printfn "operatorReality bench snapshot: %s" path
 

--- a/sidecar/projection/tests/Projection.Tests/LedgerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LedgerTests.fs
@@ -1,0 +1,99 @@
+module Projection.Tests.LedgerTests
+
+open Xunit
+open FsCheck.Xunit
+open Projection.Core
+
+// CONSTELLATION_BACKLOG card L1 (the ledger contract, R3, corrected per
+// RI-3). The contract under witness: `LedgerSpec` is the pure chain
+// algebra (Genesis / Apply / FingerprintOf); admission is SPLIT —
+// `writeAdmit` mints `Verified<_>` on an external witness, `resumeAdmit`
+// mints it on fingerprint recomputation against the live source;
+// `replay` is the FTC fold over verified entries; `resumePoint` is the
+// first position absent from the chain. The journal (L2), the episode
+// store (L3), and the G10 marker (L4) instantiate this; these witnesses
+// pin the algebra itself over a constructed-valid generic instance.
+
+/// The constructed-valid instance: a partial-sum ledger over ints. The
+/// fingerprint is derived from the entry, so "recomputation" is honest:
+/// the same entry recomputes the same fingerprint; a drifted entry does
+/// not.
+let private sumSpec : LedgerSpec<int, int, string> =
+    { Genesis = 0
+      Apply = (+)
+      FingerprintOf = fun e -> sprintf "fp:%d" e }
+
+let private admitAll (entries: int list) : Verified<int> list =
+    entries
+    |> List.map (Ledger.writeAdmit (fun _ -> Ok ()))
+    |> List.map (function Ok v -> v | Error e -> failwithf "fixture: witness refused %A" e)
+
+let private chainOf (entries: int list) : LedgerEntry<int, string> list =
+    entries |> List.mapi (Ledger.entryOf sumSpec)
+
+// -- the FTC: replay = fold ⊕ ----------------------------------------------
+
+[<Property>]
+let ``R3: replay = fold ⊕ — the FTC at the contract grain`` (entries: int list) =
+    Ledger.replay sumSpec (admitAll entries) = List.fold (+) 0 entries
+
+[<Property>]
+let ``R3: replay over a chain plus one entry = Apply of the replayed prefix — the partial-sum step`` (prefix: int list) (next: int) =
+    let viaChain = Ledger.replay sumSpec (admitAll (prefix @ [ next ]))
+    let viaStep = sumSpec.Apply (Ledger.replay sumSpec (admitAll prefix)) next
+    viaChain = viaStep
+
+// -- resume: crash at k resumes at k; drift refuses by name -----------------
+
+[<Property>]
+let ``R3: crash at chunk k resumes at k — the gapless chain's resume point is its length`` (entries: int list) =
+    // A run that crashed after journaling k chunks left positions 0..k−1.
+    Ledger.resumePoint (chainOf entries) = List.length entries
+
+[<Fact>]
+let ``R3: a crash hole resumes at the hole — the chain is an index, not a prefix`` () =
+    let recorded =
+        [ 0, 10; 1, 11; 3, 13 ]
+        |> List.map (fun (position, entry) -> Ledger.entryOf sumSpec position entry)
+    Assert.Equal(2, Ledger.resumePoint recorded)
+
+[<Fact>]
+let ``R3: resumeAdmit admits on recomputed = recorded; the token carries the entry`` () =
+    let recorded = Ledger.entryOf sumSpec 4 42
+    match Ledger.resumeAdmit (sumSpec.FingerprintOf 42) recorded with
+    | Ok token -> Assert.Equal(42, Verified.value token)
+    | Error drift -> failwithf "an unchanged source must admit; drifted at %d" drift.Position
+
+[<Fact>]
+let ``R3: fingerprint drift refuses by name — position and both fingerprints on the refusal`` () =
+    let recorded = Ledger.entryOf sumSpec 7 42
+    match Ledger.resumeAdmit (sumSpec.FingerprintOf 43) recorded with
+    | Ok _ -> failwith "a drifted source must never silently admit"
+    | Error drift ->
+        Assert.Equal(7, drift.Position)
+        Assert.Equal("fp:42", drift.Recorded)
+        Assert.Equal("fp:43", drift.Recomputed)
+
+// -- write admission: the external witness mints the token ------------------
+
+[<Fact>]
+let ``R3: writeAdmit mints the token only on a passing witness`` () =
+    match Ledger.writeAdmit (fun _ -> Ok ()) 42 with
+    | Ok token -> Assert.Equal(42, Verified.value token)
+    | Error (_: string) -> failwith "a passing witness must mint"
+
+[<Fact>]
+let ``R3: writeAdmit propagates a refusing witness — no token exists for an unverified entry`` () =
+    match Ledger.writeAdmit (fun e -> Error (sprintf "unverified:%d" e)) 42 with
+    | Ok _ -> failwith "a refusing witness must never mint"
+    | Error message -> Assert.Equal("unverified:42", message)
+
+[<Fact>]
+let ``R3: entryOf stamps the spec's fingerprint at write time — resume recomputation closes the loop`` () =
+    // Write-time stamps FingerprintOf; resume-time recomputes the same
+    // function over the (unchanged) live entry: the loop must close.
+    let recorded = Ledger.entryOf sumSpec 0 99
+    Assert.Equal("fp:99", recorded.Fingerprint)
+    match Ledger.resumeAdmit (sumSpec.FingerprintOf 99) recorded with
+    | Ok token -> Assert.Equal(99, Verified.value token)
+    | Error _ -> failwith "the write-time stamp and the resume-time recomputation are the same function"

--- a/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
+++ b/sidecar/projection/tests/Projection.Tests/PerfHarnessScenarios.fs
@@ -460,6 +460,105 @@ let ossysParse (entities: int) : PerfScenario =
             } }
 
 // -------------------------------------------------------------------------
+// P2 gate (CONSTELLATION_BACKLOG stage 6) — leveled-parallel vs sequential
+// rendered-data deploy at the operator envelope: 150 independent static
+// kinds × 42 rows = 6,300 rows (the perf-gate canary's table count and
+// volume; independent lookups ARE the static-seed topology, so the leveled
+// plan is one ParallelSafe group of 150 members). PAIRED back-to-back legs
+// on one container control drift: leg A is today's production shape (the
+// aggregated sequential batch `runEphemeral` deploys); leg B is the
+// promoted shape (per-level ParallelSafe dispatch under the existing
+// `Deploy.resolveParallelism` stack). The label pair IS the gate's
+// evidence — P2 wires or stays refused on what this prints.
+// -------------------------------------------------------------------------
+
+let private leveledSeedCatalog (kinds: int) (rowsPerKind: int) : Catalog =
+    StaticCatalogFixtures.staticCatalogOfKinds "PERF_LVL" "PerfLevelMod"
+        [ for k in 0 .. kinds - 1 ->
+            { StaticCatalogFixtures.KindKeyParts = [ sprintf "Lookup%03d" k ]
+              KindName = sprintf "PerfLevel%03d" k
+              PhysicalTable = sprintf "PerfLevel%03d" k
+              Attrs =
+                [ StaticCatalogFixtures.pk "Id" "ID" Integer
+                  StaticCatalogFixtures.attr "Code" "CODE" Text
+                  StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+              Rows =
+                [ for i in 1 .. rowsPerKind ->
+                    string i, [ string i; sprintf "C%06d" i; sprintf "Level %d row %d" k i ] ] } ]
+
+// PERF-SCENARIO: leveled-deploy 150x42 | keylabels=perf.leveledDeploy.sequential,perf.leveledDeploy.parallel,deploy.executeBatchParallel
+let leveledDeploy (kinds: int) (rowsPerKind: int) : PerfScenario =
+    let catalog = leveledSeedCatalog kinds rowsPerKind
+    { Name = sprintf "leveled-deploy-%dx%d" kinds rowsPerKind
+      Tag = "perf.leveledDeploy"
+      KeyLabels = [ "perf.leveledDeploy.sequential"; "perf.leveledDeploy.parallel"; "deploy.executeBatchParallel" ]
+      Run =
+        fun _ ->
+            task {
+                let ddl = SsdtDdlEmitter.statements catalog |> Render.toText
+                let sequentialSeed =
+                    match DataEmissionComposer.composeRendered seedPolicy catalog Profile.empty with
+                    | Ok s -> s
+                    | Error e -> failwithf "leveled-deploy compose (sequential) failed: %A" e
+                let leveled =
+                    match
+                        DataEmissionComposer.composeRenderedLeveled
+                            seedPolicy catalog Profile.empty
+                            MigrationDependencyContext.empty UserRemapContext.empty
+                    with
+                    | Ok l -> l
+                    | Error e -> failwithf "leveled-deploy compose (leveled) failed: %A" e
+                let expectTotal = int64 (kinds * rowsPerKind)
+                let assertLoaded (cnn: SqlConnection) (leg: string) =
+                    task {
+                        use check =
+                            new SqlCommand(
+                                "SELECT SUM(p.rows) FROM sys.partitions p JOIN sys.tables t ON p.object_id = t.object_id WHERE p.index_id IN (0,1);",
+                                cnn)
+                        let! loaded = check.ExecuteScalarAsync()
+                        if Convert.ToInt64 loaded <> expectTotal then
+                            failwithf "leveled-deploy %s leg loaded %d rows, expected %d" leg (Convert.ToInt64 loaded) expectTotal
+                    }
+                do!
+                    Deploy.useContainer (fun masterConn ->
+                        task {
+                            // Leg A — today's production shape: one aggregated
+                            // batch through sequential executeBatch.
+                            do!
+                                ContainerFixtureSupport.withEphemeralDatabase masterConn "PerfLvlSeq" (fun cnn _ ->
+                                    task {
+                                        do! Deploy.executeBatch cnn ddl
+                                        do!
+                                            task {
+                                                use _ = Bench.scope "perf.leveledDeploy.sequential"
+                                                do! Deploy.executeBatch cnn sequentialSeed
+                                            }
+                                        do! assertLoaded cnn "sequential"
+                                    })
+                            // Leg B — the promoted shape: per-level ParallelSafe
+                            // dispatch behind the existing parallelism resolution.
+                            do!
+                                ContainerFixtureSupport.withEphemeralDatabase masterConn "PerfLvlPar" (fun cnn perDbConn ->
+                                    task {
+                                        do! Deploy.executeBatch cnn ddl
+                                        let! parallelism = Deploy.resolveParallelism perDbConn
+                                        Bench.recordSample "perf.leveledDeploy.parallelism" (int64 parallelism)
+                                        do!
+                                            task {
+                                                use _ = Bench.scope "perf.leveledDeploy.parallel"
+                                                for level in leveled.Phase1Levels do
+                                                    if not (ParallelSafe.isEmpty level) then
+                                                        do! Deploy.executeBatchParallel perDbConn level parallelism
+                                                for level in leveled.Phase2Levels do
+                                                    if not (ParallelSafe.isEmpty level) then
+                                                        do! Deploy.executeBatchParallel perDbConn level parallelism
+                                            }
+                                        do! assertLoaded cnn "parallel"
+                                    })
+                        })
+            } }
+
+// -------------------------------------------------------------------------
 // H7 (CONSTELLATION_BACKLOG plane N9; CONSTELLATION §9.8.11) — the catalog
 // as the fifth declare-once system. `all` is the single definition site;
 // the gated facts below index into it by name (an undeclared name fails
@@ -532,7 +631,11 @@ let all : ScenarioDecl list =
       { Name = "ossys-parse-1000"
         Docker = false
         Scale = { Rows = 0; Tables = 1000; ColumnsPerTable = 8 }
-        Make = fun () -> ossysParse 1000 } ]
+        Make = fun () -> ossysParse 1000 }
+      { Name = "leveled-deploy-150x42"
+        Docker = true
+        Scale = { Rows = 6300; Tables = 150; ColumnsPerTable = 3 }
+        Make = fun () -> leveledDeploy 150 42 } ]
 
 /// Run one DECLARED scenario: gate first (no fixture construction on the
 /// skip path), then build, then verify the declared name against the
@@ -598,3 +701,6 @@ let ``PerfHarness: profiler-discover 150`` () = runDeclared "profiler-discover-1
 
 [<Fact>]
 let ``PerfHarness: ossys-parse 1000`` () = runDeclared "ossys-parse-1000"
+
+[<Fact>]
+let ``PerfHarness: leveled-deploy 150x42`` () = runDeclared "leveled-deploy-150x42"

--- a/sidecar/projection/tests/Projection.Tests/PreflightAllTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PreflightAllTests.fs
@@ -216,6 +216,7 @@ let ``G0.4: a verb that omits a gate produces a WORSE outcome than routing throu
 [<InlineData("transfer.unmappedIdentities", 9)>]
 [<InlineData("migrate.dataViolatesTightening", 9)>]
 [<InlineData("transfer.cdcTrackedSink", 9)>]
+[<InlineData("migrate.cdcTrackedSink", 9)>]
 [<InlineData("migrate.schemaReadFailed", 6)>]
 let ``G0: classify maps each KNOWN gate code to its distinct per-verb exit`` (code: string) (expected: int) =
     // §8 discriminator: the composition must NOT flatten distinct refusals to one

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="EphemeralContainerFixture.fs" />
     <Compile Include="ScaffoldingTests.fs" />
     <Compile Include="ResultTests.fs" />
+    <Compile Include="LedgerTests.fs" />
     <Compile Include="BenchTests.fs" />
     <Compile Include="LogSinkTests.fs" />
     <Compile Include="LogSinkSubscriberTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RefTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefTests.fs
@@ -46,7 +46,8 @@ let ``Ref: a runId ref resolves to the run's catalog (the Run-Ref connection)`` 
         let run : Run.Run =
             { RunId = "01HUB"; Ts = "t"; Command = "x"; InputDigest = "d"; Outcome = "succeeded"
               Canary = None; Registered = 0; Applied = 0; Declined = 0; Events = []
-              Artifacts = Map.ofList [ "model.json", minimalModel ] }
+              Artifacts = Map.ofList [ "model.json", minimalModel ]
+              Ledgers = []; Bench = None }
         Run.save dir run
         match TaskSync.run (fun () -> Ref.resolveCatalog (Ref.parse "@01HUB")) with
         | Ok c    -> Assert.NotEmpty(Catalog.allKinds c)

--- a/sidecar/projection/tests/Projection.Tests/RunHistoryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunHistoryTests.fs
@@ -40,3 +40,20 @@ let ``RunHistory: latest is the most recent run`` () =
     match RunHistory.latest h with
     | Some r -> Assert.Equal("2026-03", r.Ts)
     | None   -> Assert.Fail "expected a latest run"
+
+[<Fact>]
+let ``R1: readiness over RunHistory ≡ readiness over the ledger projection of the same runs`` () =
+    // R1e's second clause: the run subsumes the ledger row, so the gauge
+    // over stored runs and the gauge over their projected ledger rows are
+    // the SAME gauge — two stores, one definition of readiness.
+    let runs =
+        [ run "2026-01" (Some "green") 0
+          run "2026-02" None 1
+          run "2026-03" (Some "red") 0
+          run "2026-04" (Some "green") 2
+          run "2026-05" (Some "green") 0 ]
+    let viaHistory = RunHistory.ofRuns runs |> RunHistory.readiness
+    let viaLedger = RunLedger.readiness (runs |> List.map Run.toLedgerEntry)
+    Assert.Equal(viaLedger, viaHistory)
+    Assert.Equal(2, viaHistory.ConsecutiveGreen)
+    Assert.False(viaHistory.Eligible)

--- a/sidecar/projection/tests/Projection.Tests/RunHistoryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunHistoryTests.fs
@@ -9,7 +9,8 @@ open Projection.Pipeline
 let private run (ts: string) (canary: string option) (declined: int) : Run.Run =
     { RunId = ts; Ts = ts; Command = "projection canary"; InputDigest = "d"
       Outcome = "succeeded"; Canary = canary; Registered = 42; Applied = 0; Declined = declined
-      Events = []; Artifacts = Map.empty }
+      Events = []; Artifacts = Map.empty
+      Ledgers = []; Bench = None }
 
 [<Fact>]
 let ``RunHistory: ofRuns sorts chronologically (oldest first)`` () =

--- a/sidecar/projection/tests/Projection.Tests/RunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunTests.fs
@@ -83,6 +83,35 @@ let ``Run: toLedgerEntry projects the index row (subsumes LedgerRecord)`` () =
     Assert.Equal(sample.Outcome, e.Outcome)
 
 [<Fact>]
+let ``R1b: every bracketed verb's run is capturable — no orphan RunIds`` () =
+    // The bracket owner (RunEnvelope) persists the completed aggregate
+    // under PROJECTION_LEDGER_DIR: the stream's runId resolves to a stored
+    // Run carrying the events (runStart + the §10 terminal) and the bench
+    // snapshot. Opt-in: without the env var, nothing accumulates.
+    let dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
+    let prior = Environment.GetEnvironmentVariable "PROJECTION_LEDGER_DIR"
+    try
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", dir)
+        use sw = new StringWriter()
+        LogSink.reset ()
+        let mutable code = -1
+        LogSink.withWriter sw (fun () ->
+            code <- RunEnvelope.bracket "projection test-verb" ignore Map.empty (fun () -> 0, LogSink.Succeeded))
+        Assert.Equal(0, code)
+        let runId = LogSink.runId ()
+        match Run.load dir runId with
+        | Some r ->
+            Assert.Equal("projection test-verb", r.Command)
+            Assert.Equal("succeeded", r.Outcome)
+            Assert.True(r.Bench.IsSome)
+            Assert.Contains(r.Events, fun (e: string) -> e.Contains "config.runStart")
+            Assert.Contains(r.Events, fun (e: string) -> e.Contains "summary.runComplete")
+        | None -> Assert.Fail "expected the captured run aggregate under PROJECTION_LEDGER_DIR"
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", prior)
+        try Directory.Delete(dir, true) with _ -> ()
+
+[<Fact>]
 let ``Run: capture builds a Run from the live LogSink state + the artifact tree`` () =
     use sw = new StringWriter()
     LogSink.reset ()

--- a/sidecar/projection/tests/Projection.Tests/RunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunTests.fs
@@ -15,7 +15,8 @@ let private sample : Run.Run =
       InputDigest = "deadbeef"; Outcome = "succeeded"; Canary = Some "green"
       Registered = 42; Applied = 3; Declined = 1
       Events = [ """{"code":"config.runStart"}"""; """{"code":"summary.runComplete"}""" ]
-      Artifacts = Map.ofList [ "catalog.json", """{"modules":[]}"""; "summary.txt", "all green" ] }
+      Artifacts = Map.ofList [ "catalog.json", """{"modules":[]}"""; "summary.txt", "all green" ]
+      Ledgers = []; Bench = None }
 
 [<Fact>]
 let ``Run: inputDigest is stable across calls and sensitive to inputs (content-addressed)`` () =
@@ -31,6 +32,31 @@ let ``Run: save then load round-trips the aggregate including the event stream``
         Run.save dir sample
         match Run.load dir sample.RunId with
         | Some loaded -> Assert.Equal(sample, loaded)     // structural equality, events included
+        | None -> Assert.Fail "expected to load the saved run"
+    finally
+        try Directory.Delete(dir, true) with _ -> ()
+
+[<Fact>]
+let ``R1a: load(save run) = run over the completed aggregate — ledger refs and bench carried`` () =
+    // The codec-totality witness for the two R1a fields: a run that
+    // extended both chains and carried a measurement snapshot round-trips
+    // structurally (pre-R1a files load with []/None — the additive law).
+    let completed =
+        { sample with
+            RunId = "01R1AAAA"
+            Ledgers = [ Run.JournalRef "a1b2c3d4e5f60718"; Run.EpisodeRef ("dev", 3) ]
+            Bench =
+                Some ({ CapturedAtUtc = System.DateTime(2026, 6, 12, 15, 0, 0, System.DateTimeKind.Utc)
+                        Tag = "publish"
+                        Stats =
+                          [ { Label = "stage.extract"; Count = 1
+                              TotalMs = 120L; MinMs = 120L; MaxMs = 120L; MeanMs = 120.0
+                              P50Ms = 120L; P95Ms = 120L; P99Ms = 120L } ] } : Bench.Run) }
+    let dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))
+    try
+        Run.save dir completed
+        match Run.load dir completed.RunId with
+        | Some loaded -> Assert.Equal(completed, loaded)
         | None -> Assert.Fail "expected to load the saved run"
     finally
         try Directory.Delete(dir, true) with _ -> ()

--- a/sidecar/projection/tests/Projection.Tests/RunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RunTests.fs
@@ -111,6 +111,64 @@ let ``R1b: every bracketed verb's run is capturable — no orphan RunIds`` () =
         Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", prior)
         try Directory.Delete(dir, true) with _ -> ()
 
+// -- R1d: the run-vs-run delta surface (the UoM promotion's home) ----------
+
+let private benchOf (pairs: (string * int64) list) : Bench.Run =
+    { CapturedAtUtc = System.DateTime(2026, 6, 12, 12, 0, 0, System.DateTimeKind.Utc)
+      Tag = "t"
+      Stats =
+        pairs
+        |> List.map (fun (label, total) ->
+            { Label = label; Count = 1
+              TotalMs = total; MinMs = total; MaxMs = total; MeanMs = float total
+              P50Ms = total; P95Ms = total; P99Ms = total }) }
+
+[<Fact>]
+let ``R1d: Run.diff carries verdict movement, count deltas, and per-label wall-time deltas`` () =
+    let a = { sample with RunId = "A"; Registered = 40; Applied = 2; Declined = 1
+                          Bench = Some (benchOf [ "stage.extract", 100L; "stage.emit", 50L ]) }
+    let b = { sample with RunId = "B"; Registered = 42; Applied = 5; Declined = 0
+                          Outcome = "failed"
+                          Bench = Some (benchOf [ "stage.extract", 70L; "stage.profile", 25L ]) }
+    let d = Run.diff None a b
+    Assert.Equal(("A", "B"), d.RunIds)
+    Assert.Equal(("succeeded", "failed"), d.Outcomes)
+    Assert.Equal(2, d.Registered)
+    Assert.Equal(3, d.Applied)
+    Assert.Equal(-1, d.Declined)
+    // The label union, deltas typed in ms: changed, after-only, before-only.
+    let byLabel = d.BenchDeltas |> List.map (fun bd -> bd.Label, bd) |> Map.ofList
+    Assert.Equal(-30L<Run.ms>, byLabel.["stage.extract"].DeltaMs)
+    Assert.Equal(-50L<Run.ms>, byLabel.["stage.emit"].DeltaMs)      // before-only: dropped
+    Assert.Equal(25L<Run.ms>, byLabel.["stage.profile"].DeltaMs)    // after-only: appeared
+    Assert.Equal(None, byLabel.["stage.profile"].BeforeMs)
+    // Largest movement leads.
+    Assert.Equal("stage.emit", (List.head d.BenchDeltas).Label)
+
+[<Fact>]
+let ``R1d: Run.diff restricted to key labels is the harness's before/after shape`` () =
+    let a = { sample with RunId = "A"; Bench = Some (benchOf [ "k1", 10L; "noise", 999L ]) }
+    let b = { sample with RunId = "B"; Bench = Some (benchOf [ "k1", 30L; "noise", 1L ]) }
+    let d = Run.diff (Some (Set.ofList [ "k1" ])) a b
+    Assert.Equal<string list>([ "k1" ], d.BenchDeltas |> List.map (fun bd -> bd.Label))
+    Assert.Equal(20L<Run.ms>, (List.head d.BenchDeltas).DeltaMs)
+
+[<Fact>]
+let ``R1d: storeDir resolves PROJECTION_RUNS_DIR first, then PROJECTION_LEDGER_DIR`` () =
+    let priorRuns = Environment.GetEnvironmentVariable "PROJECTION_RUNS_DIR"
+    let priorLedger = Environment.GetEnvironmentVariable "PROJECTION_LEDGER_DIR"
+    try
+        Environment.SetEnvironmentVariable("PROJECTION_RUNS_DIR", "/tmp/runs-explicit")
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", "/tmp/ledger-dir")
+        Assert.Equal(Some "/tmp/runs-explicit", Run.storeDir ())
+        Environment.SetEnvironmentVariable("PROJECTION_RUNS_DIR", "")
+        Assert.Equal(Some "/tmp/ledger-dir", Run.storeDir ())
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", "")
+        Assert.Equal(None, Run.storeDir ())
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_RUNS_DIR", priorRuns)
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", priorLedger)
+
 [<Fact>]
 let ``Run: capture builds a Run from the live LogSink state + the artifact tree`` () =
     use sw = new StringWriter()

--- a/sidecar/projection/tests/Projection.Tests/StagedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StagedTests.fs
@@ -362,3 +362,41 @@ let ``S2: the declared spines carry the per-face arcs the string lists carried``
     Assert.Equal<string list>([ "deploy" ], RunSpine.keys Spines.deploy)
     Assert.Equal<string list>([ "canary" ], RunSpine.keys Spines.canary)
     Assert.Equal<string list>([ "load" ], RunSpine.keys Spines.transfer)
+
+// ---------------------------------------------------------------------------
+// R1e — the law: live view ≡ projection of the stored Run. The board
+// reconstructed from the SERIALIZED envelope trail (the exact strings
+// `Run.capture` persists as `Run.Events`) equals the board the live
+// subscriber built. The S2 spine makes the reconstruction total: every
+// crossing is on the wire, failed and aborted arms included.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``R1: live view ≡ projection of the stored Run — the reconstructed board equals the live board`` () =
+    // A mixed run: extract succeeds, deploy fails (→ Halted on the board),
+    // canary is run-stopped (ledger-only Skip — Pending on both boards).
+    let verdict, envs =
+        runCaptured (fun () ->
+            staged spine3 {
+                let! a = Staged.stage (stage "extract") (ok 1)
+                let! b = Staged.stage (stage "deploy") (err "refused")
+                let! c = Staged.stage (stage "canary") (ok (b + 1))
+                return c
+            })
+    (match verdict.Disposition with
+     | RunStopped _ -> ()
+     | other -> Assert.Fail(sprintf "expected RunStopped, got %A" other))
+    let live =
+        envs |> List.fold (fun b e -> Watch.applyEnvelope b e |> fst) (Watch.seededOf spine3)
+    // The stored form: the same trail as Run.capture's Events field.
+    let stored = LogSink.serializedEnvelopes ()
+    let reconstructed = Watch.boardOfStored (Watch.seededOf spine3) stored
+    Assert.Equal<Watch.Board>(live, reconstructed)
+    // And the projection is honest about the mixed verdict: deploy Halted,
+    // canary still Pending (its skip is ledger-only, by design).
+    (match reconstructed.Stages |> List.tryFind (fun s -> s.Key = "deploy") with
+     | Some { State = Watch.Halted _ } -> ()
+     | other -> Assert.Fail(sprintf "expected deploy Halted on the reconstructed board, got %A" other))
+    (match reconstructed.Stages |> List.tryFind (fun s -> s.Key = "canary") with
+     | Some { State = Watch.Pending } -> ()
+     | other -> Assert.Fail(sprintf "expected canary Pending on the reconstructed board, got %A" other))

--- a/sidecar/projection/tests/Projection.Tests/StaticCatalogFixtures.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticCatalogFixtures.fs
@@ -31,6 +31,58 @@ let attr (name: string) (column: string) (ty: PrimitiveType) : StaticAttrSpec =
 let pk (name: string) (column: string) (ty: PrimitiveType) : StaticAttrSpec =
     { attr name column ty with IsPrimaryKey = true }
 
+/// One static kind's spec for the multi-kind form (P2-gate measurement,
+/// 2026-06-12): the same per-kind shape `staticCatalog` always built,
+/// reified so a catalog of N independent static kinds has the SAME single
+/// definition site (the fifth hand-rolled instance stays unwritten).
+type StaticKindSpec =
+    { KindKeyParts : string list
+      KindName : string
+      PhysicalTable : string
+      Attrs : StaticAttrSpec list
+      Rows : (string * string list) list }
+
+/// Build a one-module catalog of N static kinds. Key shapes are
+/// byte-identical to `staticCatalog`'s per kind (same synthesis recipe).
+let staticCatalogOfKinds
+    (keyPrefix: string)
+    (moduleName: string)
+    (kinds: StaticKindSpec list)
+    : Catalog =
+    let mkKey parts = SsKey.synthesizedComposite keyPrefix parts |> Result.value
+    let nmx s = Name.create s |> Result.value
+    let buildKind (spec: StaticKindSpec) =
+        let attrNames = spec.Attrs |> List.map (fun a -> nmx a.Name)
+        let row (tag: string, cells: string list) =
+            { Identifier = mkKey (spec.KindKeyParts @ [ "Row"; tag ])
+              Values = List.zip attrNames cells |> Map.ofList }
+        let attribute (a: StaticAttrSpec) =
+            { Attribute.create (mkKey (spec.KindKeyParts @ [ a.Name ])) (nmx a.Name) a.Type with
+                Column = ColumnRealization.create a.Column false |> Result.value
+                IsPrimaryKey = a.IsPrimaryKey
+                IsMandatory = true }
+        { SsKey = mkKey spec.KindKeyParts
+          Name = nmx spec.KindName
+          Origin = Native
+          Modality = [ Static (spec.Rows |> List.map row) ]
+          Physical = TableId.create "dbo" spec.PhysicalTable |> Result.value
+          Attributes = spec.Attrs |> List.map attribute
+          References = []
+          Indexes = []
+          Description = None
+          IsActive = true
+          Triggers = []
+          ColumnChecks = []
+          ExtendedProperties = [] }
+    Catalog.create
+        [ { SsKey = mkKey [ "Mod" ]
+            Name = nmx moduleName
+            Kinds = kinds |> List.map buildKind
+            IsActive = true
+            ExtendedProperties = [] } ]
+        []
+    |> Result.value
+
 /// Build the shared static-population catalog shape. `rows` are
 /// `(rowTag, cells-in-attribute-order)`; every attribute is mandatory
 /// (the shared shape of all absorbed instances — a non-mandatory or
@@ -44,36 +96,9 @@ let staticCatalog
     (attrs: StaticAttrSpec list)
     (rows: (string * string list) list)
     : Catalog =
-    let mkKey parts = SsKey.synthesizedComposite keyPrefix parts |> Result.value
-    let nmx s = Name.create s |> Result.value
-    let attrNames = attrs |> List.map (fun a -> nmx a.Name)
-    let row (tag: string, cells: string list) =
-        { Identifier = mkKey (kindKeyParts @ [ "Row"; tag ])
-          Values = List.zip attrNames cells |> Map.ofList }
-    let attribute (a: StaticAttrSpec) =
-        { Attribute.create (mkKey (kindKeyParts @ [ a.Name ])) (nmx a.Name) a.Type with
-            Column = ColumnRealization.create a.Column false |> Result.value
-            IsPrimaryKey = a.IsPrimaryKey
-            IsMandatory = true }
-    let kind =
-        { SsKey = mkKey kindKeyParts
-          Name = nmx kindName
-          Origin = Native
-          Modality = [ Static (rows |> List.map row) ]
-          Physical = TableId.create "dbo" physicalTable |> Result.value
-          Attributes = attrs |> List.map attribute
-          References = []
-          Indexes = []
-          Description = None
-          IsActive = true
-          Triggers = []
-          ColumnChecks = []
-          ExtendedProperties = [] }
-    Catalog.create
-        [ { SsKey = mkKey [ "Mod" ]
-            Name = nmx moduleName
-            Kinds = [ kind ]
-            IsActive = true
-            ExtendedProperties = [] } ]
-        []
-    |> Result.value
+    staticCatalogOfKinds keyPrefix moduleName
+        [ { KindKeyParts = kindKeyParts
+            KindName = kindName
+            PhysicalTable = physicalTable
+            Attrs = attrs
+            Rows = rows } ]

--- a/sidecar/projection/tests/Projection.Tests/TopologicalOrderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TopologicalOrderTests.fs
@@ -140,7 +140,7 @@ let ``levels: solitary kind with no edges lives at level 0`` () =
             Edges = [] }
     Assert.Equal<SsKey list list>(
         [ [ customerKey ] ],
-        TopologicalOrder.levels t)
+        TopologicalOrder.levels t |> List.map ParallelSafe.members)
 
 [<Fact>]
 let ``levels: chain customer<-order<-country produces three singleton levels`` () =
@@ -152,7 +152,7 @@ let ``levels: chain customer<-order<-country produces three singleton levels`` (
                       countryKey, orderKey ] }
     Assert.Equal<SsKey list list>(
         [ [ customerKey ]; [ orderKey ]; [ countryKey ] ],
-        TopologicalOrder.levels t)
+        TopologicalOrder.levels t |> List.map ParallelSafe.members)
 
 [<Fact>]
 let ``levels: two independent kinds collapse into one level-0 group`` () =
@@ -161,7 +161,7 @@ let ``levels: two independent kinds collapse into one level-0 group`` () =
             Order = [ customerKey; countryKey ]
             Edges = [] }
     // Both at level 0; inner list sorted by SsKey.
-    let result = TopologicalOrder.levels t
+    let result = TopologicalOrder.levels t |> List.map ParallelSafe.members
     Assert.Single(result) |> ignore
     let level0 = List.head result
     Assert.Equal(2, List.length level0)
@@ -176,7 +176,7 @@ let ``levels: diamond shape — two parents at level 0; shared dependent at leve
             Order = [ customerKey; countryKey; orderKey ]
             Edges = [ orderKey, customerKey
                       orderKey, countryKey ] }
-    let result = TopologicalOrder.levels t
+    let result = TopologicalOrder.levels t |> List.map ParallelSafe.members
     Assert.Equal(2, List.length result)
     let level0 = List.head result
     let level1 = List.item 1 result
@@ -198,7 +198,7 @@ let ``levels: parallel-safety invariant holds — no edge between kinds at the s
             Edges = [ cKey, aKey  // C depends on A
                       cKey, bKey  // C depends on B
                       dKey, cKey ] }  // D depends on C
-    let levels = TopologicalOrder.levels t
+    let levels = TopologicalOrder.levels t |> List.map ParallelSafe.members
     // For each level, check no two kinds at that level have an edge between them.
     let levelOf (k: SsKey) : int =
         levels
@@ -224,7 +224,35 @@ let ``levels: cycle-broken kind receives finite level`` () =
             Order = [ aKey; bKey ]
             Edges = [ aKey, bKey
                       bKey, aKey ] }
-    let result = TopologicalOrder.levels t
+    let result = TopologicalOrder.levels t |> List.map ParallelSafe.members
     Assert.Equal(2, List.length result)
     Assert.Equal<SsKey list>([ aKey ], List.head result)
     Assert.Equal<SsKey list>([ bKey ], List.item 1 result)
+
+// ---------------------------------------------------------------------------
+// P1 / R5 — the ParallelSafe token: levels is the mint; map/choose are the
+// structure-preserving carriers (the convention witness, Bucket B).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``P1: levels mints ParallelSafe — map and choose carry the group without merging or reordering`` () =
+    let t : TopologicalOrder =
+        { TopologicalOrder.empty with
+            Order = [ customerKey; countryKey; orderKey ]
+            Edges = [ orderKey, customerKey ] }
+    let levels = TopologicalOrder.levels t
+    Assert.Equal(2, List.length levels)
+    // map: one image per member, same order — the rendering carrier.
+    let rendered = levels |> List.map (ParallelSafe.map SsKey.rootOriginal)
+    Assert.Equal<string list>(
+        List.head levels |> ParallelSafe.members |> List.map SsKey.rootOriginal,
+        List.head rendered |> ParallelSafe.members)
+    // choose: dropping a member keeps the group's remaining members intact.
+    let chosen =
+        List.head levels
+        |> ParallelSafe.choose (fun k -> if k = countryKey then None else Some k)
+    Assert.Equal<SsKey list>(
+        (List.head levels |> ParallelSafe.members |> List.filter (fun k -> k <> countryKey)),
+        ParallelSafe.members chosen)
+    // isEmpty: the empty group is detectable without unwrapping.
+    Assert.True(ParallelSafe.choose (fun _ -> None) (List.head levels) |> ParallelSafe.isEmpty)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -28,7 +28,12 @@ let private inScopeCodes : Set<string> =
           "config.validationFailed"
           // the run-face verdict codes (`RunFaces` register migration) — the
           // §4/§6 publish-and-load verdict and the §13 durable-record line
-          "load.completed"; "episode.recorded" ]
+          "load.completed"; "episode.recorded"
+          // the deploy face: the §3 verdict, the §10 SSDT rejection (server
+          // findings demoted to the disclosure), the §13 stage lines, and the
+          // §14 Docker requirement
+          "deploy.completed"; "deploy.ssdtRejected"
+          "container.starting"; "deploy.bundleEmitted"; "docker.unavailable" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -59,6 +64,10 @@ let private knownEmittableCodes : Set<string> =
           // render. `load.completed` is `full-export --load`'s publish-and-load
           // verdict; `episode.recorded` is the §13 durable-record line.
           "load.completed"; "episode.recorded"
+          // the deploy face's verdicts + stage lines + the §14 Docker
+          // requirement (shared with the canary faces)
+          "deploy.completed"; "deploy.ssdtRejected"
+          "container.starting"; "deploy.bundleEmitted"; "docker.unavailable"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -95,7 +104,11 @@ let private samplePayload : Voice.Payload =
           "artifactCount", box 7
           "capturedRows",  box 4210
           "episodeCount",  box 3
-          "timeline",      box "DEV" ]
+          "timeline",      box "DEV"
+          "purpose",       box "deploy"
+          "entryCount",    box 12
+          "database",      box "projection_canary_01"
+          "serverErrors",  box "Incorrect syntax near 'GO'.\nThe object 'dbo.Order' already exists." ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -184,6 +197,40 @@ let ``Voice register: the error frames clear the banned list`` () =
     for code in codes do
         let surface = Voice.errorSurface (ValidationError.create code "a located cause")
         assertClean (sprintf "errorSurface %s" code) (Surface.render surface)
+
+// ---------------------------------------------------------------------------
+// the deploy face's §10 rejection — statement in the register, the server's
+// findings demoted to the substantiation (the canary.divergence shape)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Voice deploy.ssdtRejected: the statement is the finding and the server lines are the disclosure`` () =
+    let payload : Voice.Payload =
+        Map.ofList
+            [ "database",     box "projection_dpl_01"
+              "serverErrors", box "Incorrect syntax near 'GO'.\nThe object 'dbo.Order' already exists." ]
+    match Voice.surfaceOf "deploy.ssdtRejected" payload with
+    | None -> Assert.Fail "deploy.ssdtRejected is unvoiced"
+    | Some surface ->
+        // The lead is a plain Bad verdict, never a raw server line.
+        match surface.Statement with
+        | View.Hero(View.Bad, text) -> Assert.Contains("rejected the change build", text)
+        | other -> Assert.Fail(sprintf "statement is not a Bad Hero: %A" other)
+        // Every server line is demoted into the disclosure, one Note each.
+        let disclosed =
+            surface.Substantiation
+            |> List.collect (function View.Disclosure(_, _, detail) -> detail | _ -> [])
+        Assert.Equal(2, List.length disclosed)
+        // The surface ends on the move.
+        match surface.Action with
+        | Some (View.Action _) -> ()
+        | other -> Assert.Fail(sprintf "no imperative next move: %A" other)
+
+[<Fact>]
+let ``Voice deploy.ssdtRejected: an empty payload still leads with the finding`` () =
+    match Voice.surfaceOf "deploy.ssdtRejected" Map.empty with
+    | Some { Statement = View.Hero(View.Bad, _) } -> ()
+    | other -> Assert.Fail(sprintf "unexpected empty-payload surface: %A" other)
 
 // ---------------------------------------------------------------------------
 // the stage-name mapping (THE_VOICE.md §13 — operator-shaped, never the verb)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -46,7 +46,9 @@ let private inScopeCodes : Set<string> =
           // the eject face: the §13 package line, the §6 self-verification
           // pair, and the §14 located store finding
           "eject.packaged"; "eject.verified"; "eject.unverified"
-          "eject.storeUnreadable" ]
+          "eject.storeUnreadable"
+          // the verify-data face: the §6 data-fidelity verdict pair
+          "verifyData.matched"; "verifyData.diverged" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -91,6 +93,8 @@ let private knownEmittableCodes : Set<string> =
           // the eject face's package + self-verification + store finding
           "eject.packaged"; "eject.verified"; "eject.unverified"
           "eject.storeUnreadable"
+          // the verify-data face's verdict pair
+          "verifyData.matched"; "verifyData.diverged"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -137,7 +141,10 @@ let private samplePayload : Voice.Payload =
           "path",          box "model.sql"
           "cause",         box "the changes could not be computed"
           "entries",       box "the Amount column narrows to a smaller type (emit.alterColumn.narrowing)"
-          "refactorLogCount", box 5 ]
+          "refactorLogCount", box 5
+          "rowDeltas",     box "OrderHeader    before=12 after=14 (change=+2)"
+          "nullDeltas",    box "OrderHeader    Email    before=0 after=3 (change=+3)"
+          "schemaWarnings", box "the After deployment carries an added index (verify.schema.indexAdded)" ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -337,6 +344,31 @@ let ``Voice errorFrame: a reconciliation argument routes to the §14 invalid fra
         match Voice.errorFrame code with
         | View.Hero(View.Bad, text), Some _ -> Assert.Contains("reconciliation argument", text)
         | other -> Assert.Fail(sprintf "unexpected reconcile frame for %s: %A" code other)
+
+// ---------------------------------------------------------------------------
+// the verify-data face's §6 pair — the divergence demotes each delta family
+// into a counted disclosure
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Voice verifyData.diverged: the finding leads and each delta family is a counted disclosure`` () =
+    let payload : Voice.Payload =
+        Map.ofList
+            [ "rowDeltas",  box "OrderHeader before=12 after=14 (change=+2)\nCountry before=8 after=7 (change=-1)"
+              "nullDeltas", box "OrderHeader Email before=0 after=3 (change=+3)" ]
+    match Voice.surfaceOf "verifyData.diverged" payload with
+    | Some surface ->
+        (match surface.Statement with
+         | View.Hero(View.Bad, text) -> Assert.Contains("diverges between the two deployments", text)
+         | other -> Assert.Fail(sprintf "statement is not a Bad Hero: %A" other))
+        let headlines =
+            surface.Substantiation
+            |> List.choose (function View.Disclosure(h, _, detail) -> Some(h, List.length detail) | _ -> None)
+        Assert.Equal<(string * int) list>([ "row counts — 2 differ", 2; "null counts — 1 differ", 1 ], headlines)
+        match surface.Action with
+        | Some (View.Action _) -> ()
+        | other -> Assert.Fail(sprintf "no next move: %A" other)
+    | None -> Assert.Fail "verifyData.diverged is unvoiced"
 
 // ---------------------------------------------------------------------------
 // the eject face's self-verification pair (§6, the P-7 freeze)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -25,7 +25,10 @@ let private inScopeCodes : Set<string> =
           "preflight.started"; "deploy.started"; "canary.started"; "load.started"
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           "summary.stageCompleted"
-          "config.validationFailed" ]
+          "config.validationFailed"
+          // the run-face verdict codes (`RunFaces` register migration) — the
+          // §4/§6 publish-and-load verdict and the §13 durable-record line
+          "load.completed"; "episode.recorded" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -50,6 +53,12 @@ let private knownEmittableCodes : Set<string> =
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           // round-trip verification verdict
           "canary.diffEmpty"; "canary.divergence"
+          // the run-face verdict codes — like the watch frames, these are not
+          // LogSink envelopes: a face renders its own verdict through the
+          // catalog (`TtyRenderer.renderVoicedTo`), one register, consumed at
+          // render. `load.completed` is `full-export --load`'s publish-and-load
+          // verdict; `episode.recorded` is the §13 durable-record line.
+          "load.completed"; "episode.recorded"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -82,7 +91,11 @@ let private samplePayload : Voice.Payload =
           "stage",       box "extract"
           "outcome",     box "succeeded"
           "followOn",    box "Verification follows."
-          "runIdentity", box 11 ]
+          "runIdentity", box 11
+          "artifactCount", box 7
+          "capturedRows",  box 4210
+          "episodeCount",  box 3
+          "timeline",      box "DEV" ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -199,6 +212,9 @@ let ``Voice errorFrame: routing is total — every code yields a verdict Hero`` 
           "migrate.connectionUnavailable"; "transfer.connectionUnavailable"
           "migrate.insufficientGrant"; "transfer.grantProbeFailed"
           "gate.intent"
+          "transfer.connection.specShape"; "transfer.connection.specEmpty"
+          "transfer.connection.refMissing"; "transfer.connection.refEmpty"
+          "transfer.connection.openFailed"; "timeline.name.empty"
           "adapter.osm.parse"; "something.unclassified" ]
     for code in codes do
         match Voice.errorFrame code with
@@ -216,6 +232,37 @@ let ``Voice errorFrame: a connection code routes to the §10 unreachable frame``
     match Voice.errorFrame "migrate.connectionUnavailable" with
     | View.Hero(_, text), Some _ -> Assert.Contains("unreachable", text)
     | other -> Assert.Fail(sprintf "unexpected connection frame: %A" other)
+
+[<Fact>]
+let ``Voice errorFrame: a malformed connection reference is an argument finding (§14 set-but-invalid)`` () =
+    // The parse-failure class must NOT borrow the reachability frame: the
+    // reference's shape is wrong; nothing was probed.
+    for code in [ "transfer.connection.specEmpty"; "transfer.connection.specShape"; "transfer.connection.specPrefix" ] do
+        match Voice.errorFrame code with
+        | View.Hero(View.Bad, text), Some _ ->
+            Assert.Contains("malformed", text)
+            Assert.DoesNotContain("unreachable", text)
+        | other -> Assert.Fail(sprintf "unexpected spec frame for %s: %A" code other)
+
+[<Fact>]
+let ``Voice errorFrame: an unresolvable connection reference names the missing secret (§14 required-and-missing)`` () =
+    for code in [ "transfer.connection.refMissing"; "transfer.connection.refEmpty" ] do
+        match Voice.errorFrame code with
+        | View.Hero(View.Bad, text), Some _ ->
+            Assert.Contains("does not resolve", text)
+        | other -> Assert.Fail(sprintf "unexpected ref frame for %s: %A" code other)
+
+[<Fact>]
+let ``Voice errorFrame: a failed connection open still routes to the §10 unreachable frame`` () =
+    match Voice.errorFrame "transfer.connection.openFailed" with
+    | View.Hero(_, text), Some _ -> Assert.Contains("unreachable", text)
+    | other -> Assert.Fail(sprintf "unexpected open frame: %A" other)
+
+[<Fact>]
+let ``Voice errorFrame: an empty timeline name is a located --env finding`` () =
+    match Voice.errorFrame "timeline.name.empty" with
+    | View.Hero(View.Bad, text), Some _ -> Assert.Contains("--env", text)
+    | other -> Assert.Fail(sprintf "unexpected timeline frame: %A" other)
 
 [<Fact>]
 let ``Voice errorFrame: the intent gate names the arming variable and a next move`` () =

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -37,7 +37,9 @@ let private inScopeCodes : Set<string> =
           // the canary faces: the §6 CDC-silence proof pair, the §13
           // both-sides-deployed line, and the §14 located source-file finding
           "canary.cdcSilent"; "canary.cdcCaptured"
-          "canary.deployed"; "canary.sourceMissing" ]
+          "canary.deployed"; "canary.sourceMissing"
+          // the drift face: the §6 no-drift verdict and the §5 drift finding
+          "drift.none"; "drift.diverged" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -75,6 +77,8 @@ let private knownEmittableCodes : Set<string> =
           // the canary faces' verdicts + stage line + located source finding
           "canary.cdcSilent"; "canary.cdcCaptured"
           "canary.deployed"; "canary.sourceMissing"
+          // the drift face's verdict pair
+          "drift.none"; "drift.diverged"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -146,7 +150,7 @@ let ``Voice totality: codes are distinct`` () =
 
 [<Fact>]
 let ``Voice totality: every entry cites a recognized THE_VOICE section`` () =
-    let recognized = Set.ofList [ "§3"; "§6"; "§10"; "§13"; "§14" ]
+    let recognized = Set.ofList [ "§3"; "§5"; "§6"; "§10"; "§13"; "§14" ]
     for c in Voice.all do
         Assert.False(System.String.IsNullOrWhiteSpace c.DocSection, sprintf "%s has no DocSection" c.Code)
         Assert.True(Set.contains c.DocSection recognized, sprintf "%s cites unrecognized section %s" c.Code c.DocSection)
@@ -342,6 +346,36 @@ let ``Voice errorFrame: an empty timeline name is a located --env finding`` () =
     match Voice.errorFrame "timeline.name.empty" with
     | View.Hero(View.Bad, text), Some _ -> Assert.Contains("--env", text)
     | other -> Assert.Fail(sprintf "unexpected timeline frame: %A" other)
+
+[<Fact>]
+let ``Voice errorFrame: a model-load failure routes to the §10 model frame`` () =
+    for code in [ "adapter.osm.fileReadFailed"; "adapter.osm.parse"; "model.resolution" ] do
+        match Voice.errorFrame code with
+        | View.Hero(View.Bad, text), Some _ -> Assert.Contains("model failed to load", text)
+        | other -> Assert.Fail(sprintf "unexpected model frame for %s: %A" code other)
+
+[<Fact>]
+let ``Voice errorFrame: a deployed-schema read failure names the schema, never a generic stop`` () =
+    match Voice.errorFrame "readside.query.failed" with
+    | View.Hero(View.Bad, text), Some _ -> Assert.Contains("deployed schema could not be read", text)
+    | other -> Assert.Fail(sprintf "unexpected readside frame: %A" other)
+
+[<Fact>]
+let ``Voice drift.diverged: the finding leads and the rendered difference is the disclosure`` () =
+    let payload : Voice.Payload = Map.ofList [ "renderedDiff", box "table dbo.Extra exists only on the server" ]
+    match Voice.surfaceOf "drift.diverged" payload with
+    | Some surface ->
+        (match surface.Statement with
+         | View.Hero(View.Warn, text) -> Assert.Contains("diverges from the model", text)
+         | other -> Assert.Fail(sprintf "statement is not a Warn Hero: %A" other))
+        let disclosed =
+            surface.Substantiation
+            |> List.collect (function View.Disclosure(_, _, detail) -> detail | _ -> [])
+        Assert.False(List.isEmpty disclosed)
+        match surface.Action with
+        | Some (View.Action _) -> ()
+        | other -> Assert.Fail(sprintf "no next move: %A" other)
+    | None -> Assert.Fail "drift.diverged is unvoiced"
 
 [<Fact>]
 let ``Voice errorFrame: the intent gate names the arming variable and a next move`` () =

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -42,7 +42,11 @@ let private inScopeCodes : Set<string> =
           "drift.none"; "drift.diverged"
           // the migrate family's shared stop channel: the §10 inexpressible
           // refusal and the generic located stop
-          "migrate.inexpressible"; "migrate.stopped" ]
+          "migrate.inexpressible"; "migrate.stopped"
+          // the eject face: the §13 package line, the §6 self-verification
+          // pair, and the §14 located store finding
+          "eject.packaged"; "eject.verified"; "eject.unverified"
+          "eject.storeUnreadable" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -84,6 +88,9 @@ let private knownEmittableCodes : Set<string> =
           "drift.none"; "drift.diverged"
           // the migrate family's shared stop channel
           "migrate.inexpressible"; "migrate.stopped"
+          // the eject face's package + self-verification + store finding
+          "eject.packaged"; "eject.verified"; "eject.unverified"
+          "eject.storeUnreadable"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -129,7 +136,8 @@ let private samplePayload : Voice.Payload =
           "targetTables",  box 300
           "path",          box "model.sql"
           "cause",         box "the changes could not be computed"
-          "entries",       box "the Amount column narrows to a smaller type (emit.alterColumn.narrowing)" ]
+          "entries",       box "the Amount column narrows to a smaller type (emit.alterColumn.narrowing)"
+          "refactorLogCount", box 5 ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -329,6 +337,22 @@ let ``Voice errorFrame: a reconciliation argument routes to the §14 invalid fra
         match Voice.errorFrame code with
         | View.Hero(View.Bad, text), Some _ -> Assert.Contains("reconciliation argument", text)
         | other -> Assert.Fail(sprintf "unexpected reconcile frame for %s: %A" code other)
+
+// ---------------------------------------------------------------------------
+// the eject face's self-verification pair (§6, the P-7 freeze)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Voice eject: the self-verification pair leads with the asserted finding`` () =
+    (match Voice.surfaceOf "eject.verified" Map.empty with
+     | Some { Statement = View.Hero(View.Ok, text); Substantiation = subs } ->
+         Assert.Contains("genesis to freeze", text)
+         Assert.False(List.isEmpty subs)   // the replay evidence rides beneath
+     | other -> Assert.Fail(sprintf "unexpected eject.verified surface: %A" other))
+    match Voice.surfaceOf "eject.unverified" Map.empty with
+    | Some { Statement = View.Hero(View.Bad, text) } ->
+        Assert.Contains("does not reproduce the frozen state", text)
+    | other -> Assert.Fail(sprintf "unexpected eject.unverified surface: %A" other)
 
 // ---------------------------------------------------------------------------
 // the stage-name mapping (THE_VOICE.md §13 — operator-shaped, never the verb)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -39,7 +39,10 @@ let private inScopeCodes : Set<string> =
           "canary.cdcSilent"; "canary.cdcCaptured"
           "canary.deployed"; "canary.sourceMissing"
           // the drift face: the §6 no-drift verdict and the §5 drift finding
-          "drift.none"; "drift.diverged" ]
+          "drift.none"; "drift.diverged"
+          // the migrate family's shared stop channel: the §10 inexpressible
+          // refusal and the generic located stop
+          "migrate.inexpressible"; "migrate.stopped" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -79,6 +82,8 @@ let private knownEmittableCodes : Set<string> =
           "canary.deployed"; "canary.sourceMissing"
           // the drift face's verdict pair
           "drift.none"; "drift.diverged"
+          // the migrate family's shared stop channel
+          "migrate.inexpressible"; "migrate.stopped"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -122,7 +127,9 @@ let private samplePayload : Voice.Payload =
           "serverErrors",  box "Incorrect syntax near 'GO'.\nThe object 'dbo.Order' already exists."
           "sourceTables",  box 300
           "targetTables",  box 300
-          "path",          box "model.sql" ]
+          "path",          box "model.sql"
+          "cause",         box "the changes could not be computed"
+          "entries",       box "the Amount column narrows to a smaller type (emit.alterColumn.narrowing)" ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -267,6 +274,61 @@ let ``Voice canary.cdcCaptured: the failed proof carries its measure on the find
     | Some { Statement = View.Hero(View.Bad, text) } ->
         Assert.Contains("4,210", text)   // humane numerals, §12
     | other -> Assert.Fail(sprintf "unexpected cdcCaptured surface: %A" other)
+
+// ---------------------------------------------------------------------------
+// the migrate stop channel (§10, mechanism 1 over the closed MigrationError DU)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Voice migrationStopDetail: every easily-constructed arm yields a plain located cause`` () =
+    // The match is exhaustive over the closed DU at compile time; this witness
+    // pins the register of the constructible arms (no DU dump, no shout).
+    let cases : (MigrationError * string) list =
+        [ ExecutionFailed "the server closed the connection", "could not be applied"
+          RefusedByTightening "4 rows exceed the new limit",  "tightening"
+          StoreReadFailed "the store is malformed",           "run history"
+          DataTransferFailed [],                              "data load"
+          SchemaReadFailed [],                                "deployed schema"
+          RefusedByCdc [ "dbo.Order" ],                       "CDC-tracked" ]
+    for e, expected in cases do
+        let detail = Voice.migrationStopDetail e
+        Assert.Contains(expected, detail)
+        assertClean (sprintf "migrationStopDetail %A" e) (View.Note detail)
+
+[<Fact>]
+let ``Voice migrate.inexpressible: the count leads and each change is the disclosure`` () =
+    let payload : Voice.Payload =
+        Map.ofList
+            [ "entryCount", box 2
+              "entries", box "first cause (code.a)\nsecond cause (code.b)" ]
+    match Voice.surfaceOf "migrate.inexpressible" payload with
+    | Some surface ->
+        (match surface.Statement with
+         | View.Hero(View.Bad, text) ->
+             Assert.Contains("cannot be expressed as a single ALTER", text)
+             Assert.Contains("The database is unchanged", text)
+         | other -> Assert.Fail(sprintf "statement is not a Bad Hero: %A" other))
+        let disclosed =
+            surface.Substantiation
+            |> List.collect (function View.Disclosure(_, _, detail) -> detail | _ -> [])
+        Assert.Equal(2, List.length disclosed)
+    | None -> Assert.Fail "migrate.inexpressible is unvoiced"
+
+[<Fact>]
+let ``Voice migrate.stopped: the frame leads and the cause rides beneath`` () =
+    let payload : Voice.Payload = Map.ofList [ "cause", box "the changes could not be built" ]
+    match Voice.surfaceOf "migrate.stopped" payload with
+    | Some { Statement = View.Hero(View.Bad, text); Substantiation = subs } ->
+        Assert.Contains("did not complete", text)
+        Assert.False(List.isEmpty subs)
+    | other -> Assert.Fail(sprintf "unexpected migrate.stopped surface: %A" other)
+
+[<Fact>]
+let ``Voice errorFrame: a reconciliation argument routes to the §14 invalid frame`` () =
+    for code in [ "transfer.reconcile.specShape"; "transfer.userMap.fileMissing" ] do
+        match Voice.errorFrame code with
+        | View.Hero(View.Bad, text), Some _ -> Assert.Contains("reconciliation argument", text)
+        | other -> Assert.Fail(sprintf "unexpected reconcile frame for %s: %A" code other)
 
 // ---------------------------------------------------------------------------
 // the stage-name mapping (THE_VOICE.md §13 — operator-shaped, never the verb)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -33,7 +33,11 @@ let private inScopeCodes : Set<string> =
           // findings demoted to the disclosure), the §13 stage lines, and the
           // §14 Docker requirement
           "deploy.completed"; "deploy.ssdtRejected"
-          "container.starting"; "deploy.bundleEmitted"; "docker.unavailable" ]
+          "container.starting"; "deploy.bundleEmitted"; "docker.unavailable"
+          // the canary faces: the §6 CDC-silence proof pair, the §13
+          // both-sides-deployed line, and the §14 located source-file finding
+          "canary.cdcSilent"; "canary.cdcCaptured"
+          "canary.deployed"; "canary.sourceMissing" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -68,6 +72,9 @@ let private knownEmittableCodes : Set<string> =
           // requirement (shared with the canary faces)
           "deploy.completed"; "deploy.ssdtRejected"
           "container.starting"; "deploy.bundleEmitted"; "docker.unavailable"
+          // the canary faces' verdicts + stage line + located source finding
+          "canary.cdcSilent"; "canary.cdcCaptured"
+          "canary.deployed"; "canary.sourceMissing"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -108,7 +115,10 @@ let private samplePayload : Voice.Payload =
           "purpose",       box "deploy"
           "entryCount",    box 12
           "database",      box "projection_canary_01"
-          "serverErrors",  box "Incorrect syntax near 'GO'.\nThe object 'dbo.Order' already exists." ]
+          "serverErrors",  box "Incorrect syntax near 'GO'.\nThe object 'dbo.Order' already exists."
+          "sourceTables",  box 300
+          "targetTables",  box 300
+          "path",          box "model.sql" ]
 
 // ---------------------------------------------------------------------------
 // code ⇔ copy totality
@@ -231,6 +241,28 @@ let ``Voice deploy.ssdtRejected: an empty payload still leads with the finding``
     match Voice.surfaceOf "deploy.ssdtRejected" Map.empty with
     | Some { Statement = View.Hero(View.Bad, _) } -> ()
     | other -> Assert.Fail(sprintf "unexpected empty-payload surface: %A" other)
+
+// ---------------------------------------------------------------------------
+// the canary faces' §6 CDC-silence proof pair — the proof and its failure are
+// both grounded findings, never a bare count
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Voice canary.cdcSilent: the silence proof leads Ok and grounds both zeros`` () =
+    match Voice.surfaceOf "canary.cdcSilent" Map.empty with
+    | Some { Statement = View.Hero(View.Ok, text); Substantiation = subs } ->
+        Assert.Contains("Confirmed idempotent", text)
+        Assert.Contains("zero rows captured", text)
+        Assert.False(List.isEmpty subs)   // the CDC = 0 evidence rides beneath
+    | other -> Assert.Fail(sprintf "unexpected cdcSilent surface: %A" other)
+
+[<Fact>]
+let ``Voice canary.cdcCaptured: the failed proof carries its measure on the finding`` () =
+    let payload : Voice.Payload = Map.ofList [ "capturedRows", box 4210 ]
+    match Voice.surfaceOf "canary.cdcCaptured" payload with
+    | Some { Statement = View.Hero(View.Bad, text) } ->
+        Assert.Contains("4,210", text)   // humane numerals, §12
+    | other -> Assert.Fail(sprintf "unexpected cdcCaptured surface: %A" other)
 
 // ---------------------------------------------------------------------------
 // the stage-name mapping (THE_VOICE.md §13 — operator-shaped, never the verb)


### PR DESCRIPTION
Face: runFullExportLoad (the smallest face; the pattern-setter).

Codes added to Voice.all + both VoiceTotalityTests registries:
- load.completed (§4/§6) — the publish-and-load verdict, statement-first,
  grounded in its CDC measure (rows captured) as the evidence beneath.
- episode.recorded (§13) — "This run recorded to the history — episode N
  on timeline T."

Shape changes, named:
1. The four command-prefixed telegraphic error headers ("projection
   full-export --load: --conn argument error:" etc.) are DELETED — the
   voiced §10/§14 error surface (printErrors → Voice.errorsSurface) is
   now the whole error face: statement first, located causes + codes in
   the substantiation. Exit codes unchanged (2/6/6/2).
2. The success narration moves from inline printfn into the catalog:
   "N artifact(s) published; seed loaded (M row(s) captured)." becomes
   the load.completed Hero with humane numerals and the CDC capture
   count demoted to the evidence field.
3. The record line becomes §13's stative form via episode.recorded
   (was "this run recorded — episode N on timeline S." lowercase
   fragment welded into the success printfn).
4. Voice.errorFrame no longer routes connection-reference PARSE failures
   to the "target is unreachable" frame (which overstated the probe):
   transfer.connection.spec* is a §14 set-but-invalid argument finding
   ("The connection reference is malformed…"); transfer.connection.ref*
   is §14 required-and-missing ("…does not resolve to a connection
   string. Provide the secret it points to, then retry.");
   timeline.name.* is a located --env finding. openFailed still routes
   to the §10 unreachable frame.

Witnesses: 4 new errorFrame routing facts + the routing-total list and
samplePayload extended. Machine-channel NDJSON untouched.

fast pool: 3082 passed / 0 failed / 211 skipped.

https://claude.ai/code/session_01Ud6ETYkBxwRQfbxbR3h83P