### PR TITLE
Invariant near-miss campaign: close NM-73 + NM-17 (+ cross-platform LF determinism)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -22899,3 +22899,60 @@ gained the field.
 **Owed after this:** NM-17 (heavy `KindFacet` diff channel), NM-62 (threshold
 constants), the `compare`-source-profiling follow-on, and the
 `MigrationDependenciesEmitter` guard extension.
+
+---
+
+## 2026-06-14 (later) — NM-17 lands: the heavy KindFacet diff channel (change-algebra capstone)
+
+**What shipped.** NM-16 took the LIGHT route — naming the kind-level erasures
+(`Triggers` / `ColumnChecks` / `Modality` / `IsActive`) as four `OpenGap`
+`ToleratedDivergence`s so `CatalogDiff.norm = 0` on a changed kind was *witnessed*,
+not silent. NM-17 takes the HEAVY route: a real `KindFacet` diff channel, retiring
+those four tolerances.
+
+- **`KindFacet = Modality | Triggers | ColumnChecks | IsActive`** + a sparse
+  `CatalogDiffData.KindFacetDiffs : Map<SsKey, Set<KindFacet>>` (parallel to
+  `AttributeDiffs`: only kinds present in both catalogs with a changed kind-OWN
+  facet; every stored set non-empty). `changedKindFacets` mirrors `changedFacets`.
+- `between` descends into each shared kind's own facets; `isEmpty` and the norm
+  account for them (`ChannelCounts.ChangedKinds = Map.count KindFacetDiffs`, one
+  move per changed kind, mirroring `ChangedAttributes`); `applyDiff` patches them
+  via `applyKindFacet` from the recorded target. The round-trip law
+  `between B (applyDiff (between A B) A) |> isEmpty` now holds on the kind facets.
+- **`compose`'s composability bridge** (which uses `isEmpty` for adjacency)
+  inherits the fix for free — NM-17's named sibling defect (a kind-facet-only
+  intermediate mismatch declared composable) closes with `isEmpty`.
+- **Retired** the four `KindTriggers/Checks/Modality/Activation UnreflectedInDiff`
+  tolerances from `Tolerance.fs` (DU + `coverage` + `allKnown` + `name`) — a closed
+  OpenGap leaves no DU variant behind (dead-algebra-retirement precedent). `allKnown`
+  12 → 8; the matrix's open-gap count 6 → 2 (`IndexOptionsUnreflected` +
+  `CompositePkFkUnreflected` remain). Closes the stale-docstring NM-65 in the same
+  edit (the `applyDiff` captured-surface comment now names modality/triggers/CHECKs/
+  activation as captured; only `Description` / ext-props / module structure remain
+  residual).
+
+**Why this is the highest-leverage invariant.** It restores the agreement between
+the two surfaces that disagreed on "what is a change": the `CatalogDiff` algebra
+(what `migrate` emits) and the canary's `PhysicalSchema.diff` (what the round-trip
+observes). A trigger / CHECK / modality / activation flip now produces `norm ≥ 1`
+and a migrate delta, instead of `norm = 0` "idempotent redeploy" + silent
+full-redeploy — the CDC-as-norm isometry the change algebra rests on.
+
+**An adjacent CRLF determinism gap, fixed in passing.** Running the suite on
+Windows surfaced `LifecycleStore.serialize` building `Utf8JsonWriter` with a bare
+`JsonWriterOptions(Indented = true)` — no pinned `NewLine`, so .NET 9 emits the host
+newline (CRLF on Windows) into a durable artifact (a T1 violation). Pinned to
+`JsonOptions.indented ()` (LF), the same single-sanctioned-home form `PinnedWriting`
+already mandates. Not an NM-17 change (the failure reproduced on the committed
+state without NM-17); folded in here since it blocked a green suite and is the same
+cross-platform-determinism class as the earlier LF pin.
+
+**Tests.** `CatalogDiffTests` — an IsActive flip surfaces `KindFacet.IsActive`
+(kind stays Unchanged, `isEmpty` honest, `norm = 1`); a Modality change surfaces
+`KindFacet.Modality`; `applyDiff` round-trips a kind-facet change. `ToleranceTests`
+/ `ManifestUnsupportedTests` / `SsdtExtendedPropertyEmissionTests` — count 12 → 8,
+retired tokens no longer parse. `MatrixLadderTests` — open gaps 6 → 2. Matrix
+regenerated (`scripts/matrix-status.sh`).
+
+**Owed after this:** NM-62's `compare`-source-profiling follow-on, and the
+`MigrationDependenciesEmitter` validate-before-apply guard extension (NM-73 scope).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -22844,3 +22844,58 @@ on GitHub — the env's SSH signing key is empty (0 bytes), so signing is imposs
 here. And the warm SQL container degrades under accumulated load and dies mid-pool
 (survival rule #2) — the OSSYS-extraction classes fail on a tired container; a
 restart + focused re-run proves health.
+
+---
+
+## 2026-06-14 (later) — NM-73 lands: EXCEPT validate-before-apply, the daylight safety slice
+
+**What shipped.** The consciously-deferred NM-73 guard is now built, end-to-end and
+green, exactly per the settled plan — no inert axis left behind (the whole slice
+lands as one change: axis → config → threading → guard → tests).
+
+- **`EmissionPolicy.DataVerification = Standard | ValidateBeforeApply`** (closed DU,
+  not a bool, so a future third posture is a named variant). Default `Standard` is
+  **byte-identical** to pre-NM-73 emission — the CDC-silence-canonical posture V2
+  commits to. `Policy.withDataVerification` is the sibling setter to
+  `withEmitIdentityAnnotations`.
+- **`emission.dataVerification` config key** (`"standard"` | `"validateBeforeApply"`),
+  parsed in `Config.fs` via `parseDataVerification`; an unrecognised value is a **loud
+  config error**, never a silent fallback (named-refusal discipline). Threaded
+  `cfg.Emission.DataVerification → EmissionPolicy.DataVerification` in `Pipeline.fs`,
+  and `policy.Emission.DataVerification → dispatchSiblings → StaticSeedsEmitter`
+  in the composer (A18 — the emitter takes the plain value, never `Policy`).
+- **The guard** (`ScriptDomBuild.buildValidateBeforeApplyGuard`) faithfully mirrors
+  V1's `StaticSeedSqlBuilder.ValidateThenApply` (`src/Osm.Emission/Seeds/
+  StaticSeedSqlBuilder.cs:102-138`): a **symmetric `EXCEPT` pair gated on a non-empty
+  target** — `IF EXISTS(target) AND (EXISTS(source EXCEPT target) OR EXISTS(target
+  EXCEPT source)) THROW 50000`. First apply over an empty target proceeds; an
+  idempotent re-apply is silent; a *drifted* re-apply aborts before the MERGE
+  overwrites. Built via the **`TSql160Parser` parse-template path** (the
+  `checkConstraint`/`tryParseTriggerBody` idiom) so the result is a typed
+  `TSqlStatement` re-rendered canonically by `generateOne` — not a hand-built AST,
+  not a text blob. The guard's inline `VALUES` reuse the exact `MergeBuildArgs` rows
+  the MERGE is about to write, so the comparison is against the real deploy source.
+- **Framing:** the guard is its own `GO` batch prepended to the MERGE batch (it
+  THROWs before the MERGE runs), composing with the IDENTITY_INSERT bracket.
+
+**Two safety choices worth recording.**
+1. **No silent downgrade of the guard.** A parse failure of the self-constructed
+   guard template is a *programmer error*, raised loudly (`invalidOp`), never a
+   recovered skip — a silently-dropped safety guard is exactly the campaign's
+   cardinal sin. The template is built from typed-rendered literals + bracket-quoted
+   identifiers, so it always parses for valid input; the loud path is the backstop.
+2. **Scope.** The guard is wired into `StaticSeedsEmitter` (the static-seed lane the
+   plan named). `MigrationDependenciesEmitter` (the sibling that also MERGEs) keeps
+   `Standard`; extending the guard there is a named follow-on, tracked with NM-D's
+   IDENTITY_INSERT-bracket sibling-divergence work.
+
+**Tests.** `StaticSeedsEmitterTests` — `Standard` is byte-identical to the
+established emit; `ValidateBeforeApply` prepends the symmetric-`EXCEPT` `THROW 50000`
+guard *before* the MERGE (structural assertions + ordering). `ConfigTests` — the
+key defaults `Standard`, parses `validateBeforeApply`, and errors loudly on garbage
+(A44: expressible ⇔ reachable). The four `*BindingTests` `EmissionSection` literals
+gained the field.
+
+**Owed after this:** NM-17 (heavy `KindFacet` diff channel), NM-62 (threshold
+constants), the `compare`-source-profiling follow-on, and the
+`MigrationDependenciesEmitter` guard extension.

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -27,14 +27,14 @@ witness covers the axis. The **Ladder** column is the honest weakest-rung summar
 
 | Axis | L1 witness | L2 faithful | L3 composed | Open tolerances | Ladder |
 |---|:--:|:--:|:--:|---|---|
-| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexOptionsUnreflected`, `KindTriggersUnreflectedInDiff`, `KindChecksUnreflectedInDiff`, `KindModalityUnreflectedInDiff`, `KindActivationUnreflectedInDiff`, `CompositePkFkUnreflected` | ◑ L2-partial |
+| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexOptionsUnreflected`, `CompositePkFkUnreflected` | ◑ L2-partial |
 | **Data** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Identity** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Time** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Decision** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 
 **Rungs reached: L1 5/5 · L2 4/5 · L3 5/5.** Tolerance set:
-12 named, of which **6 open** (`OpenGap`). A cell cannot be
+8 named, of which **2 open** (`OpenGap`). A cell cannot be
 hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance
 to be retired from `Tolerance.fs`. The generator under-claims; it never over-claims.
 
@@ -46,4 +46,4 @@ to be retired from `Tolerance.fs`. The generator under-claims; it never over-cla
 > L3 here is "a composition witness exists for the axis," not "faithful under every
 > spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
 
-_Self-reported · gate=PASS · L2 axioms live/C/D=78/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 12 (6 open)_
+_Self-reported · gate=PASS · L2 axioms live/C/D=78/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 8 (2 open)_

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -164,6 +164,24 @@ type SequenceChange =
 /// kind-scoped). Mirrors `AttributeDiff`; sequences match by `SsKey`.
 type SequenceDiff = ChannelDiff<SequenceChange>
 
+/// NM-17 — a single kind-OWN facet that `CatalogDiff` previously erased.
+/// The attribute / reference / index / sequence channels cover a kind's
+/// *children*; this channel covers the kind's own shape beyond presence/name:
+/// its population `Modality`, `Triggers`, table-level `ColumnChecks`, and the
+/// `IsActive` activation flag. NM-16 took the LIGHT route — naming these
+/// erasures as `ToleratedDivergence`s so `norm d = 0` was *witnessed*, not
+/// silent; NM-17 is the HEAVY route that reflects them as a real diff channel,
+/// retiring those tolerances and restoring the agreement between `migrate`
+/// (the `CatalogDiff` algebra) and the canary's `PhysicalSchema.diff`. Closed
+/// DU; widen when a further kind-own field (`Description` / ext-props / module
+/// structure — still unwitnessed residual) gets a consumer.
+[<RequireQualifiedAccess>]
+type KindFacet =
+    | Modality
+    | Triggers
+    | ColumnChecks
+    | IsActive
+
 /// Total decomposition of `source ∪ target` SsKeys into four pairwise-
 /// disjoint partitions. The smart constructor `CatalogDiff.between`
 /// enforces exhaustiveness — every `SsKey` in `Catalog.allKinds source`
@@ -215,6 +233,11 @@ and CatalogDiffData =
         /// C1 — the catalog-level sequence diff. Empty (all four fields empty)
         /// when source and target carry identical sequences.
         SequenceDiff : SequenceDiff
+        /// NM-17 — per-kind kind-OWN facet diffs (sparse: only kinds present in
+        /// BOTH catalogs whose `Modality` / `Triggers` / `ColumnChecks` /
+        /// `IsActive` differ). Keyed by kind `SsKey`; every stored set is
+        /// non-empty. Mirrors `AttributeDiffs`' sparsity contract.
+        KindFacetDiffs : Map<SsKey, Set<KindFacet>>
     }
 
 /// 6.A.7 — evidence that a name-derived (`Synthesized`) identity was
@@ -403,6 +426,18 @@ module CatalogDiff =
           Renamed = renamed
           Changed = changed }
 
+    /// NM-17 — the kind-OWN facets that differ between a kind's source and
+    /// target realization. Presence/name is the top-level partition; children
+    /// ride the attribute/reference/index channels; this is the kind's own
+    /// shape. Empty ⇒ the kind's own facets are identical. Mirrors
+    /// `changedFacets`.
+    let private changedKindFacets (s: Kind) (t: Kind) : Set<KindFacet> =
+        [ if s.Modality <> t.Modality then KindFacet.Modality
+          if s.Triggers <> t.Triggers then KindFacet.Triggers
+          if s.ColumnChecks <> t.ColumnChecks then KindFacet.ColumnChecks
+          if s.IsActive <> t.IsActive then KindFacet.IsActive ]
+        |> Set.ofList
+
     let private changedSequenceFacets (s: Sequence) (t: Sequence) : Set<SequenceFacet> =
         [ if s.Schema <> t.Schema then SequenceFacet.Schema
           if s.DataType <> t.DataType then SequenceFacet.DataType
@@ -524,6 +559,21 @@ module CatalogDiff =
                         if channelDiffIsEmpty d then acc else Map.add key d acc
                     | _ -> acc)
                 Map.empty
+        // NM-17 — descend into each kind's OWN facets (modality / triggers /
+        // CHECKs / activation) for every kind in BOTH catalogs; store only
+        // non-empty sets (an unchanged kind contributes nothing, so an
+        // idempotent redeploy stays empty → CDC-silence). Closes the NM-16
+        // tolerance erasure: these were named-but-unreflected; now reflected.
+        let kindFacetDiffs =
+            intersect
+            |> Set.fold
+                (fun acc key ->
+                    match Catalog.tryFindKind key source, Catalog.tryFindKind key target with
+                    | Some sk, Some tk ->
+                        let facets = changedKindFacets sk tk
+                        if Set.isEmpty facets then acc else Map.add key facets acc
+                    | _ -> acc)
+                Map.empty
         // C1 — sequences are catalog-level, not kind-scoped.
         let sequenceDiff = sequenceDiffBetween source target
         Ok
@@ -539,6 +589,7 @@ module CatalogDiff =
                     ReferenceDiffs = referenceDiffs
                     IndexDiffs = indexDiffs
                     SequenceDiff = sequenceDiff
+                    KindFacetDiffs = kindFacetDiffs
                 })
 
     let source (CatalogDiff d) : Catalog = d.Source
@@ -573,6 +624,16 @@ module CatalogDiff =
 
     /// C1 — the catalog-level sequence diff (empty when sequences are identical).
     let sequenceDiff (CatalogDiff d) : SequenceDiff = d.SequenceDiff
+
+    /// NM-17 — the per-kind kind-OWN facet diffs (sparse: only kinds present in
+    /// both catalogs with a changed `Modality` / `Triggers` / `ColumnChecks` /
+    /// `IsActive`). Keyed by kind `SsKey`.
+    let kindFacetDiffs (CatalogDiff d) : Map<SsKey, Set<KindFacet>> = d.KindFacetDiffs
+
+    /// NM-17 — the kind-facet diff for one kind, or `None` if the kind's own
+    /// facets are identical (or the kind is not present in both catalogs).
+    let kindFacetDiffOf (key: SsKey) (CatalogDiff d) : Set<KindFacet> option =
+        Map.tryFind key d.KindFacetDiffs
 
     /// 6.A.7 — the Synthesized-key renames the SsKey-matching diff could not
     /// thread. A `Synthesized` SsKey is name-derived, so a rename changes the
@@ -650,6 +711,7 @@ module CatalogDiff =
         && Map.isEmpty data.ReferenceDiffs
         && Map.isEmpty data.IndexDiffs
         && channelDiffIsEmpty data.SequenceDiff
+        && Map.isEmpty data.KindFacetDiffs
 
     // -- 6.A.11: applyDiff — the `between` peer (H-007) -----------------------
     //
@@ -669,20 +731,19 @@ module CatalogDiff =
     // (the no-cheat property test). It is NOT `fun base d -> target d`.
     //
     // **Captured surface (the law's modulus).** The diff captures kind
-    // presence/name + attribute presence/name + the nine column-shape facets
-    // (`AttributeFacet`) + references + indexes + sequences (the C1 channels,
-    // each with its own `apply*Diff` patch). It does NOT capture kind-level
-    // `Modality`, `Triggers`, `ColumnChecks`, `Description`, `IsActive`,
-    // `ExtendedProperties`, or module structure — those ride through from
-    // `base` unchanged. (NM-16 LIGHT route, 2026-06-13: the trigger / CHECK /
-    // modality / activation slice of that residual erasure is now NAMED — the
-    // `ToleratedDivergence.Kind{Triggers,Checks,Modality,Activation}Unreflected
-    // InDiff` variants witness it, each with a retirement trigger — so it is a
-    // *witnessed* gap, not a silent one. The canary's `PhysicalSchema.diff`
-    // DOES compare these, so the two surfaces still disagree on "what is a
-    // change"; retiring a variant means adding its diff channel here.
-    // `Description` / `ExtendedProperties` / module structure remain unwitnessed
-    // residual.) The round-trip law therefore holds for
+    // presence/name + the kind-OWN facets `Modality` / `Triggers` /
+    // `ColumnChecks` / `IsActive` (`KindFacet`, NM-17) + attribute
+    // presence/name + the nine column-shape facets (`AttributeFacet`) +
+    // references + indexes + sequences (the C1 channels, each with its own
+    // `apply*Diff` patch). (NM-16 took the LIGHT route — naming the trigger /
+    // CHECK / modality / activation erasure as `ToleratedDivergence`s so the
+    // gap was witnessed, not silent; NM-17, 2026-06-14, took the HEAVY route:
+    // the `KindFacet` diff channel above reflects them for real, so the
+    // `CatalogDiff` algebra and the canary's `PhysicalSchema.diff` now AGREE on
+    // "what is a change," and those four tolerances are retired.) It does NOT
+    // capture kind-level `Description`, `ExtendedProperties`, or module
+    // structure — those ride through from `base` unchanged and remain
+    // unwitnessed residual. The round-trip law therefore holds for
     // A→B evolutions within the captured surface, witnessed order-insensitively
     // by `between B (applyDiff (between A B) A) |> isEmpty`. A future
     // self-contained diff (inline payloads, no stored source/target) would
@@ -703,6 +764,18 @@ module CatalogDiff =
         | AttributeFacet.Identity     -> { dest with IsIdentity = src.IsIdentity }
         | AttributeFacet.DefaultValue -> { dest with DefaultValue = src.DefaultValue; DefaultName = src.DefaultName }
         | AttributeFacet.Computed     -> { dest with Computed = src.Computed }
+
+    /// NM-17 — patch one kind-OWN facet of `dest` from `src` (the recorded
+    /// target kind). Mirrors `applyFacet`; only the named facet moves, every
+    /// other field of `dest` rides through. `dest` is an existing `Kind`
+    /// value, so `{ dest with … }` replaces a single field (no smart-ctor
+    /// reconstruction → no default-substitution bomb).
+    let private applyKindFacet (src: Kind) (facet: KindFacet) (dest: Kind) : Kind =
+        match facet with
+        | KindFacet.Modality     -> { dest with Modality = src.Modality }
+        | KindFacet.Triggers     -> { dest with Triggers = src.Triggers }
+        | KindFacet.ColumnChecks -> { dest with ColumnChecks = src.ColumnChecks }
+        | KindFacet.IsActive     -> { dest with IsActive = src.IsActive }
 
     /// Apply a per-kind `AttributeDiff` to a kind's base attribute list,
     /// sourcing new attributes / new facet values from the recorded target
@@ -839,9 +912,11 @@ module CatalogDiff =
     /// 6.A.11 — apply a `CatalogDiff` to a base `Catalog`, reconstructing the
     /// target modulo the captured surface. Total: trusts the delta (no
     /// re-validation), so the round-trip law is `between B (applyDiff
-    /// (between A B) A) |> isEmpty`. References / indexes / modality / module
-    /// structure / sequences ride through from `base` (not captured by the
-    /// diff). H-007: the `between` peer that makes Time an evolution algebra.
+    /// (between A B) A) |> isEmpty`. Attributes / references / indexes /
+    /// sequences (C1) and the kind-OWN facets modality / triggers / CHECKs /
+    /// activation (NM-17) are all captured and patched; only kind `Description`
+    /// / ext-props / module structure ride through from `base` (the remaining
+    /// residual). H-007: the `between` peer that makes Time an evolution algebra.
     let applyDiff (baseCatalog: Catalog) (d: CatalogDiff) : Catalog =
         let (CatalogDiff data) = d
         let tgt = data.Target
@@ -859,9 +934,14 @@ module CatalogDiff =
                 match Map.tryFind k.SsKey data.ReferenceDiffs with
                 | Some rd -> { withAttrs with References = applyReferenceDiff rd tgtKind withAttrs.References }
                 | None -> withAttrs
-            match Map.tryFind k.SsKey data.IndexDiffs with
-            | Some idd -> { withRefs with Indexes = applyIndexDiff idd tgtKind withRefs.Indexes }
-            | None -> withRefs
+            let withIndexes =
+                match Map.tryFind k.SsKey data.IndexDiffs with
+                | Some idd -> { withRefs with Indexes = applyIndexDiff idd tgtKind withRefs.Indexes }
+                | None -> withRefs
+            // NM-17 — patch the kind's own facets from the recorded target.
+            match Map.tryFind k.SsKey data.KindFacetDiffs, tgtKind with
+            | Some facets, Some tk -> Set.fold (fun acc f -> applyKindFacet tk f acc) withIndexes facets
+            | _ -> withIndexes
         // Transform base's modules: drop Removed kinds, transform survivors.
         let survivingKeys =
             Catalog.allKinds baseCatalog
@@ -921,6 +1001,10 @@ module CatalogDiff =
             RenamedKinds      : int
             AddedKinds        : int
             RemovedKinds      : int
+            // NM-17 — kinds present in both catalogs whose OWN facets changed
+            // (modality / triggers / CHECKs / activation). One move per kind,
+            // mirroring `ChangedAttributes` (entity-count, not facet-count).
+            ChangedKinds      : int
             AddedAttributes   : int
             RemovedAttributes : int
             RenamedAttributes : int
@@ -952,6 +1036,7 @@ module CatalogDiff =
             RenamedKinds      = Map.count data.Renamed
             AddedKinds        = Set.count data.Added
             RemovedKinds      = Set.count data.Removed
+            ChangedKinds      = Map.count data.KindFacetDiffs
             AddedAttributes   = sumAttr (fun ad -> Set.count ad.Added)
             RemovedAttributes = sumAttr (fun ad -> Set.count ad.Removed)
             RenamedAttributes = sumAttr (fun ad -> Map.count ad.Renamed)
@@ -976,7 +1061,7 @@ module CatalogDiff =
     /// `AttributeDiff` contributes ≥ 1 to the norm).
     let norm (d: CatalogDiff) : int =
         let c = channelCounts d
-        c.RenamedKinds + c.AddedKinds + c.RemovedKinds
+        c.RenamedKinds + c.AddedKinds + c.RemovedKinds + c.ChangedKinds
         + c.AddedAttributes + c.RemovedAttributes + c.RenamedAttributes + c.ChangedAttributes
         + c.AddedReferences + c.RemovedReferences + c.RenamedReferences + c.ChangedReferences
         + c.AddedIndexes + c.RemovedIndexes + c.RenamedIndexes + c.ChangedIndexes

--- a/sidecar/projection/src/Projection.Core/Policy.fs
+++ b/sidecar/projection/src/Projection.Core/Policy.fs
@@ -87,6 +87,27 @@ module DeleteScopePolicy =
         else None
 
 
+/// NM-73 (WP6.6, operator choice C2) — the data emitters' drift-guard
+/// posture. `Standard` (the default) emits the MERGE alone: byte-identical
+/// to pre-NM-73 and the CDC-silence-canonical posture V2 commits to.
+/// `ValidateBeforeApply` is the operator's **conservative override** — it
+/// prepends a typed symmetric-`EXCEPT` drift guard before the MERGE
+/// (mirrors V1's `StaticSeedSqlBuilder.ValidateThenApply`): if the target
+/// is non-empty AND its managed rows differ — in *either* direction — from
+/// the source about to be written, `THROW 50000` aborts the batch before
+/// the MERGE overwrites. First apply over an empty target proceeds; an
+/// idempotent re-apply stays silent; a *drifted* re-apply throws. Per C2,
+/// CDC-silence stays canonical; this is the opt-in fallback until J5
+/// proves the CDC path on real UAT. Modeled as a closed DU (not a bool)
+/// so a future third verification posture lands as a named variant.
+[<RequireQualifiedAccess>]
+type DataVerification =
+    /// MERGE alone — byte-identical, CDC-silence-canonical (the default).
+    | Standard
+    /// Symmetric-`EXCEPT` drift guard prelude + `THROW 50000`, one GO
+    /// batch with the MERGE. The operator's conservative override.
+    | ValidateBeforeApply
+
 /// Emission axis. Which artifact families a projection emits. The booleans
 /// are deliberate; orthogonality of schema / data / diagnostics is the
 /// algebra's commitment (decomposition Vector 2). When emission shapes
@@ -135,6 +156,12 @@ type EmissionPolicy = {
     /// `RenderConstraintsElegant`; lifted to the SSDT emit seam at the
     /// composition layer (A18 — the emitter never reads `Policy`).
     EmitIdentityAnnotations : bool
+    /// NM-73 (WP6.6) — the data emitters' drift-guard posture. `Standard`
+    /// (the default) is byte-identical to pre-NM-73; `ValidateBeforeApply`
+    /// prepends the symmetric-`EXCEPT` `THROW 50000` guard before each
+    /// MERGE. Lifted to the data emit seam as a plain value (A18 — the
+    /// emitter never reads `Policy`). See the `DataVerification` DU.
+    DataVerification : DataVerification
 }
 
 
@@ -528,7 +555,10 @@ module EmissionPolicy =
                   // NM-70 — identity annotations emit by default (the
                   // downgrade-free posture; byte-identical to pre-NM-70 and
                   // the posture ReadSide's persisted-SsKey recovery needs).
-                  EmitIdentityAnnotations = true }
+                  EmitIdentityAnnotations = true
+                  // NM-73 — CDC-silence-canonical default; the EXCEPT drift
+                  // guard is the operator's opt-in conservative override.
+                  DataVerification = DataVerification.Standard }
 
     /// Replace `IncludePlatformAutoIndexes` while preserving the rest
     /// of the policy. Chapter 4.8 slice γ. Operators set to `false` to
