### PR TITLE
Live-source Docker witnesses + Bootstrap-always (live-hydrated) + 3 pre-existing Docker fixes

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23065,3 +23065,73 @@ profile → the section stays honestly advisory-silent. A profiling failure degr
 advisory-silent (never aborts — the schema delta still leads). Build-verified; the
 live path composes the Docker-tested `ReadSide.read` + `LiveProfiler.attach` via
 `Source.ofLive`.
+
+---
+
+## 2026-06-14 (later) — Live-source Docker witness + two adapter fixes the build-only verification hid
+
+The live-source adapter and `compare` live-profiling shipped build-verified only;
+writing their end-to-end Docker tests (`LiveSourceDockerTests`) surfaced two latent
+defects, now fixed.
+
+- **The 4.4 trap in `Source.ofLive`'s profile path.** `ReadSide.read` marks every
+  reconstructed kind `Modality.Static`; `LiveProfiler` SKIPS static kinds. So
+  profiling a ReadSide-derived catalog as-is yielded an EMPTY evidence cache and the
+  `compare` dealbreaker section was silently never populated — the feature was inert.
+  `AcquireProfile` now strips the Static mark (`Catalog.stripStaticPopulations`,
+  Static-only — the N2 over-erasure precedent) before profiling, exactly as
+  `Preflight.tighteningPreflight` and `DataIntegrityChecker` already do. The
+  dealbreaker Docker test fails without this.
+- **Unhandled connection exceptions escaping the `Task<Result<_>>` boundary.** A
+  malformed / unreachable live connection threw rather than returning a typed
+  failure, which would crash the CLI's `.GetAwaiter().GetResult()` in
+  `runCompare`/`runDiff`. Both live capabilities now wrap their body in a `guard`
+  that surfaces `source.live.connectionFailed` / `.profileFailed` — "refusals named,
+  downgrades never silent." The stale `RefTests` "live ref fails loud (adapter
+  pending)" (red since the adapter shipped) now asserts this contract.
+
+---
+
+## 2026-06-14 (later) — Bootstrap-always: the Bootstrap lane gains its row source; `AllData` dispatch corrected; NM-73 on bootstrap (operator-directed)
+
+Closes the WP6 step 3 row-source gap (the slice-ζ MVP shipped Bootstrap as a
+structural stub fed `Map.empty`). Operator framing (2026-06-14, verbatim intent):
+*"Bootstrap is all the data from the database, with an optional flag to make it the
+non-intersecting portion of what's not in StaticSeeds or MigrationData — no reason to
+load twice."* That maps exactly onto the existing `DataComposition` DU: **`AllData`**
+= Bootstrap covers everything (the full snapshot); **`AllRemaining`** (default) =
+Bootstrap covers the complement of (Static ∪ Migration). DynamicData is a deprecated
+V1 term (retired in favour of the bootstrap snapshot + static seeds, per
+`docs/full-export-artifact-contract.md`); V2's Bootstrap is V1's
+`AllEntitiesIncludingStatic` snapshot, not the dead DynamicData lane.
+
+- **Row source threaded.** `BootstrapEmitter.emitWithTopoWithVerification` takes a
+  `Map<SsKey, StaticRow list>` (replacing the hardcoded `Map.empty`) and delegates to
+  the shared static-seeds renderer (A40). The composer threads it via the new
+  `DataEmissionComposer.composeRenderedBundleWithBootstrap`; the existing public
+  compose entries pass `Map.empty` (byte-identical — zero caller churn). The pure
+  composer renders what it is handed; the pipeline's hydration step computes the
+  per-composition scope and streams the rows (B2).
+- **`AllData` dispatch corrected.** `dispatchSiblings` previously fired StaticSeeds
+  under `AllData` (contradicting the `AllData` doc — "Static + Migration skipped").
+  Harmless while Bootstrap was an empty stub; once Bootstrap is populated it would
+  trip the `unionSiblings` `OverlappingEmitterCoverage` partition law. Fixed:
+  `AllData` skips Static + Migration (only Bootstrap fires, covering everything);
+  `AllRemaining` keeps all three disjoint. The MVP test that codified the bug
+  (`compose AllData … matches AllRemaining`) now asserts the corrected, differentiated
+  behaviour, plus a positive test that Bootstrap covers the static kind under
+  `AllData` with the partition holding.
+- **NM-73 on bootstrap (operator decision).** The validate-before-apply drift guard
+  now rides the Bootstrap lane too (it was on StaticSeeds + MigrationDependencies):
+  `dispatchSiblings` threads `DataVerification` into Bootstrap, which delegates to
+  `StaticSeedsEmitter.emitFromPlanWithVerification`. Bootstrap carries **no delete
+  scope** (`None`) — it is the additive upsert lane.
+- **Golden re-bless.** `DataLaneGoldenTests` is upgraded to a three-lane scenario
+  (StaticSeeds + MigrationData + Bootstrap), the Bootstrap lane sourced in-memory
+  (the hydration shape) on a disjoint kind (Customer) so the partition holds.
+  `Golden/data-lanes/Data/Bootstrap.sql` is newly recorded (a real MERGE via the
+  shared renderer). Re-record blessed under this note (THE_GOLDEN_EMISSION.md §2).
+
+Default stays `AllRemaining`; `AllData` is opt-in (the config flag lands in B2 with
+the pipeline hydration + Docker golden). Supplemental kinds (`ossys_User` beyond the
+catalog's own entities) deferred per operator. Pure pool green (3311/0).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23135,3 +23135,39 @@ V1 term (retired in favour of the bootstrap snapshot + static seeds, per
 Default stays `AllRemaining`; `AllData` is opt-in (the config flag lands in B2 with
 the pipeline hydration + Docker golden). Supplemental kinds (`ossys_User` beyond the
 catalog's own entities) deferred per operator. Pure pool green (3311/0).
+
+---
+
+## 2026-06-14 (later) — Bootstrap-always (B2): the pipeline hydrates the Bootstrap lane from the live source; `AllData` reachable via config
+
+B1 made the composer render a Bootstrap row source; B2 feeds it live rows on the
+config-driven path (publish + store-leg), so `Data/Bootstrap.sql` is created
+"basically always, both Docker and live source" (operator intent).
+
+- **`Hydration.hydrateBootstrapRows cfg catalog`** — streams the bootstrap-eligible
+  kinds' rows from `cfg.Model.Ossys` (the same second connection `hydrateCatalog`
+  uses; `Ingestion.collectInOrderFor`, never `ReadSide.read` — survival rule 8) into
+  the `Map<SsKey, StaticRow list>` the BootstrapEmitter renders. Scope by
+  composition: every data-bearing kind under `AllData`; the complement of
+  (Static-marked ∪ Migration) under `AllRemaining`/`AllExceptStatic` — disjoint from
+  the Static lane, so the partition law holds. Data-off / no live OSSYS / no eligible
+  kinds ⇒ the empty Map (the named skip is the shared `Hydration.diagnostics`); the
+  empty Map is byte-identical to the prior behaviour.
+- **`AllData` reachable via config** — new `emission.bootstrapAllData` (default
+  `false` ⇒ `AllRemaining`; `true` ⇒ `AllData`). The single derivation
+  `Config.dataCompositionOf` is shared by `buildPolicyFromConfig` (which emitters
+  fire) and `hydrateBootstrapRows` (which kinds the lane streams), so dispatch and
+  row-scope cannot drift.
+- **Threading** (minimal-churn `*WithBootstrap` variants): `readAndHydrate
+  ConfigModel` returns `(Catalog * bootstrapRows)`; `projectWithStateWithPinsAnd
+  Bootstrap` (compose → `composeRenderedBundleWithBootstrap`) and `composeRendered
+  LeveledWithBootstrap` carry the rows; `runWithConfigCore` + `projectSeedPlan`
+  thread them; the existing public entries delegate `Map.empty` (byte-identical, zero
+  caller churn). Both the publish path and the store-leg seed plan thread the SAME
+  rows — the deployed Bootstrap never drifts from the published one (the parity duty).
+- **Witnesses**: `LiveSourceDockerTests` "hydrateBootstrapRows streams live rows into
+  a populated Data/Bootstrap.sql" (deploy a non-static table + rows → hydrate via
+  `model.ossys=env:` → compose → `Data/Bootstrap.sql` carries the MERGE);
+  `HydrationTests` covers the no-connection branches (data-off / no-ossys / the
+  AllRemaining-excludes-static scoping). Pure pool 3314/0; the live-path Docker class
+  3/3.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,76 @@
+# Handoff addendum — 2026-06-14 (night), THE LIVE-SOURCE CHAPTER — both owed items CLOSED + VERIFIED: live-path Docker witnesses (+ two adapter fixes) and Bootstrap-always (live-hydrated, AllData via config); 3 pre-existing Docker breakages also fixed
+
+To the next agent.
+
+You are inheriting a **closed chapter**. The two items the predecessor letter
+(below) left owed are both **shipped and Docker-verified**, the design question
+behind Bootstrap was **resolved with the operator**, and three pre-existing
+Docker-pool breakages surfaced along the way are fixed. Everything is on branch
+`claude/projection-invariant-audit-b6iknj` as **4 commits on top of `main`**
+(`739e2505`); a fresh PR was opened (the predecessor's #607/#608 are merged). The
+plan that drove this — `PLAN_2026_06_14_LIVE_SOURCE_AND_BOOTSTRAP.md` — is now
+fully executed.
+
+**What shipped (don't redo).**
+
+1. **Live-path Docker witnesses + two adapter fixes** (commit `063f4e37`).
+   `tests/.../LiveSourceDockerTests.fs` proves `live:`-ref catalog readback and
+   `compare` live-profiling end-to-end. Writing them exposed two latent defects in
+   the build-only-verified adapter: (a) **the 4.4 trap** — `Source.ofLive`'s
+   profile path profiled a ReadSide-derived (all-`Static`) catalog, which
+   `LiveProfiler` skips, so the dealbreaker section was silently always empty;
+   fixed with `Catalog.stripStaticPopulations` (the `Preflight`/`DataIntegrity
+   Checker` precedent). (b) **connection exceptions escaped** the `Source` port's
+   `Task<Result<_>>` boundary; now wrapped as the named `source.live.connection
+   Failed` / `.profileFailed` refusals. The stale `RefTests` "live ref fails loud
+   (adapter pending)" (red since the adapter shipped) now asserts the real contract.
+
+2. **Bootstrap-always** (B1 `dbcf0ef4` composer; B2 `c081fe6e` pipeline). The
+   operator's model (verbatim, recorded in DECISIONS): *Bootstrap = all the data,
+   with a flag to make it the non-intersecting complement.* That maps onto the
+   existing `DataComposition` DU — `AllData` (everything) vs `AllRemaining`
+   (complement of Static ∪ Migration, the default). **DynamicData is a deprecated
+   V1 term** — V2's Bootstrap is V1's `AllEntitiesIncludingStatic` snapshot. The
+   `BootstrapEmitter` now renders a real row source; `Hydration.hydrateBootstrap
+   Rows` streams the bootstrap-eligible kinds live (scoped per composition,
+   disjoint from Static so the partition law holds); `emission.bootstrapAllData`
+   makes `AllData` reachable; NM-73's drift guard rides Bootstrap too (operator
+   decision). `Data/Bootstrap.sql` golden re-blessed (DECISIONS-noted) + a Docker
+   hydration witness. A latent `AllData`-dispatch bug (Static fired under AllData,
+   would trip `OverlappingEmitterCoverage` once Bootstrap is populated) was fixed.
+
+3. **3 pre-existing Docker breakages** (commit `ae3e54b6`, NOT regressions from
+   this work — the full Docker pool just hadn't been run): two `MigrationCanary
+   Tests` AC-X1 looked up the retired fused `Data/seed.sql` (the per-lane
+   retirement missed them — `FullExportDataBundleTests` was updated, these
+   Docker-only tests weren't) → now `Data/StaticSeeds.sql`; `CanaryRoundTripTests`
+   6.A.6 built a `Reference` in the illegal constraint-state quadrant → added
+   `HasDbConstraint = true`.
+
+**Verified:** pure pool **3314/0** (211 skip); the live-path Docker class **3/3**;
+the 3 fixed tests green focused; the full Docker pool re-run was the green gate.
+
+**What you might pick up next (all deferred, none blocking).**
+- **Supplemental bootstrap kinds** — V1's snapshot injects `ossys_User` et al.
+  beyond the catalog's own entities; deferred per operator. The `UserRemapContext`
+  plumbing through Bootstrap already exists.
+- **Migration-context wiring** — the production compose path still threads
+  `MigrationDependencyContext.empty`; `hydrateBootstrapRows` already excludes
+  migration kinds from the bootstrap complement, so confirm the partition
+  end-to-end when migration is wired.
+- **The `AllData` double-stream** — under `AllData`, `hydrateCatalog` still grafts
+  static rows (unused, StaticSeeds skipped) AND `hydrateBootstrapRows` re-streams
+  them; a one-pass unification is a perf-only cleanup (correctness-first was the
+  operator's call).
+- **The wider reconciliation program** — `V1_FULL_EXPORT_RECONCILIATION_PLAN.md`
+  WP7 (SSDT byte-parity), WP8 (`Order_Num`), WP9 (config samples + the `compare`
+  verb's design slice) remain.
+
+Hold the spine — read the plan, run the tests warm, and note that the live path now
+has its Docker witness and Bootstrap is no longer a hollow lane.
+
+---
+
 # Handoff addendum — 2026-06-14 (evening), THE LIVE-SOURCE CHAPTER — campaign owed-work CLOSED + operator data-artifact direction; live-source adapter + compare-profiling SHIPPED build-verified; OWED: Docker smoke tests for the live path + Bootstrap-always (has a real open question)
 
 To the next agent.

--- a/sidecar/projection/src/Projection.Pipeline/Config.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Config.fs
@@ -181,6 +181,15 @@ module Config =
         StaticSeeds           : bool
         MigrationDependencies : bool
         Bootstrap             : bool
+        /// Bootstrap-always (2026-06-14) — `emission.bootstrapAllData`. `false`
+        /// (the default) keeps the promoted-lane `AllRemaining` composition:
+        /// Bootstrap covers the NON-intersecting complement of (Static ∪
+        /// Migration), so nothing loads twice. `true` selects `AllData`:
+        /// Bootstrap covers EVERY data-bearing kind (Static + Migration lanes
+        /// skipped) — the full first-deploy snapshot (V1's
+        /// `AllEntitiesIncludingStatic`). Threads via `Config.dataCompositionOf`
+        /// to `EmissionPolicy.DataComposition`.
+        BootstrapAllData      : bool
         DecisionLog           : bool
         Opportunities         : bool
         Validations           : bool
@@ -322,6 +331,18 @@ module Config =
         Output       : OutputSection
     }
 
+    /// The single derivation of `DataComposition` from the config's data-lane
+    /// toggles — the one source of truth both `buildPolicyFromConfig` (which
+    /// emitters fire) and `Hydration.hydrateBootstrapRows` (which kinds the
+    /// Bootstrap lane streams) read, so the dispatch and the row-scope can never
+    /// drift. `bootstrapAllData` ⇒ `AllData` (Bootstrap covers everything);
+    /// else `staticSeeds` ⇒ `AllRemaining` (Bootstrap = complement); else
+    /// `AllExceptStatic` (Static skipped upstream).
+    let dataCompositionOf (cfg: Config) : DataComposition =
+        if cfg.Emission.BootstrapAllData then AllData
+        elif cfg.Emission.StaticSeeds then AllRemaining
+        else AllExceptStatic
+
     // -----------------------------------------------------------------------
     // Defaults — applied when a section is absent from the JSON.
     // -----------------------------------------------------------------------
@@ -355,6 +376,8 @@ module Config =
         StaticSeeds           = true
         MigrationDependencies = true
         Bootstrap             = true
+        // Bootstrap-always default: AllRemaining (complement), not AllData.
+        BootstrapAllData      = false
         DecisionLog           = true
         Opportunities         = true
         Validations           = true
@@ -1054,6 +1077,9 @@ module Config =
                                     match read "bootstrap" defaultEmission.Bootstrap with
                                     | Error es -> Error es
                                     | Ok boot ->
+                                        match read "bootstrapAllData" defaultEmission.BootstrapAllData with
+                                        | Error es -> Error es
+                                        | Ok bootAll ->
                                         match read "decisionLog" defaultEmission.DecisionLog with
                                         | Error es -> Error es
                                         | Ok dlog ->
@@ -1087,6 +1113,7 @@ module Config =
                                                         StaticSeeds = seeds
                                                         MigrationDependencies = migDeps
                                                         Bootstrap = boot
+                                                        BootstrapAllData = bootAll
                                                         DecisionLog = dlog
                                                         Opportunities = opps
                                                         Validations = vals

--- a/sidecar/projection/src/Projection.Pipeline/Hydration.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Hydration.fs
@@ -137,9 +137,64 @@ module Hydration =
                             return Result.success hydrated
         }
 
+    /// The Bootstrap lane's row source (Bootstrap-always, 2026-06-14). Streams
+    /// the bootstrap-eligible kinds' rows from the live OSSYS source into the
+    /// `Map<SsKey, StaticRow list>` shape `DataLoadPlan.build` consumes — every
+    /// data-bearing kind under `AllData`, the complement of (Static-marked ∪
+    /// Migration) under `AllRemaining`/`AllExceptStatic`. (Migration is empty in
+    /// the production path today; the complement excludes its kinds when it is
+    /// wired.) Disjoint from the Static lane's catalog-grafted populations, so
+    /// the composer's `OverlappingEmitterCoverage` partition law holds. Data-off
+    /// / no live OSSYS source / no eligible kinds ⇒ the empty Map (the
+    /// file-sourced skip is NAMED in `diagnostics`, never silent). Scoped via
+    /// `Ingestion.collectInOrderFor` — never the mark-everything `ReadSide.read`
+    /// (survival rule 8). A SECOND short-lived connection (the model-read
+    /// connection is use-disposed), mirroring `hydrateCatalog`.
+    let hydrateBootstrapRows (cfg: Config.Config) (catalog: Catalog) : Task<Result<Map<SsKey, StaticRow list>>> =
+        task {
+            if not (emitDataOf cfg) then
+                return Result.success Map.empty
+            else
+                // A kind carries rows worth bootstrapping only if it has columns
+                // to write (PK-less / attribute-less artifacts have no MERGE).
+                let isDataBearing (k: Kind) = not (List.isEmpty k.Attributes)
+                let composition = Config.dataCompositionOf cfg
+                let eligible =
+                    Catalog.allKinds catalog
+                    |> List.filter (fun k ->
+                        isDataBearing k
+                        && (match composition with
+                            | AllData -> true
+                            | AllRemaining | AllExceptStatic -> not (isStaticKind k)))
+                    |> List.map (fun k -> k.SsKey)
+                    |> Set.ofList
+                if Set.isEmpty eligible then
+                    return Result.success Map.empty
+                else
+                    match cfg.Model.Ossys with
+                    | None -> return Result.success Map.empty
+                    | Some connSpec ->
+                        match LiveModelRead.parseConnRef connSpec with
+                        | Error es -> return Result.failure es
+                        | Ok connRef ->
+                            let sub : Substrate =
+                                { Environment   = Environment.Named "ossys-bootstrap-source"
+                                  Role          = SubstrateRole.Source
+                                  ConnectionRef = connRef }
+                            match! ConnectionResolver.openSubstrate sub with
+                            | Error es -> return Result.failure es
+                            | Ok cnn ->
+                                use cnn = cnn
+                                let topo = (TopologicalOrderPass.runWith TreatAsCycle catalog).Value
+                                let! rows = Ingestion.collectInOrderFor eligible cnn catalog topo
+                                return Result.success rows
+        }
+
     /// Registry metadata (pillar 9). Read-only observation — DataIntent
     /// (mirrors the OSSYS `CatalogReader` / Transfer `Ingestion` adapters).
     let registeredMetadata : RegisteredTransformMetadata =
         RegisteredTransformMetadata.adapter "fullExportHydration" Data
             [ TransformSite.dataIntent "staticRowHydration"
-                "Stream static-entity rows from the live OSSYS source (Ingestion.collectInOrderFor, scoped to static-marked kinds — never ReadSide.read) and graft them onto the catalog's Static populations before the data lanes render. The model.ossys connection ref may be env: or file: (both hydrate identically). Observation only — the rows are what the source holds; no operator opinion enters. A model with no live OSSYS source (read from model.path) skips with the named data.hydration.skippedNoLiveSource diagnostic." ]
+                "Stream static-entity rows from the live OSSYS source (Ingestion.collectInOrderFor, scoped to static-marked kinds — never ReadSide.read) and graft them onto the catalog's Static populations before the data lanes render. The model.ossys connection ref may be env: or file: (both hydrate identically). Observation only — the rows are what the source holds; no operator opinion enters. A model with no live OSSYS source (read from model.path) skips with the named data.hydration.skippedNoLiveSource diagnostic."
+              TransformSite.dataIntent "bootstrapRowHydration"
+                "Stream the Bootstrap lane's rows from the live OSSYS source (Ingestion.collectInOrderFor, scoped per DataComposition — every data-bearing kind under AllData, the complement of Static ∪ Migration under AllRemaining/AllExceptStatic; never ReadSide.read) into the Map<SsKey, StaticRow list> the BootstrapEmitter renders. Observation only — the rows are what the source holds; no operator opinion enters. Disjoint from the Static lane (the partition law). Data-off / file-sourced ⇒ the empty Map (named skip in diagnostics)." ]

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -690,12 +690,13 @@ module Compose =
     /// `LogicalTableEmission` chain step skips the pinned kinds so a physical-form
     /// `tableRenames` override survives into the emitted physical table.
     /// `Set.empty` is `projectWithState` (byte-identical default).
-    let projectWithStateWithPins
+    let projectWithStateWithPinsAndBootstrap
         (logicalEmissionPins: Set<SsKey>)
         (fullPolicy: Policy)
         (profile: Profile)
         (folders: EmissionFolders)
         (groups: TransformGroups)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
         (catalog: Catalog)
         : Outputs * ComposeState =
         let chain = RegisteredTransforms.allChainStepsForWithPins logicalEmissionPins fullPolicy profile
@@ -727,7 +728,12 @@ module Compose =
             if not fullPolicy.Emission.EmitData then outputs
             else
                 use _ = Bench.scope "emit.dataBundle.compose"
-                match DataComposer.composeRenderedBundle fullPolicy finalState.Catalog profile with
+                // Bootstrap-always (2026-06-14) — thread the hydrated Bootstrap
+                // row source into the per-lane render so `Data/Bootstrap.sql`
+                // carries content. `bootstrapRows = Map.empty` (the non-hydrated
+                // path, all callers but the config-driven publish path) is
+                // byte-identical to the prior `composeRenderedBundle`.
+                match DataComposer.composeRenderedBundleWithBootstrap fullPolicy finalState.Catalog profile Projection.Targets.Data.MigrationDependencyContext.empty bootstrapRows UserRemapContext.empty with
                 | Ok bundle when not (System.String.IsNullOrWhiteSpace bundle.Fused) ->
                     // The PER-LANE files (`Data/StaticSeeds.sql` /
                     // `Data/MigrationData.sql` / `Data/Bootstrap.sql`) are the
@@ -749,6 +755,21 @@ module Compose =
                     // fails the composer (the keyset is `Catalog.allKinds`).
                     invalidOp (sprintf "Compose.projectWithState: DataEmissionComposer.composeRenderedBundle: %A" err)
         decorated, finalState
+
+    /// `projectWithStateWithPins` — no Bootstrap row source
+    /// (`projectWithStateWithPinsAndBootstrap` with `Map.empty`; byte-identical
+    /// to the pre-Bootstrap-always behaviour). The established call shape for
+    /// every caller but the config-driven publish path, which hydrates the
+    /// Bootstrap lane and routes through the `…AndBootstrap` entry.
+    let projectWithStateWithPins
+        (logicalEmissionPins: Set<SsKey>)
+        (fullPolicy: Policy)
+        (profile: Profile)
+        (folders: EmissionFolders)
+        (groups: TransformGroups)
+        (catalog: Catalog)
+        : Outputs * ComposeState =
+        projectWithStateWithPinsAndBootstrap logicalEmissionPins fullPolicy profile folders groups Map.empty catalog
 
     /// The canonical `projectWithState` — no physical-rename pins (byte-identical
     /// default; the existing callers are unchanged).
@@ -1116,8 +1137,12 @@ module Compose =
                 cfg.Emission.StaticSeeds
                 || cfg.Emission.MigrationDependencies
                 || cfg.Emission.Bootstrap
-            let dataComposition =
-                if cfg.Emission.StaticSeeds then AllRemaining else AllExceptStatic
+            // Bootstrap-always (2026-06-14) — the SINGLE composition derivation
+            // (`Config.dataCompositionOf`), shared with the Bootstrap-lane
+            // hydration so dispatch and row-scope can never drift. `AllData`
+            // (Bootstrap covers everything) is now reachable via
+            // `emission.bootstrapAllData`.
+            let dataComposition = Config.dataCompositionOf cfg
             // NM-02 (2026-06-13) — translate the schema / diagnostics emission
             // toggles into the EmissionPolicy, mirroring the data-lane wiring
             // above. `emission.ssdt` gates the CREATE/SSDT schema bundle;
@@ -1224,6 +1249,7 @@ module Compose =
     let private runWithConfigCore
         (cfg: Config.Config)
         (parsed: Result<Catalog>)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
         (profile: Profile)
         : Result<RunReport> =
         match parsed with
@@ -1243,7 +1269,7 @@ module Compose =
                 match policyR, overridesR, foldersR, groupsR with
                 | Ok policy, Ok overrides, Ok folders, Ok groups ->
                     let outputs, finalState =
-                        projectWithStateWithPins pins policy profile folders groups renamedCatalog
+                        projectWithStateWithPinsAndBootstrap pins policy profile folders groups bootstrapRows renamedCatalog
                     // `emission.dacpac: true` — compile the .dacpac over the SAME
                     // emitted catalog the SSDT step projected (the post-chain
                     // catalog under the identical platform-auto-index filter —
@@ -1409,12 +1435,25 @@ module Compose =
     /// shared by the publish path (the extract stage) and the store leg
     /// (`emittedSeedPlan`), so the deployed seed never drifts from the
     /// published one (the parity duty).
-    let readAndHydrateConfigModel (cfg: Config.Config) : Task<Result<Catalog>> =
+    /// Bootstrap-always (2026-06-14) — returns BOTH the static-hydrated catalog
+    /// (StaticSeeds lane, rows grafted onto `Modality.Static`) AND the Bootstrap
+    /// lane's row source (`Hydration.hydrateBootstrapRows`, scoped per
+    /// composition). Both callers — the publish path and the store-leg seed plan
+    /// — thread the same pair, so the deployed Bootstrap never drifts from the
+    /// published one (the parity duty). Empty bootstrap Map on the file-sourced /
+    /// data-off path (the named skip is in `Hydration.diagnostics`).
+    let readAndHydrateConfigModel (cfg: Config.Config) : Task<Result<Catalog * Map<SsKey, StaticRow list>>> =
         task {
             let! parsed = readConfigModel cfg
             match parsed with
-            | Error _ -> return parsed
-            | Ok catalog -> return! Hydration.hydrateCatalog cfg catalog
+            | Error es -> return Result.failure es
+            | Ok catalog ->
+                match! Hydration.hydrateCatalog cfg catalog with
+                | Error es -> return Result.failure es
+                | Ok hydrated ->
+                    match! Hydration.hydrateBootstrapRows cfg hydrated with
+                    | Error es      -> return Result.failure es
+                    | Ok bootRows   -> return Result.success (hydrated, bootRows)
         }
 
     /// THE_CONFIG_CONTROL_PLANE §6 (S3) — project a **caller-supplied**
@@ -1555,21 +1594,24 @@ module Compose =
             // that never reached it).
             let! verdict =
                 staged Spines.pipeline {
-                    let! catalog =
+                    let! extracted =
                         Staged.stage Stages.extract (fun () ->
                             task {
                                 // §7.2 extract — OSSYS catalog read + WP6 step-4
                                 // data hydration (graft live static rows when
-                                // OSSYS-sourced + data on; identity otherwise).
+                                // OSSYS-sourced + data on; identity otherwise) +
+                                // the Bootstrap lane's row source (Bootstrap-always).
                                 let! parsed = readAndHydrateConfigModel cfg
                                 match parsed with
-                                | Ok catalog ->
+                                | Ok (catalog, bootRows) ->
                                     emitStageMarker LogSink.Extract "extract.completed" LogSink.End
                                         (Map.ofList [ "moduleCount", box (List.length catalog.Modules) ])
-                                    return Ok catalog
+                                    return Ok (catalog, bootRows)
                                 | Error errors ->
                                     return Error errors
                             })
+                    let catalog = fst extracted
+                    let bootstrapRows = snd extracted
                     let! profile =
                         Staged.stage Stages.profile (fun () ->
                             task {
@@ -1585,7 +1627,7 @@ module Compose =
                             task {
                                 // §7.5 emit — pass chain + sibling-Π emission +
                                 // artifact write.
-                                let result = runWithConfigCore cfg (Ok catalog) profile
+                                let result = runWithConfigCore cfg (Ok catalog) bootstrapRows profile
                                 emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
                                 return result
                             })
@@ -1634,6 +1676,7 @@ module Compose =
     let private projectSeedPlan
         (cfg: Config.Config)
         (parsed: Result<Catalog>)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
         : Result<Catalog * DataComposer.LeveledDeploymentText> =
         match parsed |> Result.bind (applyRenames cfg) with
         | Error es -> Result.failure es
@@ -1648,9 +1691,13 @@ module Compose =
                     Result.success (catalog, DataComposer.LeveledDeploymentText.empty)
                 else
                     match
-                        DataComposer.composeRenderedLeveled
+                        // Bootstrap-always — the store-leg threads the SAME
+                        // Bootstrap rows the publish path does (parity duty), so
+                        // the deployed leveled seed never drifts from the bundle.
+                        DataComposer.composeRenderedLeveledWithBootstrap
                             policy finalState.Catalog Profile.empty
                             Projection.Targets.Data.MigrationDependencyContext.empty
+                            bootstrapRows
                             UserRemapContext.empty
                     with
                     | Ok plan -> Result.success (catalog, plan)
@@ -1672,7 +1719,9 @@ module Compose =
             // publish path does (`readAndHydrateConfigModel`), so the deployed
             // seed plan reflects the same hydrated rows the bundle published.
             let! parsed = readAndHydrateConfigModel cfg
-            return projectSeedPlan cfg parsed
+            match parsed with
+            | Error es -> return Result.failure es
+            | Ok (catalog, bootRows) -> return projectSeedPlan cfg (Ok catalog) bootRows
         }
 
     /// State A — the prior emission's schema, reconstructed from the durable

--- a/sidecar/projection/src/Projection.Pipeline/Source.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Source.fs
@@ -78,20 +78,49 @@ module Source =
                 do! c.OpenAsync()
                 return c
             }
+        // A connection open (or read) can throw — a malformed connection
+        // string, an unreachable endpoint, a refused login. The `Source` port's
+        // contract is `Task<Result<_>>`: a failure is a NAMED Error, never a
+        // raw exception escaping the boundary (an escaped exception crashes the
+        // CLI's `.GetAwaiter().GetResult()` instead of printing a clean refusal).
+        // `guard` wraps a capability body so every failure surfaces as the typed
+        // `source.live.connectionFailed` refusal.
+        let guard (code: string) (body: unit -> Task<Result<'a>>) : Task<Result<'a>> =
+            task {
+                try return! body ()
+                with ex ->
+                    return
+                        Result.failureOf
+                            (ValidationError.create code
+                                (System.String.Concat(
+                                    "live source ", conn, ": ", ex.Message)))
+            }
         { Identity       = "live:" + conn
           Capabilities   = Set.ofList [ ReadCatalog; Profile; Live ]
           ReadCatalog    =
             (fun () ->
-                task {
-                    use! cnn = openConnection ()
-                    return! ReadSide.read cnn
-                })
+                guard "source.live.connectionFailed" (fun () ->
+                    task {
+                        use! cnn = openConnection ()
+                        return! ReadSide.read cnn
+                    }))
           AcquireProfile =
             Some (fun catalog ->
-                task {
-                    use! cnn = openConnection ()
-                    return! LiveProfiler.attach cnn catalog Profile.empty
-                }) }
+                guard "source.live.profileFailed" (fun () ->
+                    task {
+                        use! cnn = openConnection ()
+                        // `ReadSide.read` marks every reconstructed data-bearing
+                        // kind `Modality.Static`, but `LiveProfiler` SKIPS static
+                        // kinds (`captureEvidenceCacheWith` filters `not isStaticKind`)
+                        // — so profiling a ReadSide-derived catalog as-is yields an
+                        // EMPTY evidence cache and the dealbreaker section is silently
+                        // never populated (the 4.4 trap). Strip the Static mark ONLY
+                        // (preserving authored marks — the N2 over-erasure precedent),
+                        // exactly as `Preflight.tighteningPreflight` and
+                        // `DataIntegrityChecker` do before they profile a live read.
+                        let profileCatalog = Catalog.stripStaticPopulations catalog
+                        return! LiveProfiler.attach cnn profileCatalog Profile.empty
+                    })) }
 
     /// Enrich a source with the `Profile` capability (the live / profilable
     /// form). The capability is the presence of the function — cf.

--- a/sidecar/projection/src/Projection.Targets.Data/BootstrapEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/BootstrapEmitter.fs
@@ -87,34 +87,62 @@ module BootstrapEmitter =
         use _ = Bench.scope "emit.bootstrap.emitFromPlan"
         StaticSeedsEmitter.emitFromPlanWith None catalog profile plan
 
-    /// Π_Bootstrap emit (composer-facing; hoisted-topo + UserRemap
-    /// context). Converts the operator's `UserRemapContext` to a
-    /// `SurrogateRemapContext` (the anticipated conversion — same route
-    /// `MigrationDependenciesEmitter.buildPlan` takes), then builds the
-    /// plan and delegates to `emitFromPlan`. The per-kind row source is
-    /// `Map.empty` until the WP6 hydration step grafts the supplemental +
-    /// remaining-kind rows; with no rows the converted remap applies to
-    /// nothing (byte-stable). **Partition law:** the hydrated row source
-    /// MUST be the complement of (Static-populated ∪ Migration-context)
-    /// kinds — feeding Bootstrap a kind another lane also populates trips
-    /// the composer's `OverlappingEmitterCoverage` assertion (a
-    /// production `invalidOp`).
+    /// Convert the operator's `UserRemapContext` to a `SurrogateRemapContext`
+    /// keyed under the catalog-discovered user kind (the same route
+    /// `MigrationDependenciesEmitter.buildPlan` takes). No user kind / a failed
+    /// conversion ⇒ the empty remap (the dominant case until OSSYS IsUserFk
+    /// detection lands).
+    let private resolveRemap (catalog: Catalog) (userRemap: UserRemapContext) : SurrogateRemapContext =
+        match tryDiscoverUserKind catalog with
+        | Some userKindKey ->
+            match UserRemapContext.toSurrogate userKindKey userRemap with
+            | Ok r    -> r
+            | Error _ -> SurrogateRemapContext.empty
+        | None -> SurrogateRemapContext.empty
+
+    /// Π_Bootstrap emit (composer-facing; hoisted-topo + UserRemap + the
+    /// hydrated row source + NM-73 verification). Converts the `UserRemap
+    /// Context`, builds the plan over `bootstrapRows`, and delegates to the
+    /// shared static-seeds renderer (A40 — same algebra over the same
+    /// `DataLoadPlan`). The row source is what the pipeline's hydration step
+    /// streamed for the bootstrap lane: every data-bearing kind under
+    /// `AllData`, the complement of (Static-populated ∪ Migration-context)
+    /// under `AllRemaining`; empty until hydrated (byte-stable empty per kind).
+    /// `verification` threads the operator's NM-73 drift-guard posture; the
+    /// guard is enabled on this lane (operator decision 2026-06-14). Bootstrap
+    /// carries **no delete scope** (`None`) — it is the additive upsert lane.
+    /// **Partition law:** the hydrated row source MUST be the complement of
+    /// (Static-populated ∪ Migration-context) kinds whenever those lanes also
+    /// fire (i.e. under `AllRemaining`/`AllExceptStatic`) — feeding Bootstrap a
+    /// kind another active lane also populates trips the composer's
+    /// `OverlappingEmitterCoverage` assertion (a production `invalidOp`). Under
+    /// `AllData` the sibling lanes are dispatched empty, so Bootstrap covers
+    /// every kind without overlap.
+    let emitWithTopoWithVerification
+        (verification: DataVerification)
+        (topo: TopologicalOrder)
+        (catalog: Catalog)
+        (profile: Profile)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
+        (userRemap: UserRemapContext)
+        : Result<ArtifactByKind<DataInsertScript>, EmitError> =
+        use _ = Bench.scope "emit.bootstrap.emitWithTopo"
+        let remap = resolveRemap catalog userRemap
+        let plan = DataLoadPlan.build catalog topo bootstrapRows remap
+        StaticSeedsEmitter.emitFromPlanWithVerification verification None catalog profile plan
+
+    /// NM-73 — the pre-verification / pre-row-source entry:
+    /// `emitWithTopoWithVerification` with `DataVerification.Standard` and an
+    /// empty row source (byte-identical to the slice-ζ stub shape). Preserves
+    /// the established `emitWithTopo` call shape (the standalone `emit` + the
+    /// MVP tests).
     let emitWithTopo
         (topo: TopologicalOrder)
         (catalog: Catalog)
         (profile: Profile)
         (userRemap: UserRemapContext)
         : Result<ArtifactByKind<DataInsertScript>, EmitError> =
-        use _ = Bench.scope "emit.bootstrap.emitWithTopo"
-        let remap =
-            match tryDiscoverUserKind catalog with
-            | Some userKindKey ->
-                match UserRemapContext.toSurrogate userKindKey userRemap with
-                | Ok r    -> r
-                | Error _ -> SurrogateRemapContext.empty
-            | None -> SurrogateRemapContext.empty
-        let plan = DataLoadPlan.build catalog topo Map.empty remap
-        emitFromPlan catalog profile plan
+        emitWithTopoWithVerification DataVerification.Standard topo catalog profile Map.empty userRemap
 
     /// Π_Bootstrap emit (standalone). Convenience for callers that
     /// don't go through the `DataEmissionComposer`. Slice ζ MVP

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -491,11 +491,18 @@ module DataEmissionComposer =
     /// `composeRenderedFull` are (a) per-level grouping via
     /// `TopologicalOrder.levels`, (b) structured return type, (c)
     /// empty-level dropping.
-    let composeRenderedLeveled
+    /// Level-aware sibling WITH the hydrated Bootstrap row source (Bootstrap-
+    /// always, 2026-06-14) — the store-leg counterpart of
+    /// `composeRenderedBundleWithBootstrap`, so the deployed leveled seed plan
+    /// carries the same Bootstrap rows the published bundle does (the parity
+    /// duty). Byte-identical to `composeRenderedLeveled` when
+    /// `bootstrapRows = Map.empty`.
+    let composeRenderedLeveledWithBootstrap
         (policy: Policy)
         (catalog: Catalog)
         (profile: Profile)
         (migration: MigrationDependencyContext)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
         (userRemap: UserRemapContext)
         : Result<LeveledDeploymentText, EmitError> =
         use _ = Bench.scope "compose.data.composeRenderedLeveled"
@@ -507,7 +514,7 @@ module DataEmissionComposer =
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
         let verification = policy.Emission.DataVerification
-        match dispatchSiblings composition deleteScope verification topo catalog profile migration Map.empty userRemap with
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration bootstrapRows userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with
@@ -542,6 +549,19 @@ module DataEmissionComposer =
                 Bench.recordSample "compose.data.composeRenderedLeveled.phase1Levels" (int64 phase1.Length)
                 Bench.recordSample "compose.data.composeRenderedLeveled.phase2Levels" (int64 phase2.Length)
                 Ok { Phase1Levels = phase1; Phase2Levels = phase2 }
+
+    /// Level-aware sibling of `composeRenderedFull` — no Bootstrap row source
+    /// (`composeRenderedLeveledWithBootstrap` with `Map.empty`; byte-identical
+    /// to the pre-Bootstrap-always behaviour). The established call shape for
+    /// the canary / perf callers that do not hydrate a Bootstrap lane.
+    let composeRenderedLeveled
+        (policy: Policy)
+        (catalog: Catalog)
+        (profile: Profile)
+        (migration: MigrationDependencyContext)
+        (userRemap: UserRemapContext)
+        : Result<LeveledDeploymentText, EmitError> =
+        composeRenderedLeveledWithBootstrap policy catalog profile migration Map.empty userRemap
 
     /// Π_Data compose-rendered (canary-test convenience). Defaults
     /// migration + userRemap to empty.

--- a/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/DataEmissionComposer.fs
@@ -103,15 +103,20 @@ module DataEmissionComposer =
         (catalog: Catalog)
         (profile: Profile)
         (migration: MigrationDependencyContext)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
         (userRemap: UserRemapContext)
         : Result<SiblingArtifacts, EmitError> =
         use _ = Bench.scope "compose.data.dispatchSiblings"
         let staticSeeds =
             use _ = Bench.scope "compose.data.dispatchSiblings.staticSeeds"
             match composition with
-            | AllRemaining
-            | AllData         -> StaticSeedsEmitter.emitWithTopoWithVerification verification deleteScope topo catalog profile
-            | AllExceptStatic -> emptyArtifact catalog
+            // `AllData` means Bootstrap covers EVERYTHING (static included), so
+            // Static is skipped — else both lanes claim the static kinds and the
+            // partition law (`unionSiblings`) trips once Bootstrap is populated
+            // (the slice-ζ differentiation the prior MVP test anticipated).
+            | AllRemaining    -> StaticSeedsEmitter.emitWithTopoWithVerification verification deleteScope topo catalog profile
+            | AllExceptStatic
+            | AllData         -> emptyArtifact catalog
         let migrationDependencies =
             use _ = Bench.scope "compose.data.dispatchSiblings.migrationDeps"
             match composition with
@@ -120,7 +125,11 @@ module DataEmissionComposer =
             | AllData         -> emptyArtifact catalog
         let bootstrap =
             use _ = Bench.scope "compose.data.dispatchSiblings.bootstrap"
-            BootstrapEmitter.emitWithTopo topo catalog profile userRemap
+            // NM-73 — the drift-guard posture rides Bootstrap too (operator
+            // decision 2026-06-14); the hydrated row source is the bootstrap
+            // lane's content (the complement of Static ∪ Migration under
+            // AllRemaining; every kind under AllData).
+            BootstrapEmitter.emitWithTopoWithVerification verification topo catalog profile bootstrapRows userRemap
         match staticSeeds, migrationDependencies, bootstrap with
         | Ok s, Ok m, Ok b ->
             Ok { StaticSeeds = s; MigrationDependencies = m; Bootstrap = b }
@@ -215,7 +224,7 @@ module DataEmissionComposer =
         // Result), distinct from V2's `Result<'a> = Result<'a,
         // ValidationError list>` alias whose bind is in scope.
         let result =
-            match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
+            match dispatchSiblings composition deleteScope verification topo catalog profile migration Map.empty userRemap with
             | Ok siblings -> unionSiblings catalog siblings
             | Error e     -> Error e
         topoLineage |> Lineage.map (fun _ -> result)
@@ -327,7 +336,7 @@ module DataEmissionComposer =
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
         let verification = policy.Emission.DataVerification
-        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration Map.empty userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with
@@ -385,7 +394,7 @@ module DataEmissionComposer =
         let composition = policy.Emission.DataComposition
         let deleteScope = policy.Emission.DeleteScope
         let verification = policy.Emission.DataVerification
-        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration Map.empty userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with
@@ -406,6 +415,41 @@ module DataEmissionComposer =
             policy catalog profile
             MigrationDependencyContext.empty
             UserRemapContext.empty
+
+    /// Π_Data compose-rendered bundle WITH the hydrated Bootstrap row source
+    /// (WP6 step 3, completed 2026-06-14). The pipeline's hydration step
+    /// streams the bootstrap lane's rows (`Map<SsKey, StaticRow list>`) from
+    /// the live source — every data-bearing kind under `AllData`, the
+    /// complement of (Static ∪ Migration) under `AllRemaining` — and threads
+    /// them here so `Data/Bootstrap.sql` carries content. Byte-identical to
+    /// `composeRenderedBundleFull` when `bootstrapRows = Map.empty` (the
+    /// non-hydrated path). The non-Docker data-lane golden supplies an
+    /// in-memory `bootstrapRows`; the Docker golden supplies the live-hydrated
+    /// one — the same entry, the same render, differing only in the row source.
+    let composeRenderedBundleWithBootstrap
+        (policy: Policy)
+        (catalog: Catalog)
+        (profile: Profile)
+        (migration: MigrationDependencyContext)
+        (bootstrapRows: Map<SsKey, StaticRow list>)
+        (userRemap: UserRemapContext)
+        : Result<RenderedDataBundle, EmitError> =
+        use _ = Bench.scope "compose.data.composeRenderedBundleWithBootstrap"
+        let topoLineage = TopologicalOrderPass.runWith TreatAsCycle catalog
+        let topo = topoLineage.Value
+        let composition = policy.Emission.DataComposition
+        let deleteScope = policy.Emission.DeleteScope
+        let verification = policy.Emission.DataVerification
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration bootstrapRows userRemap with
+        | Error e -> Error e
+        | Ok siblings ->
+            match unionSiblings catalog siblings with
+            | Error e -> Error e
+            | Ok union ->
+                Ok { Fused         = renderArtifactInTopoOrder topo union
+                     StaticSeeds   = renderArtifactInTopoOrder topo siblings.StaticSeeds
+                     MigrationData = renderArtifactInTopoOrder topo siblings.MigrationDependencies
+                     Bootstrap     = renderArtifactInTopoOrder topo siblings.Bootstrap }
 
     /// Per-level rendered scripts for parallel-safe deployment. Each
     /// `ParallelSafe<string>` group carries one kind's rendered SQL per
@@ -463,7 +507,7 @@ module DataEmissionComposer =
         // the plain value; the emitters never see `Policy` (A18 amended).
         let deleteScope = policy.Emission.DeleteScope
         let verification = policy.Emission.DataVerification
-        match dispatchSiblings composition deleteScope verification topo catalog profile migration userRemap with
+        match dispatchSiblings composition deleteScope verification topo catalog profile migration Map.empty userRemap with
         | Error e -> Error e
         | Ok siblings ->
             match unionSiblings catalog siblings with

--- a/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
@@ -772,7 +772,11 @@ let ``6.A.6 (schema round-trip): an untrusted FK survives emit / deploy / ReadSi
             { Kind.create childKey (nameSafe "Child")
                 (mkTableId "dbo" "OSUSR_RT6_CHILD")
                 [ mkAttr childIdKey "Id" true; mkAttr parentFkAttr "ParentId" false ]
-              with References = [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with IsConstraintTrusted = false } ] }
+              // An untrusted FK that EXISTS (the NOCHECK case) — HasDbConstraint
+              // = true is required, else the catalog smart-constructor rejects
+              // the illegal (constraint-absent ∧ untrusted) quadrant
+              // (catalog.reference.illegalConstraintState).
+              with References = [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with HasDbConstraint = true; IsConstraintTrusted = false } ] }
         let catalog =
             match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_RT6"; Name = nameSafe "Rt6Mod"; Kinds = [ parent; child ]; IsActive = true; ExtendedProperties = [] } ] [] with
             | Ok c -> c | Error e -> failwithf "catalog %A" e

