### PR TITLE
Migration-context wiring: the operator-curated Migration lane gains a real row source

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23171,3 +23171,55 @@ config-driven path (publish + store-leg), so `Data/Bootstrap.sql` is created
   `HydrationTests` covers the no-connection branches (data-off / no-ossys / the
   AllRemaining-excludes-static scoping). Pure pool 3314/0; the live-path Docker class
   3/3.
+
+## 2026-06-15 — Migration-context wiring: the deferred migration-ingestion adapter cashes out; the data triumvirate is whole
+
+The Bootstrap-always chapter left the production compose path threading
+`MigrationDependencyContext.empty` — the Static and Bootstrap lanes hydrated live,
+but the Migration lane had no row source. `overrides.migrationDependencies.path`
+parsed into config (`Config.fs`) but **nothing read it**: the
+`MigrationDependenciesEmitter`'s "boundary adapter deferred until a real ingestion
+path surfaces" note (the chapter-4.1.B slice-ε NDJSON-adapter deferral). The
+config-driven full-export IS that ingestion path; the trigger has fired.
+
+- **File format — JSON, logical-keyed (operator decision 2026-06-15).** The operator
+  authors rows under the logical `Module.Entity` coordinate (no raw `SsKey` GUIDs);
+  each row carries a stable `id` + logical-column → raw-value cells (the same
+  raw-string surface as `StaticRow.Values`; `""` is NULL):
+  `{ "kinds": [ { "module": …, "entity": …, "rows": [ { "id": …, "values": {…} } ] } ] }`.
+  The NDJSON shape the slice-ε deferral sketched is superseded by the operator's
+  logical-keyed JSON choice.
+- **The adapter — `MigrationDependenciesBinding.fromConfig catalog cfg`
+  (`Projection.Pipeline`).** Resolves `(module, entity)` → the kind's `SsKey` via the
+  shared `CatalogResolution.tryKindByLogical` (rename-invariant, A1 — resolution
+  against the pre-rename catalog is sound because the `SsKey` flows downstream);
+  synthesizes each row's `Identifier` (`SsKey.synthesizedComposite "migration"
+  [module; entity; id]`). No path ⇒ the empty context (no-op; byte-identical to the
+  prior threading). A path that is set but unreadable / malformed / names an
+  unresolved kind FAILS LOUD (`pipeline.migrationDependencies.*`) — the operator
+  declared the file, so we honor it strictly (no silent emptiness, §4).
+- **Threaded the SAME seam the Bootstrap rows ride** (publish + store-leg, for parity):
+  `readAndHydrateConfigModel` now returns `(Catalog * bootstrapRows * migration)`;
+  `runWithConfigCore` + `projectWithStateWithPinsAndBootstrap` →
+  `composeRenderedBundleWithBootstrap` (publish) and `projectSeedPlan` →
+  `composeRenderedLeveledWithBootstrap` (store-leg) carry it. Both legs thread the
+  SAME context, so the deployed Migration lane never drifts from the published one.
+  Every non-config caller delegates `MigrationDependencyContext.empty` (byte-identical,
+  zero churn) — the established default-supplying-wrapper idiom, not a back-compat shim.
+- **The partition law held structurally.** `hydrateBootstrapRows` →
+  `hydrateBootstrapRowsExcluding migrationKinds`: under `AllRemaining`/`AllExceptStatic`
+  the Bootstrap complement now excludes (Static ∪ **Migration**), so the three lanes
+  stay disjoint and the composer's `OverlappingEmitterCoverage` cannot trip once both
+  lanes populate. Under `AllData` the Migration lane is skipped (`dispatchSiblings`),
+  so the exclusion correctly does not apply. `Set.empty` (no migration file) is
+  byte-identical to the prior Static-only exclusion.
+- **Witnesses.** `MigrationDependenciesBindingTests` (7, pure) — no-path / valid
+  resolution / scalar-cell coercion (number/bool/null-as-empty) / unresolved-kind /
+  malformed-JSON / missing-id / missing-file fail-loud paths. `LiveSourceDockerTests`
+  "the data triumvirate: StaticSeeds + MigrationData + Bootstrap all populate live and
+  stay disjoint" — a live source feeds the Static + Bootstrap lanes, the file feeds the
+  Migration lane, all three `Data/*.sql` carry their own row and only their own
+  (`OverlappingEmitterCoverage` is the guard `mustOkEmit` would trip on). Pure pool of
+  the touched classes 109/0; the live-path Docker class 4/4 against the warm container.
+- **Deferred (operator): supplemental bootstrap kinds** (`ossys_User` et al. beyond
+  the catalog's own entities) stay deferred — untouched here.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,69 @@
+# Handoff addendum — 2026-06-15, MIGRATION-CONTEXT WIRING — the data triumvirate is whole: the operator-curated Migration lane now has a real row source (JSON file → MigrationDependencyContext), threaded the same seam as Bootstrap, partition-disjoint, Docker-witnessed three lanes live
+
+To the next agent.
+
+You are inheriting a **clean, single-slice branch paused for review.** Branch
+`claude/migration-context-wiring`, one commit on top of `main` (`02bba071`, the
+merged live-source/Bootstrap chapter). The operator asked to commit this slice and
+stop for review before the next one. Everything below it is the prior chapter's
+letter history.
+
+**What shipped (don't redo) — handoff task 1, "migration-context wiring", complete
+and verified.** The production compose path used to thread
+`MigrationDependencyContext.empty`; the Migration lane had no row source. It does now:
+
+1. **`MigrationDependenciesBinding.fs`** (new, `Projection.Pipeline`) reads the
+   operator-curated file at `overrides.migrationDependencies.path` into a
+   `MigrationDependencyContext`. **Format = JSON, logical-keyed (operator decision):**
+   `{ "kinds": [ { "module", "entity", "rows": [ { "id", "values": {col:val} } ] } ] }`.
+   Resolves `(module, entity)` → `SsKey` via `CatalogResolution.tryKindByLogical`;
+   synthesizes row ids via `SsKey.synthesizedComposite "migration" […]`; values are
+   raw strings (`""` = NULL; number/bool coerce). No path ⇒ empty context (no-op).
+   Malformed / unresolved / unreadable ⇒ loud `pipeline.migrationDependencies.*`. This
+   cashes out the deferred slice-ε ingestion adapter.
+2. **Threaded the SAME seam Bootstrap rides** (parity): `readAndHydrateConfigModel`
+   returns `(Catalog * bootstrapRows * migration)`; publish
+   (`projectWithStateWithPinsAndBootstrap` → `composeRenderedBundleWithBootstrap`) and
+   store-leg (`projectSeedPlan` → `composeRenderedLeveledWithBootstrap`) both carry it.
+   Non-config callers delegate `…empty` (byte-identical).
+3. **Partition stays disjoint**: `hydrateBootstrapRowsExcluding migrationKinds` drops
+   (Static ∪ **Migration**) from the bootstrap complement under
+   `AllRemaining`/`AllExceptStatic`, so `OverlappingEmitterCoverage` can't trip. Under
+   `AllData` the Migration lane is skipped, so no exclusion needed.
+
+**Verified.** `MigrationDependenciesBindingTests` 7/7 (pure); `LiveSourceDockerTests`
+4/4 against the warm container incl. the new **"data triumvirate"** witness (Static +
+Migration + Bootstrap all populate live, disjoint — TRX-confirmed it ran, not
+skipped). 109/0 across the touched pure classes. DECISIONS 2026-06-15 entry written;
+`MigrationDependenciesEmitter` docstring updated.
+
+**What you should pick up next (operator's task list; both independent, larger
+slices).**
+- **Task 2 — the AllData double-stream cleanup (perf-only).** Under `AllData`,
+  `hydrateCatalog` still grafts static rows (unused — StaticSeeds is skipped under
+  AllData) AND `hydrateBootstrapRows` re-streams every kind incl. static. One-pass
+  unification (skip the static graft under AllData, or share one stream). Bench
+  before/after — correctness-first was the operator's call, so this is pure
+  optimization.
+- **Task 3 — reconciliation WP7–WP9** (`V1_FULL_EXPORT_RECONCILIATION_PLAN.md` §4–5):
+  WP7 SSDT byte-parity (GO → `"\nGO\n\n"`, per-table constraint formatting, IX/UIX
+  logical-name synthesis, FK 128-char cap, MS_Description pinning); WP8 `Order_Num`
+  Service-Studio ordering pass (C3); WP9 first-run-complete `projection.sample.json`
+  (which should now showcase the `migrationDependencies` file too), ossys-only
+  provenance-arm fix, `compare`-verb design slice. Independent — sequence per §5.
+
+**Watch-fors (this session's scars).** `dotnet` isn't on the bash PATH — prefix
+`export PATH="/c/Users/danny/AppData/Local/Microsoft/dotnet:$PATH"`. The Docker gate
+(`Deploy.Docker.ensureRunning`) probes a **Unix socket** that doesn't exist on
+Windows, so it soft-skips unless `PROJECTION_MSSQL_CONN_STR` is set — point it at the
+warm container (`Server=localhost,11433;User Id=sa;Password=Projection@Strong1;
+TrustServerCertificate=True;Encrypt=False`) and a 6 s / 4-test run is real; a 33 ms /
+4-test "pass" is a soft-skip (survival rule 12 — check the TRX, not the green count).
+Never run pure+Docker as one `dotnet test`. The warm container was "Up 48 min" — if a
+connection batch starts failing, restart it, don't assume a regression.
+
+---
+
 # Handoff addendum — 2026-06-14 (night), THE LIVE-SOURCE CHAPTER — both owed items CLOSED + VERIFIED: live-path Docker witnesses (+ two adapter fixes) and Bootstrap-always (live-hydrated, AllData via config); 3 pre-existing Docker breakages also fixed
 
 To the next agent.

--- a/sidecar/projection/src/Projection.Pipeline/Hydration.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Hydration.fs
@@ -141,16 +141,28 @@ module Hydration =
     /// the bootstrap-eligible kinds' rows from the live OSSYS source into the
     /// `Map<SsKey, StaticRow list>` shape `DataLoadPlan.build` consumes — every
     /// data-bearing kind under `AllData`, the complement of (Static-marked ∪
-    /// Migration) under `AllRemaining`/`AllExceptStatic`. (Migration is empty in
-    /// the production path today; the complement excludes its kinds when it is
-    /// wired.) Disjoint from the Static lane's catalog-grafted populations, so
-    /// the composer's `OverlappingEmitterCoverage` partition law holds. Data-off
-    /// / no live OSSYS source / no eligible kinds ⇒ the empty Map (the
-    /// file-sourced skip is NAMED in `diagnostics`, never silent). Scoped via
-    /// `Ingestion.collectInOrderFor` — never the mark-everything `ReadSide.read`
-    /// (survival rule 8). A SECOND short-lived connection (the model-read
-    /// connection is use-disposed), mirroring `hydrateCatalog`.
-    let hydrateBootstrapRows (cfg: Config.Config) (catalog: Catalog) : Task<Result<Map<SsKey, StaticRow list>>> =
+    /// Migration) under `AllRemaining`/`AllExceptStatic`. Disjoint from the
+    /// Static lane's catalog-grafted populations AND the operator-curated
+    /// Migration lane, so the composer's `OverlappingEmitterCoverage` partition
+    /// law holds. Data-off / no live OSSYS source / no eligible kinds ⇒ the
+    /// empty Map (the file-sourced skip is NAMED in `diagnostics`, never
+    /// silent). Scoped via `Ingestion.collectInOrderFor` — never the
+    /// mark-everything `ReadSide.read` (survival rule 8). A SECOND short-lived
+    /// connection (the model-read connection is use-disposed), mirroring
+    /// `hydrateCatalog`.
+    ///
+    /// `migrationKinds` (migration-context wiring, 2026-06-15) is the set of
+    /// kind `SsKey`s the operator-curated Migration lane populates
+    /// (`MigrationDependenciesBinding.kindKeysOf`). Under `AllRemaining`/
+    /// `AllExceptStatic` those kinds are excluded from the Bootstrap complement
+    /// so the three lanes stay disjoint; under `AllData` the Migration lane is
+    /// skipped (`dispatchSiblings`) so the exclusion does not apply. `Set.empty`
+    /// (no migration file) is byte-identical to the prior Static-only exclusion.
+    let hydrateBootstrapRowsExcluding
+        (migrationKinds: Set<SsKey>)
+        (cfg: Config.Config)
+        (catalog: Catalog)
+        : Task<Result<Map<SsKey, StaticRow list>>> =
         task {
             if not (emitDataOf cfg) then
                 return Result.success Map.empty
@@ -165,7 +177,8 @@ module Hydration =
                         isDataBearing k
                         && (match composition with
                             | AllData -> true
-                            | AllRemaining | AllExceptStatic -> not (isStaticKind k)))
+                            | AllRemaining | AllExceptStatic ->
+                                not (isStaticKind k) && not (Set.contains k.SsKey migrationKinds)))
                     |> List.map (fun k -> k.SsKey)
                     |> Set.ofList
                 if Set.isEmpty eligible then
@@ -189,6 +202,14 @@ module Hydration =
                                 let! rows = Ingestion.collectInOrderFor eligible cnn catalog topo
                                 return Result.success rows
         }
+
+    /// No-migration-lane Bootstrap hydration (`hydrateBootstrapRowsExcluding`
+    /// with `Set.empty`) — byte-identical to the pre-migration-wiring behaviour.
+    /// The established call shape for callers without an operator-curated
+    /// Migration lane (canary / golden tests); the config-driven publish path
+    /// routes through `…Excluding` with the resolved migration kinds.
+    let hydrateBootstrapRows (cfg: Config.Config) (catalog: Catalog) : Task<Result<Map<SsKey, StaticRow list>>> =
+        hydrateBootstrapRowsExcluding Set.empty cfg catalog
 
     /// Registry metadata (pillar 9). Read-only observation — DataIntent
     /// (mirrors the OSSYS `CatalogReader` / Transfer `Ingestion` adapters).

--- a/sidecar/projection/src/Projection.Pipeline/MigrationDependenciesBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationDependenciesBinding.fs
@@ -1,0 +1,242 @@
+namespace Projection.Pipeline
+
+open System.IO
+open System.Text.Json
+open Projection.Core
+open Projection.Targets.Data
+
+/// The migration-dependency file adapter (the boundary the
+/// `MigrationDependenciesEmitter` docstring deferred until a real
+/// ingestion path surfaced — that path is now the config-driven
+/// full-export run). Reads the operator-curated row inventory at
+/// `overrides.migrationDependencies.path` into the typed
+/// `MigrationDependencyContext` the composer threads to the emitter.
+///
+/// **File format (JSON, logical-keyed; operator decision 2026-06-15).**
+/// The operator authors rows under the logical `Module.Entity`
+/// coordinate — no raw `SsKey` GUIDs — and each row carries a stable
+/// `id` plus logical-column → raw-value cells (the same raw-string
+/// surface as `StaticRow.Values`; `RawValueCodec` applies the
+/// per-column type at MERGE construction; `""` is NULL):
+///
+/// ```json
+/// {
+///   "kinds": [
+///     {
+///       "module": "ServiceCenter",
+///       "entity": "Role",
+///       "rows": [
+///         { "id": "Admin",   "values": { "Id": "1", "Label": "Administrator" } },
+///         { "id": "Auditor", "values": { "Id": "2", "Label": "Auditor" } }
+///       ]
+///     }
+///   ]
+/// }
+/// ```
+///
+/// The logical `(module, entity)` resolves to the kind's `SsKey` via
+/// the shared `CatalogResolution.tryKindByLogical` (rename-invariant,
+/// A1 — resolution against the pre-rename catalog is sound because the
+/// `SsKey` is what flows downstream). The row `id` synthesizes a stable
+/// `Identifier` (`SsKey.synthesizedComposite "migration" [module;
+/// entity; id]`) so cross-version diffs and re-publication track per
+/// the `MigrationDependencyRow.Identifier` contract.
+///
+/// **Fail loud, never silent (standing law §4).** No path ⇒ the empty
+/// context (no-op; byte-identical to the prior `MigrationDependency
+/// Context.empty` threading). A path that is set but unreadable /
+/// malformed / names an unresolved kind is a NAMED failure
+/// (`pipeline.migrationDependencies.*`) — the operator declared the
+/// file, so we honor it strictly.
+[<RequireQualifiedAccess>]
+module MigrationDependenciesBinding =
+
+    let private bindError (code: string) (message: string) : ValidationError =
+        ValidationError.create (sprintf "pipeline.migrationDependencies.%s" code) message
+
+    /// Read a required non-blank string property. `None` when absent,
+    /// the wrong kind, JSON `null`, or whitespace — the caller supplies
+    /// the structural error (mirrors `Config.getString`'s null handling
+    /// under `<Nullable>enable</Nullable>`).
+    let private tryNonBlankString (element: JsonElement) (key: string) : string option =
+        match element.TryGetProperty(key) with
+        | true, v when v.ValueKind = JsonValueKind.String ->
+            match v.GetString() with
+            | null -> None
+            | s when System.String.IsNullOrWhiteSpace s -> None
+            | s -> Some s
+        | _ -> None
+
+    /// The raw, pre-resolution shape of one kind entry — logical
+    /// coordinate + its rows. Resolution against the catalog happens in
+    /// a second pass so a parse error and a resolution error stay
+    /// distinct in the operator's diagnostics.
+    type private RawRow =
+        { Id     : string
+          Values : Map<Name, string> }
+
+    type private RawKind =
+        { Module : string
+          Entity : string
+          Rows   : RawRow list }
+
+    /// Project one JSON value cell to its raw invariant-culture string.
+    /// Strings pass through; numbers / booleans render via `GetRawText`
+    /// (invariant by `System.Text.Json` contract); `null` is the NULL
+    /// convention (`""`, per `StaticRow.Values`). Objects / arrays are a
+    /// named error — a migration cell is a scalar.
+    let private cellValue (column: string) (v: JsonElement) : Result<string> =
+        match v.ValueKind with
+        | JsonValueKind.String                       ->
+            match v.GetString() with
+            | null -> Result.success ""
+            | s    -> Result.success s
+        | JsonValueKind.Number                       -> Result.success (v.GetRawText())
+        | JsonValueKind.True | JsonValueKind.False   -> Result.success (v.GetRawText())
+        | JsonValueKind.Null                         -> Result.success ""
+        | _ ->
+            Result.failureOf (
+                bindError "cellNotScalar"
+                    (sprintf "migration values cell '%s' must be a string, number, boolean, or null." column))
+
+    let private parseValues (rowLabel: string) (element: JsonElement) : Result<Map<Name, string>> =
+        match element.TryGetProperty("values") with
+        | false, _ -> Result.success Map.empty
+        | true, v ->
+            match v.ValueKind with
+            | JsonValueKind.Null | JsonValueKind.Undefined -> Result.success Map.empty
+            | JsonValueKind.Object ->
+                v.EnumerateObject()
+                |> Seq.map (fun prop ->
+                    match Name.create prop.Name, cellValue prop.Name prop.Value with
+                    | Ok name, Ok value    -> Result.success (name, value)
+                    | Error es, Error es2  -> Error (es @ es2)
+                    | Error es, _          -> Error es
+                    | _, Error es          -> Error es)
+                |> Result.aggregate
+                |> Result.map Map.ofList
+            | _ ->
+                Result.failureOf (
+                    bindError "valuesNotObject"
+                        (sprintf "migration row %s 'values' must be a JSON object of column → value." rowLabel))
+
+    let private parseRow (kindLabel: string) (element: JsonElement) : Result<RawRow> =
+        match tryNonBlankString element "id" with
+        | None ->
+            Result.failureOf (
+                bindError "rowMissingId"
+                    (sprintf "every migration row under %s needs a non-blank string 'id'." kindLabel))
+        | Some id ->
+            parseValues (sprintf "%s/%s" kindLabel id) element
+            |> Result.map (fun values -> { Id = id; Values = values })
+
+    let private parseKind (element: JsonElement) : Result<RawKind> =
+        let getReqStr (key: string) : Result<string> =
+            match tryNonBlankString element key with
+            | Some s -> Result.success s
+            | None ->
+                Result.failureOf (
+                    bindError "kindMissingCoordinate"
+                        (sprintf "every migration kind entry needs a non-blank string '%s'." key))
+        match getReqStr "module", getReqStr "entity" with
+        | Ok moduleName, Ok entityName ->
+            let kindLabel = sprintf "%s.%s" moduleName entityName
+            let rowsR =
+                match element.TryGetProperty("rows") with
+                | false, _ -> Result.success []
+                | true, v ->
+                    match v.ValueKind with
+                    | JsonValueKind.Null | JsonValueKind.Undefined -> Result.success []
+                    | JsonValueKind.Array ->
+                        v.EnumerateArray()
+                        |> Seq.map (parseRow kindLabel)
+                        |> Result.aggregate
+                    | _ ->
+                        Result.failureOf (
+                            bindError "rowsNotArray"
+                                (sprintf "migration kind %s 'rows' must be an array." kindLabel))
+            rowsR |> Result.map (fun rows -> { Module = moduleName; Entity = entityName; Rows = rows })
+        | m, e ->
+            Error ((match m with Error es -> es | _ -> []) @ (match e with Error es -> es | _ -> []))
+
+    /// Parse the document text into the raw (pre-resolution) kind list.
+    /// Root must be an object with an optional `kinds` array.
+    let private parseDocument (text: string) : Result<RawKind list> =
+        try
+            use doc = JsonDocument.Parse(text)
+            let root = doc.RootElement
+            if root.ValueKind <> JsonValueKind.Object then
+                Result.failureOf (
+                    bindError "rootNotObject"
+                        "the migration-dependencies file must be a JSON object with a 'kinds' array.")
+            else
+                match root.TryGetProperty("kinds") with
+                | false, _ -> Result.success []
+                | true, v ->
+                    match v.ValueKind with
+                    | JsonValueKind.Null | JsonValueKind.Undefined -> Result.success []
+                    | JsonValueKind.Array ->
+                        v.EnumerateArray()
+                        |> Seq.map parseKind
+                        |> Result.aggregate
+                    | _ ->
+                        Result.failureOf (
+                            bindError "kindsNotArray" "'kinds' must be an array.")
+        with :? JsonException as ex ->
+            Result.failureOf (bindError "malformedJson" (sprintf "could not parse the migration-dependencies file as JSON: %s" ex.Message))
+
+    /// Resolve one raw kind entry against the catalog — logical
+    /// `(module, entity)` → the kind's `SsKey`; each row's `id` → a
+    /// synthesized `Identifier`. Unresolved coordinate ⇒ a named error.
+    let private resolveKind (catalog: Catalog) (raw: RawKind) : Result<MigrationDependencyRow list> =
+        match CatalogResolution.tryKindByLogical catalog raw.Module raw.Entity with
+        | None ->
+            Result.failureOf (
+                bindError "unresolvedKind"
+                    (sprintf "migration kind %s.%s did not match any catalog kind." raw.Module raw.Entity))
+        | Some kindKey ->
+            raw.Rows
+            |> List.map (fun row ->
+                SsKey.synthesizedComposite "migration" [ raw.Module; raw.Entity; row.Id ]
+                |> Result.map (fun identifier ->
+                    { KindKey    = kindKey
+                      Identifier = identifier
+                      Values     = row.Values }))
+            |> Result.aggregate
+
+    /// Read + parse + resolve the file at `path` into a context.
+    let private readFile (catalog: Catalog) (path: string) : Result<MigrationDependencyContext> =
+        let textR =
+            try Result.success (File.ReadAllText path)
+            with ex ->
+                Result.failureOf (
+                    bindError "readFailed"
+                        (sprintf "could not read the migration-dependencies file at '%s': %s" path ex.Message))
+        textR
+        |> Result.bind parseDocument
+        |> Result.bind (fun rawKinds ->
+            rawKinds
+            |> List.map (resolveKind catalog)
+            |> Result.aggregate
+            |> Result.map (fun perKind -> { Rows = List.concat perKind }))
+
+    /// Build the typed `MigrationDependencyContext` from a parsed
+    /// `Config` + the resolved `Catalog`. No `overrides.migration
+    /// Dependencies.path` ⇒ the empty context (no-op; byte-identical to
+    /// the prior `MigrationDependencyContext.empty` threading). A path
+    /// that is present but unreadable / malformed / names an unresolved
+    /// kind fails loud (`pipeline.migrationDependencies.*`).
+    let fromConfig
+        (catalog: Catalog)
+        (cfg: Config.Config)
+        : Result<MigrationDependencyContext> =
+        match cfg.Overrides.MigrationDependencies with
+        | None      -> Result.success MigrationDependencyContext.empty
+        | Some over -> readFile catalog over.Path
+
+    /// The set of kind `SsKey`s the migration context populates — the
+    /// Bootstrap-complement exclusion set (so `hydrateBootstrapRows`
+    /// keeps the three lanes disjoint; the partition law). Empty for the
+    /// empty context.
+    let kindKeysOf (ctx: MigrationDependencyContext) : Set<SsKey> =
+        ctx.Rows |> List.map (fun r -> r.KindKey) |> Set.ofList

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -696,6 +696,7 @@ module Compose =
         (profile: Profile)
         (folders: EmissionFolders)
         (groups: TransformGroups)
+        (migration: Projection.Targets.Data.MigrationDependencyContext)
         (bootstrapRows: Map<SsKey, StaticRow list>)
         (catalog: Catalog)
         : Outputs * ComposeState =
@@ -733,7 +734,13 @@ module Compose =
                 // carries content. `bootstrapRows = Map.empty` (the non-hydrated
                 // path, all callers but the config-driven publish path) is
                 // byte-identical to the prior `composeRenderedBundle`.
-                match DataComposer.composeRenderedBundleWithBootstrap fullPolicy finalState.Catalog profile Projection.Targets.Data.MigrationDependencyContext.empty bootstrapRows UserRemapContext.empty with
+                // Migration-context wiring (2026-06-15) — the operator-curated
+                // Migration lane rides the SAME seam; `MigrationDependency
+                // Context.empty` (no migration file) is byte-identical to the
+                // prior threading. The Bootstrap complement already excludes the
+                // migration kinds (`hydrateBootstrapRowsExcluding`), so the
+                // composer's `OverlappingEmitterCoverage` partition law holds.
+                match DataComposer.composeRenderedBundleWithBootstrap fullPolicy finalState.Catalog profile migration bootstrapRows UserRemapContext.empty with
                 | Ok bundle when not (System.String.IsNullOrWhiteSpace bundle.Fused) ->
                     // The PER-LANE files (`Data/StaticSeeds.sql` /
                     // `Data/MigrationData.sql` / `Data/Bootstrap.sql`) are the
@@ -769,7 +776,7 @@ module Compose =
         (groups: TransformGroups)
         (catalog: Catalog)
         : Outputs * ComposeState =
-        projectWithStateWithPinsAndBootstrap logicalEmissionPins fullPolicy profile folders groups Map.empty catalog
+        projectWithStateWithPinsAndBootstrap logicalEmissionPins fullPolicy profile folders groups Projection.Targets.Data.MigrationDependencyContext.empty Map.empty catalog
 
     /// The canonical `projectWithState` — no physical-rename pins (byte-identical
     /// default; the existing callers are unchanged).
@@ -1250,6 +1257,7 @@ module Compose =
         (cfg: Config.Config)
         (parsed: Result<Catalog>)
         (bootstrapRows: Map<SsKey, StaticRow list>)
+        (migration: Projection.Targets.Data.MigrationDependencyContext)
         (profile: Profile)
         : Result<RunReport> =
         match parsed with
@@ -1269,7 +1277,7 @@ module Compose =
                 match policyR, overridesR, foldersR, groupsR with
                 | Ok policy, Ok overrides, Ok folders, Ok groups ->
                     let outputs, finalState =
-                        projectWithStateWithPinsAndBootstrap pins policy profile folders groups bootstrapRows renamedCatalog
+                        projectWithStateWithPinsAndBootstrap pins policy profile folders groups migration bootstrapRows renamedCatalog
                     // `emission.dacpac: true` — compile the .dacpac over the SAME
                     // emitted catalog the SSDT step projected (the post-chain
                     // catalog under the identical platform-auto-index filter —
@@ -1442,18 +1450,33 @@ module Compose =
     /// — thread the same pair, so the deployed Bootstrap never drifts from the
     /// published one (the parity duty). Empty bootstrap Map on the file-sourced /
     /// data-off path (the named skip is in `Hydration.diagnostics`).
-    let readAndHydrateConfigModel (cfg: Config.Config) : Task<Result<Catalog * Map<SsKey, StaticRow list>>> =
+    /// Migration-context wiring (2026-06-15) — completes the data triumvirate.
+    /// The operator-curated Migration lane's rows are bound from
+    /// `overrides.migrationDependencies.path` against the read catalog
+    /// (rename-invariant `SsKey`, A1); the resolved context is threaded the
+    /// SAME seam the Bootstrap rows ride (publish + store-leg, for parity) and
+    /// its kinds are EXCLUDED from the Bootstrap complement so the three lanes
+    /// stay disjoint (the partition law). No path ⇒ the empty context (no-op;
+    /// byte-identical). A malformed / unresolvable file fails loud
+    /// (`pipeline.migrationDependencies.*`).
+    let readAndHydrateConfigModel
+        (cfg: Config.Config)
+        : Task<Result<Catalog * Map<SsKey, StaticRow list> * Projection.Targets.Data.MigrationDependencyContext>> =
         task {
             let! parsed = readConfigModel cfg
             match parsed with
             | Error es -> return Result.failure es
             | Ok catalog ->
-                match! Hydration.hydrateCatalog cfg catalog with
+                match MigrationDependenciesBinding.fromConfig catalog cfg with
                 | Error es -> return Result.failure es
-                | Ok hydrated ->
-                    match! Hydration.hydrateBootstrapRows cfg hydrated with
-                    | Error es      -> return Result.failure es
-                    | Ok bootRows   -> return Result.success (hydrated, bootRows)
+                | Ok migration ->
+                    match! Hydration.hydrateCatalog cfg catalog with
+                    | Error es -> return Result.failure es
+                    | Ok hydrated ->
+                        let migrationKinds = MigrationDependenciesBinding.kindKeysOf migration
+                        match! Hydration.hydrateBootstrapRowsExcluding migrationKinds cfg hydrated with
+                        | Error es      -> return Result.failure es
+                        | Ok bootRows   -> return Result.success (hydrated, bootRows, migration)
         }
 
     /// THE_CONFIG_CONTROL_PLANE §6 (S3) — project a **caller-supplied**
@@ -1603,15 +1626,14 @@ module Compose =
                                 // the Bootstrap lane's row source (Bootstrap-always).
                                 let! parsed = readAndHydrateConfigModel cfg
                                 match parsed with
-                                | Ok (catalog, bootRows) ->
+                                | Ok (catalog, bootRows, migration) ->
                                     emitStageMarker LogSink.Extract "extract.completed" LogSink.End
                                         (Map.ofList [ "moduleCount", box (List.length catalog.Modules) ])
-                                    return Ok (catalog, bootRows)
+                                    return Ok (catalog, bootRows, migration)
                                 | Error errors ->
                                     return Error errors
                             })
-                    let catalog = fst extracted
-                    let bootstrapRows = snd extracted
+                    let catalog, bootstrapRows, migration = extracted
                     let! profile =
                         Staged.stage Stages.profile (fun () ->
                             task {
@@ -1627,7 +1649,7 @@ module Compose =
                             task {
                                 // §7.5 emit — pass chain + sibling-Π emission +
                                 // artifact write.
-                                let result = runWithConfigCore cfg (Ok catalog) bootstrapRows profile
+                                let result = runWithConfigCore cfg (Ok catalog) bootstrapRows migration profile
                                 emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
                                 return result
                             })
@@ -1677,6 +1699,7 @@ module Compose =
         (cfg: Config.Config)
         (parsed: Result<Catalog>)
         (bootstrapRows: Map<SsKey, StaticRow list>)
+        (migration: Projection.Targets.Data.MigrationDependencyContext)
         : Result<Catalog * DataComposer.LeveledDeploymentText> =
         match parsed |> Result.bind (applyRenames cfg) with
         | Error es -> Result.failure es
@@ -1694,9 +1717,11 @@ module Compose =
                         // Bootstrap-always — the store-leg threads the SAME
                         // Bootstrap rows the publish path does (parity duty), so
                         // the deployed leveled seed never drifts from the bundle.
+                        // Migration-context wiring (2026-06-15) — likewise the
+                        // SAME operator-curated Migration lane, for the same parity.
                         DataComposer.composeRenderedLeveledWithBootstrap
                             policy finalState.Catalog Profile.empty
-                            Projection.Targets.Data.MigrationDependencyContext.empty
+                            migration
                             bootstrapRows
                             UserRemapContext.empty
                     with
@@ -1721,7 +1746,7 @@ module Compose =
             let! parsed = readAndHydrateConfigModel cfg
             match parsed with
             | Error es -> return Result.failure es
-            | Ok (catalog, bootRows) -> return projectSeedPlan cfg (Ok catalog) bootRows
+            | Ok (catalog, bootRows, migration) -> return projectSeedPlan cfg (Ok catalog) bootRows migration
         }
 
     /// State A — the prior emission's schema, reconstructed from the durable

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="FkSelectivityDiagnostics.fs" />
     <Compile Include="JointDependencyDiagnostics.fs" />
     <Compile Include="EmissionFoldersBinding.fs" />
+    <Compile Include="MigrationDependenciesBinding.fs" />
     <Compile Include="TransformGroupsBinding.fs" />
     <Compile Include="InsertionPolicyBinding.fs" />
     <Compile Include="LiveModelRead.fs" />

--- a/sidecar/projection/src/Projection.Targets.Data/MigrationDependenciesEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/MigrationDependenciesEmitter.fs
@@ -10,18 +10,19 @@ open Projection.Targets.SSDT  // LINT-ALLOW: cross-target dependency for ScriptD
 // Per `CHAPTER_4_PRESCOPE_DATA_TRIUMVIRATE.md` §2.2: migration-dependency
 // status is operator intent, not catalog-resident evidence. The context
 // carries actual row data (not behavioral configuration), so it is
-// **Profile-shaped sibling input** rather than `Policy`. Adapter at
-// the boundary (NDJSON / CSV pickup directory; deferred until I/O
-// consumer demand surfaces) reads into this typed shape; the emitter
-// is pure F# in Core-adjacent.
+// **Profile-shaped sibling input** rather than `Policy`. The emitter is
+// pure F# in Core-adjacent; the boundary adapter lives at the pipeline
+// layer.
 //
-// **Slice ε scope (chapter 4.1.B).** The typed context shape lands;
-// the boundary adapter is deferred until a real ingestion path
-// surfaces (production migration teams may publish via a different
-// format or via an existing config surface — I/O choice deferred per
-// IR-grows-under-evidence). MVP consumers construct the context
-// programmatically; tests use `MigrationDependencyContext.empty` and
-// hand-rolled fixtures.
+// **Ingestion adapter (cashed out 2026-06-15).** The slice-ε boundary-
+// adapter deferral fired: `Projection.Pipeline.MigrationDependenciesBinding
+// .fromConfig` reads the operator-curated file at
+// `overrides.migrationDependencies.path` (JSON, logical-keyed — see that
+// module) into this typed shape, resolving logical `(Module, Entity)` to
+// `SsKey` against the catalog. The config-driven full-export run threads
+// the resolved context through the composer (publish + store-leg). Direct
+// consumers (canary / golden tests) still construct the context
+// programmatically or pass `MigrationDependencyContext.empty`.
 // ---------------------------------------------------------------------------
 
 /// One row of legacy-domain data the migration team is publishing

--- a/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LiveSourceDockerTests.fs
@@ -227,3 +227,121 @@ type LiveSourceDockerTests(fixture: EphemeralContainerFixture) =
         Assert.Contains("MERGE", boot)
         Assert.Contains("OSUSR_BOOT_WIDGET", boot)
         Assert.Contains("Gadget", boot)
+
+    // -- Test 4 — the data triumvirate: all three lanes live + disjoint ----
+    //
+    // Migration-context wiring (2026-06-15). The three data lanes populate
+    // from THREE sources end-to-end:
+    //   * StaticSeeds  ← live OSSYS hydration of a Static-marked kind
+    //                     (`Hydration.hydrateCatalog`).
+    //   * MigrationData ← the operator-curated file at
+    //                     `overrides.migrationDependencies.path`
+    //                     (`MigrationDependenciesBinding.fromConfig`).
+    //   * Bootstrap    ← live OSSYS hydration of the complement
+    //                     (`Hydration.hydrateBootstrapRowsExcluding`, the
+    //                     migration kind excluded so the lanes stay disjoint).
+    // The composer's `OverlappingEmitterCoverage` partition law is the guard
+    // that the three lanes don't double-claim a kind — `mustOkEmit` trips on
+    // it. Each lane's `Data/*.sql` is asserted non-empty + carrying its row.
+    [<Fact>]
+    member _.``the data triumvirate: StaticSeeds + MigrationData + Bootstrap all populate live and stay disjoint`` () =
+        if not (skipIfNoDocker "data-triumvirate-live") then () else
+        let envVar = "PROJECTION_TEST_TRIUM_CONN"
+        let bundle =
+            fixture.WithEphemeralDatabase "TriumSrc" (fun cnn connStr ->
+                task {
+                    // Static lane source: a Static-marked kind, rows live.
+                    do!
+                        Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[OSUSR_TRIUM_COUNTRY] (" +
+                             "[ID] INT NOT NULL PRIMARY KEY, " +
+                             "[NAME] NVARCHAR(100) NOT NULL);")
+                    do!
+                        Deploy.executeBatch cnn
+                            ("INSERT INTO [dbo].[OSUSR_TRIUM_COUNTRY] ([ID], [NAME]) " +
+                             "VALUES (1, N'Atlantis');")
+                    // Bootstrap lane source: a non-static kind, rows live.
+                    do!
+                        Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[OSUSR_TRIUM_WIDGET] (" +
+                             "[ID] INT NOT NULL PRIMARY KEY, " +
+                             "[NAME] NVARCHAR(100) NOT NULL);")
+                    do!
+                        Deploy.executeBatch cnn
+                            ("INSERT INTO [dbo].[OSUSR_TRIUM_WIDGET] ([ID], [NAME]) " +
+                             "VALUES (1, N'Sprocket');")
+                    // A `Static`-marked Country, a non-static Widget (bootstrap),
+                    // and a non-static Role (migration; its rows come from the
+                    // file, never the DB — no Role table is deployed).
+                    let mkKind (entity: string) (table: string) (extraName: string) (modality: ModalityMark list) : Kind =
+                        { Kind.create (mkKey [entity]) (mkName entity)
+                            (TableId.create "dbo" table |> mustOk)
+                            [ { Attribute.create (mkKey [entity; "Id"]) (mkName "Id") Integer with
+                                  Column = ColumnRealization.create "ID" false |> Result.value
+                                  IsPrimaryKey = true; IsMandatory = true }
+                              { Attribute.create (mkKey [entity; extraName]) (mkName extraName) Text with
+                                  Column = ColumnRealization.create (extraName.ToUpperInvariant()) false |> Result.value
+                                  Length = Some 100; IsMandatory = true } ]
+                          with Modality = modality }
+                    let country = mkKind "Country" "OSUSR_TRIUM_COUNTRY" "Name" [ Static [] ]
+                    let widget  = mkKind "Widget"  "OSUSR_TRIUM_WIDGET"  "Name" []
+                    let role    = mkKind "Role"    "OSUSR_TRIUM_ROLE"    "Label" []
+                    let catalog : Catalog =
+                        { Modules =
+                            [ { SsKey = mkKey ["M"]; Name = mkName "M"
+                                Kinds = [ country; widget; role ]; IsActive = true; ExtendedProperties = [] } ]
+                          Sequences = [] }
+                    // The operator-curated migration file (logical-keyed JSON).
+                    let migJson =
+                        """{ "kinds": [ { "module": "M", "entity": "Role",
+                              "rows": [ { "id": "Admin", "values": { "Id": "1", "Label": "Administrator" } } ] } ] }"""
+                    let migPath =
+                        System.IO.Path.Combine(
+                            System.IO.Path.GetTempPath(),
+                            System.String.Concat("trium_mig_", System.Guid.NewGuid().ToString("N"), ".json"))
+                    System.IO.File.WriteAllText(migPath, migJson)
+                    System.Environment.SetEnvironmentVariable(envVar, connStr)
+                    try
+                        let cfg =
+                            { Config.defaultConfig with
+                                Model = { Config.defaultConfig.Model with
+                                            Ossys = Some ("env:" + envVar); Path = None }
+                                Overrides = { Config.defaultConfig.Overrides with
+                                                MigrationDependencies = Some { Path = migPath } } }
+                        // The pipeline's extract-stage seam, called directly.
+                        let migration = mustOk (MigrationDependenciesBinding.fromConfig catalog cfg)
+                        let migrationKinds = MigrationDependenciesBinding.kindKeysOf migration
+                        let! hydratedR = Hydration.hydrateCatalog cfg catalog
+                        let hydrated = mustOk hydratedR
+                        let! bootR = Hydration.hydrateBootstrapRowsExcluding migrationKinds cfg hydrated
+                        let bootstrapRows = mustOk bootR
+                        // The migration kind is NOT in the bootstrap source (disjoint).
+                        Assert.False(
+                            Map.containsKey role.SsKey bootstrapRows,
+                            "the migration kind leaked into the Bootstrap row source")
+                        let bundle =
+                            DataEmissionComposer.composeRenderedBundleWithBootstrap
+                                Policy.empty hydrated Profile.empty
+                                migration bootstrapRows UserRemapContext.empty
+                            |> mustOkEmit
+                        return bundle
+                    finally
+                        System.Environment.SetEnvironmentVariable(envVar, null)
+                        (try System.IO.File.Delete migPath with _ -> ())
+                })
+            |> fun t -> t.GetAwaiter().GetResult()
+        let files = DataEmissionComposer.RenderedDataBundle.perLaneFiles bundle
+        // All three per-lane files are emitted (≥1 row each) — the triumvirate.
+        Assert.True(Map.containsKey "Data/StaticSeeds.sql" files,   "Data/StaticSeeds.sql missing")
+        Assert.True(Map.containsKey "Data/MigrationData.sql" files, "Data/MigrationData.sql missing")
+        Assert.True(Map.containsKey "Data/Bootstrap.sql" files,     "Data/Bootstrap.sql missing")
+        // Each lane carries its own source's row, and only its own.
+        let staticSeeds = Map.find "Data/StaticSeeds.sql" files
+        Assert.Contains("OSUSR_TRIUM_COUNTRY", staticSeeds)
+        Assert.Contains("Atlantis", staticSeeds)
+        let migData = Map.find "Data/MigrationData.sql" files
+        Assert.Contains("OSUSR_TRIUM_ROLE", migData)
+        Assert.Contains("Administrator", migData)
+        let boot = Map.find "Data/Bootstrap.sql" files
+        Assert.Contains("OSUSR_TRIUM_WIDGET", boot)
+        Assert.Contains("Sprocket", boot)

--- a/sidecar/projection/tests/Projection.Tests/MigrationDependenciesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationDependenciesBindingTests.fs
@@ -1,0 +1,219 @@
+module Projection.Tests.MigrationDependenciesBindingTests
+
+open System.IO
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Targets.Data
+
+/// Migration-context wiring (2026-06-15) — `MigrationDependenciesBinding
+/// .fromConfig` coverage. Mirrors `EmissionFoldersBindingTests`: a small
+/// V1 JSON fixture loads a real catalog through `Compose.readJson`; the
+/// binder is exercised across no-path / valid / unresolved / malformed /
+/// missing-id / cell-coercion paths; structured errors carry the
+/// `pipeline.migrationDependencies.*` code namespace.
+
+let private v1Json : string =
+    """{
+  "exportedAtUtc": "2026-05-20T00:00:00.0000000+00:00",
+  "modules": [
+    {
+      "name": "AppCore",
+      "isSystem": false,
+      "isActive": true,
+      "entities": [
+        {
+          "name": "Role",
+          "physicalName": "OSUSR_APPCORE_ROLE",
+          "isStatic": false,
+          "isExternal": false,
+          "isActive": true,
+          "db_catalog": null,
+          "db_schema": "dbo",
+          "attributes": [
+            {
+              "name": "Id", "physicalName": "ID", "originalName": null,
+              "dataType": "Identifier", "length": null, "precision": null, "scale": null,
+              "default": null, "isMandatory": true, "isIdentifier": true, "isAutoNumber": true,
+              "isActive": true, "isReference": 0, "refEntityId": null,
+              "refEntity_name": null, "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0,
+              "external_dbType": null, "physical_isPresentButInactive": 0
+            },
+            {
+              "name": "Label", "physicalName": "LABEL", "originalName": null,
+              "dataType": "Text", "length": 100, "precision": null, "scale": null,
+              "default": null, "isMandatory": true, "isIdentifier": false, "isAutoNumber": false,
+              "isActive": true, "isReference": 0, "refEntityId": null,
+              "refEntity_name": null, "refEntity_physicalName": null,
+              "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0,
+              "external_dbType": null, "physical_isPresentButInactive": 0
+            }
+          ],
+          "relationships": [], "indexes": [], "triggers": []
+        }
+      ]
+    }
+  ]
+}"""
+
+let private loadCatalog () : Catalog =
+    let task () = Compose.readJson v1Json
+    match TaskSync.run task with
+    | Ok c -> c
+    | Error errs -> failwithf "test fixture invalid: %A" errs
+
+let private roleKind (catalog: Catalog) : Kind =
+    Catalog.allKinds catalog |> List.find (fun k -> Name.value k.Name = "Role")
+
+let private emptyOverrides : Config.OverridesSection = {
+    TableRenames           = []
+    MigrationDependencies  = None
+    StaticData             = None
+    CircularDependencies   = None
+    AllowMissingPrimaryKey = []
+    EmissionFolders        = []
+}
+
+let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
+    {
+        Model       = {
+            Path                   = Some "ignored.json"
+            Ossys                  = None
+            Modules                = []
+            IncludeSystemModules   = false
+            IncludeInactiveModules = false
+            OnlyActiveAttributes   = true
+        }
+        Profile     = { Path = None }
+        Profiler    = { Provider = "fixture" }
+        Overrides   = overrides
+        Emission    = {
+            Ssdt = true; Dacpac = true; Json = true; Distributions = true
+            StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; RenderConstraintsElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard
+        }
+        Policy      = {
+            Insertion       = "SchemaOnly"
+            Tightening      = None
+            TransformGroups = []
+        }
+        Output      = { Dir = "out/" }
+    }
+
+/// Write `content` to a fresh temp file, run `f` against its path, then
+/// delete the file. The migration file is config-relative-to-cwd (the
+/// `model.path` precedent), so an absolute temp path is faithful.
+let private withTempFile (content: string) (f: string -> 'a) : 'a =
+    let path = Path.Combine(Path.GetTempPath(), sprintf "migdeps_%s.json" (System.Guid.NewGuid().ToString("N")))
+    File.WriteAllText(path, content)
+    try f path
+    finally (try File.Delete path with _ -> ())
+
+let private cfgWithPath (path: string) : Config.Config =
+    mkConfig { emptyOverrides with MigrationDependencies = Some { Path = path } }
+
+let private hasErrorCode (code: string) (errs: ValidationError list) : bool =
+    errs |> List.exists (fun e -> e.Code = code)
+
+// ----------------------------------------------------------------------
+// No path — the empty context (byte-identical to the prior threading)
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``no migrationDependencies path yields the empty context`` () =
+    let catalog = loadCatalog ()
+    let cfg = mkConfig emptyOverrides
+    match MigrationDependenciesBinding.fromConfig catalog cfg with
+    | Ok ctx ->
+        Assert.Empty ctx.Rows
+        Assert.True(Set.isEmpty (MigrationDependenciesBinding.kindKeysOf ctx))
+    | Error errs -> Assert.Fail(sprintf "expected Ok, got %A" errs)
+
+// ----------------------------------------------------------------------
+// Valid file — logical resolution + row synthesis
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``valid file resolves logical Module.Entity to the kind SsKey with synthesized row identity`` () =
+    let catalog = loadCatalog ()
+    let role = roleKind catalog
+    let json =
+        """{ "kinds": [ { "module": "AppCore", "entity": "Role",
+              "rows": [ { "id": "Admin",   "values": { "Id": "1", "Label": "Administrator" } },
+                        { "id": "Auditor", "values": { "Id": "2", "Label": "Auditor" } } ] } ] }"""
+    let ctx =
+        withTempFile json (fun path ->
+            match MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path) with
+            | Ok c -> c
+            | Error errs -> failwithf "expected Ok, got %A" errs)
+    Assert.Equal(2, List.length ctx.Rows)
+    // Every row owns the resolved Role kind key.
+    Assert.True(ctx.Rows |> List.forall (fun r -> r.KindKey = role.SsKey))
+    // The complement-exclusion set is exactly { Role }.
+    Assert.Equal<Set<SsKey>>(Set.ofList [ role.SsKey ], MigrationDependenciesBinding.kindKeysOf ctx)
+    // Values resolve by logical column name.
+    let admin = ctx.Rows |> List.find (fun r -> Map.tryFind (Name.create "Label" |> Result.value) r.Values = Some "Administrator")
+    Assert.Equal(Some "1", Map.tryFind (Name.create "Id" |> Result.value) admin.Values)
+    // Row identities are distinct (synthesized from id).
+    Assert.Equal(2, ctx.Rows |> List.map (fun r -> r.Identifier) |> List.distinct |> List.length)
+
+// ----------------------------------------------------------------------
+// Cell coercion — number / bool / null
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``scalar cells coerce: number and bool render raw, null is the empty-string NULL convention`` () =
+    let catalog = loadCatalog ()
+    let json =
+        """{ "kinds": [ { "module": "AppCore", "entity": "Role",
+              "rows": [ { "id": "R", "values": { "Id": 7, "Label": null } } ] } ] }"""
+    let ctx =
+        withTempFile json (fun path ->
+            match MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path) with
+            | Ok c -> c
+            | Error errs -> failwithf "expected Ok, got %A" errs)
+    let row = List.exactlyOne ctx.Rows
+    Assert.Equal(Some "7", Map.tryFind (Name.create "Id" |> Result.value) row.Values)
+    Assert.Equal(Some "", Map.tryFind (Name.create "Label" |> Result.value) row.Values)
+
+// ----------------------------------------------------------------------
+// Fail-loud paths
+// ----------------------------------------------------------------------
+
+[<Fact>]
+let ``unresolved logical kind fails loud`` () =
+    let catalog = loadCatalog ()
+    let json = """{ "kinds": [ { "module": "AppCore", "entity": "Ghost", "rows": [] } ] }"""
+    let result =
+        withTempFile json (fun path -> MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path))
+    match result with
+    | Ok _ -> Assert.Fail "expected an unresolved-kind error"
+    | Error errs -> Assert.True(hasErrorCode "pipeline.migrationDependencies.unresolvedKind" errs)
+
+[<Fact>]
+let ``malformed JSON fails loud`` () =
+    let catalog = loadCatalog ()
+    let result =
+        withTempFile "{ not json" (fun path -> MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path))
+    match result with
+    | Ok _ -> Assert.Fail "expected a malformed-JSON error"
+    | Error errs -> Assert.True(hasErrorCode "pipeline.migrationDependencies.malformedJson" errs)
+
+[<Fact>]
+let ``a row without an id fails loud`` () =
+    let catalog = loadCatalog ()
+    let json = """{ "kinds": [ { "module": "AppCore", "entity": "Role", "rows": [ { "values": { "Id": "1" } } ] } ] }"""
+    let result =
+        withTempFile json (fun path -> MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path))
+    match result with
+    | Ok _ -> Assert.Fail "expected a row-missing-id error"
+    | Error errs -> Assert.True(hasErrorCode "pipeline.migrationDependencies.rowMissingId" errs)
+
+[<Fact>]
+let ``a missing file fails loud`` () =
+    let catalog = loadCatalog ()
+    let path = Path.Combine(Path.GetTempPath(), sprintf "absent_%s.json" (System.Guid.NewGuid().ToString("N")))
+    match MigrationDependenciesBinding.fromConfig catalog (cfgWithPath path) with
+    | Ok _ -> Assert.Fail "expected a read-failed error"
+    | Error errs -> Assert.True(hasErrorCode "pipeline.migrationDependencies.readFailed" errs)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="FkSelectivityDiagnosticsTests.fs" />
     <Compile Include="JointDependencyDiagnosticsTests.fs" />
     <Compile Include="EmissionFoldersBindingTests.fs" />
+    <Compile Include="MigrationDependenciesBindingTests.fs" />
     <Compile Include="EmissionFoldersOverlayTests.fs" />
     <Compile Include="FullExportDataBundleTests.fs" />
     <Compile Include="TransformGroupsBindingTests.fs" />


### PR DESCRIPTION
## Summary

Completes the **data triumvirate** for the config-driven full-export. The production compose path threaded `MigrationDependencyContext.empty` — the Static and Bootstrap lanes hydrated live, but the **Migration lane had no row source**. `overrides.migrationDependencies.path` parsed into config yet nothing read it (the deferred slice-ε ingestion adapter). This wires that path to a real `MigrationDependencyContext`, threaded the same seam the Bootstrap rows ride.

## What changed

- **New adapter — `MigrationDependenciesBinding.fs`** (`Projection.Pipeline`). Reads the operator-curated file at `overrides.migrationDependencies.path` into a `MigrationDependencyContext`.
  - **Format: JSON, logical-keyed** (operator decision): `{ "kinds": [ { "module", "entity", "rows": [ { "id", "values": {col:val} } ] } ] }`.
  - Resolves `(module, entity) → SsKey` via the shared `CatalogResolution.tryKindByLogical` (rename-invariant, A1); synthesizes row identities via `SsKey.synthesizedComposite "migration" […]`; values are raw strings (`""` = NULL; number/bool coerce).
  - No path ⇒ empty context (byte-identical to the prior threading). Missing / malformed / unresolved-kind ⇒ **loud** `pipeline.migrationDependencies.*` (the operator declared the file, so we honor it strictly — no silent emptiness).
- **Threaded both compose seams for parity** — `readAndHydrateConfigModel` now returns `(Catalog * bootstrapRows * migration)`; publish (`projectWithStateWithPinsAndBootstrap → composeRenderedBundleWithBootstrap`) and store-leg (`projectSeedPlan → composeRenderedLeveledWithBootstrap`) both carry it, so the deployed Migration lane never drifts from the published one. Non-config callers delegate `MigrationDependencyContext.empty` (zero churn, byte-identical).
- **Partition stays disjoint** — `hydrateBootstrapRows → hydrateBootstrapRowsExcluding migrationKinds` drops (Static ∪ **Migration**) from the bootstrap complement under `AllRemaining`/`AllExceptStatic`, so the composer's `OverlappingEmitterCoverage` can't trip once both lanes populate. Under `AllData` the Migration lane is skipped, so the exclusion correctly does not apply.

## Why

This was the first item on the post-Bootstrap-always task list: it completes the three-lane data model (StaticSeeds + MigrationData + Bootstrap) so an operator can publish curated legacy-domain rows alongside the live-hydrated lanes. It cashes out the deferred slice-ε migration-ingestion adapter, with the operator picking the file format.

## Tests

- **`MigrationDependenciesBindingTests`** (7, pure) — no-path / valid resolution / scalar-cell coercion (number/bool/null-as-empty) / unresolved-kind / malformed-JSON / missing-id / missing-file fail-loud paths.
- **`LiveSourceDockerTests` "the data triumvirate"** — a live source feeds Static + Bootstrap, the file feeds Migration; all three `Data/*.sql` carry their own row and only their own (disjoint).
- Verified green: 109/0 across the touched pure classes; the live-path Docker class **4/4** against the warm container (TRX-confirmed the triumvirate test executed, not soft-skipped).

## Reviewer notes

- Books: `DECISIONS.md` 2026-06-15 entry; `MigrationDependenciesEmitter` docstring refreshed to point at the new binding; forward-looking `HANDOFF.md` letter at top.
- The `hydrateBootstrapRows` / `projectWithStateWithPins` wrappers that delegate the empty default are the established default-supplying-wrapper idiom (same shape as the existing `…WithBootstrap` variants), not back-compat shims.
- Out of scope (operator-deferred): supplemental bootstrap kinds. Still pending from the task list: AllData double-stream perf cleanup, and reconciliation WP7–WP9 (incl. a `migrationDependencies` example in the rewritten sample config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)