@@ -550,6 +580,13 @@ module EmissionPolicy =
     /// `withRenderConstraintsElegant`.
     let withEmitIdentityAnnotations (emit: bool) (policy: EmissionPolicy) : EmissionPolicy =
         { policy with EmitIdentityAnnotations = emit }
+
+    /// NM-73 (WP6.6) — replace `DataVerification` while preserving the rest
+    /// of the policy. Operators set `ValidateBeforeApply` to prepend the
+    /// symmetric-`EXCEPT` drift guard before the data MERGEs (the C2
+    /// conservative override). Sibling to `withEmitIdentityAnnotations`.
+    let withDataVerification (verification: DataVerification) (policy: EmissionPolicy) : EmissionPolicy =
+        { policy with DataVerification = verification }
 
     /// Project a catalog by the `IncludePlatformAutoIndexes` toggle. When
     /// the policy says `true` (V1 default), returns the catalog

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -74,45 +74,15 @@ type ToleratedDivergence =
     /// @ladder IndexOptionsUnreflected Schema OpenGap
     | IndexOptionsUnreflected
 
-    /// NM-16 — `CatalogDiff.between` compares kinds by NAME and descends
-    /// only into attributes / references / indexes / sequences; a kind's
-    /// `Triggers` are NOT a diff channel. A changed / added / removed
-    /// trigger produces `norm d = 0` ("idempotent redeploy") and
-    /// `migrate A B` emits nothing — yet the canary's `PhysicalSchema.diff`
-    /// surface CAN see trigger drift, so the two surfaces disagree on
-    /// "what is a change." Named here so the kind-level trigger erasure in
-    /// the `CatalogDiff` algebra is *closed* (witnessed), not silent —
-    /// satisfying "nothing lost in silence" (the LIGHT route, not a full
-    /// `KindFacet` diff channel). Retiring it: add a kind-trigger diff
-    /// channel to `CatalogDiff.between` (mirroring the attribute facet
-    /// descent) with `applyDiff` patches + a fixture.
-    /// @ladder KindTriggersUnreflectedInDiff Schema OpenGap
-    | KindTriggersUnreflectedInDiff
-
-    /// NM-16 — a kind's `ColumnChecks` (table-level CHECK constraints) are
-    /// not a `CatalogDiff.between` channel; a changed / added / removed
-    /// CHECK produces `norm d = 0` and `migrate` emits nothing, while the
-    /// physical canary can observe the change. Named here so the erasure
-    /// is *closed* (witnessed), not silent. Retiring it: add a kind-CHECK
-    /// diff channel with `applyDiff` patches + a fixture.
-    /// @ladder KindChecksUnreflectedInDiff Schema OpenGap
-    | KindChecksUnreflectedInDiff
-
-    /// NM-16 — a kind's `Modality` (the static-vs-dynamic / population
-    /// modality mark) is not a `CatalogDiff.between` channel; a modality
-    /// flip produces `norm d = 0` and `migrate` emits nothing. Named here
-    /// so the erasure is *closed* (witnessed), not silent. Retiring it: add
-    /// a kind-modality diff channel with `applyDiff` patches + a fixture.
-    /// @ladder KindModalityUnreflectedInDiff Schema OpenGap
-    | KindModalityUnreflectedInDiff
-
-    /// NM-16 — a kind's `IsActive` activation flag is not a
-    /// `CatalogDiff.between` channel; activating / deactivating a kind
-    /// produces `norm d = 0` and `migrate` emits nothing. Named here so the
-    /// erasure is *closed* (witnessed), not silent. Retiring it: add a
-    /// kind-activation diff channel with `applyDiff` patches + a fixture.
-    /// @ladder KindActivationUnreflectedInDiff Schema OpenGap
-    | KindActivationUnreflectedInDiff
+    // NM-16's four kind-facet tolerances (KindTriggersUnreflectedInDiff /
+    // KindChecksUnreflectedInDiff / KindModalityUnreflectedInDiff /
+    // KindActivationUnreflectedInDiff) were RETIRED by NM-17 (2026-06-14):
+    // `CatalogDiff` now reflects these as a real `KindFacet` diff channel
+    // (modality / triggers / CHECKs / activation), so the erasure they named
+    // no longer exists — the `migrate` algebra and the canary's
+    // `PhysicalSchema.diff` agree on "what is a change." A retired tolerance
+    // leaves no DU variant behind (an OpenGap that closed is deleted, not kept
+    // as a no-op), per the dead-algebra-retirement precedent.
 
     /// Static-entity populations (INSERT statements) are absent
     /// from `PhysicalSchema`'s comparison surface (same docstring).