--- a/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
@@ -143,18 +143,46 @@ let ``compose AllExceptStatic: Static skipped (no Phase1Merges even for static k
     Assert.Empty script.Phase2Updates
 
 [<Fact>]
-let ``compose AllData: Static fires for every kind (matches AllRemaining for static-only catalog)`` () =
+let ``compose AllData: Static lane is SKIPPED (Bootstrap covers everything; differs from AllRemaining)`` () =
+    // Slice ζ shipped (2026-06-14): Bootstrap now renders a real row source, so
+    // `AllData` (Bootstrap covers everything, static included) SKIPS the Static
+    // lane — else both lanes claim the static kind and the partition law trips.
+    // Through the plain `compose` (no hydrated bootstrap rows), `AllData` yields
+    // an EMPTY script for the static kind (Static skipped, Bootstrap row source
+    // empty), while `AllRemaining` fires the Static lane (2 merges). The two are
+    // now observably DIFFERENT — the differentiation the MVP test anticipated.
     let country = mkCountryKind ()
     let catalog = mkCatalog [ country ]
     let allData = DataEmissionComposer.compose (policyWith AllData) catalog Profile.empty |> mustOkEmit
     let allRemaining = DataEmissionComposer.compose (policyWith AllRemaining) catalog Profile.empty |> mustOkEmit
-    // MVP scope: with no Migration/Bootstrap consumers shipped yet,
-    // AllData and AllRemaining are observably equivalent. Slice ζ
-    // (Bootstrap) will differentiate them by having Bootstrap emit
-    // even Static kinds under AllData.
     let s1 = ArtifactByKind.toMap allData |> Map.find country.SsKey
     let s2 = ArtifactByKind.toMap allRemaining |> Map.find country.SsKey
-    Assert.Equal<string> (s1.Rendered, s2.Rendered)
+    // AllData with no bootstrap rows: the static kind renders empty.
+    Assert.Empty s1.Phase1Merges
+    // AllRemaining: the Static lane fires for the static kind.
+    Assert.Equal (2, List.length s2.Phase1Merges)
+    Assert.NotEqual<string> (s2.Rendered, s1.Rendered)
+
+[<Fact>]
+let ``compose AllData WITH a bootstrap row source: Bootstrap covers the static kind (no overlap, partition holds)`` () =
+    // The positive half: under `AllData`, a hydrated bootstrap row source makes
+    // Bootstrap emit the (otherwise-static) kind — and because the Static lane
+    // is skipped, the partition law holds (exactly one lane populates the kind).
+    let country = mkCountryKind ()
+    let catalog = mkCatalog [ country ]
+    let rows : Map<SsKey, StaticRow list> =
+        Map.ofList
+            [ country.SsKey,
+              [ { Identifier = mkKey ["TestModule"; "Country"; "Row"; "1"]
+                  Values = country.Attributes |> List.map (fun a -> a.Name, "1") |> Map.ofList } ] ]
+    let bundle =
+        DataEmissionComposer.composeRenderedBundleWithBootstrap
+            (policyWith AllData) catalog Profile.empty
+            MigrationDependencyContext.empty rows UserRemapContext.empty
+        |> mustOkEmit
+    // Bootstrap lane carries the MERGE; Static lane is empty (skipped).
+    Assert.Contains("MERGE", bundle.Bootstrap)
+    Assert.True(System.String.IsNullOrWhiteSpace bundle.StaticSeeds)
 
 // ---------------------------------------------------------------------------
 // T11 — every catalog kind appears in the composer's keyset.

--- a/sidecar/projection/tests/Projection.Tests/DataLaneGoldenTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataLaneGoldenTests.fs
@@ -7,17 +7,19 @@ module Projection.Tests.DataLaneGoldenTests
 // only — its single static lane means the production ≥2-lane rule omits the
 // per-lane files. This harness lets an operator review the PER-LANE data
 // SQL byte-for-byte, just like the SSDT goldens: it composes a scenario with
-// TWO non-empty data lanes (StaticSeeds + MigrationData) through the SAME
-// production composer (`DataEmissionComposer.composeRenderedBundleFull`) and
-// pins each lane's bytes under tests/Projection.Tests/Golden/data-lanes/.
+// all THREE non-empty data lanes (StaticSeeds + MigrationData + Bootstrap)
+// through the SAME production composer
+// (`DataEmissionComposer.composeRenderedBundleWithBootstrap`) and pins each
+// lane's bytes under tests/Projection.Tests/Golden/data-lanes/.
 //
-// Why no Bootstrap lane: `BootstrapEmitter` renders from an empty row source
-// in every non-hydrated path (its rows are grafted only by the live Pipeline
-// hydration step, which reads a real SQL source — Docker-gated). An empty lane
-// is dropped by `RenderedDataBundle.perLaneFiles`, so `Data/Bootstrap.sql` is
-// absent BY CONSTRUCTION here. Bootstrap shares the StaticSeeds MERGE renderer
-// (WP6 step 2), so `Data/StaticSeeds.sql` IS its render shape; a populated
-// Bootstrap golden would need a Docker hydration scenario (see DECISIONS).
+// The Bootstrap lane (added 2026-06-14, Bootstrap-always): in production its
+// rows arrive from the live Pipeline hydration step (Docker-gated); here they
+// are supplied IN-MEMORY (the same `Map<SsKey, StaticRow list>` seam hydration
+// fills), keyed on a non-static, non-migration kind (Customer) so the three
+// lanes stay DISJOINT and the composer's `OverlappingEmitterCoverage`
+// partition law holds. Bootstrap shares the StaticSeeds MERGE renderer (A40),
+// so `Data/Bootstrap.sql` reads like a static-seed MERGE; the live-hydrated
+// shape is witnessed end-to-end by the Docker golden.
 //
 // Blessing protocol (mirrors GoldenEmissionTests / THE_GOLDEN_EMISSION.md §2):
 //   GOLDEN_RECORD=1 rewrites the corpus instead of asserting. A re-record
@@ -72,10 +74,31 @@ let private migRow (n: int) : MigrationDependencyRow =
       Identifier = SsKey.synthesized "Assignment" (sprintf "MigRow%d" n) |> Result.value
       Values     = migrationKind.Attributes |> List.map cell |> Map.ofList }
 
