### PR TITLE
card P2: the load leg deploys the seed leveled-parallel; the ParallelSafe mint gains its mode guard

### DIFF
--- a/sidecar/projection/CLAUDE.md
+++ b/sidecar/projection/CLAUDE.md
@@ -146,6 +146,12 @@ within their first session. Everything not on this list, this file only points t
 12. **Docker-gated tests that soft-skip are indistinguishable from passes at summary level.**
     When the Docker pool's verdict matters, confirm against the TRX or `test.sh status`,
     not the green count.
+13. **A perf-gate verdict taken while anything else runs on the host is VOID** — a
+    concurrent build or test pool inflates the CPU-bound gated tier 2–3× and false-trips
+    the gate (2026-06-12: `emit.staticPopulation.statements.stream` read 4841 → 6738 →
+    9830 ms across three captures as concurrent load grew; the quiet re-run was clean on
+    the same tree). Re-run solo before believing a regression — and especially before
+    reaching for `PERF_GATE_RECORD=1`.
 
 ## 5 — The load-bearing commitments (standing law, one line each)
 

--- a/sidecar/projection/CONSTELLATION_BACKLOG.md
+++ b/sidecar/projection/CONSTELLATION_BACKLOG.md
@@ -683,23 +683,41 @@ retired (RI-5). The primitive tests mint through the REAL prover. The manifest's
 Bucket-B convention witness (+1); the leveled ≡ sequential equivalence ran GATE-OPEN
 (comprehensive canary 1/1, 4m17s, empty PhysicalSchema diff).
 