@@ -226,10 +196,6 @@ module ToleratedDivergence =
         | ToleratedDivergence.HeaderCommentsOmitted          -> ToleratedDivergence.HeaderCommentsOmitted
         | ToleratedDivergence.PostDeployForeignKeysSplit     -> ToleratedDivergence.PostDeployForeignKeysSplit
         | ToleratedDivergence.IndexOptionsUnreflected             -> ToleratedDivergence.IndexOptionsUnreflected
-        | ToleratedDivergence.KindTriggersUnreflectedInDiff  -> ToleratedDivergence.KindTriggersUnreflectedInDiff
-        | ToleratedDivergence.KindChecksUnreflectedInDiff    -> ToleratedDivergence.KindChecksUnreflectedInDiff
-        | ToleratedDivergence.KindModalityUnreflectedInDiff  -> ToleratedDivergence.KindModalityUnreflectedInDiff
-        | ToleratedDivergence.KindActivationUnreflectedInDiff -> ToleratedDivergence.KindActivationUnreflectedInDiff
         | ToleratedDivergence.StaticPopulationsUnreflected   -> ToleratedDivergence.StaticPopulationsUnreflected
         | ToleratedDivergence.EmptyTextNormalizedToNull      -> ToleratedDivergence.EmptyTextNormalizedToNull
         | ToleratedDivergence.CompositePkFkUnreflected       -> ToleratedDivergence.CompositePkFkUnreflected