+// The bootstrap lane is a NON-static, NON-migration kind (Customer) so the
+// three lanes are disjoint (the partition law holds). Its rows are supplied in
+// memory — the same `Map<SsKey, StaticRow list>` shape the live hydration step
+// fills (Bootstrap-always, 2026-06-14). Derived from the live kind so they
+// cannot drift from the fixture.
+let private bootstrapKind : Kind =
+    Catalog.allKinds catalog
+    |> List.find (fun k -> Name.value k.Name = "Customer")
+
+let private bootRow (n: int) : StaticRow =
+    let cell (a: Attribute) : Name * string =
+        a.Name,
+        match a.Type with
+        | Integer -> string n
+        | _       -> sprintf "Customer%d" n
+    { Identifier = SsKey.synthesized "Customer" (sprintf "BootRow%d" n) |> Result.value
+      Values     = bootstrapKind.Attributes |> List.map cell |> Map.ofList }
+
+let private bootstrapRows : Map<SsKey, StaticRow list> =
+    Map.ofList [ bootstrapKind.SsKey, [ bootRow 1; bootRow 2 ] ]
+
 let private bundle : DataEmissionComposer.RenderedDataBundle =
     let ctx : MigrationDependencyContext = { Rows = [ migRow 1; migRow 2 ] }