-**P2 · Production leveled data deploy.** The canary-only wiring promoted to the CLI deploy
-path behind the existing parallelism resolution stack. *Witness:* operator-reality canary +
-perf-gate (baseline re-record only if the floor moves, with its DECISIONS amendment). S.
-Deps: P1 (met), and a Stage-0/1 measurement showing the win at operator scale — **gate MET
-2026-06-12**: the declared `leveled-deploy-150x42` scenario (150 independent static kinds ×
-42 rows = the operator envelope, through the REAL composer + leveled plan + the existing
-`resolveParallelism` stack, paired legs on one container) replicated **2.59× / 2.65× /
-2.85×** across three runs (sequential ~2.0–2.1s → leveled-parallel ~0.74–0.79s at
-parallelism 4). One command re-runs it: `perf-harness.sh run leveled-deploy`. *What the
-wiring slice must decide (named so it isn't re-derived):* the two candidate faces are
-`runDeploy → runFromCatalogWith → runEphemeral` (deploys `aggregateSsdt`'s fused
-schema+seeds single batch — splitting schema-vs-data there must keep the deploy FAITHFUL to
-the published bundle, never a re-composition that can diverge from it) and the full-export
-load leg (`Compose.runWithConfigAndLoad` takes an injected `SqlConnection -> string -> Task`
-executor — `executeBatchParallel` needs the connection STRING for per-segment opens, so the
-executor seam needs re-threading). Witnesses stay as carded: operator-reality canary +
-perf-gate, baseline re-record only if the floor moves, with its DECISIONS amendment.
+**P2 · Production leveled data deploy — DONE 2026-06-12** (the wire; gate was MET earlier
+same day, below). The full-export load leg is the production face and it now deploys the
+seed LEVELED: `runFullExportLoad` → `Compose.runWithConfigAndLoad` (seam re-threaded — the
+injected executor is `Deploy.executeLeveledSeed <connection string>`; partial application
+carries the string the per-segment opens need, `sink` stays the CDC measure's connection) →
+`Compose.loadLeveledSeedAndRecord` → `Deploy.executeLeveledSeed` (the ONE owner of the
+leveled order: Phase-1 levels then Phase-2 levels, levels sequential, within-level
+concurrency licensed by the token, under `resolveParallelism`). Faithfulness is the
+partition law, property-witnessed: the leveled plan's GO-batch segment multiset equals the
+fused `Data/seed.sql`'s — same artifact, same rendered strings, nothing re-rendered.
+*Two card corrections, named:* (a) the `runDeploy → runEphemeral` batch is **schema-only**
+— `aggregateSsdt` never carried seeds (`Data/seed.sql` lives in `Outputs.DataBundle`, not
+`SsdtBundle`); the "fused schema+seeds" parenthetical was the probe's error, and the open
+question (are seed entries per-kind?) resolves to NO — there are no seed entries in that
+batch at all. Face (a) is REFUSED: nothing data-shaped to level there; schema leveling is
+P3's territory, trigger-held. (b) **A mint defect found and fixed under the wire:** under
+`Mode = Alphabetical` (any unresolved cycle — one self-FK kind suffices) `levels`' "unknown
+parent contributes 0" rule collapsed real FK chains into ONE ParallelSafe group — the
+token's no-edge-within-group law was violated at the mint. `TopologicalOrder.levels` now
+licenses multi-member groups only under `Topological` mode; degraded modes yield singleton
+groups in order (≡ the sequential deploy, exactly). *Witnesses shipped:* the partition law
++ level-precedence + singleton-degrade + isEmpty-parity (pure), the mint-mode witness
+(TopologicalOrderTests), and the live leg (`MigrationCanaryTests` P2: two independent kinds
+through ONE two-member level via `executeLeveledSeed` — measured delta, recorded episode,
+CDC-silent re-load). The operator envelope stays acyclic (150 independent lookups) so the
+2.6–2.9× win rides; baseline NOT re-recorded (no floor moved — the canary path is
+unchanged; the load leg gained parallelism, which the gate's μ+σ ceiling tolerates
+downward).
+
+> *Gate record (MET 2026-06-12, pre-wire):* the declared `leveled-deploy-150x42` scenario
+> (150 independent static kinds × 42 rows = the operator envelope, through the REAL
+> composer + leveled plan + the existing `resolveParallelism` stack, paired legs on one
+> container) replicated **2.59× / 2.65× / 2.85×** across three runs (sequential ~2.0–2.1s
+> → leveled-parallel ~0.74–0.79s at parallelism 4). One command re-runs it:
+> `perf-harness.sh run leveled-deploy`.
 
 **P3 · Schema-side levels.** `statementsWith` gains a leveled grouping (inline-FK fact makes
 level-by-level the only safe shape — RI-5); deploy through `ParallelSafe`. **Trigger-held:**

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -21816,3 +21816,59 @@ leg injects a `SqlConnection -> string -> Task` executor, while
 `executeBatchParallel` needs the connection STRING for per-segment
 opens — the seam needs re-threading. Witnesses for the wire stay as
 carded (operator-reality canary + perf-gate).
+
+## 2026-06-12 — P2 lands: the load leg deploys the seed leveled-parallel; the mint gains its mode guard
+
+The wire, on the gate met earlier today. Three disciplines with teeth:
+
+**1. The face was found, not assumed — and the card's premise was
+corrected.** The probe's "fused schema+seeds" claim about
+`runDeploy → runEphemeral` was FALSE: `aggregateSsdt` joins
+`Outputs.SsdtBundle` (per-table schema files; `manifest.json` filtered),
+and the seeds live in `Outputs.DataBundle` as ONE fused `Data/seed.sql`
+— the deploy face never carried data, so there was nothing data-shaped
+to level there (refused; schema leveling stays P3, trigger-held). The
+production data face is the full-export load leg, whose sequential
+shape (`executeBatch sink <fused seed>`) was exactly the measured
+gate's LOSING leg. The wire: `runFullExportLoad` →
+`runWithConfigAndLoad` (executor re-threaded to
+`Deploy.executeLeveledSeed <connection string>` — partial application
+carries the string for per-segment pooled opens; `sink` stays the CDC
+measure's connection) → `loadLeveledSeedAndRecord` (same CDC bracket,
+same episode recording; the fused `loadSeedAndRecord` remains as the
+published-artifact contract witness) → `executeLeveledSeed`, the ONE
+owner of the leveled order (Phase-1 levels then Phase-2, levels
+sequential, within-level concurrency by the token, parallelism from
+`resolveParallelism` with the `PROJECTION_DEPLOY_PARALLELISM` override).
+
+**2. Faithfulness is a LAW, not a comment.** The leveled plan is a
+PARTITION of the published seed: `composeRenderedLeveled` selects the
+same per-kind `RenderedPhase1`/`RenderedPhase2` strings the fused
+`composeRenderedFull` concatenates. Property-witnessed at the execution
+plane: the GO-batch segment multiset of the leveled members equals the
+fused string's, on both a Topological catalog and an Alphabetical-mode
+one. Error semantics named: a failing segment fails its level's
+`WhenAll` and no later level starts; the MERGE seed is idempotent, so a
+re-run converges and is CDC-silent on landed rows.
+
+**3. The wire surfaced a mint defect — fixed at the mint, not the
+consumer.** Under `Mode = Alphabetical` (ANY unresolved cycle; one
+self-FK kind suffices — common in real estates), `levels`' "unknown
+parent contributes 0" rule collapsed real FK chains into ONE
+`ParallelSafe` group: the token's no-edge-within-group law was violated
+at its only mint, and P2 would have promoted that to CONCURRENT
+execution. `TopologicalOrder.levels` now matches on mode: only
+`Topological` licenses multi-member groups; `Alphabetical` /
+`JunctionDeferred` yield singleton groups in order — vacuously safe,
+exactly the sequential deploy. The operator envelope (independent
+lookups) stays Topological, so the 2.6–2.9× win is untouched.
+**Named residual, not cured here:** under Alphabetical mode the FUSED
+path already deploys MERGEs in alphabetical order, which can violate a
+non-cycle FK chain among seeded kinds (loud SQL error, not silent) —
+pre-existing, now equal-not-worse under the leveled path. Trigger to
+cure: a real catalog hitting Alphabetical mode with FK-dependent static
+seeds (the cure is cycle-resolution reach, not deploy-order surgery).
+
+Perf-gate baseline NOT re-recorded: no floor legitimately moved (the
+canary's compose/deploy labels are path-unchanged; the load leg gained
+speed, and the gate ceilings tolerate downward movement).

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,87 @@
+# Handoff addendum — 2026-06-12, generation 7 CLOSE (P2 is WIRED: the load leg deploys the seed leveled-parallel; the mint gained its mode guard)
+
+To the next agent.
+
+**P2 is DONE — the wire landed on the gate generation 6 met.** The
+production data face was FOUND, not assumed: the card's "fused
+schema+seeds" premise about `runDeploy → runEphemeral` was the probe's
+error — `aggregateSsdt` joins `SsdtBundle` (schema files only;
+`Data/seed.sql` lives in `DataBundle` and never rode the deploy face),
+so face (a) is REFUSED on the card (nothing data-shaped to level;
+schema leveling stays P3, trigger-held). The real face is the
+full-export load leg, whose old shape (`executeBatch sink <fused
+seed>`) was exactly the measured gate's losing leg. Now:
+`runFullExportLoad` → `Compose.runWithConfigAndLoad` (executor seam
+re-threaded: inject `Deploy.executeLeveledSeed <connection string>` —
+partial application carries the string for per-segment pooled opens;
+`sink` stays the CDC measure's connection) →
+`Compose.loadLeveledSeedAndRecord` → `Deploy.executeLeveledSeed`, the
+ONE owner of the leveled order (Phase-1 levels then Phase-2, levels
+sequential, within-level concurrency by the token, parallelism via
+`resolveParallelism`). Faithfulness is a LAW: the leveled plan
+PARTITIONS the published seed (GO-batch segment-multiset equality,
+property-witnessed in both ordering modes); the fused
+`loadSeedAndRecord` stays as the published-artifact contract witness.
+
+**The wire surfaced a mint defect — fixed at the mint.** Under
+`Mode = Alphabetical` (any unresolved cycle; ONE self-FK kind anywhere
+suffices), `TopologicalOrder.levels`' "unknown parent contributes 0"
+rule collapsed real FK chains into ONE ParallelSafe group — the
+token's no-edge-within-group law was violated at its only mint, and
+the wire would have promoted that to CONCURRENT execution. `levels`
+now licenses multi-member groups only under `Topological`; degraded
+modes yield singleton groups in order (≡ the sequential deploy,
+exactly). A named residual rides the DECISIONS entry: the FUSED path's
+alphabetical MERGE order under that mode is a PRE-EXISTING hazard for
+non-cycle FK chains among seeded kinds (loud FK error, not silent);
+cure trigger = a real catalog hitting it (cycle-resolution reach, not
+deploy-order surgery).
+
+**Witness state at close (this host runs ~20% slower than gen 6's —
+calibrate before comparing):** inherited fast pool replicated EXACTLY
+at open (3116/0/211); with the wire, fast 3121/0/211 at 137s (+5 pure:
+partition law, level precedence, singleton degrade, isEmpty parity,
+the mint-mode witness) and docker 231/0 at 374s (+2 over the inherited
+229 = gen 6's gated leveled-deploy scenario fact + the new live leg —
+confirmed EXERCISED, not soft-skipped, per §4 rule 12); comprehensive
+canary gate-open 1/1 at 4m02s, empty PhysicalSchema diff, leveled
+target-deploy at parallelism 4 with 3 real Phase-1 levels (the guard
+did not degrade the acyclic path); `perf-harness.sh run leveled-deploy`
+replicated 2.78× post-wire (1932 ms → 696 ms, parallelism 4 — inside
+the gate's 2.59–2.85× band); readside-rowstream 1042 ms / 206 ms at
+100k×12 (above the 869/165 band by the same ~20% this host runs
+everything; elements exact at 100000); perf-gate CLEAN solo (132
+labels; baseline NOT re-recorded — no floor moved); lint surface
+byte-identical to the clean tree.
+
+**Traps from this session:** (a) the pass chain rewrites `Physical` to
+the LOGICAL name (the D.1.a move) — a fixture whose KindName and
+PhysicalTable differ deploys under the KIND name; the existing X1
+tests only worked because theirs coincide; compose any test plan over
+the POST-CHAIN catalog (`finalState.Catalog`), as `projectSeedPlan`
+does. (b) §4 rule 12 bit live: my first leveled-leg run "passed" while
+soft-skipping on a swallowed CDC-enable error — grep the live log for
+the SKIP marker before counting a docker witness. (c) NEW §4 rule 13:
+a perf-gate verdict taken while anything else runs on the host is VOID
+— the CPU-bound tier false-tripped 3.3× over baseline during a
+concurrent build; the solo re-run was clean on the same tree.
+
+**Your queue, by the backlog's graph:** the Voice lane's named
+remainder (migrate success verdicts the natural small face; transfer
+narration wants TransferReport → Surface; explain/suggest want
+View/Surface documents — reasons in the lane's commits), P3 stays
+trigger-held, the §6 armed items keep their wake conditions (F1-hex
+unchanged — `digestOf` untouched). J5 — a writable UAT connection —
+still trumps everything.
+
+Hold the spine; balance the books; keep the patient breathing; re-run
+the witnesses you inherit before you stand on them — mine are one
+command each: `scripts/test.sh fast`, `scripts/test.sh docker`,
+`perf-harness.sh run leveled-deploy`, `perf-harness.sh run
+readside-rowstream`, `scripts/perf-gate.sh` (solo, per rule 13).
+
+— Generation 7, the wire-layer, 2026-06-12
+
 # Handoff addendum — 2026-06-12, generation 6 SECOND POSTSCRIPT (P2's gate is MET: 2.6–2.9× at the operator envelope; the wiring slice is yours)
 
 The half-met gate in the postscript below is now FULLY MET. The

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -135,7 +135,10 @@ let runFullExportLoad
                         task {
                             use sink = new Microsoft.Data.SqlClient.SqlConnection(connStr)
                             do! sink.OpenAsync()
-                            return! Compose.runWithConfigAndLoad Deploy.cdcCaptureTotal Deploy.executeBatch cfg sink storePath tl env at
+                            // Card P2 — the seed loads leveled-parallel: the executor
+                            // closes over the connection STRING (per-segment pooled
+                            // opens); `sink` stays the CDC measure's connection.
+                            return! Compose.runWithConfigAndLoad Deploy.cdcCaptureTotal (Deploy.executeLeveledSeed connStr) cfg sink storePath tl env at
                         }
                     let code =
                         match work.GetAwaiter().GetResult() with

--- a/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
+++ b/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
@@ -276,32 +276,52 @@ module TopologicalOrder =
     /// depth, so no member depends on another and the group may deploy
     /// concurrently. Levels themselves stay ordered (level k+1 may
     /// depend on level k); only WITHIN a group is parallelism licensed.
+    ///
+    /// **The mint refuses to license parallelism it cannot prove (card
+    /// P2 finding, 2026-06-12).** The level computation's safety rests
+    /// on `t.Order` placing parents before children; only
+    /// `Mode = Topological` carries that guarantee. Under
+    /// `Alphabetical` (an unresolved cycle anywhere in the catalog) an
+    /// FK child can sort BEFORE its parent — the "unknown parent
+    /// contributes 0" rule then collapsed a real FK chain into one
+    /// "level", minting a group whose members were NOT independent
+    /// (one self-FK kind anywhere was enough to flatten everything).
+    /// Under `JunctionDeferred` the deferred suffix is likewise
+    /// non-topological. For both, the honest degenerate is SINGLETON
+    /// groups in `t.Order` order: every group is vacuously
+    /// parallel-safe and the leveled deploy equals the sequential one
+    /// exactly.
     let levels (t: TopologicalOrder) : ParallelSafe<SsKey> list =
-        let parentsOf =
-            t.Edges
-            |> List.groupBy fst
-            |> List.map (fun (child, edges) -> child, edges |> List.map snd)
-            |> Map.ofList
-        let computeLevel (levelMap: Map<SsKey, int>) (k: SsKey) : int =
-            match Map.tryFind k parentsOf with
-            | None -> 0
-            | Some parents ->
-                let knownLevels =
-                    parents |> List.choose (fun p -> Map.tryFind p levelMap)
-                if List.isEmpty knownLevels then 0
-                else (List.max knownLevels) + 1
-        let finalMap =
-            t.Order
-            |> List.fold
-                (fun acc k -> Map.add k (computeLevel acc k) acc)
-                Map.empty
-        finalMap
-        |> Map.toList
-        |> List.groupBy snd
-        |> List.sortBy fst
-        |> List.map (fun (_, pairs) ->
-            // The mint: one dependency depth = one concurrent-safe group.
-            ParallelSafe (pairs |> List.map fst |> List.sort))
+        match t.Mode with
+        | Alphabetical
+        | JunctionDeferred ->
+            t.Order |> List.map (fun k -> ParallelSafe [ k ])
+        | Topological ->
+            let parentsOf =
+                t.Edges
+                |> List.groupBy fst
+                |> List.map (fun (child, edges) -> child, edges |> List.map snd)
+                |> Map.ofList
+            let computeLevel (levelMap: Map<SsKey, int>) (k: SsKey) : int =
+                match Map.tryFind k parentsOf with
+                | None -> 0
+                | Some parents ->
+                    let knownLevels =
+                        parents |> List.choose (fun p -> Map.tryFind p levelMap)
+                    if List.isEmpty knownLevels then 0
+                    else (List.max knownLevels) + 1
+            let finalMap =
+                t.Order
+                |> List.fold
+                    (fun acc k -> Map.add k (computeLevel acc k) acc)
+                    Map.empty
+            finalMap
+            |> Map.toList
+            |> List.groupBy snd
+            |> List.sortBy fst
+            |> List.map (fun (_, pairs) ->
+                // The mint: one dependency depth = one concurrent-safe group.
+                ParallelSafe (pairs |> List.map fst |> List.sort))
 
 
 /// H-037 — result of schema island detection. Each inner list is one

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -497,6 +497,36 @@ module Deploy =
             ()
         }
 
+    /// **Production leveled seed dispatch (card P2)** — the ONE owner of
+    /// the leveled deploy order, so faces cannot misorder it: Phase-1
+    /// levels in level order, THEN Phase-2 levels in level order; levels
+    /// are sequential (level k+1 may depend on level k); only WITHIN a
+    /// level does `executeBatchParallel` dispatch concurrently, licensed
+    /// by the `ParallelSafe` token each level carries. Parallelism rides
+    /// the existing resolution stack (`resolveParallelism`: the
+    /// `PROJECTION_DEPLOY_PARALLELISM` operator override, else the DMV
+    /// probe cached per connection string, else 4) and the Max-Pool-Size
+    /// cap inside `executeBatchParallel`.
+    ///
+    /// The connection STRING (not an open connection) is the argument
+    /// because every segment opens its own pooled connection — the seam
+    /// the P2 card named. Error semantics: a failing segment surfaces
+    /// from its level's `Task.WhenAll` and no later level starts; the
+    /// seed is an idempotent MERGE, so a re-run after a partial failure
+    /// converges (and is CDC-silent on the already-landed rows).
+    let executeLeveledSeed
+            (connectionString: string)
+            (plan: Projection.Targets.Data.DataEmissionComposer.LeveledDeploymentText)
+            : Task<unit> =
+        task {
+            use _ = Bench.scope "deploy.executeLeveledSeed"
+            let! parallelism = resolveParallelism connectionString
+            for level in plan.Phase1Levels do
+                do! executeBatchParallel connectionString level parallelism
+            for level in plan.Phase2Levels do
+                do! executeBatchParallel connectionString level parallelism
+        }
+
     /// Default bulk batch size — per session-35 bench, 1000 was
     /// network-round-trip dominant (~12 ms per 1000-row batch on a
     /// warm container). Bumping to 5000 amortizes the round-trip

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -31,6 +31,10 @@ open Projection.Targets.OperationalDiagnostics
 [<RequireQualifiedAccess>]
 module Compose =
 
+    // Card P2 — the seed-load seam names the data composer's leveled plan;
+    // module abbreviations are file-local, so nothing is re-exported.
+    module DataComposer = Projection.Targets.Data.DataEmissionComposer
+
     /// Per-emitter output captured into memory before being written to
     /// disk. Tests assert against these values without round-tripping
     /// through the file system.
@@ -1361,14 +1365,23 @@ module Compose =
             return parsed |> Result.bind (applyRenames cfg)
         }
 
-    /// AC-X1 (part B) — the emitted catalog + the rendered data-seed script for
-    /// the live-load leg. Re-projects the config's model (genesis profile shape;
-    /// the seed rows are catalog-borne `Modality.Static`, profile-independent) so
-    /// the load consumes exactly the `Data/seed.sql` the bundle published. Empty
-    /// seed when data emission is off.
-    /// Synchronous core of `emittedSeed` (extracted so the task surface is a
+    /// AC-X1 (part B, leveled per card P2) — the emitted catalog + the LEVELED
+    /// seed plan for the live-load leg. Re-projects the config's model (genesis
+    /// profile shape; the seed rows are catalog-borne `Modality.Static`,
+    /// profile-independent) through the SAME chain the bundle rode, then renders
+    /// the per-kind seed scripts grouped by topological level
+    /// (`composeRenderedLeveled`). The plan is a faithful PARTITION of the
+    /// published `Data/seed.sql` — same `dispatchSiblings + unionSiblings`
+    /// artifact, same per-kind `RenderedPhase1`/`RenderedPhase2` strings the
+    /// fused bundle concatenates; nothing is re-rendered (the partition law is
+    /// property-witnessed in `DataEmissionComposerTests`). Empty plan when data
+    /// emission is off or the catalog projects no seed statements.
+    /// Synchronous core of `emittedSeedPlan` (extracted so the task surface is a
     /// single `let!` + `return`, statically compilable in Release — FS3511).
-    let private projectSeed (cfg: Config.Config) (parsed: Result<Catalog>) : Result<Catalog * string> =
+    let private projectSeedPlan
+        (cfg: Config.Config)
+        (parsed: Result<Catalog>)
+        : Result<Catalog * DataComposer.LeveledDeploymentText> =
         match parsed |> Result.bind (applyRenames cfg) with
         | Error es -> Result.failure es
         | Ok catalog ->
@@ -1376,10 +1389,23 @@ module Compose =
                   EmissionFoldersBinding.fromConfig catalog cfg,
                   TransformGroupsBinding.fromConfig cfg with
             | Ok policy, Ok folders, Ok groups ->
-                let outputs, _ =
+                let _, finalState =
                     projectWithState policy Profile.empty EmissionPolicy.empty folders groups catalog
-                let seed = Map.tryFind "Data/seed.sql" outputs.DataBundle |> Option.defaultValue ""
-                Result.success (catalog, seed)
+                if not policy.Emission.EmitData then
+                    Result.success (catalog, DataComposer.LeveledDeploymentText.empty)
+                else
+                    match
+                        DataComposer.composeRenderedLeveled
+                            policy finalState.Catalog Profile.empty
+                            Projection.Targets.Data.MigrationDependencyContext.empty
+                            UserRemapContext.empty
+                    with
+                    | Ok plan -> Result.success (catalog, plan)
+                    | Error err ->
+                        // Mirrors the bundle decoration's invariant: a valid
+                        // catalog never fails the composer (the keyset is
+                        // `Catalog.allKinds`).
+                        invalidOp (sprintf "Compose.projectSeedPlan: DataEmissionComposer.composeRenderedLeveled: %A" err)
             | p, f, g ->
                 let errs =
                     (match p with Error e -> e | _ -> [])
@@ -1387,10 +1413,10 @@ module Compose =
                     @ (match g with Error e -> e | _ -> [])
                 Result.failure errs
 
-    let private emittedSeed (cfg: Config.Config) : Task<Result<Catalog * string>> =
+    let private emittedSeedPlan (cfg: Config.Config) : Task<Result<Catalog * DataComposer.LeveledDeploymentText>> =
         task {
             let! parsed = readConfigModel cfg
-            return projectSeed cfg parsed
+            return projectSeedPlan cfg parsed
         }
 
     /// State A — the prior emission's schema, reconstructed from the durable
@@ -1634,6 +1660,33 @@ module Compose =
             | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
         | _ -> Result.success (None, cdcDelta)
 
+    /// The CDC-bracketed load-measure-record core shared by the two load
+    /// shapes (fused-string and leveled). `load` is a thunk so the work
+    /// starts AFTER the baseline capture; the caller selects it
+    /// synchronously (an unconditional `do!` of a pre-selected Task is
+    /// the FS3511-safe shape).
+    let private loadMeasureAndRecord
+        (cdcCaptureTotal: SqlConnection -> Task<int>)
+        (load: unit -> Task<unit>)
+        (emitted: Catalog)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option * int>> =
+        task {
+            let! baseline = cdcCaptureTotal sink
+            let loading = load ()
+            do! loading
+            let! post = cdcCaptureTotal sink
+            return recordLoad emitted (post - baseline) storePath timeline environment at
+        }
+
+    /// The fused-string load shape — what an operator executing the
+    /// published `Data/seed.sql` by hand gets; the witness surface for
+    /// the bundle's idempotent-MERGE contract (AC-X1 part B tests).
+    /// The CLI load leg rides `loadLeveledSeedAndRecord` since card P2.
     let loadSeedAndRecord
         (cdcCaptureTotal: SqlConnection -> Task<int>)
         (executeBatch: SqlConnection -> string -> Task<unit>)
@@ -1648,32 +1701,58 @@ module Compose =
         // `cdcCaptureTotal` / `executeBatch` are injected (the `Deploy` module
         // compiles AFTER this one, so Compose cannot name it; callers pass
         // `Deploy.cdcCaptureTotal` / `Deploy.executeBatch`).
-        task {
-            let! baseline = cdcCaptureTotal sink
-            // Unconditional `do!` of a synchronously-selected Task (a *conditional*
-            // `do!` is the FS3511 trigger): an empty seed loads nothing.
-            let execSeed =
+        loadMeasureAndRecord
+            cdcCaptureTotal
+            (fun () ->
+                // An empty seed loads nothing.
                 if System.String.IsNullOrWhiteSpace seed then Task.FromResult ()
-                else executeBatch sink seed
-            do! execSeed
-            let! post = cdcCaptureTotal sink
-            return recordLoad emitted (post - baseline) storePath timeline environment at
-        }
+                else executeBatch sink seed)
+            emitted sink storePath timeline environment at
+
+    /// Card P2 — the LEVELED production load: same CDC bracket, same
+    /// episode recording, but the seed deploys as the leveled plan
+    /// through the injected executor (callers pass
+    /// `Deploy.executeLeveledSeed <connection string>` — the executor
+    /// closes over the connection STRING because every segment opens its
+    /// own pooled connection; `sink` stays the CDC measure's connection).
+    let loadLeveledSeedAndRecord
+        (cdcCaptureTotal: SqlConnection -> Task<int>)
+        (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
+        (emitted: Catalog)
+        (plan: DataComposer.LeveledDeploymentText)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option * int>> =
+        loadMeasureAndRecord
+            cdcCaptureTotal
+            (fun () ->
+                // An empty plan loads nothing (data emission off, or no
+                // seed statements in scope) — parity with the fused form's
+                // whitespace gate.
+                if DataComposer.LeveledDeploymentText.isEmpty plan then Task.FromResult ()
+                else executeLeveled plan)
+            emitted sink storePath timeline environment at
 
     /// AC-X1 (part B) — `runWithConfig` PLUS the live data-load leg the W1-B
     /// store leg deferred. After the bundle is published (unchanged), the
-    /// idempotent CDC-aware seed (`Data/seed.sql`) is loaded into the
-    /// already-deployed `sink`, the movement is measured, and (with a store) the
-    /// episode is recorded with the measured `DataObservation`. The schema is
-    /// assumed already deployed on the sink (the publication→deploy→load premise:
-    /// the operator deploys the published DDL + enables CDC for the SSIS consumer,
-    /// then the data lands).
-    /// Emit-then-load for a config: re-project the seed and load it. Extracted
-    /// so `runWithConfigAndLoad` keeps a two-level await depth (FS3511-safe;
-    /// the three-level `let!`-in-match nesting does not statically compile).
+    /// idempotent CDC-aware seed is loaded into the already-deployed `sink` as
+    /// the LEVELED plan (card P2 — a faithful partition of the published
+    /// `Data/seed.sql`, dispatched per level through the injected executor),
+    /// the movement is measured, and (with a store) the episode is recorded
+    /// with the measured `DataObservation`. The schema is assumed already
+    /// deployed on the sink (the publication→deploy→load premise: the operator
+    /// deploys the published DDL + enables CDC for the SSIS consumer, then the
+    /// data lands).
+    /// Emit-then-load for a config: re-project the seed plan and load it.
+    /// Extracted so `runWithConfigAndLoad` keeps a two-level await depth
+    /// (FS3511-safe; the three-level `let!`-in-match nesting does not
+    /// statically compile).
     let private loadFromConfig
         (cdcCaptureTotal: SqlConnection -> Task<int>)
-        (executeBatch: SqlConnection -> string -> Task<unit>)
+        (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
         (cfg: Config.Config)
         (sink: SqlConnection)
         (storePath: string option)
@@ -1682,17 +1761,21 @@ module Compose =
         (at: System.DateTimeOffset)
         : Task<Result<FullExportStoreLeg option * int>> =
         task {
-            let! seedR = emittedSeed cfg
+            let! seedR = emittedSeedPlan cfg
             return!
                 match seedR with
                 | Error errors -> Task.FromResult (Result.failure errors)
-                | Ok (emitted, seed) ->
-                    loadSeedAndRecord cdcCaptureTotal executeBatch emitted seed sink storePath timeline environment at
+                | Ok (emitted, plan) ->
+                    loadLeveledSeedAndRecord cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
         }
 
+    /// Card P2 re-threaded seam: the second argument is the LEVELED seed
+    /// executor (`Deploy.executeLeveledSeed <connection string>` at the CLI
+    /// face — partial application carries the connection string the
+    /// per-segment opens need; `sink` remains the CDC measure's connection).
     let runWithConfigAndLoad
         (cdcCaptureTotal: SqlConnection -> Task<int>)
-        (executeBatch: SqlConnection -> string -> Task<unit>)
+        (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
         (cfg: Config.Config)
         (sink: SqlConnection)
         (storePath: string option)
@@ -1705,6 +1788,6 @@ module Compose =
             match reportResult with
             | Error errors -> return Result.failure errors
             | Ok report ->
-                let! loadResult = loadFromConfig cdcCaptureTotal executeBatch cfg sink storePath timeline environment at
+                let! loadResult = loadFromConfig cdcCaptureTotal executeLeveled cfg sink storePath timeline environment at
                 return loadResult |> Result.map (fun (leg, cdcDelta) -> report, leg, cdcDelta)
         }

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -351,6 +351,17 @@ module DataEmissionComposer =
         Phase2Levels : ParallelSafe<string> list
     }
 
+    /// Companion surface for the leveled plan (card P2 — the load leg's
+    /// "nothing to deploy" arm needs both, mirroring the fused form's
+    /// `IsNullOrWhiteSpace` gate). `composeRenderedLeveled` drops empty
+    /// levels, so `isEmpty` ⇔ the catalog projected no seed statements.
+    [<RequireQualifiedAccess>]
+    module LeveledDeploymentText =
+        let empty : LeveledDeploymentText =
+            { Phase1Levels = []; Phase2Levels = [] }
+        let isEmpty (plan: LeveledDeploymentText) : bool =
+            List.isEmpty plan.Phase1Levels && List.isEmpty plan.Phase2Levels
+
     /// Level-aware sibling of `composeRenderedFull` — returns the
     /// rendered text grouped by topological level so callers can
     /// dispatch each level's segments in parallel via

--- a/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
@@ -585,3 +585,191 @@ let ``5.13.data-emission-registry: cross-emitter coverage holds the partition in
         Assert.Equal(1, List.length legacyScript.Phase2Updates)
         Assert.Equal(0, List.length countryScript.Phase2Updates)
     | Error e -> Assert.Fail (sprintf "expected partition success, got %A" e)
+
+// ---------------------------------------------------------------------------
+// Card P2 — the leveled plan is a faithful PARTITION of the fused seed.
+//
+// The wiring constraint the P2 card pre-derived: the production load leg
+// (`Compose.loadLeveledSeedAndRecord` → `Deploy.executeLeveledSeed`) must
+// stay faithful to the published `Data/seed.sql` — a partition of the same
+// rendered per-kind strings, never a re-composition that can diverge. Both
+// `composeRenderedFull` and `composeRenderedLeveled` derive from the SAME
+// `dispatchSiblings + unionSiblings` artifact; these witnesses pin the
+// claim at the execution plane: the GO-batch SEGMENT multiset the leveled
+// plan dispatches equals the segment multiset the fused string deploys
+// (within-level order is SsKey-sorted, so order is a permutation — the
+// multiset, all-Phase-1-before-Phase-2, and level precedence are the laws).
+// ---------------------------------------------------------------------------
+
+/// A static kind with `rowIds` rows and (optionally) a cross-kind FK to
+/// `target` on a nullable TARGETID column — the level-graph fixture.
+let private mkStaticLevelKind (name: string) (table: string) (target: Kind option) (rowIds: string list) : Kind =
+    let kindKey = mkKey ["TestModule"; name]
+    let idKey = mkKey ["TestModule"; name; "Id"]
+    let targetIdKey = mkKey ["TestModule"; name; "TargetId"]
+    let row (rid: string) =
+        let baseValues = [ mkName "Id", rid ]
+        let values =
+            match target with
+            | Some _ -> (mkName "TargetId", rid) :: baseValues
+            | None   -> baseValues
+        { Identifier = mkKey ["TestModule"; name; "Row"; rid]
+          Values = Map.ofList values }
+    let fkAttrs =
+        match target with
+        | Some _ ->
+            [ { Attribute.create targetIdKey (mkName "TargetId") Integer with
+                  Column = ColumnRealization.create ("TARGETID") (true) |> Result.value } ]
+        | None -> []
+    let references =
+        match target with
+        | Some t ->
+            [ Reference.create (mkKey ["TestModule"; name; "RefTarget"]) (mkName "RefTarget") targetIdKey t.SsKey ]
+        | None -> []
+    {
+        SsKey    = kindKey
+        Name     = mkName name
+        Origin   = Native
+        Modality = [ Static (rowIds |> List.map row) ]
+        Physical = mkTableId "dbo" table
+        Attributes =
+            { Attribute.create idKey (mkName "Id") Integer with
+                Column = ColumnRealization.create ("ID") (false) |> Result.value
+                IsPrimaryKey = true
+                IsMandatory = true }
+            :: fkAttrs
+        References = references
+        Indexes    = []
+        Description = None
+        IsActive = true
+        Triggers = []
+        ColumnChecks = []
+        ExtendedProperties = []
+        }
+
+/// A static kind with a self-FK cycle on nullable PARENTID — produces a
+/// Phase-2 UPDATE, so the partition law covers both phases.
+let private mkStaticSelfCycleKind (name: string) (table: string) : Kind =
+    let kindKey = mkKey ["TestModule"; name]
+    let idKey = mkKey ["TestModule"; name; "Id"]
+    let parentKey = mkKey ["TestModule"; name; "ParentId"]
+    let row =
+        { Identifier = mkKey ["TestModule"; name; "Row"; "1"]
+          Values = Map.ofList [ mkName "Id", "1"; mkName "ParentId", "1" ] }
+    {
+        SsKey    = kindKey
+        Name     = mkName name
+        Origin   = Native
+        Modality = [ Static [ row ] ]
+        Physical = mkTableId "dbo" table
+        Attributes =
+            [
+                { Attribute.create idKey (mkName "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
+                { Attribute.create parentKey (mkName "ParentId") Integer with Column = ColumnRealization.create ("PARENTID") (true) |> Result.value }
+            ]
+        References =
+            [ Reference.create (mkKey ["TestModule"; name; "RefSelf"]) (mkName "RefSelf") parentKey kindKey ]
+        Indexes    = []
+        Description = None
+        IsActive = true
+        Triggers = []
+        ColumnChecks = []
+        ExtendedProperties = []
+        }
+
+/// The ACYCLIC level-graph catalog: Root ← Mid ← Leaf (a 3-deep FK
+/// chain) and Indep (no FKs — shares Root's level). `Mode = Topological`
+/// ⇒ the mint licenses real multi-member levels.
+let private mkAcyclicLeveledCatalog () : Kind list =
+    let root  = mkStaticLevelKind "LvlRoot" "OSUSR_TEST_LVL_ROOT" None [ "1"; "2" ]
+    let mid   = mkStaticLevelKind "LvlMid"  "OSUSR_TEST_LVL_MID"  (Some root) [ "1"; "2" ]
+    let leaf  = mkStaticLevelKind "LvlLeaf" "OSUSR_TEST_LVL_LEAF" (Some mid)  [ "1" ]
+    let indep = mkStaticLevelKind "LvlIndep" "OSUSR_TEST_LVL_INDEP" None [ "1" ]
+    [ root; mid; leaf; indep ]
+
+/// The same graph PLUS a self-cycle kind. The unresolved 1-node SCC puts
+/// the WHOLE order into `Mode = Alphabetical` — the mint's degraded arm
+/// (singleton groups; no parallelism licensed) and the Phase-2 surface
+/// (the deferred self-FK re-points by UPDATE).
+let private mkCycleBearingCatalog () : Kind list =
+    mkAcyclicLeveledCatalog () @ [ mkStaticSelfCycleKind "LvlCyc" "OSUSR_TEST_LVL_CYC" ]
+
+let private composeBoth (kinds: Kind list) =
+    let catalog = mkCatalog kinds
+    let policy = policyWith AllRemaining
+    let fused =
+        DataEmissionComposer.composeRenderedFull
+            policy catalog Profile.empty
+            MigrationDependencyContext.empty UserRemapContext.empty
+        |> mustOkEmit
+    let leveled =
+        DataEmissionComposer.composeRenderedLeveled
+            policy catalog Profile.empty
+            MigrationDependencyContext.empty UserRemapContext.empty
+        |> mustOkEmit
+    fused, leveled
+
+let private segments (sql: string) =
+    Projection.Targets.SSDT.BatchSplitter.splitOnGoLineFold sql |> Array.toList
+
+let private leveledSegmentsOf (leveled: DataEmissionComposer.LeveledDeploymentText) =
+    (leveled.Phase1Levels @ leveled.Phase2Levels)
+    |> List.collect ParallelSafe.members
+    |> List.collect segments
+
+[<Fact>]
+let ``P2: composeRenderedLeveled PARTITIONS composeRenderedFull — segment multiset equality (faithful split, never a re-render)`` () =
+    // The law holds in BOTH modes: the Topological catalog (real levels)
+    // and the cycle-bearing one (Alphabetical fallback, singleton groups).
+    for kinds in [ mkAcyclicLeveledCatalog (); mkCycleBearingCatalog () ] do
+        let fused, leveled = composeBoth kinds
+        let fusedSegments = segments fused |> List.sort
+        let leveledSegments = leveledSegmentsOf leveled |> List.sort
+        Assert.NotEmpty fusedSegments
+        Assert.Equal<string list>(fusedSegments, leveledSegments)
+
+[<Fact>]
+let ``P2: the leveled plan deploys FK parents at earlier Phase-1 levels; FK-independent kinds share a level`` () =
+    let _, leveled = composeBoth (mkAcyclicLeveledCatalog ())
+    let levelIndexOf (table: string) =
+        leveled.Phase1Levels
+        |> List.findIndex (fun lvl ->
+            ParallelSafe.members lvl |> List.exists (fun s -> s.Contains table))
+    let root = levelIndexOf "OSUSR_TEST_LVL_ROOT"
+    let mid  = levelIndexOf "OSUSR_TEST_LVL_MID"
+    let leaf = levelIndexOf "OSUSR_TEST_LVL_LEAF"
+    Assert.True(root < mid && mid < leaf,
+                sprintf "FK chain must descend levels: root=%d mid=%d leaf=%d" root mid leaf)
+    // Indep has no FK edges — it shares the chain root's level, and that
+    // group genuinely carries more than one member (the parallel prize).
+    Assert.Equal(root, levelIndexOf "OSUSR_TEST_LVL_INDEP")
+    let rootMembers = ParallelSafe.members (List.item root leveled.Phase1Levels)
+    Assert.True(List.length rootMembers >= 2, "the root level must carry ≥2 concurrent members")
+    // Acyclic ⇒ no deferred FKs ⇒ no Phase-2 levels.
+    Assert.Empty leveled.Phase2Levels
+
+[<Fact>]
+let ``P2: an unresolved cycle anywhere degrades the plan to singleton groups — parallelism is never licensed on an alphabetical order`` () =
+    // One self-FK kind puts the WHOLE catalog into Mode = Alphabetical
+    // (the resolver does not break 1-node SCCs); under it "parents
+    // precede children" no longer holds, so the mint refuses multi-member
+    // groups — the leveled deploy degrades to exactly the fused
+    // sequential order, never to unproven concurrency. (The P2-wire
+    // finding: before the mode guard, this catalog collapsed the real
+    // Root←Mid←Leaf FK chain into ONE concurrent group.)
+    let _, leveled = composeBoth (mkCycleBearingCatalog ())
+    for level in leveled.Phase1Levels @ leveled.Phase2Levels do
+        Assert.Equal(1, ParallelSafe.members level |> List.length)
+    // The self-cycle kind's deferred FK still lands in Phase 2.
+    Assert.NotEmpty leveled.Phase2Levels
+
+[<Fact>]
+let ``P2: LeveledDeploymentText.isEmpty parity — no seed statements ⇔ empty plan ⇔ whitespace fused text`` () =
+    // A static kind with ZERO rows projects no seed statements: the fused
+    // form is whitespace (the load leg's IsNullOrWhiteSpace gate) and the
+    // leveled form is the empty plan (the load leg's isEmpty gate).
+    let emptyKind = mkStaticLevelKind "LvlEmpty" "OSUSR_TEST_LVL_EMPTY" None []
+    let fused, leveled = composeBoth [ emptyKind ]
+    Assert.True(System.String.IsNullOrWhiteSpace fused)
+    Assert.True(DataEmissionComposer.LeveledDeploymentText.isEmpty leveled)
+    Assert.True(DataEmissionComposer.LeveledDeploymentText.isEmpty DataEmissionComposer.LeveledDeploymentText.empty)

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -876,6 +876,114 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
         finally
             if System.IO.File.Exists storePath then System.IO.File.Delete storePath
 
+    // -- Card P2 (live) — the PRODUCTION load shape: the seed deploys as the
+    //    LEVELED plan through `Deploy.executeLeveledSeed` ----------------------
+    //
+    // THE STANDARD: `runFullExportLoad` now rides `Compose.loadLeveledSeedAndRecord`
+    // + `Deploy.executeLeveledSeed <connStr>` (card P2 — the gate-met promotion).
+    // This witnesses that face's exact dispatch end-to-end: the plan is minted
+    // through the REAL prover (`composeRenderedLeveled` → `TopologicalOrder.levels`
+    // → `ParallelSafe`), two independent static kinds share ONE level (genuinely
+    // concurrent members), the rows land, the movement is MEASURED and RECORDED,
+    // and the idempotent re-load is CDC-silent — the same contract the fused
+    // sequential leg (`loadSeedAndRecord`, above) witnesses for the published
+    // `Data/seed.sql` artifact.
+    [<Fact>]
+    member _.``P2: the leveled load leg lands the seed through ParallelSafe levels, measures it, and is CDC-silent on the re-load`` () =
+        if not (Deploy.Docker.ensureRunning ()) then () else
+        let catalog =
+            StaticCatalogFixtures.staticCatalogOfKinds "OS_P2L" "Mod"
+                [ { StaticCatalogFixtures.KindKeyParts = [ "Mod"; "P2LCountry" ]
+                    KindName = "P2LCountry"
+                    PhysicalTable = "P2LCountry"
+                    Attrs =
+                      [ StaticCatalogFixtures.pk "Id" "ID" Integer
+                        StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+                    Rows =
+                      [ "1", [ "1"; "United States" ]
+                        "2", [ "2"; "Canada" ] ]
+                  }
+                  { StaticCatalogFixtures.KindKeyParts = [ "Mod"; "P2LRegion" ]
+                    KindName = "P2LRegion"
+                    PhysicalTable = "P2LRegion"
+                    Attrs =
+                      [ StaticCatalogFixtures.pk "Id" "ID" Integer
+                        StaticCatalogFixtures.attr "Label" "LABEL" Text ]
+                    Rows =
+                      [ "1", [ "1"; "North" ]
+                        "2", [ "2"; "South" ] ]
+                  } ]
+        let policy =
+            { Policy.empty with Emission = { Policy.empty.Emission with EmitData = true; DataComposition = AllRemaining } }
+        let outputs, finalState =
+            Compose.projectWithState policy Profile.empty EmissionPolicy.empty EmissionFolders.empty TransformGroups.empty catalog
+        let ddl = Compose.aggregateSsdt outputs.SsdtBundle
+        // The plan composes over the POST-CHAIN catalog — exactly what the
+        // production seam (`Compose.projectSeedPlan`) does, so the MERGEs
+        // target the same (logical-named) tables the deployed DDL created.
+        let plan =
+            Projection.Targets.Data.DataEmissionComposer.composeRenderedLeveled
+                policy finalState.Catalog Profile.empty
+                Projection.Targets.Data.MigrationDependencyContext.empty UserRemapContext.empty
+            |> function
+               | Ok p -> p
+               | Error e -> failwithf "composeRenderedLeveled: %A" e
+        // The plan shape the prover minted: two FK-independent kinds form ONE
+        // Phase-1 level with TWO members (genuine within-level parallelism);
+        // no cycles ⇒ no Phase-2 levels.
+        Assert.Equal(1, List.length plan.Phase1Levels)
+        Assert.Equal(2, ParallelSafe.members (List.head plan.Phase1Levels) |> List.length)
+        Assert.Empty plan.Phase2Levels
+        let storePath =
+            System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.String.Concat("p2lvl-", System.Guid.NewGuid().ToString("N"), ".lifecycle.json"))
+        try
+            TaskSync.run (fun () ->
+                fixture.WithEphemeralDatabase "P2LeveledLoad" (fun conn perDbConn ->
+                    task {
+                        do! Deploy.executeBatch conn ddl
+                        let! enabled =
+                            task {
+                                try
+                                    do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_db;"
+                                    do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_table @source_schema=N'dbo', @source_name=N'P2LCountry', @role_name=NULL, @supports_net_changes=0;"
+                                    do! Deploy.executeBatch conn "EXEC sys.sp_cdc_enable_table @source_schema=N'dbo', @source_name=N'P2LRegion', @role_name=NULL, @supports_net_changes=0;"
+                                    let! c = scalarInt conn "SELECT COUNT(*) FROM sys.tables WHERE is_tracked_by_cdc = 1 AND name IN (N'P2LCountry', N'P2LRegion');"
+                                    return c = 2
+                                with _ -> return false
+                            }
+                        if not enabled then
+                            printfn "SKIP P2 (leveled load leg): container did not enable CDC"
+                        else
+                            let tl = Timeline.create "p2load" |> Result.value
+                            let at = System.DateTimeOffset.UtcNow
+                            // LEG 1 — first leveled load: the face's exact dispatch
+                            // (executeLeveledSeed over the per-DB connection STRING).
+                            let! first = Compose.loadLeveledSeedAndRecord Deploy.cdcCaptureTotal (Deploy.executeLeveledSeed perDbConn) catalog plan conn (Some storePath) tl Environment.Dev at
+                            match first with
+                            | Error es -> Assert.Fail(sprintf "leveled load leg failed: %A" es)
+                            | Ok (legOpt, delta1) ->
+                                Assert.Equal(4, delta1)   // 2 + 2 static rows captured (measured).
+                                match legOpt with
+                                | None -> Assert.Fail("a store was supplied; an episode must be recorded")
+                                | Some leg ->
+                                    let recorded = EpisodicLifecycle.latest leg.Chain
+                                    Assert.Equal(4, recorded.Data.CdcCaptureCount)
+                            // LEG 2 — idempotent leveled re-load: CDC-silent, non-overwriting.
+                            let! second = Compose.loadLeveledSeedAndRecord Deploy.cdcCaptureTotal (Deploy.executeLeveledSeed perDbConn) catalog plan conn None tl Environment.Dev at
+                            match second with
+                            | Error es -> Assert.Fail(sprintf "leveled re-load failed: %A" es)
+                            | Ok (_, delta2) ->
+                                Assert.Equal(0, delta2)
+                                let! countries = scalarInt conn "SELECT COUNT(*) FROM [dbo].[P2LCountry];"
+                                let! regions   = scalarInt conn "SELECT COUNT(*) FROM [dbo].[P2LRegion];"
+                                Assert.Equal(2, countries)
+                                Assert.Equal(2, regions)
+                    }))
+        finally
+            if System.IO.File.Exists storePath then System.IO.File.Delete storePath
+
     // -- AC-S8 — RENAME is CDC-transparent (‖rename‖_data = 0) ----------------
     //
     // THE STANDARD (obligations §0): a discriminating LIVE witness. A RENAME via

--- a/sidecar/projection/tests/Projection.Tests/TopologicalOrderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TopologicalOrderTests.fs
@@ -211,6 +211,28 @@ let ``levels: parallel-safety invariant holds — no edge between kinds at the s
             sprintf "edge (%A → %A): parent level %d should be < child level %d" parent child parentLvl childLvl)
 
 [<Fact>]
+let ``P2: levels under Alphabetical mode mints only singleton groups — no parallelism on an order without parent-precedence proof`` () =
+    // The P2-wire finding (2026-06-12): the level computation rests on
+    // "parents precede children", which only Mode = Topological carries.
+    // Under the Alphabetical fallback (any unresolved cycle in the
+    // catalog) a child can sort before its parent; the "unknown parent
+    // contributes 0" rule then collapsed this REAL FK chain into one
+    // "level" — a ParallelSafe group with FK edges inside it. The mode
+    // guard refuses: singleton groups in Order order, vacuously safe,
+    // exactly the sequential deploy.
+    let t : TopologicalOrder =
+        { TopologicalOrder.empty with
+            Mode  = Alphabetical
+            // Alphabetical order happens to put dependents first here —
+            // the shape that previously flattened everything to level 0.
+            Order = [ countryKey; orderKey; customerKey ]
+            Edges = [ orderKey, customerKey     // order depends on customer
+                      countryKey, orderKey ] }  // country depends on order
+    Assert.Equal<SsKey list list>(
+        [ [ countryKey ]; [ orderKey ]; [ customerKey ] ],
+        TopologicalOrder.levels t |> List.map ParallelSafe.members)
+
+[<Fact>]
 let ``levels: cycle-broken kind receives finite level`` () =
     // A ⟶ B ⟶ A (self-cycle). Cycle-resolver picks A first; B follows.
     // Edge (A, B) means A depends on B — but B comes AFTER A in Order


### PR DESCRIPTION
The wire, on the gate met 2026-06-12 (2.85x/2.59x/2.65x at the operator
envelope, perf-harness leveled-deploy-150x42).

- Deploy.executeLeveledSeed <connStr> <plan> — the ONE owner of the
  leveled deploy order: Phase-1 levels then Phase-2 levels, levels
  sequential, within-level concurrency licensed by the ParallelSafe
  token, parallelism via the existing resolveParallelism stack
  (PROJECTION_DEPLOY_PARALLELISM override honored). The connection
  STRING is the argument — per-segment pooled opens, the seam the card
  named.
- Compose seam re-threaded: runWithConfigAndLoad now injects a
  LeveledDeploymentText -> Task executor (the CLI partial-applies
  Deploy.executeLeveledSeed connStr; sink stays the CDC measure's
  connection). projectSeedPlan composes the leveled plan over the
  post-chain catalog; loadLeveledSeedAndRecord shares the CDC-bracketed
  measure+record core with the fused loadSeedAndRecord (kept: the
  published-artifact contract witness). Empty-plan gate = the fused
  whitespace gate (parity witnessed).
- runFullExportLoad (projection full-export --load) rides the leveled
  path.

Card corrections, named on the card: runDeploy -> runEphemeral deploys
aggregateSsdt over SsdtBundle — SCHEMA-only; seeds live in DataBundle
as one fused Data/seed.sql and never rode the deploy face. The card's
"fused schema+seeds" was the probe's error; face (a) is REFUSED
(nothing data-shaped to level there; schema leveling stays P3,
trigger-held).

Mint defect found under the wire, fixed at the mint: under
Mode=Alphabetical (any unresolved cycle — one self-FK kind suffices)
TopologicalOrder.levels' "unknown parent contributes 0" rule collapsed
real FK chains into ONE ParallelSafe group, violating the token's
no-edge-within-group law at its only mint. levels now licenses
multi-member groups only under Topological; Alphabetical /
JunctionDeferred yield singleton groups in order — exactly the
sequential deploy. Named residual (DECISIONS): the FUSED path's
alphabetical MERGE order under that mode is a pre-existing hazard for
non-cycle FK chains among seeded kinds; the leveled path is now
equal-not-worse; cure trigger recorded.

Faithfulness is a law, not a comment: the leveled plan PARTITIONS the
published seed — GO-batch segment-multiset equality property-witnessed
on a Topological catalog and an Alphabetical-mode one; nothing is
re-rendered.

Witnesses at this commit: fast pool 3121/0/211 in 137s (+5 pure:
partition law, level precedence, singleton degrade, isEmpty parity,
the mint-mode witness; inherited 3116/0/211 replicated exactly at
open); docker pool 231/0 in 374s (+2 over the inherited 229: the
gate's declared scenario fact and the new live leg) including the live
leveled leg (two kinds through one two-member level via
executeLeveledSeed against the per-DB connection string — delta=4
measured AND recorded on the episode, re-load CDC-silent, rows intact;
confirmed exercised, not soft-skipped, per CLAUDE.md §4 rule 12);
comprehensive canary gate-open 1/1 at 4m02s, empty PhysicalSchema
diff, leveled target-deploy at parallelism 4 with 3 real Phase-1
levels (Topological mode preserved by the guard); lint surface
byte-identical to the clean tree. Perf-gate + the harness scenario
re-runs land with the books commit that follows.

https://claude.ai/code/session_013viEQSBkeAPyKsSwX4htNF