@@ -253,10 +219,6 @@ module ToleratedDivergence =
                 coverage ToleratedDivergence.HeaderCommentsOmitted
                 coverage ToleratedDivergence.PostDeployForeignKeysSplit
                 coverage ToleratedDivergence.IndexOptionsUnreflected
-                coverage ToleratedDivergence.KindTriggersUnreflectedInDiff
-                coverage ToleratedDivergence.KindChecksUnreflectedInDiff
-                coverage ToleratedDivergence.KindModalityUnreflectedInDiff
-                coverage ToleratedDivergence.KindActivationUnreflectedInDiff
                 coverage ToleratedDivergence.StaticPopulationsUnreflected
                 coverage ToleratedDivergence.EmptyTextNormalizedToNull
                 coverage ToleratedDivergence.CompositePkFkUnreflected
@@ -274,10 +236,6 @@ module ToleratedDivergence =
         | ToleratedDivergence.HeaderCommentsOmitted        -> "HeaderCommentsOmitted"
         | ToleratedDivergence.PostDeployForeignKeysSplit   -> "PostDeployForeignKeysSplit"
         | ToleratedDivergence.IndexOptionsUnreflected           -> "IndexOptionsUnreflected"
-        | ToleratedDivergence.KindTriggersUnreflectedInDiff   -> "KindTriggersUnreflectedInDiff"
-        | ToleratedDivergence.KindChecksUnreflectedInDiff     -> "KindChecksUnreflectedInDiff"
-        | ToleratedDivergence.KindModalityUnreflectedInDiff   -> "KindModalityUnreflectedInDiff"
-        | ToleratedDivergence.KindActivationUnreflectedInDiff -> "KindActivationUnreflectedInDiff"
         | ToleratedDivergence.StaticPopulationsUnreflected -> "StaticPopulationsUnreflected"
         | ToleratedDivergence.EmptyTextNormalizedToNull    -> "EmptyTextNormalizedToNull"
         | ToleratedDivergence.CompositePkFkUnreflected     -> "CompositePkFkUnreflected"

--- a/sidecar/projection/src/Projection.Pipeline/Config.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Config.fs
@@ -208,6 +208,12 @@ module Config =
         /// degrades to name-derived SsKeys, with a diagnostic). Threads to
         /// `EmissionPolicy.EmitIdentityAnnotations`.
         EmitIdentityAnnotations : bool
+        /// NM-73 (WP6.6) — `emission.dataVerification`. `"standard"` (the
+        /// default) emits the data MERGEs alone (byte-identical, CDC-silence
+        /// canonical); `"validateBeforeApply"` prepends the symmetric-`EXCEPT`
+        /// drift guard (`THROW 50000` on drift). Threads to
+        /// `EmissionPolicy.DataVerification`.
+        DataVerification : DataVerification
     }
 
     // NM-03 (2026-06-13) — `policy.selection` and `policy.userMatching` were
@@ -358,6 +364,8 @@ module Config =
         RenderConstraintsElegant = true
         // NM-70 — default-on (identity annotations emit; byte-identical).
         EmitIdentityAnnotations = true
+        // NM-73 — CDC-silence-canonical default (byte-identical).
+        DataVerification = DataVerification.Standard
     }
 
     let private defaultPolicy : PolicySection = {
@@ -568,6 +576,21 @@ module Config =
             | _ ->
                 Result.failureOf (
                     configError "typeMismatch" (sprintf "Property '%s' is not a string when present." name))
+
+    /// NM-73 — parse the `emission.dataVerification` string key into the
+    /// typed `DataVerification` DU. Absent / null → `Standard` (the
+    /// byte-identical default). An unrecognised value is a loud config error,
+    /// never a silent fallback (named-refusal discipline).
+    let private parseDataVerification (element: JsonElement) : Result<DataVerification> =
+        match getOptionalString element "dataVerification" with
+        | Error es -> Error es
+        | Ok None -> Result.success DataVerification.Standard
+        | Ok (Some "standard") -> Result.success DataVerification.Standard
+        | Ok (Some "validateBeforeApply") -> Result.success DataVerification.ValidateBeforeApply
+        | Ok (Some other) ->
+            Result.failureOf (
+                configError "invalidValue"
+                    (sprintf "emission.dataVerification must be \"standard\" or \"validateBeforeApply\"; got \"%s\"." other))
 
     let private getBoolOr (element: JsonElement) (name: string) (defaultValue: bool) : Result<bool> =
         match element.TryGetProperty(name) with
@@ -1050,6 +1073,9 @@ module Config =
                                                     match read "identityAnnotations" defaultEmission.EmitIdentityAnnotations with
                                                     | Error es -> Error es
                                                     | Ok identityAnnotations ->
+                                                    match parseDataVerification element with
+                                                    | Error es -> Error es
+                                                    | Ok dataVerification ->
                                                     match parseDeleteScope element with
                                                     | Error es -> Error es
                                                     | Ok deleteScope ->
@@ -1068,6 +1094,7 @@ module Config =
                                                         DeleteScope = deleteScope
                                                         RenderConstraintsElegant = renderElegant
                                                         EmitIdentityAnnotations = identityAnnotations
+                                                        DataVerification = dataVerification
                                                     }
 
     let private getOptionalBool (element: JsonElement) (name: string) : Result<bool option> =

--- a/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
@@ -145,7 +145,11 @@ module LifecycleStore =
 
     let private serialize (lifecycle: EpisodicLifecycle) : byte[] =
         use stream = new System.IO.MemoryStream()
-        (use jw = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
+        // Pinned LF newlines (`JsonOptions.indented` sets NewLine = "\n"): the
+        // lifecycle store is a durable artifact, so its bytes must be identical
+        // across platforms (T1). A bare `JsonWriterOptions(Indented = true)`
+        // inherits the host newline (CRLF on Windows) under .NET 9.
+        (use jw = new Utf8JsonWriter(stream, JsonOptions.indented ())
          jw.WriteStartObject()
          jw.WriteString("timeline", Timeline.name (EpisodicLifecycle.timeline lifecycle))
          jw.WritePropertyName "episodes"

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -1155,7 +1155,12 @@ module Compose =
                                      // threads the operator's identity-annotation
                                      // gate (default true = current behavior;
                                      // false is the named downgrade).
-                                     EmitIdentityAnnotations = cfg.Emission.EmitIdentityAnnotations }
+                                     EmitIdentityAnnotations = cfg.Emission.EmitIdentityAnnotations
+                                     // NM-73 — `emission.dataVerification` threads
+                                     // the operator's drift-guard posture (default
+                                     // Standard = byte-identical; ValidateBeforeApply
+                                     // prepends the symmetric-EXCEPT THROW guard).
+                                     DataVerification = cfg.Emission.DataVerification }
             }
         | _ ->
             let tighteningErrs = match tighteningR with Ok _ -> [] | Error es -> es

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -98,6 +98,7 @@ module DataEmissionComposer =
     let private dispatchSiblings
         (composition: DataComposition)
         (deleteScope: DeleteScopePolicy option)