-    DataEmissionComposer.composeRenderedBundleFull
-        Policy.empty catalog Profile.empty ctx UserRemapContext.empty
+    DataEmissionComposer.composeRenderedBundleWithBootstrap
+        Policy.empty catalog Profile.empty ctx bootstrapRows UserRemapContext.empty
     |> mustOkEmit
 
 /// The reviewable data files: the non-empty per-lane renderings, exactly as the
@@ -122,12 +145,15 @@ let ``data-lane golden: the per-lane static + migration data files match the ble
             Assert.Equal(body, Map.find rel dataFiles)
 
 [<Fact>]
-let ``data-lane golden: exactly the static + migration lanes are present (no fused seed.sql; bootstrap empty without hydration)`` () =
+let ``data-lane golden: all three lanes are present (static + migration + bootstrap; no fused seed.sql)`` () =
     // The reviewable set is the per-lane files only. The fused Data/seed.sql is
-    // no longer emitted (operator decision). Bootstrap is absent because its
-    // rows arrive only via live hydration (covered by the Docker golden).
+    // no longer emitted (operator decision). All three lanes carry content: the
+    // Bootstrap lane is populated from an in-memory row source (the live
+    // hydration shape) on a disjoint kind (Bootstrap-always, 2026-06-14).
     let keys = dataFiles |> Map.toSeq |> Seq.map fst |> Set.ofSeq
     Assert.Contains("Data/StaticSeeds.sql", keys)
     Assert.Contains("Data/MigrationData.sql", keys)