+        (verification: DataVerification)
         (topo: TopologicalOrder)
         (catalog: Catalog)
         (profile: Profile)
@@ -109,7 +110,7 @@ module DataEmissionComposer =
             use _ = Bench.scope "compose.data.dispatchSiblings.staticSeeds"
             match composition with
             | AllRemaining
-            | AllData         -> StaticSeedsEmitter.emitWithTopoWith deleteScope topo catalog profile
+            | AllData         -> StaticSeedsEmitter.emitWithTopoWithVerification verification deleteScope topo catalog profile
             | AllExceptStatic -> emptyArtifact catalog
         let migrationDependencies =
             use _ = Bench.scope "compose.data.dispatchSiblings.migrationDeps"
@@ -208,12 +209,13 @@ module DataEmissionComposer =
         // Emission). The composer resolves it OFF `Policy` here and threads
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
+        let verification = policy.Emission.DataVerification
         // Match-bind explicitly: dispatchSiblings + unionSiblings
         // both return `Result<_, EmitError>` (the BCL two-parameter
         // Result), distinct from V2's `Result<'a> = Result<'a,
         // ValidationError list>` alias whose bind is in scope.
         let result =
-            match dispatchSiblings composition deleteScope topo catalog profile migration userRemap with
+            match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
             | Ok siblings -> unionSiblings catalog siblings
             | Error e     -> Error e
         topoLineage |> Lineage.map (fun _ -> result)
@@ -324,7 +326,8 @@ module DataEmissionComposer =
         // Emission). The composer resolves it OFF `Policy` here and threads
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
-        match dispatchSiblings composition deleteScope topo catalog profile migration userRemap with
+        let verification = policy.Emission.DataVerification
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with
@@ -381,7 +384,8 @@ module DataEmissionComposer =
         let topo = topoLineage.Value
         let composition = policy.Emission.DataComposition
         let deleteScope = policy.Emission.DeleteScope
-        match dispatchSiblings composition deleteScope topo catalog profile migration userRemap with
+        let verification = policy.Emission.DataVerification
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with
@@ -458,7 +462,8 @@ module DataEmissionComposer =
         // Emission). The composer resolves it OFF `Policy` here and threads
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
-        match dispatchSiblings composition deleteScope topo catalog profile migration userRemap with
+        let verification = policy.Emission.DataVerification
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with

--- a/sidecar/projection/src/Projection.Targets.Data/StaticSeedsEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/StaticSeedsEmitter.fs
@@ -148,6 +148,7 @@ module StaticSeedsEmitter =
     /// VALUES so cycle-participating rows can INSERT before their
     /// same-SCC FK targets exist.
     let private renderMerge
+        (verification: DataVerification)
         (deleteScope: ScriptDomBuild.DeleteScope option)
         (cdcAware: bool)
         (deferred: Set<Name>)
@@ -201,10 +202,11 @@ module StaticSeedsEmitter =
         // The terminal-text boundary appends `;` + `GO`.
         let mergeText =
             ScriptDomGenerate.generateOne (mergeStmt :> Microsoft.SqlServer.TransactSql.ScriptDom.TSqlStatement)
-        if not bracketIdentity then
+        let mergeBatch =
+          if not bracketIdentity then
             System.String.Concat(  // LINT-ALLOW: terminal MERGE statement-terminator + GO-batch suffix on the rendered MERGE; segments are typed (output of `ScriptDomGenerate.generateOne` from typed AST + SQL Server's required MERGE statement-terminator + V1 batch-separator literal); BCL `String.Concat` is the right primitive at this terminal-text boundary
                 mergeText, ";\nGO\n")
-        else
+          else
             // WP6 step 1 (DECISIONS 2026-06-13) — an IDENTITY-PK static
             // kind (`IdentityDisposition.AssignedBySink`) seeds explicit PK
             // values, so the MERGE's WHEN-NOT-MATCHED INSERT writes into the
@@ -233,6 +235,19 @@ module StaticSeedsEmitter =
                 setIdentityInsert true, ";\n",
                 mergeText, ";\n",
                 setIdentityInsert false, ";\nGO\n")
+        // NM-73 — prepend the validate-before-apply drift guard as its OWN
+        // GO batch before the MERGE (mirrors V1 `ValidateThenApply` ordering:
+        // the guard THROWs before the MERGE batch can run). `Standard` is
+        // byte-identical to the pre-NM-73 emission; the guard is the typed
+        // parse-template render of V1's symmetric-`EXCEPT` THROW. The MERGE's
+        // `args` already names the exact source rows we're about to write.
+        match verification with
+        | DataVerification.Standard -> mergeBatch
+        | DataVerification.ValidateBeforeApply ->
+            let guardText =
+                ScriptDomGenerate.generateOne (ScriptDomBuild.buildValidateBeforeApplyGuard args)
+            System.String.Concat(  // LINT-ALLOW: terminal guard-batch prefix (NM-73); the guard is the typed-AST parse-template render of V1's symmetric-EXCEPT THROW, framed as its own GO batch ahead of the MERGE; the V1 `GO` batch separator is the terminal-text literal; BCL `String.Concat` is the right primitive at this terminal-text boundary
+                guardText, "\nGO\n", mergeBatch)
 
     /// Render one Phase-2 UPDATE statement for a row whose Phase-1
     /// MERGE deferred its same-SCC FK columns to NULL. The UPDATE
@@ -308,6 +323,7 @@ module StaticSeedsEmitter =
     /// is bracketed with `SET IDENTITY_INSERT` (WP6 step 1) — the
     /// slice-E "suppress the PK" note is overturned (HANDOFF, WP6).
     let private kindToScript
+        (verification: DataVerification)
         (deleteScope: DeleteScopePolicy option)
         (cdc: CdcAwareness)
         (kind: Kind)
@@ -354,7 +370,7 @@ module StaticSeedsEmitter =
                     row.Identifier,
                     staticRowToTypedValues typeLookup kind.Attributes row)
             let renderedPhase1 =
-                renderMerge scopeForKind cdcAware deferred bracketIdentity kind (typedRows |> List.map snd)
+                renderMerge verification scopeForKind cdcAware deferred bracketIdentity kind (typedRows |> List.map snd)
             let renderedPhase2 =
                 if Set.isEmpty deferred then ""
                 else
@@ -408,7 +424,8 @@ module StaticSeedsEmitter =
     /// the policy resolves against (`DeleteScopePolicy.resolveFor`). The
     /// emitter consumes the scope VALUE, never `Policy` (A18 amended);
     /// the composer threads it from `EmissionPolicy.DeleteScope`.
-    let emitFromPlanWith
+    let emitFromPlanWithVerification
+        (verification: DataVerification)
         (deleteScope: DeleteScopePolicy option)
         (catalog: Catalog)
         (profile: Profile)
@@ -421,8 +438,20 @@ module StaticSeedsEmitter =
             { Phase1Merges = []; Phase2Updates = []; RenderedPhase1 = ""; RenderedPhase2 = ""; Rendered = "" }
         ArtifactByKind.perKindBenched "emit.staticSeeds.kind" catalog (fun k ->
             match Map.tryFind k.SsKey loadByKind with
-            | Some load -> kindToScript deleteScope cdc k load
+            | Some load -> kindToScript verification deleteScope cdc k load
             | None      -> emptyScript)
+
+    /// NM-73 — the pre-verification entry: `emitFromPlanWithVerification`
+    /// with `DataVerification.Standard` (byte-identical). Preserves the
+    /// established `emitFromPlanWith deleteScope …` call shape for the
+    /// composer + scope tests.
+    let emitFromPlanWith
+        (deleteScope: DeleteScopePolicy option)
+        (catalog: Catalog)
+        (profile: Profile)
+        (plan: DataLoadPlan)
+        : Result<ArtifactByKind<DataInsertScript>, EmitError> =
+        emitFromPlanWithVerification DataVerification.Standard deleteScope catalog profile plan
 
     /// Π_StaticSeeds emit (canonical; plan-consuming). The upsert-only
     /// default form — `emitFromPlanWith` with no delete scope. Output is
@@ -439,7 +468,8 @@ module StaticSeedsEmitter =
     /// remap (the static-seeds row source is catalog-resident
     /// evidence; operators wanting identity substitution build the
     /// plan themselves via `DataLoadPlan.build` + `emitFromPlan`).
-    let emitWithTopoWith
+    let emitWithTopoWithVerification
+        (verification: DataVerification)
         (deleteScope: DeleteScopePolicy option)
         (topo: TopologicalOrder)
         (catalog: Catalog)
@@ -451,7 +481,18 @@ module StaticSeedsEmitter =
             |> List.map (fun k -> k.SsKey, Kind.staticPopulations k)
             |> Map.ofList
         let plan = DataLoadPlan.build catalog topo rawRows SurrogateRemapContext.empty
-        emitFromPlanWith deleteScope catalog profile plan
+        emitFromPlanWithVerification verification deleteScope catalog profile plan
+
+    /// NM-73 — the pre-verification entry: `emitWithTopoWithVerification`
+    /// with `DataVerification.Standard`. Preserves the established
+    /// `emitWithTopoWith deleteScope …` call shape (composer + scope tests).
+    let emitWithTopoWith
+        (deleteScope: DeleteScopePolicy option)
+        (topo: TopologicalOrder)
+        (catalog: Catalog)
+        (profile: Profile)
+        : Result<ArtifactByKind<DataInsertScript>, EmitError> =
+        emitWithTopoWithVerification DataVerification.Standard deleteScope topo catalog profile
 
     let emitWithTopo
         (topo: TopologicalOrder)

--- a/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/SummaryFormatter.fs
+++ b/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/SummaryFormatter.fs
@@ -251,7 +251,10 @@ module SummaryFormatter =
         (foreignKey: ForeignKeyDecisionSet)
         : string =
         format nullability uniqueIndex foreignKey
-        |> String.concat System.Environment.NewLine
+        // LF, not Environment.NewLine: `manifest.summary.txt` is an
+        // emitted artifact and must be byte-identical across platforms
+        // (T1). A host-dependent newline would yield CRLF on Windows.
+        |> String.concat "\n"
 
     /// `RegisteredTransform` metadata view per the pillar 9 +
     /// L3-CC-Transform-Totality discipline. Classifies as

--- a/sidecar/projection/src/Projection.Targets.SSDT/ConstraintFormatter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ConstraintFormatter.fs
@@ -106,7 +106,11 @@ module ConstraintFormatter =
               TransformSite.operatorIntent "extendedPropertyExecWrap" Emission
                 "Wrap `EXEC sys.sp_addextendedproperty` calls at @level0type / @level1type / @level2type boundaries with 4-space continuation indent. Mirrors V1's MS_Description emission shape. Operator emission-axis intent." ]
 
-    let private newLine = Environment.NewLine
+    // LF, not Environment.NewLine: this formatter reshapes ScriptDom's
+    // CREATE TABLE constraint lines into the emitted SSDT artifact, so
+    // its newline must be byte-identical across platforms (T1). A
+    // host-dependent newline here would re-introduce CRLF on Windows.
+    let private newLine = "\n"
 
     /// True iff the (already-trimmed) text starts with `CONSTRAINT [`
     /// — a table-level constraint declaration in ScriptDom's output.

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -995,6 +995,87 @@ module ScriptDomBuild =
         Diagnostics.ofValue (buildMergeStatementCore args)
 
     // -----------------------------------------------------------------------
+    // NM-73 — validate-before-apply drift guard (WP6.6, operator choice C2).
+    // -----------------------------------------------------------------------
+    // Carbon-copied semantics from V1's
+    // `src/Osm.Emission/Seeds/StaticSeedSqlBuilder.cs:102-138`
+    // (`ValidateThenApply`): a SYMMETRIC `EXCEPT` pair gated on a non-empty
+    // target — `IF EXISTS(target) AND (EXISTS(source EXCEPT target) OR
+    // EXISTS(target EXCEPT source)) THROW 50000`. First apply over an empty
+    // target proceeds; an idempotent re-apply is silent; a re-apply over a
+    // DRIFTED target (managed rows differ in either direction) aborts the
+    // batch before the MERGE can overwrite. Built via the parse-template
+    // path (the `checkConstraint` / `tryParseTriggerBody` idiom) so the
+    // result is a typed `TSqlStatement`, not a hand-built AST or text blob
+    // — `generateOne` re-renders it canonically (pinned options, LF).
+
+    /// `[name]` as text, with any `]` doubled per T-SQL bracket-quoting.
+    let private bracketText (name: string) : string =
+        System.String.Concat("[", name.Replace("]", "]]"), "]")
+
+    /// `[schema].[table]` text for a `TableId`. The catalog qualifier is
+    /// omitted — seeds deploy to the connection's catalog, exactly as the
+    /// MERGE target (`schemaObjectFromTableId`) does.
+    let private tableIdText (t: TableId) : string =
+        System.String.Concat(bracketText (TableId.schemaText t), ".", bracketText (TableId.tableText t))
+
+    /// Render one typed `SqlLiteral` to its T-SQL text via ScriptDom, so the
+    /// guard's inline `VALUES` literals (`N'..'` / `0x..` / numeric) match
+    /// the MERGE's own literal rendering. A fresh generator per cell; cells
+    /// are few and this path runs only under the opt-in guard.
+    let private literalText (lit: SqlLiteral) : string =
+        let generator = Sql160ScriptGenerator(SqlScriptGeneratorOptions())
+        let mutable text : string | null = null
+        generator.GenerateScript(buildSqlLiteral lit :> TSqlFragment, &text)
+        (text |> Option.ofObj |> Option.defaultValue "").Trim()
+
+    /// Build the validate-before-apply drift guard as a typed
+    /// `TSqlStatement`, mirroring V1's `ValidateThenApply`. The guard
+    /// references the SAME source rows the MERGE is about to write
+    /// (`args.Rows` over `args.AllColumns`). `THROW 50000` aborts on drift.
+    ///
+    /// Invariant: the guard template is self-constructed from typed-rendered
+    /// literals + bracket-quoted identifiers, so it ALWAYS parses; a parse
+    /// failure is a programmer error, raised loudly (never a silent
+    /// downgrade of the safety guard). The caller is responsible for only
+    /// invoking this with a non-empty `args.Rows` (an empty source would
+    /// yield an invalid `VALUES ()` clause); `renderMerge` guarantees it.
+    let buildValidateBeforeApplyGuard (args: MergeBuildArgs) : TSqlStatement =
+        let targetText = tableIdText args.Target
+        let colList = args.AllColumns |> List.map bracketText |> String.concat ", "
+        let valuesText =
+            args.Rows
+            |> List.map (fun row ->
+                row |> List.map literalText |> String.concat ", " |> sprintf "(%s)")
+            |> String.concat ", "
+        let sourceSelect =
+            sprintf "SELECT %s FROM (VALUES %s) AS [Source] (%s)" colList valuesText colList
+        let targetSelect =
+            sprintf "SELECT %s FROM %s AS [Existing]" colList targetText
+        let message =
+            (sprintf "Static seed drift on %s: existing managed rows differ from the deploy source; aborting before MERGE (NM-73 validate-before-apply)." targetText)
+                .Replace("'", "''")
+        let template =
+            sprintf
+                "IF EXISTS (SELECT 1 FROM %s) AND (EXISTS (%s EXCEPT %s) OR EXISTS (%s EXCEPT %s)) BEGIN THROW 50000, '%s', 1; END"
+                targetText sourceSelect targetSelect targetSelect sourceSelect message
+        use reader = new System.IO.StringReader(template)
+        let frag, errors = threadLocalParser.Value.Parse(reader)
+        let errorCount = if isNull errors then 0 else errors.Count
+        let parsed =
+            if errorCount > 0 then None
+            else
+                match frag with
+                | :? TSqlScript as s ->
+                    s.Batches |> Seq.tryHead |> Option.bind (fun b -> b.Statements |> Seq.tryHead)
+                | _ -> None
+        match parsed with
+        | Some stmt -> stmt
+        | None ->
+            invalidOp
+                (sprintf "NM-73: validate-before-apply guard template failed to parse for %s — programmer error, not a recoverable downgrade." targetText)
+
+    // -----------------------------------------------------------------------
     // UPDATE statement (chapter 4.1.B slice δ; two-phase insertion /
     // cycle-breaking).
     //

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomGenerate.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomGenerate.fs
@@ -52,9 +52,12 @@ module ScriptDomGenerate =
         // Keyword casing — uppercase per SSDT convention. ScriptDom
         // default is `Uppercase`; we re-pin for explicitness.
         opts.KeywordCasing <- KeywordCasing.Uppercase
-        // Statement-level newline / indentation. Pin to LF newlines
-        // and 4-space indent (SSDT convention); `IncludeSemicolons`
-        // = true ensures every statement terminates explicitly.
+        // Statement-level line breaks / indentation. (The newline
+        // *character* is pinned to LF separately in `pinNewlines` —
+        // ScriptDom emits `Environment.NewLine`, which these flags do
+        // not control.) 4-space indent (SSDT convention);
+        // `IncludeSemicolons` = true ensures every statement
+        // terminates explicitly.
         opts.NewLineBeforeFromClause <- true
         opts.NewLineBeforeWhereClause <- true
         opts.NewLineBeforeOrderByClause <- true
@@ -86,6 +89,16 @@ module ScriptDomGenerate =
         opts.SqlEngineType <- SqlEngineType.All
         opts
 
+    /// ScriptDom's `Sql160ScriptGenerator.GenerateScript` emits the
+    /// host's `Environment.NewLine` (CRLF on Windows, LF on Linux);
+    /// `SqlScriptGeneratorOptions` exposes no newline-character axis.
+    /// Pin to LF so emission is byte-identical across platforms — T1
+    /// determinism is constructed at the boundary, not inherited from
+    /// the host. A no-op on LF hosts; collapses CRLF (and any lone CR)
+    /// to LF.
+    let private pinNewlines (text: string) : string =
+        text.Replace("\r\n", "\n").Replace("\r", "\n")
+
     /// Generate T-SQL text for a single typed `TSqlStatement` via
     /// `Sql160ScriptGenerator`. Returns the rendered text without
     /// trailing newline; callers append the framing.
@@ -108,7 +121,7 @@ module ScriptDomGenerate =
         let generator = Sql160ScriptGenerator(pinnedOptions ())
         let mutable text : string | null = null
         generator.GenerateScript(stmt :> TSqlFragment, &text)
-        text |> Option.ofObj |> Option.defaultValue ""
+        text |> Option.ofObj |> Option.defaultValue "" |> pinNewlines
 
     /// Generate T-SQL text for any `TSqlFragment` sub-tree (data type
     /// references, identifiers, expressions) that doesn't constitute a
@@ -130,7 +143,7 @@ module ScriptDomGenerate =
         let generator = Sql160ScriptGenerator(pinnedOptions ())
         let mutable text : string | null = null
         generator.GenerateScript(fragment :> TSqlFragment, &text)