+    Assert.Contains("Data/Bootstrap.sql", keys)
     Assert.DoesNotContain("Data/seed.sql", keys)
-    Assert.DoesNotContain("Data/Bootstrap.sql", keys)
+    // The bootstrap lane is a real MERGE (the renderer is shared with StaticSeeds).
+    Assert.Contains("MERGE", Map.find "Data/Bootstrap.sql" dataFiles)

--- a/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
@@ -97,7 +97,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Overrides   = overrides
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
-            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
             DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {

--- a/sidecar/projection/tests/Projection.Tests/Golden/data-lanes/Data/Bootstrap.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/data-lanes/Data/Bootstrap.sql
@@ -1,0 +1,9 @@
+SET IDENTITY_INSERT [dbo].[GOLD_CUSTOMER] ON;
+MERGE INTO [dbo].[GOLD_CUSTOMER]
+ AS [Target]
+USING (VALUES (1, N'Customer1'), (2, N'Customer2')) AS [Source]([ID], [NAME]) ON [Target].[ID] = [Source].[ID]
+WHEN MATCHED THEN UPDATE 
+    SET [Target].[NAME] = [Source].[NAME]
+WHEN NOT MATCHED THEN INSERT ([ID], [NAME]) VALUES ([Source].[ID], [Source].[NAME]);
+SET IDENTITY_INSERT [dbo].[GOLD_CUSTOMER] OFF;
+GO

--- a/sidecar/projection/tests/Projection.Tests/HydrationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/HydrationTests.fs
@@ -147,3 +147,41 @@ let ``WP6 step 4: hydrateCatalog is the identity for a model.path source (no liv
     let cfg = Config.defaultConfig |> withModel None (Some "model.json")
     let catalog = mkCatalog [ staticKind "Country" [] ]
     Assert.Equal<Catalog> (catalog, runHydrate cfg catalog)
+
+// ---------------------------------------------------------------------------
+// hydrateBootstrapRows — the no-connection branches (Bootstrap-always).
+// The live stream is the Docker test's job (LiveSourceDockerTests); here we
+// cover the parts that don't need a connection: data-off, no-ossys, and the
+// composition scoping (AllRemaining excludes static-marked kinds, so an
+// all-static catalog yields the empty Map WITHOUT attempting a connection).
+// ---------------------------------------------------------------------------
+
+let private runHydrateBoot (cfg: Config.Config) (catalog: Catalog) : Map<SsKey, StaticRow list> =
+    (Hydration.hydrateBootstrapRows cfg catalog).GetAwaiter().GetResult() |> mustOk
+
+[<Fact>]
+let ``Bootstrap-always: hydrateBootstrapRows is the empty Map when data emission is off`` () =
+    // Data off + a live ossys ref + an eligible (non-static) kind: still empty.
+    let cfg = Config.defaultConfig |> withModel (Some "env:OSSYS") None |> dataOff
+    let catalog = mkCatalog [ plainKind "Order" ]
+    Assert.True (Map.isEmpty (runHydrateBoot cfg catalog))
+
+[<Fact>]
+let ``Bootstrap-always: hydrateBootstrapRows is the empty Map for a model.path source (no live OSSYS)`` () =
+    // An eligible non-static kind is present, but no live source ⇒ empty
+    // (the named skip is the shared Hydration.diagnostics).
+    let cfg = Config.defaultConfig |> withModel None (Some "model.json")
+    let catalog = mkCatalog [ plainKind "Order" ]
+    Assert.True (Map.isEmpty (runHydrateBoot cfg catalog))
+
+[<Fact>]
+let ``Bootstrap-always: under AllRemaining the bootstrap scope EXCLUDES static-marked kinds (empty without a connection)`` () =
+    // AllRemaining (the default) ⇒ Bootstrap = complement of Static. An
+    // all-static catalog has NO bootstrap-eligible kind, so the function
+    // short-circuits to the empty Map BEFORE any connection is opened — the
+    // partition: static kinds belong to StaticSeeds, not Bootstrap. The ossys
+    // ref is intentionally never reached.
+    let cfg = Config.defaultConfig |> withModel (Some "env:UNREACHED") None
+    Assert.Equal<DataComposition> (AllRemaining, Config.dataCompositionOf cfg)
+    let catalog = mkCatalog [ staticKind "Country" []; staticKind "Region" [] ]
+    Assert.True (Map.isEmpty (runHydrateBoot cfg catalog))

--- a/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
@@ -32,7 +32,7 @@ let private mkConfig (insertion: string) : Config.Config =
         }
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
-            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
             DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {

--- a/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
@@ -34,6 +34,7 @@ open Microsoft.Data.SqlClient
 open Xunit
 open Projection.Core
 open Projection.Pipeline
+open Projection.Targets.Data
 
 [<Xunit.Collection("Docker-SqlServer")>]
 type LiveSourceDockerTests(fixture: EphemeralContainerFixture) =
@@ -53,6 +54,14 @@ type LiveSourceDockerTests(fixture: EphemeralContainerFixture) =
                 |> List.map (fun e -> System.String.Concat(e.Code, ": ", e.Message))
                 |> String.concat " | "
             invalidOp (System.String.Concat("expected Ok; got: ", detail))
+
+    let mustOkEmit (r: Result<'a, EmitError>) : 'a =
+        match r with
+        | Ok v -> v
+        | Error e -> invalidOp (sprintf "expected Ok; got %A" e)
+
+    let mkName (s: string) : Name = Name.create s |> mustOk
+    let mkKey (parts: string list) : SsKey = SsKey.synthesizedComposite "OS_BOOT" parts |> mustOk
 
     interface IClassFixture<EphemeralContainerFixture>
 
@@ -146,3 +155,75 @@ type LiveSourceDockerTests(fixture: EphemeralContainerFixture) =
         Assert.True(
             (not (List.isEmpty report.DataDealbreakers)),
             "expected a NOT-NULL data dealbreaker from A's NULL row against B's model")
+
+    // -- Test 3 — Bootstrap-always: live hydration populates Data/Bootstrap.sql --
+
+    [<Fact>]
+    member _.``Bootstrap-always: hydrateBootstrapRows streams live rows into a populated Data/Bootstrap.sql`` () =
+        if not (skipIfNoDocker "bootstrap-live-hydration") then () else
+        // A NON-static, data-bearing kind whose rows live in a real DB. The
+        // config's model.ossys points at that DB (via an env: ref); the
+        // Bootstrap lane hydrates its rows and renders Data/Bootstrap.sql — the
+        // operator's "Bootstrap created, both Docker and live source."
+        let envVar = "PROJECTION_TEST_BOOT_CONN"
+        let bundle =
+            fixture.WithEphemeralDatabase "BootSrc" (fun cnn connStr ->
+                task {
+                    do!
+                        Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[OSUSR_BOOT_WIDGET] (" +
+                             "[ID] INT NOT NULL PRIMARY KEY, " +
+                             "[NAME] NVARCHAR(100) NOT NULL);")
+                    do!
+                        Deploy.executeBatch cnn
+                            ("INSERT INTO [dbo].[OSUSR_BOOT_WIDGET] ([ID], [NAME]) " +
+                             "VALUES (1, N'Gadget'), (2, N'Gizmo');")
+                    // A programmatic NON-static catalog kind over the deployed
+                    // table — non-static ⇒ bootstrap-eligible under AllRemaining.
+                    let widget : Kind =
+                        { Kind.create (mkKey ["Widget"]) (mkName "Widget")
+                            (TableId.create "dbo" "OSUSR_BOOT_WIDGET" |> mustOk)
+                            [ { Attribute.create (mkKey ["Widget"; "Id"]) (mkName "Id") Integer with
+                                  Column = ColumnRealization.create "ID" false |> Result.value
+                                  IsPrimaryKey = true; IsMandatory = true }
+                              { Attribute.create (mkKey ["Widget"; "Name"]) (mkName "Name") Text with
+                                  Column = ColumnRealization.create "NAME" false |> Result.value
+                                  Length = Some 100; IsMandatory = true } ]
+                          with Modality = [] }
+                    let catalog : Catalog =
+                        { Modules =
+                            [ { SsKey = mkKey ["M"]; Name = mkName "M"
+                                Kinds = [ widget ]; IsActive = true; ExtendedProperties = [] } ]
+                          Sequences = [] }
+                    // model.ossys = env:<var> → the per-DB connection string.
+                    System.Environment.SetEnvironmentVariable(envVar, connStr)
+                    try
+                        let cfg =
+                            { Config.defaultConfig with
+                                Model = { Config.defaultConfig.Model with
+                                            Ossys = Some ("env:" + envVar); Path = None } }
+                        let! rowsR = Hydration.hydrateBootstrapRows cfg catalog
+                        let bootstrapRows = mustOk rowsR
+                        // The live rows reached the bootstrap row source.
+                        Assert.True(
+                            Map.containsKey widget.SsKey bootstrapRows,
+                            "hydrateBootstrapRows did not stream the widget kind's rows")
+                        let bundle =
+                            DataEmissionComposer.composeRenderedBundleWithBootstrap
+                                Policy.empty catalog Profile.empty
+                                MigrationDependencyContext.empty bootstrapRows UserRemapContext.empty
+                            |> mustOkEmit
+                        return bundle
+                    finally
+                        System.Environment.SetEnvironmentVariable(envVar, null)
+                })
+            |> fun t -> t.GetAwaiter().GetResult()
+        // Data/Bootstrap.sql is emitted and carries the live rows.
+        let files = DataEmissionComposer.RenderedDataBundle.perLaneFiles bundle
+        Assert.True(
+            Map.containsKey "Data/Bootstrap.sql" files,
+            "Data/Bootstrap.sql was not emitted from the live-hydrated bootstrap lane")
+        let boot = Map.find "Data/Bootstrap.sql" files
+        Assert.Contains("MERGE", boot)
+        Assert.Contains("OSUSR_BOOT_WIDGET", boot)
+        Assert.Contains("Gadget", boot)

--- a/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
@@ -1,0 +1,148 @@
+namespace Projection.Tests
+
+// Docker-gated end-to-end witness for the LIVE-SOURCE path
+// (`PLAN_2026_06_14_LIVE_SOURCE_AND_BOOTSTRAP.md` §2). The live-source
+// adapter (`Source.ofLive`; `Ref` `live:` resolution) and `compare`
+// live-profiling shipped build-verified; these tests prove they work
+// end-to-end against a real SQL Server — the witness the build-only
+// verification could not give.
+//
+// The pure capability surface is already covered (`SourceTests` —
+// `canProfile` false for a snapshot, true for a live source;
+// `CompareTests` — a no-profile operand is advisory-silent). What needs
+// a real database, and is asserted here:
+//
+//   1. **Live catalog readback** — `live:<connStr>` resolves through
+//      `Ref.resolveCatalog` → `Source.ofLive` → `ReadSide.read`, and the
+//      reconstructed `Catalog` carries the deployed table.
+//   2. **`compare` live-profiling dealbreaker** — A's live data is
+//      profiled against B's declared model, and a row in A that violates
+//      B's NOT NULL declaration surfaces as a data dealbreaker. This is
+//      the test that catches the 4.4 trap: `ReadSide` marks every
+//      reconstructed kind `Static`, and `LiveProfiler` SKIPS static kinds
+//      — so without `Source.ofLive` stripping the Static mark before it
+//      profiles, the dealbreaker section would be silently empty and
+//      `compare`'s live-profiling feature would be inert. The assertion
+//      `DataDealbreakers` is NON-empty is the executable guard on that.
+//
+// Soft-skip on `Deploy.Docker.ensureRunning ()` (mirrors
+// `CanaryRoundTripTests`). `IClassFixture<EphemeralContainerFixture>`
+// shares one container; each test (and each operand) takes its own
+// `<prefix>_<guid>` database via `WithEphemeralDatabase`.
+
+open Microsoft.Data.SqlClient
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type LiveSourceDockerTests(fixture: EphemeralContainerFixture) =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else
+            printfn "SKIP %s: Docker daemon not reachable." label
+            false
+
+    let mustOk (r: Result<'a>) : 'a =
+        match r with
+        | Ok v -> v
+        | Error es ->
+            let detail =
+                es
+                |> List.map (fun e -> System.String.Concat(e.Code, ": ", e.Message))
+                |> String.concat " | "
+            invalidOp (System.String.Concat("expected Ok; got: ", detail))
+
+    interface IClassFixture<EphemeralContainerFixture>
+
+    // -- Test 1 — live catalog readback -----------------------------------
+
+    [<Fact>]
+    member _.``live: ref resolves a deployed schema's catalog back through ReadSide`` () =
+        if not (skipIfNoDocker "live-catalog-readback") then () else
+        let found =
+            fixture.WithEphemeralDatabase "LiveSrcRead" (fun cnn connStr ->
+                task {
+                    do!
+                        Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[OSUSR_LIVE_WIDGET] (" +
+                             "[ID] INT NOT NULL PRIMARY KEY, " +
+                             "[NAME] NVARCHAR(50) NOT NULL);")
+                    // Resolve the live ref exactly as the CLI does.
+                    let! catR = Ref.resolveCatalog (Ref.parse ("live:" + connStr))
+                    let catalog = mustOk catR
+                    return
+                        Catalog.allKinds catalog
+                        |> List.exists (fun k -> TableId.tableText k.Physical = "OSUSR_LIVE_WIDGET")
+                })
+            |> fun t -> t.GetAwaiter().GetResult()
+        Assert.True(
+            found,
+            "live: ref did not reconstruct the deployed OSUSR_LIVE_WIDGET table via ReadSide")
+
+    // -- Test 2 — compare live-profiling end-to-end -----------------------
+
+    [<Fact>]
+    member _.``compare live-profiling: A's NULL data against B's NOT NULL model surfaces a dealbreaker`` () =
+        if not (skipIfNoDocker "compare-live-dealbreaker") then () else
+        // Target B (the declared model): STATUS is NOT NULL.
+        // Source A (the live env):       STATUS is NULLABLE and holds a NULL —
+        // a row B's declared model would reject. Both tables share physical
+        // coordinates, so ReadSide synthesizes identical `READSIDE_ATTR` keys
+        // and A's profile correlates with B's declared columns.
+        let report =
+            fixture.WithEphemeralDatabase "CmpTarget" (fun cnnB connB ->
+                task {
+                    do!
+                        Deploy.executeBatch cnnB
+                            ("CREATE TABLE [dbo].[OSUSR_CMP_ORDER] (" +
+                             "[ID] INT NOT NULL PRIMARY KEY, " +
+                             "[STATUS] INT NOT NULL);")
+                    return!
+                        fixture.WithEphemeralDatabase "CmpSource" (fun cnnA connA ->
+                            task {
+                                do!
+                                    Deploy.executeBatch cnnA
+                                        ("CREATE TABLE [dbo].[OSUSR_CMP_ORDER] (" +
+                                         "[ID] INT NOT NULL PRIMARY KEY, " +
+                                         "[STATUS] INT NULL);")
+                                // The dealbreaker: a NULL in a column B declares NOT NULL.
+                                do!
+                                    Deploy.executeBatch cnnA
+                                        ("INSERT INTO [dbo].[OSUSR_CMP_ORDER] ([ID], [STATUS]) " +
+                                         "VALUES (1, NULL);")
+                                // Resolve A as a profilable Source, B's catalog only —
+                                // mirroring `RunFaces.runCompare`.
+                                let! srcA = Ref.resolveSource (Ref.parse ("live:" + connA))
+                                let srcA = mustOk srcA
+                                let! aCatR = Source.read srcA
+                                let aCat = mustOk aCatR
+                                let! bCatR = Ref.resolveCatalog (Ref.parse ("live:" + connB))
+                                let bCat = mustOk bCatR
+                                let! profileA =
+                                    match Source.profile srcA with
+                                    | None -> task { return None }
+                                    | Some acquire ->
+                                        task {
+                                            let! p = acquire aCat
+                                            return (match p with Ok v -> Some v | Error _ -> None)
+                                        }
+                                let source : Compare.Operand =
+                                    { Label = "live:A"; Catalog = aCat; Profile = profileA }
+                                let target : Compare.Operand =
+                                    { Label = "live:B"; Catalog = bCat; Profile = None }
+                                return Compare.compute source target
+                            })
+                })
+            |> fun t -> t.GetAwaiter().GetResult()
+        // A is a live env → evidence is available (the source was profiled).
+        Assert.True(
+            report.DataEvidenceAvailable,
+            "expected live source A to carry profiled data evidence")
+        // The injected NULL violates B's NOT NULL STATUS → at least one dealbreaker.
+        // (Empty here would mean the 4.4 trap is back: the Static mark was not
+        // stripped before profiling, so LiveProfiler skipped every kind.)
+        Assert.True(
+            (not (List.isEmpty report.DataDealbreakers)),
+            "expected a NOT-NULL data dealbreaker from A's NULL row against B's model")

--- a/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationCanaryTests.fs
@@ -770,7 +770,11 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
             Compose.projectWithState policy Profile.empty EmissionFolders.empty TransformGroups.empty catalog
             |> fst
         let ddl = Compose.aggregateSsdt outputs.SsdtBundle
-        let seed = Map.find "Data/seed.sql" outputs.DataBundle
+        // The fused Data/seed.sql FILE is retired (per-lane artifacts, DECISIONS
+        // 2026-06-14); this single-static-lane catalog's idempotent MERGE is now
+        // the Data/StaticSeeds.sql lane. (The prior retirement missed this
+        // Docker-only AC-X1 pair.)
+        let seed = Map.find "Data/StaticSeeds.sql" outputs.DataBundle
         TaskSync.run (fun () ->
             fixture.WithEphemeralDatabase "X1FreshSeed" (fun conn _ ->
                 task {
@@ -831,7 +835,11 @@ type MigrationCanaryTests(fixture: EphemeralContainerFixture) =
             Compose.projectWithState policy Profile.empty EmissionFolders.empty TransformGroups.empty catalog
             |> fst
         let ddl = Compose.aggregateSsdt outputs.SsdtBundle
-        let seed = Map.find "Data/seed.sql" outputs.DataBundle
+        // The fused Data/seed.sql FILE is retired (per-lane artifacts, DECISIONS
+        // 2026-06-14); this single-static-lane catalog's idempotent MERGE is now
+        // the Data/StaticSeeds.sql lane. (The prior retirement missed this
+        // Docker-only AC-X1 pair.)
+        let seed = Map.find "Data/StaticSeeds.sql" outputs.DataBundle
         let storePath =
             System.IO.Path.Combine(
                 System.IO.Path.GetTempPath(),

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="TestCollections.fs" />
     <Compile Include="TaskSync.fs" />
     <Compile Include="EphemeralContainerFixture.fs" />
+    <Compile Include="LiveSourceDockerTests.fs" />
     <Compile Include="ScaffoldingTests.fs" />
     <Compile Include="ResultTests.fs" />
     <Compile Include="LedgerTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RefTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefTests.fs
@@ -57,7 +57,15 @@ let ``Ref: a runId ref resolves to the run's catalog (the Run-Ref connection)`` 
         try Directory.Delete(dir, true) with _ -> ()
 
 [<Fact>]
-let ``Ref: a live ref fails loud (capability exists; adapter pending)`` () =
-    match TaskSync.run (fun () -> Ref.resolveCatalog (Ref.Live "uat")) with
-    | Ok _    -> Assert.Fail "live should be unavailable, not silently wrong"
-    | Error _ -> ()
+let ``Ref: a live ref resolves through the adapter and fails loud as a NAMED Error on an unreachable endpoint`` () =
+    // The live adapter shipped (Source.ofLive): a `live:` ref now resolves
+    // through ReadSide over a real connection. An unreachable / malformed
+    // endpoint must surface as the port's typed refusal — NOT a silent success
+    // (the original "don't be silently wrong" guarantee) and NOT a raw
+    // exception escaping the `Task<Result<_>>` boundary (which would crash the
+    // CLI's `.GetAwaiter().GetResult()` instead of printing a clean error).
+    // A short login timeout keeps the test fast without reaching any server.
+    match TaskSync.run (fun () -> Ref.resolveCatalog (Ref.Live "Server=127.0.0.1,1;Connect Timeout=1;TrustServerCertificate=True;Encrypt=False")) with
+    | Ok _     -> Assert.Fail "live should fail on an unreachable endpoint, not silently succeed"
+    | Error es ->
+        Assert.Contains(es, fun e -> e.Code = "source.live.connectionFailed")

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
@@ -97,7 +97,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Overrides   = overrides
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
-            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
             DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {

--- a/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
@@ -31,7 +31,7 @@ let private mkConfig (entries: Config.TransformGroupEntry list) : Config.Config 
         }
         Emission    = {
             Ssdt = true; Dacpac = true; Json = true; Distributions = true
-            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
             DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
         }
         Policy      = {


### PR DESCRIPTION
Finishes the operator-directed live-source + data-artifact chapter
(`PLAN_2026_06_14_LIVE_SOURCE_AND_BOOTSTRAP.md`), on top of `main` (#607/#608
merged). Five commits.

## What's here

**1. Live-path Docker witnesses + two adapter fixes** (`063f4e37`)
New `LiveSourceDockerTests.fs` proves `live:`-ref catalog readback and `compare`
live-profiling end-to-end. Writing them exposed two latent defects in the
build-only-verified adapter:
- **The 4.4 trap**: `Source.ofLive`'s profile path profiled a ReadSide-derived
  (all-`Static`) catalog, which `LiveProfiler` skips → the dealbreaker section was
  silently always empty. Fixed with `Catalog.stripStaticPopulations` (the
  `Preflight`/`DataIntegrityChecker` precedent). The dealbreaker Docker test fails
  without this.
- **Escaping connection exceptions**: the live capabilities let a
  malformed/unreachable connection throw past the `Task<Result<_>>` boundary
  (crashing the CLI). Now wrapped as named `source.live.connectionFailed` /
  `.profileFailed` refusals. Stale `RefTests` updated to assert the real contract.

**2. Bootstrap-always** (B1 `dbcf0ef4` composer; B2 `c081fe6e` pipeline)
Operator model: Bootstrap = all the data, with a flag for the non-intersecting
complement — which maps onto the existing `DataComposition` DU (`AllData` vs
`AllRemaining`, default). DynamicData is a deprecated V1 term; V2's Bootstrap is
V1's `AllEntitiesIncludingStatic` snapshot.
- `BootstrapEmitter` renders a real row source (was `Map.empty`); `Hydration.
  hydrateBootstrapRows` streams the bootstrap-eligible kinds live, scoped per
  composition and disjoint from Static so the `unionSiblings` partition law holds.
- `emission.bootstrapAllData` makes `AllData` reachable (default `AllRemaining`).
  `Config.dataCompositionOf` is the single composition derivation shared by
  dispatch and row-scope so they can't drift.
- NM-73's validate-before-apply guard rides Bootstrap too (operator decision).
- Fixed a latent `AllData`-dispatch bug (Static fired under `AllData`, which would
  trip `OverlappingEmitterCoverage` once Bootstrap is populated).
- `Data/Bootstrap.sql` golden re-blessed (DECISIONS-noted) + a Docker hydration
  witness.

**3. Three pre-existing Docker-pool breakages** (`ae3e54b6`) — surfaced by running
the full pool (it just hadn't been run); not regressions from this work:
- `MigrationCanaryTests` AC-X1 (×2) looked up the retired fused `Data/seed.sql`
  → now `Data/StaticSeeds.sql`.
- `CanaryRoundTripTests` 6.A.6 built a `Reference` in the illegal constraint-state
  quadrant → added `HasDbConstraint = true`.

**4. Books** (`c2d88b1b`) — chapter-close handoff letter.

## Verification
- Pure pool **3314/0** (211 skip).
- Full Docker pool **green** (exit=0, 515s).
- Live-path Docker class 3/3.

## Deferred (none blocking; in the handoff)
Supplemental bootstrap kinds (`ossys_User`); migration-context wiring; the
`AllData` double-stream perf cleanup; reconciliation WP7–WP9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)