-        text |> Option.ofObj |> Option.defaultValue ""
+        text |> Option.ofObj |> Option.defaultValue "" |> pinNewlines
 
     /// Render a comment line through the SSDT-canonical inline
     /// comment form. Per chapter 3.5 deep audit (2026-05-09):

--- a/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
@@ -196,6 +196,48 @@ let ``CatalogDiff: a column type change surfaces as an attribute-level Changed e
         Assert.Equal(customerNameKey, change.AttributeKey)
         Assert.Contains(AttributeFacet.DataType, change.Facets)
 
+// ---------------------------------------------------------------------------
+// NM-17 — the KindFacet diff channel. A kind's OWN facets (modality / triggers
+// / CHECKs / activation) are now a real diff channel, retiring the NM-16
+// "unreflected" tolerances: the change is reflected, not erased.
+// ---------------------------------------------------------------------------
+
+/// Rebuild `sampleCatalog` with the Customer KIND itself transformed.
+let private catalogWithCustomerKind (f: Kind -> Kind) : Catalog =
+    let m = { salesModule with Kinds = [ f customer; order; country ] }
+    Catalog.create [ m ] [] |> Result.value
+
+[<Fact>]
+let ``NM-17: a kind IsActive flip surfaces a KindFacet change (kind stays Unchanged; isEmpty honest)`` () =
+    let target = catalogWithCustomerKind (fun k -> { k with IsActive = not k.IsActive })
+    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    // Kind-level partition preserved: name stable → Unchanged.
+    Assert.Contains(customerKey, CatalogDiff.unchanged diff)
+    // The kind-facet change is visible and isEmpty is honest (NM-16 erasure closed).
+    Assert.False(CatalogDiff.isEmpty diff)
+    match CatalogDiff.kindFacetDiffOf customerKey diff with
+    | None -> Assert.Fail "expected a KindFacet diff for Customer"
+    | Some facets -> Assert.Contains(KindFacet.IsActive, facets)
+    // One move on the kind channel (norm = 0 ⟺ isEmpty).
+    Assert.Equal(1, CatalogDiff.norm diff)
+
+[<Fact>]
+let ``NM-17: a kind Modality change surfaces the Modality facet`` () =
+    let target = catalogWithCustomerKind (fun k -> { k with Modality = [ ModalityMark.SystemOwned ] })
+    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    match CatalogDiff.kindFacetDiffOf customerKey diff with
+    | None -> Assert.Fail "expected a KindFacet diff for Customer"
+    | Some facets -> Assert.Contains(KindFacet.Modality, facets)
+
+[<Fact>]
+let ``NM-17: applyDiff round-trips a kind-facet change (between B (applyDiff (between A B) A) is empty)`` () =
+    let a = sampleCatalog
+    let b = catalogWithCustomerKind (fun k -> { k with IsActive = not k.IsActive; Modality = [ ModalityMark.SystemOwned ] })
+    let d = CatalogDiff.between a b |> mustOk
+    let reconstructed = CatalogDiff.applyDiff a d
+    // The round-trip law holds on the kind-facet channel (the NM-17 fixture).
+    Assert.True(CatalogDiff.between b reconstructed |> mustOk |> CatalogDiff.isEmpty)
+
 [<Fact>]
 let ``CatalogDiff: a column widening (length change) names the Length facet (TEXT -> NVARCHAR(256))`` () =
     // The audit's headline scenario: type category stable, declared length

--- a/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
@@ -353,6 +353,24 @@ let ``NM-70: Config.parse: emission.identityAnnotations false parses (the named 
     let cfg = Config.parse json |> mustOk
     Assert.False(cfg.Emission.EmitIdentityAnnotations)
 
+[<Fact>]
+let ``NM-73: Config.parse: emission.dataVerification defaults Standard when absent`` () =
+    let cfg = Config.parse """{ "model": { "path": "m.json" } }""" |> mustOk
+    Assert.Equal(DataVerification.Standard, cfg.Emission.DataVerification)
+
+[<Fact>]
+let ``NM-73: Config.parse: emission.dataVerification "validateBeforeApply" parses (the conservative override)`` () =
+    let json = """{ "model": { "path": "m.json" }, "emission": { "dataVerification": "validateBeforeApply" } }"""
+    let cfg = Config.parse json |> mustOk
+    Assert.Equal(DataVerification.ValidateBeforeApply, cfg.Emission.DataVerification)
+
+[<Fact>]
+let ``NM-73: Config.parse: an unrecognised emission.dataVerification is a loud error, not a silent fallback`` () =
+    let json = """{ "model": { "path": "m.json" }, "emission": { "dataVerification": "yolo" } }"""
+    match Config.parse json with
+    | Ok _ -> Assert.Fail("expected a config error for an invalid dataVerification value")
+    | Error _ -> ()
+
 // -----------------------------------------------------------------------
 // AC-D7 / AC-G4 — emission.deleteScope (the convergent-delete gate).
 // -----------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
@@ -98,7 +98,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
@@ -33,7 +33,7 @@ let private mkConfig (insertion: string) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {
             Insertion       = insertion

--- a/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
@@ -47,7 +47,8 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
     // this test surfaces it (closed-DU expansion empirical-test sibling).
     // 6.A.4 (2026-06-02) added EmptyTextNormalizedToNull. AC-D6 added the
     // two representation-only tolerances (Char/Decimal) that do not fire CDC.
-    // NM-16 (2026-06-13) added the four kind-facet diff-erasure tolerances.
+    // NM-17 (2026-06-14) RETIRED the four NM-16 kind-facet diff-erasure
+    // tolerances (now a real `KindFacet` diff channel in `CatalogDiff`).
     let result = Unsupported.compute () |> Set.ofList
     let expected =
         Set.ofList
@@ -57,10 +58,6 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
               "EmptyTextNormalizedToNull"
               "HeaderCommentsOmitted"
               "IndexOptionsUnreflected"
-              "KindActivationUnreflectedInDiff"
-              "KindChecksUnreflectedInDiff"
-              "KindModalityUnreflectedInDiff"
-              "KindTriggersUnreflectedInDiff"
               "PostDeployForeignKeysSplit"
               "StaticPopulationsUnreflected" ]
     Assert.Equal<Set<string>> (expected, result)

--- a/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
@@ -77,13 +77,14 @@ let ``D1: an axis with only accepted tolerances reaches L3 (the generator discri
     Assert.DoesNotContain("L2-partial", data)
 
 [<Fact>]
-let ``D1: exactly six tolerances are open fidelity gaps today`` () =
+let ``D1: exactly two tolerances are open fidelity gaps today`` () =
     // The matrix's open-gap count is the codebase's named schema-fidelity debt.
     // Pinning it makes a silently-added OpenGap — or a silently-retired one
     // without regenerating — fail here. NM-16 (2026-06-13) added four kind-facet
     // diff-erasure tolerances (KindTriggers / KindChecks / KindModality /
     // KindActivation UnreflectedInDiff), all Schema OpenGap, joining
     // IndexOptionsUnreflected — so the count moved 1 → 5. NM-28 (2026-06-14)
-    // added CompositePkFkUnreflected (Schema OpenGap) → 6. Retiring any
-    // legitimately decrements this and the assertion updates in the same commit.
-    Assert.Contains("6 open", generatedMatrix)
+    // added CompositePkFkUnreflected (Schema OpenGap) → 6. NM-17 (2026-06-14)
+    // RETIRED the four kind-facet OpenGaps by building the real `KindFacet`
+    // diff channel → back to 2 (IndexOptionsUnreflected + CompositePkFkUnreflected).
+    Assert.Contains("2 open", generatedMatrix)

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
@@ -98,7 +98,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -194,19 +194,16 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
         | ToleratedDivergence.HeaderCommentsOmitted        -> ()
         | ToleratedDivergence.PostDeployForeignKeysSplit   -> ()
         | ToleratedDivergence.IndexOptionsUnreflected           -> ()
-        | ToleratedDivergence.KindTriggersUnreflectedInDiff   -> ()
-        | ToleratedDivergence.KindChecksUnreflectedInDiff     -> ()
-        | ToleratedDivergence.KindModalityUnreflectedInDiff   -> ()
-        | ToleratedDivergence.KindActivationUnreflectedInDiff -> ()
         | ToleratedDivergence.StaticPopulationsUnreflected -> ()
         | ToleratedDivergence.EmptyTextNormalizedToNull    -> ()
         | ToleratedDivergence.CompositePkFkUnreflected     -> ()
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> ()
         | ToleratedDivergence.DecimalScaleTolerated        -> ()
     // AC-D6 (NEITHER→HELD) added the two representation-only tolerances;
-    // NM-16 (2026-06-13) added the four kind-facet diff-erasure tolerances;
-    // NM-28 (2026-06-14) added CompositePkFkUnreflected.
-    Assert.Equal(12, Set.count ToleratedDivergence.allKnown)
+    // NM-28 (2026-06-14) added CompositePkFkUnreflected; NM-17 (2026-06-14)
+    // RETIRED the four NM-16 kind-facet diff-erasure tolerances (now a real
+    // `KindFacet` diff channel), dropping the count from 12 to 8.
+    Assert.Equal(8, Set.count ToleratedDivergence.allKnown)
 
 // ---------------------------------------------------------------------------
 // NM-70 (WP5) — the identity-annotation emit | omit gate.

--- a/sidecar/projection/tests/Projection.Tests/StaticSeedsEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticSeedsEmitterTests.fs
@@ -709,6 +709,43 @@ let ``AC-D7: no scope is byte-identical to the established upsert-only emit`` ()
         StaticSeedsEmitter.emitWithTopoWith None (topoOf catalog) catalog Profile.empty |> mustOkEmit
     Assert.Equal<Map<SsKey, DataInsertScript>>(ArtifactByKind.toMap viaDefault, ArtifactByKind.toMap viaExplicitNone)
 
+// -- NM-73 (WP6.6, C2): validate-before-apply drift guard --------------------
+// `Standard` is byte-identical (CDC-silence canonical); `ValidateBeforeApply`
+// prepends V1 `ValidateThenApply`'s symmetric-EXCEPT THROW guard as its own
+// GO batch before the MERGE. Built via the typed parse-template path.
+
+[<Fact>]
+let ``NM-73: Standard verification is byte-identical to the established emit`` () =
+    let catalog = mkCatalog [ mkCountryKind () ]
+    let viaDefault = StaticSeedsEmitter.emit catalog Profile.empty |> mustOkEmit
+    let viaStandard =
+        StaticSeedsEmitter.emitWithTopoWithVerification DataVerification.Standard None (topoOf catalog) catalog Profile.empty
+        |> mustOkEmit
+    Assert.Equal<Map<SsKey, DataInsertScript>>(ArtifactByKind.toMap viaDefault, ArtifactByKind.toMap viaStandard)
+
+[<Fact>]
+let ``NM-73: ValidateBeforeApply prepends the symmetric-EXCEPT THROW guard before the MERGE`` () =
+    let country = mkCountryKind ()
+    let catalog = mkCatalog [ country ]
+    let artifact =
+        StaticSeedsEmitter.emitWithTopoWithVerification DataVerification.ValidateBeforeApply None (topoOf catalog) catalog Profile.empty
+        |> mustOkEmit
+    let rendered = (ArtifactByKind.toMap artifact |> Map.find country.SsKey).Rendered
+    let r = normWs rendered
+    // V1 ValidateThenApply shape: guarded on a non-empty target, THROW on drift.
+    Assert.Contains ("IF EXISTS (SELECT 1 FROM [dbo].[OSUSR_TEST_COUNTRY])", r)
+    Assert.Contains ("THROW 50000", r)
+    // Symmetric EXCEPT pair (drift in either direction).
+    let exceptCount = (r.Split([| "EXCEPT" |], System.StringSplitOptions.None)).Length - 1
+    Assert.Equal (2, exceptCount)
+    // The guard validates against the same target the MERGE writes.
+    Assert.Contains ("[Existing]", r)
+    // The guard is its own batch BEFORE the MERGE — it THROWs first.
+    Assert.True (rendered.IndexOf("THROW") < rendered.IndexOf("MERGE INTO"), "the drift guard must precede the MERGE")
+    // The MERGE still follows intact.
+    Assert.Contains ("MERGE INTO [dbo].[OSUSR_TEST_COUNTRY] AS [Target]", r)
+    Assert.EndsWith ("GO", r)
+
 // ---------------------------------------------------------------------------
 // NM-26 — StaticPopulation + StaticSeeds agree on IDENTITY_INSERT bracketing.
 // Both now route through `IdentityDisposition.needsIdentityInsert` (any

--- a/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
@@ -83,7 +83,10 @@ let ``Closed-DU coverage: ToleratedDivergence.allKnown contains twelve variants 
     // **NM-28 (2026-06-14):** 12 — CompositePkFkUnreflected names the
     // composite-target-PK FK whose second-and-later legs the single-column
     // Reference IR cannot reflect (only the first leg round-trips).
-    Assert.Equal (12, Set.count ToleratedDivergence.allKnown)
+    // **NM-17 (2026-06-14):** back to 8 — the four NM-16 kind-facet
+    // diff-erasure tolerances are RETIRED (now a real `KindFacet` diff
+    // channel in `CatalogDiff`, not an erased tolerance).
+    Assert.Equal (8, Set.count ToleratedDivergence.allKnown)
 
 [<Fact>]
 let ``Tolerance.ofSet round-trips through divergences`` () =
@@ -152,33 +155,28 @@ let ``3.4: every ToleratedDivergence name round-trips through tryParse`` () =
     |> Set.forall (fun d -> ToleratedDivergence.tryParse (ToleratedDivergence.name d) = Some d)
 
 // ---------------------------------------------------------------------------
-// NM-16 — the kind-level facet erasure in the `CatalogDiff.between` algebra
-// (a changed/added/removed kind Trigger / ColumnCheck / Modality / IsActive
-// yields norm=0, "idempotent redeploy", migrate emits nothing) is now a
-// WITNESSED ToleratedDivergence rather than a silent erasure. These four
-// variants exist, are members of `allKnown`, and parse round-trip — so the
-// gap is named with a retirement trigger (the LIGHT route per the audit;
-// retiring each adds the corresponding diff channel to `CatalogDiff.between`).
+// NM-17 — the four NM-16 kind-facet diff-erasure tolerances
+// (KindTriggers/Checks/Modality/Activation UnreflectedInDiff) are RETIRED:
+// `CatalogDiff` now reflects modality / triggers / CHECKs / activation as a
+// real `KindFacet` diff channel, so the erasure they named no longer exists.
+// A retired OpenGap leaves no DU variant behind — its config token no longer
+// parses and it is absent from `allKnown`.
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``NM-16: the four kind-facet diff-erasure tolerances exist, are in allKnown, and round-trip`` () =
-    let kindFacetVariants =
-        [ ToleratedDivergence.KindTriggersUnreflectedInDiff
-          ToleratedDivergence.KindChecksUnreflectedInDiff
-          ToleratedDivergence.KindModalityUnreflectedInDiff
-          ToleratedDivergence.KindActivationUnreflectedInDiff ]
-    for d in kindFacetVariants do
-        // Each is a member of the closed-DU coverage set.
-        Assert.True(
-            Set.contains d ToleratedDivergence.allKnown,
-            sprintf "%s must be in allKnown" (ToleratedDivergence.name d))
-        // name >> tryParse is the identity (parse round-trip).
-        Assert.Equal<ToleratedDivergence option>(
-            Some d, ToleratedDivergence.tryParse (ToleratedDivergence.name d))
-    // The four tokens are distinct (no name collision).
-    let names = kindFacetVariants |> List.map ToleratedDivergence.name
-    Assert.Equal(4, List.length (List.distinct names))
+let ``NM-17: the four NM-16 kind-facet diff-erasure tolerance tokens are retired (no longer parse)`` () =
+    let retiredTokens =
+        [ "KindTriggersUnreflectedInDiff"
+          "KindChecksUnreflectedInDiff"
+          "KindModalityUnreflectedInDiff"
+          "KindActivationUnreflectedInDiff" ]
+    for token in retiredTokens do
+        // The token no longer maps to any variant (fail-closed parse).
+        Assert.Equal<ToleratedDivergence option>(None, ToleratedDivergence.tryParse token)
+    // None of the surviving tolerances carries a retired token.
+    let liveNames = ToleratedDivergence.allKnown |> Set.toList |> List.map ToleratedDivergence.name |> Set.ofList
+    for token in retiredTokens do
+        Assert.False(Set.contains token liveNames, sprintf "%s must be absent from allKnown" token)
 
 [<Fact>]
 let ``3.4: parse accepts every known token and yields a tolerance that tolerates them`` () =

--- a/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
@@ -32,7 +32,7 @@ let private mkConfig (entries: Config.TransformGroupEntry list) : Config.Config 
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {
             Insertion       = "SchemaOnly"


### PR DESCRIPTION
Closes the three owed slices from the invariant near-miss campaign (`AUDIT_2026_06_13_INVARIANT_NEAR_MISS_HUNT.md` § Disposition). Built on top of the already-merged PR #606; this is the continuation.

Three commits, each green-gated under `TreatWarningsAsErrors`:

### `52bcaed1` — fix: pin LF newlines in SQL/text emission (cross-platform T1 determinism)
ScriptDom's `GenerateScript` has no newline option and emits the host newline → LF on Linux, CRLF on Windows, breaking the byte-identical golden invariants on Windows. Pinned LF at the three emission newline sources (`ScriptDomGenerate.pinNewlines`, `ConstraintFormatter`, `SummaryFormatter`). No-op on Linux (blessed corpus stays byte-identical); strengthens T1 rather than relaxing the tests.

### `a76b9c01` — NM-73: EXCEPT validate-before-apply drift guard (WP6.6, operator choice C2)
The safety-critical conservative override. `EmissionPolicy.DataVerification = Standard | ValidateBeforeApply` (default `Standard`, byte-identical, CDC-silence canonical) + `emission.dataVerification` config key → composer → `StaticSeedsEmitter`. `ValidateBeforeApply` prepends V1's symmetric-`EXCEPT` `THROW 50000` guard before the MERGE, built via the `TSql160Parser` parse-template path (typed AST, not hand-built/text). First apply over an empty target proceeds; idempotent re-apply is silent; a drifted re-apply aborts. No silent downgrade (a parse failure of the self-built template is loud).

### `5ea45a56` — NM-17: the heavy KindFacet diff channel (change-algebra capstone)
NM-16 named the kind-level erasures as `OpenGap` tolerances; NM-17 builds the real channel. `KindFacet = Modality | Triggers | ColumnChecks | IsActive` in `CatalogDiff` (`between`/`isEmpty`/`norm`/`applyDiff` all account for it; round-trip law holds on kind facets; `compose`'s adjacency inherits the `isEmpty` fix). Retired the four NM-16 tolerances (`allKnown` 12→8; matrix open-gaps 6→2; regenerated). Restores agreement between the `migrate` algebra and the canary's `PhysicalSchema.diff` — the CDC-as-norm isometry. Also closes the stale NM-65 docstring and pins `LifecycleStore`'s JSON writer to LF (a Windows-CRLF gap in a durable artifact, surfaced while running the suite — not an NM-17 change).

### Verification
- Emission/golden sweep (663), diff/migrate/manifest/lifecycle/matrix sweep (519), tolerance/catalog-diff sweep (126), goldens 3/3 — all green; matrix regenerated; clean under `TreatWarningsAsErrors`.
- NM-62 was already satisfied (thresholds already named constants). Minor follow-ons (the `compare` source-profiling, the `MigrationDependenciesEmitter` guard extension) are noted in `DECISIONS.md`.

Note: commits are unsigned (the env's SSH signing key is empty — environment, not a discipline lapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)