### PR TITLE
Reverse-leg DML execution: Phases 2–5 + operator probe package + database-archetype design

### DIFF
--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -473,10 +473,12 @@ tables/columns add·drop·rename, the change-norm `‖δ‖`, statement/rename c
 `SkippedReferences` (FK orphans), unbreakable cycles, capture-lane descents. Declared-loss gates
 (`--allow-drops`, `--allow-cdc`); grant-refusal at plan time for schema-into-`grant:data` (exit 9).
 
-- **GAP:** the combined `migrate-with-data` path (the headline reverse leg with rekeying) has **no DryRun
-  arm** (`RunFaces.fs:1833`, always `Transfer.Execute`). `RowsWritten` is forced to 0 in DryRun (`:790`) and
-  the streaming DryRun ingests nothing — so **no row-count estimate**, **no DML/row preview**, **no
-  rekey-map preview**, **no resume-state preview** ("which chunks would skip vs re-move"). The grant-refusal
+- **PARTLY CLOSED (Phase 4, 2026-06-15):** the streaming reverse-leg DryRun previously ingested nothing, so it
+  gave **no row-count estimate**. It now reports per-kind "N rows would move" via a cheap exact `COUNT_BIG(*)`
+  (`countKindRows`), with the reconciled kind at 0 and the **rekey-map preview** (`UnmatchedIdentities` /
+  `AmbiguousIdentities`) on the same report. Still **STAGED**: the **resume-state preview** ("which chunks would
+  skip vs re-move") and the **live row-grained ETA bar** (the parked `SpectreProgressAdapter` — its denominator
+  now exists, but the live rendering's wake is the real-wire run). The grant-refusal
   "gate" on the live move is **advisory-only** today (R6 dual-track: the survey warns then proceeds); it flips
   to a hard per-pair stop at cutover.
 
@@ -623,11 +625,17 @@ Dependency-ordered. Each phase has an exit test.
   (`ReverseLegStreamingTests` "chunk resume"). The scale-representative journal size + live socket-drop are the
   staged real-wire residuals.
 
-### Phase 4 — Movement dry-run + row-grained progress
-- **Movement dry-run**: row-count estimate, rekey-map preview, resume-state preview, for `migrate-with-data`.
-- **Row-grained progress/ETA**: feed the parked `SpectreProgressAdapter` a rows-written/rows-remaining
-  denominator + a durable surface surviving a reconnect.
-- **Exit:** an operator can preview "N rows / M chunks would move, K would skip" and watch it live.
+### Phase 4 — Movement dry-run + row-grained progress — **preview DONE 2026-06-15; live bar STAGED**
+- ✅ **Movement dry-run row-count estimate**: the streaming DryRun now reports per-kind "N rows would move"
+  via a cheap exact `COUNT_BIG(*)` (`countKindRows`) — a reconciled kind previews 0 (re-keyed, not re-imported),
+  `RowsWritten` 0, and the rekey-map preview (`UnmatchedIdentities` / `AmbiguousIdentities`) rides the same
+  report. (The materialized DryRun already reported counts; this closes the streaming-DryRun-ingests-nothing GAP.)
+- ⏳ **STAGED — row-grained progress/ETA** (the live bar): the denominator the parked
+  `SpectreProgressAdapter : IProgressRunner` needs now exists (`countKindRows`), but the live ETA rendering is a
+  TTY surface whose wake is the **real-wire multi-hour run** — a Docker test has nothing to watch. Wiring the
+  parked adapter + a durable reconnect-surviving surface is the carry-over, gated on Phase 1's real wire.
+- ✅ **Exit (preview half):** an operator can preview "N rows would move per kind, K users matched / J unmatched"
+  before any DML (`ReverseLegStreamingTests` "Phase 4 dry-run preview"). The "watch it live" half is the staged bar.
 
 ### Phase 5 — Cutover-readiness gates
 - ≥1 **full production-shaped dry-run** (the deferred cutover gate).

--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -661,6 +661,18 @@ The mechanisms are built or already exist; what remains is operator governance (
 2. **Transfer-host memory budget** — sets the packed-remap spill trigger.
 3. **The two un-run probes** — hand the operator the **P10** user-directory metadata probe now (read-only;
    confirms ReconciledByRule available) and design the **P7b** throughput harness for Phase 1.
+4. **Target archetype per environment** — classify each target as **full-rights** (on-prem: DDL + DML +
+   IDENTITY_INSERT — the schema+data home) or **managed-DML** (the J5 cloud profile). The class flips a
+   *bundle* of engine dispositions (identity strategy, resume mechanism, schema deploy, wipe, rollback),
+   so it should become a reusable, **verified** config disposition rather than a scatter of implicit
+   branches. Verify the on-prem profile with `REVERSE_LEG_OPERATOR_PROBE_SHEET.md` **Part E** (E1–E5);
+   the design + assumptions + slice plan are in **`DATABASE_ARCHETYPES.md`** (`DECISIONS.md` 2026-06-15).
+
+## Operator-actionable companions
+- **`REVERSE_LEG_OPERATOR_PROBE_SHEET.md`** — 16 generic, runnable probes naming the per-table unknowns
+  (schema shape, data fidelity, capability, archetype) + the results ledger. All catalog SQL validated.
+- **`PHASE_1_REAL_WIRE_HARNESS.md`** — the P7b throughput-bench procedure + the estate-sizing survey.
+- **`DATABASE_ARCHETYPES.md`** — the target capability-class design (the archetype as a config disposition).
 
 ## Risk register (carried from the discovery)
 

--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -433,18 +433,21 @@ Crash-resume at chunk granularity is witnessed (`ReverseLegStreamingTests.fs:87-
 
 - **Idempotent re-migration already exists — conditionally.** A completed journaled streaming run re-runs
   as a **full SKIP** with zero duplicates (`TransferRun.fs:1253-1270`; witnessed `…StreamingTests.fs:149-174`),
-  closing the **G3** duplicate hazard *whenever a journal is supplied*. **GAP (the lever):** `--streaming
-  --execute` **without** `--journal` is accepted and **doubles every AssignedBySink kind** (`TransferRun.fs:89`;
-  `MovementSurface.fs:1171`). The open work is to **force or default a journal** (or refuse journal-less
-  streaming-execute by name) — not to build idempotency. Caveat: idempotence is keyed to the same plan-marker
+  closing the **G3** duplicate hazard *whenever a journal is supplied*. **CLOSED (Phase 3, 2026-06-15):**
+  `--streaming --execute` **without** `--journal` is now **refused by name**
+  (`transfer.reverseLeg.streamingExecuteRequiresJournal`, the pure `ReverseLegRealization.executeJournalGate`) —
+  so every streaming execute carries a journal and is idempotent by construction; the duplicate hazard is closed
+  by construction, not merely "whenever a journal is supplied." Caveat: idempotence is keyed to the same plan-marker
   **and** a byte-identical source slice (changed source ⇒ drift refusal). The journal is client-side NDJSON
   *because the DML-only grant forbids the `CREATE TABLE` a sink-resident progress table would need*.
 - **ARMED:** journal compaction — resume loads the **entire NDJSON** (tens of bytes per captured pair, GBs at
   full-estate scale) into memory (`CaptureJournal.fs:66-74`); wake = any real resume > ~10M pairs. Envelope spill (`RunState.Envelopes`
   accumulates in memory) — ARMED, same scale wake.
-- **GAP:** the built resume is *journal-replay on re-run*, **not live socket-drop reconnect/retry**
-  mid-transfer. **Risk:** the journal filename **is** its content digest (`transfer-<digest16>.ndjson`,
-  `CaptureJournal.fs:60`) — any byte change orphans every existing journal into a silent fresh run.
+- **GAP (STAGED):** the built resume is *journal-replay on re-run*, **not live socket-drop reconnect/retry**
+  mid-transfer (Phase-1 real-wire co-requisite). **Risk (mitigated, Phase 3):** the journal filename **is** its
+  content digest (`transfer-<digest16>.ndjson`, `CaptureJournal.fs`) — a byte change still orphans the prior
+  journal, but the orphaning is no longer *silent*: `CaptureJournal.siblingJournalsUnderDrift` + the
+  `transfer.resume.journalAddressDrift` refusal halt a would-be fresh-run-over-orphaned-journal by name.
 
 ## 3. Operator progress — **PARTIAL**
 
@@ -603,13 +606,22 @@ Dependency-ordered. Each phase has an exit test.
 - ✅ **Exit met:** a reverse-leg move re-keys users by email with a pre-write orphan halt, witnessed
   (`ReverseLegStreamingTests` — re-key-never-re-imported + the pre-write halt; `DECISIONS.md` 2026-06-15).
 
-### Phase 3 — Harden resume + idempotency for scale
-- **Force/default a journal** on `--streaming --execute` (close the duplicate hazard — the small lever).
-- **Journal compaction** (stop the full-NDJSON load at resume) + decouple the resume-address from the content
-  digest (the filename-coupling risk).
-- **Live connection resilience**: socket-drop reconnect/retry mid-transfer (distinct from re-run replay).
-- **Exit:** a killed connection resumes from the last committed chunk with no duplicates, at scale-representative
-  journal size.
+### Phase 3 — Harden resume + idempotency for scale — **buildable levers DONE 2026-06-15; two STAGED**
+- ✅ **Forced a journal** on `--streaming --execute` (closed the duplicate hazard — the small lever):
+  `transfer.reverseLeg.streamingExecuteRequiresJournal` (the pure `ReverseLegRealization.executeJournalGate`).
+  A journal-less streaming execute now refuses by name; every streaming execute is idempotent by construction.
+- ✅ **Address-drift guard** for the filename-coupling risk: `transfer.resume.journalAddressDrift`
+  (`CaptureJournal.siblingJournalsUnderDrift`) — a marker/schema byte-change that orphans the prior journal now
+  refuses by name instead of silently re-streaming. (This converts the silence into a refusal; it does not
+  re-address the journal — multi-transfer-per-dir coexistence is preserved.)
+- ⏳ **STAGED — journal compaction** (stop the full-NDJSON load at resume): ARMED, wake = any real resume
+  > ~10M captured pairs. Not built — Docker scale is KB; a speculative scale-build has no witness.
+- ⏳ **STAGED — live socket-drop reconnect/retry** mid-transfer (distinct from re-run replay): needs a real
+  dropped connection to prove — a Phase-1 real-wire co-requisite, not Docker-witnessable.
+- **Exit:** the duplicate hazard is closed by construction (every streaming execute carries a journal);
+  the killed-connection-resumes-no-duplicates witness already holds at chunk granularity
+  (`ReverseLegStreamingTests` "chunk resume"). The scale-representative journal size + live socket-drop are the
+  staged real-wire residuals.
 
 ### Phase 4 — Movement dry-run + row-grained progress
 - **Movement dry-run**: row-count estimate, rekey-map preview, resume-state preview, for `migrate-with-data`.

--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -589,12 +589,16 @@ Dependency-ordered. Each phase has an exit test.
   (OPEN-3) lands.
 - **Exit:** the canonical stores (DECISIONS + this compendium) carry the ledger; the playbook is deprecated.
 
-### Phase 1 — Close the real-wire loop *(mostly measurement)*
+### Phase 1 — Close the real-wire loop *(mostly measurement)* — **HARNESS PREPPED 2026-06-15; run is operator-gated**
 - Run the set-based streaming lane against a real managed OutSystems environment at representative scale → measure rows/sec (**P7b**).
   **Exit:** the throughput floor sustained, or the escape hatches (parallel wavefronts P4, 50k-chunk sweep, sink-resident
   spill) are triggered with a plan.
 - **Estate survey**: row-count + FK-fan-in (gates resident-map vs sink-resident spill) + the P5 trigger map
   across OSUSR tables + the **G1** object-scope-DENY check (P1b).
+- ✅ **The harness + survey SQL are prepped and operator-actionable: `PHASE_1_REAL_WIRE_HARNESS.md`** (the P7b
+  bench procedure + escape-hatch plan; six read-only survey queries; the hand-off checklist). The agent cannot
+  run the wire — this is staged for the operator. The streaming reconcile lane it exercises is built + witnessed
+  (Phases 2–4).
 
 ### Phase 2 — Wire user reconciliation onto the reverse leg *(the "rekey users" gap)* — **DONE 2026-06-15**
 - ✅ Built **reconcile∘streaming**: composed `Reconciliation.reconcileKind` (ByEmail/…) + `reconcileAgainstSink`
@@ -637,10 +641,18 @@ Dependency-ordered. Each phase has an exit test.
 - ✅ **Exit (preview half):** an operator can preview "N rows would move per kind, K users matched / J unmatched"
   before any DML (`ReverseLegStreamingTests` "Phase 4 dry-run preview"). The "watch it live" half is the staged bar.
 
-### Phase 5 — Cutover-readiness gates
-- ≥1 **full production-shaped dry-run** (the deferred cutover gate).
-- Flip the grant-refusal gate **advisory → hard pre-write stop** (per-pair at cutover, R6).
-- Arm the **NM-73 auto-fallback** (CDC-silence → EXCEPT) now that J5 settles the CDC path (OPEN-3).
+### Phase 5 — Cutover-readiness gates — **governance-gated, not code (assessed 2026-06-15)**
+All three are real-wire / CDC-verdict / cutover-governance bound — no buildable code lever that respects R6.
+The mechanisms are built or already exist; what remains is operator governance (which the Phase-1 harness unblocks).
+- ⏳ **Production-shaped dry-run** — the *mechanism* is the Phase-4 movement dry-run preview (built, witnessed);
+  "production-shaped" = run it against the real estate (`PHASE_1_REAL_WIRE_HARNESS.md`). A real-wire action.
+- ⏳ **Grant gate advisory → hard** — the *mechanism already exists*: `projection survey` HARD-STOPS (exit 7) on a
+  blocked capability (`Program.fs:314`); the in-flow advisory warns by R6 design. The "flip" is wiring `projection
+  survey` into the **per-pair cutover CI** — a governance action under the N=10-canary + sign-off ladder, NOT a
+  blanket in-flow env flip (a speculative flip was deliberately not built — it would bypass the per-pair
+  governance R6 mandates; see `DECISIONS.md` 2026-06-15 Phase-5 entry, the R6 amendment).
+- ⏳ **NM-73 auto-fallback** (CDC-silence → EXCEPT) — CDC-verdict-gated; OPEN-3 is still PARTIAL (CDC path not yet
+  exercised on the real wire). The manual override shipped; the auto-fallback arms on the harness §6 CDC verdict.
 
 ## Decisions needed from the operator
 

--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -504,18 +504,27 @@ schema-identity skip is schema-only — and additionally unsound for non-name fa
 compares by name only; a changed trigger/CHECK/modality yields `‖δ‖ = 0` while the canary `PhysicalSchema.diff`
 *does* see it — `AUDIT_2026_06_13:89`, sev High).
 
-## 6. Two-phase rekey / users — **GAP (functional)**
+## 6. Two-phase rekey / users — **BUILT (Phase 2 landed 2026-06-15)**
 
-Entity-row rekey is BUILT (capture ladder + `PackedSurrogateRemap`; Part VI). **But user rekey on the reverse
-leg is REFUSED by name** — `transfer.reverseLeg.reconcileUnsupported` (`RunFaces.fs:787-792`): the B→A leg is
-a straight load today. Reconcile∘streaming is unbuilt; the streaming arm has only a *post*-write orphan exit-9,
-no pre-write halt (NM-31, `TransferRun.fs:1483-1490`). The design-time `UserFkReflowPass.discover` exists and
-writes `ComposeState.UserRemap` (all four strategies; `UserFkReflowPass.fs:195-348`) but is a **production
-no-op** — `IsUserFk` is always false and there is no live user-population reader (a CHAPTER-4.2 deferral); the
-discovered map is discarded at emit and never persisted. So at hundreds-of-millions-of-rows scale the User rekey is achievable only via
-the **runtime** AssignedBySink path (`PackedSurrogateRemap` + `CaptureJournal`), which does **not** exercise
-the reconcile-by-email discovery pass the "golden" discipline (Part V §4) describes. Wiring reconcile +
-`validate-user-map` onto the reverse leg is Phase 2.
+Entity-row rekey is BUILT (capture ladder + `PackedSurrogateRemap`; Part VI). **User rekey on the reverse leg
+is now BUILT** (`DECISIONS.md` 2026-06-15 — "Phase 2: reconcile ∘ streaming on the reverse leg"). The blanket
+`transfer.reverseLeg.reconcileUnsupported` refusal is **LIFTED**: the CLI face parses + resolves reconcile /
+user-map specs against the physical sink contract (a bad spec still refuses by name, exit 2, before any
+connection). The streaming runner (`runStreamingReconcilingWithRenames`) reconciles the named kinds (the User
+family by email) against the sink BEFORE the stream and re-keys every FK targeting them through a combined
+packed-∪-reconcile lookup, never re-importing a sink-owned row (`reclassifyReconciled` → `ReconciledByRule`,
+phase-1/2 skipped). The **`validate-user-map` pre-write halt now runs on the streaming arm** (NM-31 / N4 closed):
+an unmapped source user refuses `transfer.unmappedIdentities` with the sink untouched, unless `--allow-drops`
+downgrades it. The materialized arm reconciles through `runCore` too, so an inadmissible-combination request
+never silently drops the reconcile. Witnessed by `ReverseLegStreamingTests` (the re-key-never-re-imported pair
++ the pre-write halt).
+
+**The residual (still open):** the reconcile here is the **runtime** path — `reconcileAgainstSink` reads the
+sink's user inventory live and matches by the operator ruleset. The design-time `UserFkReflowPass.discover`
+(all four strategies; `UserFkReflowPass.fs:195-348`) remains a **production no-op** — `IsUserFk` is always
+false and the discovered map is discarded at emit (a CHAPTER-4.2 deferral). Populating that live
+user-population *discovery* reader is the remaining Phase-2 thread; the runtime reconcile path the charter's
+exit test names is built and witnessed.
 
 ---
 
@@ -552,9 +561,10 @@ fallback/override until J5 proves the CDC path on a managed OutSystems environme
   in the real estate; flag prominently (changes preflight refinement priority). *Residual probe (P1b).*
 - **G3** — streaming duplicate hazard. **Closed** whenever a `--journal` is supplied.
 - **G10** — the resumable/idempotent marker envelope (materialized arm). Built; not exercised on the reverse leg.
-- **N4 / AC-I5** — the pre-write `validate-user-map` gate. Present on the materialized arm; **absent on
-  streaming** (NM-31).
-- **NM-31** — streaming pre-write orphan halt (needs a streaming reconcile leg). Named follow-on.
+- **N4 / AC-I5** — the pre-write `validate-user-map` gate. Present on the materialized arm; **now also on
+  streaming** (Phase 2, 2026-06-15 — was NM-31).
+- **NM-31** — streaming pre-write orphan halt. **CLOSED** (Phase 2): `runStreamingReconcilingWithRenames` has
+  the reconcile leg + the `validateUserMap` halt; the realizations are no longer drop-asymmetric.
 - **NM-73** — EXCEPT validate-before-apply DataVerification override. Manual override shipped; auto-fallback
   J5-gated.
 
@@ -581,13 +591,17 @@ Dependency-ordered. Each phase has an exit test.
 - **Estate survey**: row-count + FK-fan-in (gates resident-map vs sink-resident spill) + the P5 trigger map
   across OSUSR tables + the **G1** object-scope-DENY check (P1b).
 
-### Phase 2 — Wire user reconciliation onto the reverse leg *(the "rekey users" gap)*
-- Build **reconcile∘streaming**: compose `Reconciliation.reconcileKind` (ByEmail/…) + `UserRemapContext` onto
-  the streaming path; lift `reconcileUnsupported`.
-- Add the **`validate-user-map` pre-write gate** on the streaming arm (close N4 / NM-31): halt before any DML
-  if an orphan user is unmapped.
-- Populate the discovery pass (live user-population reader; today a `Map.empty` stub).
-- **Exit:** a reverse-leg move re-keys users by email with a pre-write orphan halt, witnessed.
+### Phase 2 — Wire user reconciliation onto the reverse leg *(the "rekey users" gap)* — **DONE 2026-06-15**
+- ✅ Built **reconcile∘streaming**: composed `Reconciliation.reconcileKind` (ByEmail/…) + `reconcileAgainstSink`
+  + `SurrogateRemapContext` onto the streaming path (`runStreamingReconcilingWithRenames`); **lifted
+  `reconcileUnsupported`** at the CLI face. The materialized arm reconciles through `runCore` too (no silent
+  loss on inadmissible combos).
+- ✅ Added the **`validate-user-map` pre-write gate** on the streaming arm (closed N4 / NM-31): halts before any
+  DML on an unmapped orphan (`transfer.unmappedIdentities`), `--allow-drops` downgrades.
+- ⏳ **Residual:** the live user-population *discovery* pass (`UserFkReflowPass.discover`) is still a production
+  no-op; the runtime reconcile-against-sink path is built. Populating the discovery reader is the carry-over.
+- ✅ **Exit met:** a reverse-leg move re-keys users by email with a pre-write orphan halt, witnessed
+  (`ReverseLegStreamingTests` — re-key-never-re-imported + the pre-write halt; `DECISIONS.md` 2026-06-15).
 
 ### Phase 3 — Harden resume + idempotency for scale
 - **Force/default a journal** on `--streaming --execute` (close the duplicate hazard — the small lever).

--- a/sidecar/projection/DATABASE_ARCHETYPES.md
+++ b/sidecar/projection/DATABASE_ARCHETYPES.md
@@ -1,0 +1,243 @@
+# Database Archetypes — the target's capability class as a first-class config disposition
+
+> **What this is.** The codebase's assumptions about the *class* of database it writes to, made
+> explicit — and a proposal to lift that class from a scattered set of implicit/hardcoded behaviors
+> into **one named, reusable configuration disposition** that programmatically drives how the
+> pipeline may safely interact with each target. It is the conceptual companion to
+> `REVERSE_LEG_OPERATOR_PROBE_SHEET.md` Part E (the probes that *verify* a target's archetype) and an
+> enrichment of the existing `Grant` / `Rendition` config facets (`MovementSurface.fs:33,48`).
+>
+> **Dated 2026-06-15.** Direction recorded in `DECISIONS.md` (2026-06-15 — "Database archetype as a
+> config disposition"). This is a design + assumptions surface; the F# slice is sequenced in §6.
+
+---
+
+## §0 — The problem: there are (at least) two classes of target, and the engine already branches on them
+
+The migration touches **two databases that are not the same kind of thing**:
+
+1. **The on-prem SQL Server** — the database the migration team owns. It receives the **emitted SSDT
+   schema** (`CREATE TABLE` / `ALTER` — full DDL) and hosts a database carrying **the same schema +
+   the migrated data** (the `Logical` / **B** rendition). It is the schema home and the verification
+   home. We **likely** have `CREATE TABLE` here (operator to verify — probe sheet Part E); the access
+   is *similar to but not identical to* the cloud's.
+2. **The managed cloud SQL** — the platform-managed production target the reverse leg loads into. The
+   J5 capability spike settled its profile: a **DML-only** managed login — `SELECT/INSERT/UPDATE/
+   DELETE` permitted; **no `ALTER`, no `IDENTITY_INSERT`, no `CREATE TABLE`** (the `Physical` / **A**
+   rendition).
+
+These two classes have **materially different capability profiles**, and the engine *already* behaves
+differently for them — but the difference lives in three uneven places:
+
+- a **coarse binary facet** — `Grant = SchemaAndData | DataOnly` (`MovementSurface.fs:33`), which the
+  `CapabilitySurvey` reconciles against probed `fn_my_permissions` evidence;
+- a **metadata facet** — `Rendition = Physical | Logical` (`MovementSurface.fs:48`), which only marks
+  which rendition a place bears;
+- and a layer of **hardcoded, cloud-shaped assumptions** baked into the engine because the
+  estate-scale path was built against the managed-DML sink first (see §3).
+
+The coarse `Grant` covers "may schema change vs data-only." It does **not** capture the finer
+dispositions the engine genuinely forks on — whether the sink can preserve source keys, where resume
+state can live, whether constraints can be bypassed, how a rollback is proven. Those are decided
+*implicitly* today. The proposal: name the **archetype**, let it **expand** to the full disposition
+bundle, and **verify** it against probed evidence (A44 — expressible ⇔ reachable).
+
+---
+
+## §1 — The archetype catalog (the capability profile per class)
+
+| Capability / disposition | **FullRights** (on-prem, the schema+data home) | **ManagedDml** (cloud, the J5 profile) |
+|---|---|---|
+| DDL — `CREATE TABLE` / `ALTER` | **yes** | **no** |
+| `IDENTITY_INSERT` | **yes** (verify: probe E3) | **no** (denied, error 1088) |
+| **Default identity disposition** | **PreservedFromSource** — write the source key directly | **AssignedBySink** — sink mints, capture + remap |
+| FK re-keying required? | **no** (keys preserved ⇒ FK values stay valid) | **yes** (every FK to a minted kind re-pointed) |
+| Schema deploy (SSDT) | **yes** — `migrate-with-data` (DDL + data) | **no** — data-only `transfer` |
+| **Resume checkpoint** | **sink-resident progress table** (needs `CREATE TABLE`) | **client-side NDJSON journal** (no DDL ⇒ off-box) |
+| Staging | persistent server-side staging tables | `#` temp tables only |
+| Constraint / trigger bypass | `NOCHECK` / `DISABLE TRIGGER` (needs `ALTER`) | none — the capture-ladder descent handles triggers |
+| Wipe / refresh | `TRUNCATE` (fast; needs `ALTER`) | child-first `DELETE` (slower; the only DML-legal path) |
+| Rollback channel | SQL (full — `DELETE` / `TRUNCATE` / transaction) | SQL `DELETE` + transaction (J5-proven) |
+| User handling | preserve, or reconcile by business key | `ReconciledByRule` (the directory pre-exists; never re-imported) |
+| Derived `Grant` facet | `SchemaAndData` | `DataOnly` |
+| Typical `Rendition` | `Logical` (B) | `Physical` (A) |
+
+The two columns are not a binary the existing `Grant` already encodes — they are a **bundle of
+covarying dispositions** that the archetype names once. `FullRights` is not merely "schema+data
+grant"; it is "the engine may preserve keys, checkpoint sink-side, bypass constraints, and truncate."
+`ManagedDml` is the J5 verdict made reusable: "sink mints, journal off-box, descend the capture
+ladder, delete to roll back."
+
+> **Extensibility.** The catalog is a closed set today (two members) but is built to grow: a future
+> target class (a read-replica, a different managed platform, a no-trigger bulk-staging instance)
+> joins as a new archetype with its own profile, and every consumer that is *total over the archetype*
+> (the renderer, the disposition selector, the gate set) gets the new case by construction — the
+> closed-DU / `registered ⇔ executed` discipline (`CONSTELLATION.md` §9.8.9), applied to capability.
+
+---
+
+## §2 — What the archetype drives (the dispositions it should programmatically set)
+
+Declaring an archetype on an environment should **expand** to these engine decisions, so the operator
+states intent **once** and the pipeline derives safe interaction:
+
+1. **The identity disposition default.** `FullRights ⇒ PreservedFromSource` (write source keys; no
+   capture, no remap, no FK re-point — dramatically simpler and faster). `ManagedDml ⇒ AssignedBySink`
+   (the J5 path). *(Per-table structural overrides still apply — a `ReconciledByRule` user table, a
+   composite-key refusal — but the archetype sets the default the structural classifier starts from.)*
+2. **The realization + resume mechanism.** `FullRights ⇒` a **sink-resident progress table** becomes
+   available (a durable, queryable, mid-run checkpoint with no filename-digest coupling — the Phase-3
+   address-drift and compaction concerns evaporate). `ManagedDml ⇒` the client-side NDJSON journal
+   (the only option when `CREATE TABLE` is denied).
+3. **The schema-deploy lane.** `FullRights ⇒ migrate-with-data` (emit + apply DDL, then load).
+   `ManagedDml ⇒ transfer` (data-only; the schema is frozen).
+4. **The constraint-handling strategy.** `FullRights ⇒` optionally `NOCHECK` constraints + disable
+   triggers for a fast straight load. `ManagedDml ⇒` the capture-ladder descent (the only path under a
+   no-`ALTER` grant).
+5. **The wipe strategy.** `FullRights ⇒ TRUNCATE` (the cheap refresh). `ManagedDml ⇒` child-first
+   `DELETE` (the `2·|rows|` CDC-costed path).
+6. **The pre-write gate set.** The archetype declares the *expected* grant, so the `CapabilitySurvey`
+   reconciles against it (§5); a `FullRights` target missing `CREATE TABLE`, or a `ManagedDml` target
+   that *unexpectedly* permits `IDENTITY_INSERT`, is a **named declared-vs-actual mismatch**, not a
+   silent surprise mid-load.
+7. **The user-handling default.** `ManagedDml ⇒ ReconciledByRule` (the cloud owns its users — the
+   Phase-2 reverse-leg re-key). `FullRights ⇒` preserve (same key space) unless reconcile is declared.
+
+---
+
+## §3 — The assumptions we make today (honest inventory: implicit / hardcoded → should be archetype-driven)
+
+The estate-scale reverse-leg path was built against the **managed-DML** sink first, so several
+ManagedDml assumptions are currently **baked in** rather than chosen by archetype. Naming them is half
+the value of this document — each is a place the engine *assumes* the cloud profile and would behave
+sub-optimally (or refuse unnecessarily) against an on-prem `FullRights` target:
+
+| # | Current assumption (where) | True for | What the archetype unlocks for `FullRights` |
+|---|---|---|---|
+| H1 | The reverse-leg sink is `AssignedBySink` (the J5 default; `TransferRun.fs` reverse-leg wiring) | ManagedDml | `PreservedFromSource` — write source keys directly; **no capture/remap/FK-repoint at all** (a different, simpler engine path that the IDENTITY_INSERT grant makes correct) |
+| H2 | Resume state is a **client-side NDJSON journal** *because the DML-only grant forbids the `CREATE TABLE` a sink-resident progress table would need* (`CaptureJournal.fs` docstring) | ManagedDml | a **sink-resident progress table** — durable, queryable mid-run, no filename↔digest coupling (the Phase-3 hazards do not exist on this archetype) |
+| H3 | Staging is a session `#` temp table cloned from the sink (`SurrogateCapture.fs`) | ManagedDml | persistent server-side staging (re-usable across chunks; spill-friendly) |
+| H4 | Constraints/triggers are handled only by the capture-ladder **descent** (no bypass; `SurrogateCapture.fs:21-46`) | ManagedDml | `NOCHECK` / disable-trigger fast lane (the `ALTER` grant the cloud lacks) |
+| H5 | Wipe is child-first `DELETE` (`wipeFkOrdered`) | ManagedDml | `TRUNCATE` (the `ALTER`-gated fast refresh) |
+| H6 | The grant gate proves `INSERT`/`DELETE` coverage (data load); schema rights are a separate flow | both (correctly, via `Grant`) | the archetype makes the *expected* full set declarable + verified in one place |
+
+> None of these are bugs — each is the **correct** behavior for the ManagedDml class the path was
+> proven against. The point is that they are **class-specific**, currently chosen implicitly, and an
+> explicit archetype lets the engine pick the right one per target instead of assuming the cloud shape
+> everywhere. The on-prem `FullRights` strategies (H1–H5 right column) are *foreclosed today* by the
+> cloud-shaped defaults; the archetype is what re-opens them.
+
+---
+
+## §4 — The proposal: `Archetype` as a first-class config facet
+
+Add an **`Archetype`** facet to `Environment` (sibling to `Grant` / `Rendition`,
+`MovementSurface.fs:55`), declared once per place in `projection.json`, that **expands** to a
+`CapabilityProfile` the pipeline reads instead of re-deciding per site:
+
+```fsharp
+/// The capability CLASS of a target — the bundle of covarying dispositions the
+/// engine forks on (§1/§2). Closed so every consumer (the disposition selector,
+/// the resume-mechanism chooser, the gate set, the renderer) is TOTAL over it —
+/// a new target class joins by construction, never by a parallel hand-list.
+[<RequireQualifiedAccess>]
+type Archetype =
+    | FullRights      // on-prem, DDL+DML+IDENTITY_INSERT: the schema+data home
+    | ManagedDml      // a managed DML-only sink (the J5 profile): sink-mints, no DDL
+
+/// What an archetype EXPANDS to — the disposition defaults the pipeline consumes.
+/// Pure derivation; `of` is total over `Archetype`.
+type CapabilityProfile =
+    { Grant               : Grant                  // derived facet (subsumes the coarse one)
+      IdentityDefault     : IdentityDisposition    // PreservedFromSource | AssignedBySink
+      DdlPermitted        : bool                    // schema deploy + sink-resident progress
+      IdentityInsert      : bool                    // PreservedFromSource viability
+      ConstraintBypass    : bool                    // NOCHECK / disable-trigger
+      ResumeCheckpoint    : ResumeKind              // SinkResidentTable | ClientJournal
+      WipeStrategy        : WipeKind }              // Truncate | ChildFirstDelete
+```
+
+Design commitments:
+
+- **The archetype subsumes `Grant`.** `Grant` becomes a *derived* projection of the archetype
+  (`FullRights → SchemaAndData`, `ManagedDml → DataOnly`), so the existing `CapabilitySurvey` /
+  `requiredFor` machinery keeps working unchanged — it now reads `archetype.Grant` instead of a hand-set
+  facet. (Migration §6 keeps `Grant`-only configs valid by *inferring* the archetype from the grant.)
+- **`Rendition` stays orthogonal** (it is *which rendition*, not *what class*) but the two correlate in
+  practice (on-prem=Logical, cloud=Physical); the archetype does not narrow it.
+- **One definition site, total consumers.** `CapabilityProfile.of : Archetype -> CapabilityProfile` is
+  the single expansion; the disposition selector, the resume chooser, and the gate set read the profile
+  — none re-derive "is this DML-only?" from scattered checks. This is the `ArtifactByKind` /
+  `chainSteps` discipline (one definition site, structural totality) applied to target capability.
+- **Reusable.** An operator declares `"archetype": "FullRights"` once on the on-prem place and
+  `"archetype": "ManagedDml"` on the cloud place; every flow touching them inherits the safe-interaction
+  profile. No per-flow capability flags, no per-site re-decision.
+
+---
+
+## §5 — Verify, don't trust: the archetype is a *declared assumption* the survey confirms (A44)
+
+The archetype is the operator's **declaration** of a target's class. The engine must not *trust* it
+blindly — it must **reconcile it against probed evidence**, exactly as the `CapabilitySurvey` already
+reconciles the declared `Grant` against `fn_my_permissions` (`required ⇔ surveyed`). This is the J5
+covenant generalized from a one-time spike into a standing, per-class gate:
+
+- A declared **`FullRights`** target whose live grant **lacks `CREATE TABLE` or `IDENTITY_INSERT`**
+  (probe sheet E1/E3) is a **named declared-vs-actual mismatch** — refuse before any write, because the
+  engine would have chosen `PreservedFromSource` + a sink-resident checkpoint that the real grant cannot
+  support.
+- A declared **`ManagedDml`** target that **unexpectedly permits `IDENTITY_INSERT`** is *also* a
+  surfaced mismatch (a safer-than-declared surprise, but still a divergence the operator should see —
+  it means `PreservedFromSource` is *available* and the simpler path could be chosen).
+- An **unverifiable** grant (least-privilege denies `fn_my_permissions`) stays **blocking** (the
+  existing `GrantUnreadable` / NM-55 posture) — an unprobed archetype claim is *unverified*, not
+  *confirmed*.
+
+This makes the archetype **expressible ⇔ reachable** (A44): what the operator can declare, the survey
+can prove (or refuse). The J5 ledger becomes the *seed profile* for `ManagedDml` (the verified
+verdicts: no ALTER, no IDENTITY_INSERT, AssignedBySink, SQL rollback); the probe sheet Part E is the
+*seed verification* for `FullRights`. The disposition decision (the archetype) holds across instances
+*of the same class*, so verifying it once de-risks every same-class cutover — the original J5 thesis,
+now structural.
+
+---
+
+## §6 — Migration path (non-breaking slices)
+
+1. **Slice A — the type + the expansion, derived from `Grant` (no behavior change).** Add `Archetype` +
+   `CapabilityProfile.of`; add the optional `Environment.Archetype` field (parsed from `projection.json`,
+   defaulting to **inferred from the existing `Grant`** — `SchemaAndData → FullRights`,
+   `DataOnly → ManagedDml`, `None → None`). Existing configs are byte-identical: nothing reads the
+   profile yet. Property test: `(infer ∘ derive-grant)` round-trips.
+2. **Slice B — route the survey through the profile.** `CapabilitySurvey.requiredOf` reads
+   `archetype.Grant` instead of the raw facet (identical results — the derivation is exact); add the
+   declared-vs-probed **archetype** reconciliation (E1/E3 capabilities), surfaced as the new named
+   mismatch. Witness: a `FullRights`-declared sink with no `CREATE TABLE` grant refuses by name.
+3. **Slice C — the resume-mechanism fork (the highest-value unlock).** On a `FullRights` archetype,
+   offer the **sink-resident progress table** as the resume checkpoint (gated on the verified
+   `CREATE TABLE` grant); `ManagedDml` keeps the client journal. This is where the archetype first
+   *changes* engine behavior — and it retires the Phase-3 address-drift/compaction hazards on the
+   on-prem class.
+4. **Slice D — the identity-disposition fork.** On `FullRights`, default to `PreservedFromSource`
+   (IDENTITY_INSERT verified) — the *simpler* load (no capture/remap/FK-repoint). This is a large,
+   high-value path that the on-prem archetype makes correct.
+5. **Slices E+ — constraint bypass / TRUNCATE wipe**, each gated on the verified `ALTER` grant.
+
+Each slice is independently shippable and witnessable; none regresses the ManagedDml path (its profile
+is byte-identical to today's hardcoded behavior).
+
+---
+
+## §7 — What it unlocks (the one-line summary)
+
+> The operator declares a target's **class once**; the pipeline derives — and the survey **verifies** —
+> how it may safely be touched. The cloud path stays exactly as J5 proved it; the on-prem path stops
+> being forced into cloud-shaped assumptions (off-box journals, sink-minting, descent-only constraint
+> handling) and gains the strategies its full grant actually permits (sink-resident resume, key
+> preservation, truncate-refresh). The capability class becomes a **reusable, verified, single-source
+> disposition** instead of a scatter of implicit branches — and a new target class joins by adding one
+> closed-DU case, total-over-the-engine by construction.
+
+*See `REVERSE_LEG_OPERATOR_PROBE_SHEET.md` Part E for the operator probes that verify a target's
+archetype, and `DECISIONS.md` (2026-06-15 — "Database archetype as a config disposition") for the
+recorded direction.*

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23284,3 +23284,78 @@ synthesis (the P1–P11 taxonomy, the ledger, the forward charter) lives in
   P10); no `PreservedFromSource`. M5's prerequisite ledger now exists (here + the compendium).
   Remaining status-surface flips (`AUDIT_2026_06_13` "J5 (ops-gated)"; the `HANDOFF.md` /
   backlog preemption letters) and the NM-73 auto-fallback arming are follow-ons.
+
+## 2026-06-15 (later) — Phase 2: reconcile ∘ streaming on the reverse leg; the `reconcileUnsupported` refusal LIFTED; the validate-user-map pre-write halt reaches the streaming arm (NM-31 / N4 closed)
+
+The charter's (`CHARTER_REVERSE_LEG_EXECUTION.md` Part IX) **Phase 2** — wire user
+reconciliation onto the reverse leg — is landed. It is the highest-value buildable gap: it is
+what makes "re-key users" actually run on the B→A up-leg. The reverse leg now reconciles the
+operator-named kinds (the User family) to the pre-existing **sink** identities by business key
+(email) and re-keys every FK pointing at them, **without re-importing a single user row** (the
+"cloud owns its users" / golden discipline, `THE_DATA_PRODUCERS` §; Part V §4) — on the
+bounded-memory **streaming** realization, the estate-scale path. This was an integration, not a
+build: every primitive existed (`Reconciliation.reconcileKind` with the ByEmail/BySsKey/
+ManualOverride/Fallback strategies; `reconcileAgainstSink`; `validateUserMap`;
+`SurrogateRemapContext`; the packed remap; `DataLoadPlan.reclassifyReconciled`). The work was
+composing them onto the streaming path and lifting two refusals.
+
+- **The named refusal `transfer.reverseLeg.reconcileUnsupported` is LIFTED.** The CLI face
+  (`RunFaces.runReverseLegTransfer`) no longer refuses reconcile/user-map specs up front. It
+  now parses (`parseReconcileSpec` / `parseUserMapCsv`) and resolves
+  (`TransferSpec.resolveAllReconciliation`) them against the **physical sink contract**
+  (the rendition the up-leg writes into — `findKindByTable` matches physical names, consistent
+  with the forward face's live-read contract) exactly as the forward `transfer` face does. A
+  malformed or unresolvable spec still refuses BY NAME (arg-error exit 2) **before any
+  connection opens**; a well-formed resolvable spec is accepted. The CLI args (`opts.Reconcile`
+  / `opts.Rekey`) already flowed into the reverse-leg face — only the face refused them — so no
+  `MovementSpec` / `Program` / `MovementSurface` change was needed.
+
+- **The streaming reconcile leg (`runStreamingReconcilingWithRenames`).** Before the stream,
+  the runner reconciles the named kinds against the sink (read-only — safe in DryRun): it
+  materializes ONLY the reconciled kinds' source rows (the small User population; the
+  FK-target bulk never materializes), re-points them to the sink's names, and matches them to
+  the pre-existing sink rows. The resulting `SurrogateRemapContext` is threaded into
+  `writePlanStreaming` alongside the stream-captured `PackedSurrogateRemap`; the per-quantum
+  FK re-point consults a **combined lookup** over `assignedBySinkKinds ∪ reconciledKinds`
+  (disjoint by kind, so the fall-through never double-resolves). Reconciled kinds are
+  `reclassifyReconciled`'d to `ReconciledByRule` and **skipped in phase 1 / phase 2** of the
+  streaming load — the sink already owns their rows. The old `runStreamingWithRenames` is now
+  a thin straight-load wrapper (empty reconciliation, inert `allowDrops`) — byte-identical to
+  the pre-Phase-2 realization, so its five existing witnesses are unchanged.
+
+- **The validate-user-map pre-write halt on the streaming arm (NM-31 / N4 closed for
+  streaming).** The streaming arm previously had NO pre-write reconcile-orphan halt (the
+  `ReverseLegRealization` docstring named this asymmetry as the follow-on). It now runs the
+  SAME `validateUserMap allowDrops reconciled` gate the materialized AC-I5 path uses, in the
+  same precedence order (`executeGate` then the orphan halt). An unmapped source user is a
+  **pre-write refusal** (`transfer.unmappedIdentities`, the Sink untouched), not a post-write
+  drop — unless `--allow-drops` downgrades it to the reported-drop path. The `choose` selector
+  and the `ReverseLegRealization` type docstring's NM-31 caveat are updated: the arms are no
+  longer drop-asymmetric.
+
+- **No silent reconcile loss on the materialized arm.** Lifting the CLI refusal means a
+  reconcile request on an inadmissible streaming combination (`--tables` / `--resumable` /
+  WipeAndLoad) routes to the materialized arm. Rather than let it straight-load and **silently
+  drop the reconcile** (the cardinal sin), `runReverseLegThroughConnections` now threads the
+  reconciliation map through `runCore`'s existing reconcile leg (the same path the forward
+  `TransferCanaryTests` prove). Both arms reconcile; neither loses it silently.
+
+- **Witnessed.** Two Docker witnesses promoted from the reserved `ReverseLegBoundaryTests`
+  Skip-stub into `ReverseLegStreamingTests`: (a) *"User (Customer) reconciled by email on the
+  up-leg — identities re-keyed, never re-imported"* — pre-seeds the sink's own Customer
+  inventory, reverse-leg-reconciles by email, asserts Customer stays at 2 rows (no re-import,
+  ReconciledByRule, zero writes) while every Account/Invoice Customer-FK joins the sink's own
+  users by email; (b) *"validate-user-map pre-write halt"* — an unmatched source user refuses
+  `transfer.unmappedIdentities` with the sink untouched (zero Account/Invoice/Payment rows).
+  The three reverse-leg face refusal tests are rewritten (malformed → exit 2; unknown table →
+  exit 2; well-formed → accepted, NOT exit 2). Build clean; 37 reverse-leg suite tests +
+  184 pure transfer/movement/reconciliation tests green warm.
+
+- **What this does NOT close (the charter's named residuals stand).** This is the Docker-scale
+  composition; the real-wire bench (P7b, Phase 1), the live user-population *discovery* pass
+  (`UserFkReflowPass` is still a production no-op — the reconcile here reads the sink's user
+  inventory directly via `reconcileAgainstSink`, which is the runtime AssignedBySink/reconcile
+  path, not the design-time discovery pass), journal-on-execute forcing (Phase 3), the
+  movement dry-run + row-grained progress (Phase 4), and the cutover gates (Phase 5) remain.
+  Phase 2's exit test — "a reverse-leg move re-keys users by email with a pre-write orphan
+  halt, witnessed" — is met.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23449,3 +23449,47 @@ could not see "N rows would move" before committing a destructive estate-scale l
   All Phase 2–4 Docker witnesses were re-run with that env var set and confirmed real via
   per-test TRX durations (seconds, not ms). NEVER trust the green count for Docker-gated tests
   here — check the durations.
+
+## 2026-06-15 (later) — Phase 5 + Phase 1: the real-wire harness + estate survey package; the cutover gates are governance-gated, not code (R6)
+
+The charter's **Phase 5** (cutover gates) and **Phase 1** (the real wire). Unlike Phases 2–4,
+Phase 5 has **no buildable code lever that respects R6** — all three gates are real-wire /
+CDC-verdict / cutover-governance bound. The honest, high-value deliverable is the operator-ready
+**`PHASE_1_REAL_WIRE_HARNESS.md`** (the P7b throughput bench procedure + the read-only estate
+survey SQL) plus this cutover-readiness assessment. This is also exactly what the mission's
+Phase 1 asks ("you can't fake the wire — prep the harness + survey queries and flag it for the
+operator").
+
+- **The harness package (`PHASE_1_REAL_WIRE_HARNESS.md`).** Part A: the P7b throughput bench —
+  the shipped streaming reverse leg is already `Bench`-instrumented, so a real-wire run prints
+  rows/sec with no new code; the doc is the operator procedure + the escape-hatch plan (50k-chunk
+  sweep, parallel wavefronts port, sink-resident spill) if it lands materially below 20k. Part B:
+  six read-only survey queries — §1 row counts (sizes the run), §2 FK fan-in + `approx_remap_MB`
+  (resident remap vs spill), §3 trigger map (the capture-ladder descent map), §4 G1 object-scope
+  DENY (P1b — promotes the table-scope preflight if found), §5 P10 user directory (confirms
+  ReconciledByRule on the real estate — the Phase-2 reverse-leg re-key's real input), §6 CDC
+  (the verdict that arms NM-73). Part C: the hand-off checklist.
+
+- **Cutover-readiness assessment — why each Phase-5 gate is NOT a code change here.**
+  1. **Production-shaped dry-run** — the *mechanism* is the Phase-4 movement dry-run preview (row
+     counts + rekey-map preview, witnessed Docker); "production-shaped" means running it against
+     the **real estate** — a real-wire action (harness Part A/B), not a code lever.
+  2. **Grant gate advisory → hard** — the *mechanism already exists*: the standalone `projection
+     survey` verb HARD-STOPS (exit 7) on a blocked `CapabilitySurvey.blocked` report
+     (`Program.fs:314`); the in-flow G0c advisory only warns **by R6 design** (V2 owns no
+     production write path during dual-track). The "flip" is the operator wiring `projection
+     survey` into the **per-pair cutover CI as a required gate** — a *governance* action governed
+     by the N=10-consecutive-green-canary + operator-sign-off ladder (the load-bearing R6
+     commitment), NOT a blanket in-flow env flip. **A speculative in-flow flip was deliberately
+     NOT built** — it would be redundant with the existing survey hard-stop and would bypass the
+     per-pair canary governance R6 mandates. (This entry is the R6 amendment for the
+     not-built decision; the default advisory posture is unchanged, byte-identical.)
+  3. **NM-73 auto-fallback (CDC-silence → EXCEPT)** — explicitly CDC-verdict-gated ("revisit
+     after J5"); OPEN-3 is still PARTIAL (the CDC path is not yet exercised on a real managed
+     environment). The manual `emission.dataVerification = ValidateBeforeApply` override shipped
+     (NM-73 / WP6.6); the auto-fallback arms on the harness §6 CDC verdict, not before — building
+     it now would fire a deferral whose wake (the CDC verdict) has not landed.
+
+- **Net for Phase 5:** the gates' mechanisms are built or exist; what remains is operator/real-wire
+  governance, which the harness package unblocks. No code shipped for Phase 5 by design (R6); the
+  deliverable is the harness + this assessment.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23409,3 +23409,43 @@ close a SILENT duplicate/re-run hazard with a NAMED refusal — the cardinal-sin
   on re-run) — **needs a real dropped connection to prove**; it is a Phase-1 real-wire
   co-requisite, not a Docker-witnessable lever. Both stay named with their wake; the built
   levers above close the duplicate hazard that gated the rest.
+
+## 2026-06-15 (later) — Phase 4: the movement dry-run row-count estimate (streaming preview); the live progress bar STAGED
+
+The charter's **Phase 4** buildable lever. The materialized reverse-leg DryRun already reports
+real per-kind row counts (it materializes the rows); the **streaming** DryRun ingested nothing
+(the rows stream at write time), so its preview reported zero rows-would-move — an operator
+could not see "N rows would move" before committing a destructive estate-scale load.
+
+- **The streaming DryRun row-count estimate (`countKindRows`).** The streaming DryRun arm of
+  `runStreamingReconcilingWithRenames` now estimates each kind's rows-would-move with a cheap
+  EXACT count (`COUNT_BIG(*)` aggregate — one round-trip per kind, no row scan) and reports it
+  as `RowsIngested`. A **reconciled** kind previews 0 (ReconciledByRule — the sink owns it; it
+  is re-keyed, not re-imported), every other kind previews its source count, `RowsWritten`
+  stays 0 (a preview writes nothing), and the reconcile outcome (`UnmatchedIdentities` /
+  `AmbiguousIdentities`, from Phase 2) rides the same report — the **rekey-map preview**. So the
+  operator now previews per-kind "N rows would move" + "K users matched / J unmatched" before
+  any DML, on the estate-scale path.
+
+- **Witnessed.** `ReverseLegStreamingTests` "Phase 4 dry-run preview": a streaming DryRun on the
+  seeded estate previews Account=3 / Invoice=3 / Payment=4 (exact source counts), the reconciled
+  Customer kind previews 0, every `RowsWritten` is 0, `UnmatchedIdentities` is empty (full match),
+  and the sink is unchanged. **Run for real against the warm container** (`PROJECTION_MSSQL_CONN_STR`),
+  per-test duration ~1.2s — NOT a no-op (see the env note below). Build clean.
+
+- **STAGED — the live row-grained progress bar.** The denominator the parked
+  `SpectreProgressAdapter : IProgressRunner` (Tier-3, `REPORTING_HORIZON.md` / `DYNAMIC_DISPLAY.md`)
+  needs — rows-total per kind — now exists (the same `countKindRows`). But the live ETA bar is a
+  TTY rendering surface whose **wake is the real-wire multi-hour run**: a 40-second Docker test
+  has nothing to watch, and a deterministic witness for a live bar is not Docker-shaped. Wiring
+  the parked adapter to the row denominator + a durable reconnect-surviving surface is the
+  remaining Phase-4 thread, gated on Phase 1's real wire. The stage-grained `--watch` board and
+  the row-count preview ship now; the live row bar stays parked with its wake named.
+
+- **⚠️ Process note (cost real time this session; memory `local-windows-dev-env` updated).** On
+  the Windows dev box, `DockerDaemon.ensureRunning()` checks only a **Linux** socket, so every
+  `EphemeralContainerFixture` test SILENTLY NO-OPs (a 0.4ms `()` pass — the survival-rule-#12
+  trap) unless `PROJECTION_MSSQL_CONN_STR` points at the warm `projection-mssql-warm` container.
+  All Phase 2–4 Docker witnesses were re-run with that env var set and confirmed real via
+  per-test TRX durations (seconds, not ms). NEVER trust the green count for Docker-gated tests
+  here — check the durations.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23493,3 +23493,46 @@ operator").
 - **Net for Phase 5:** the gates' mechanisms are built or exist; what remains is operator/real-wire
   governance, which the harness package unblocks. No code shipped for Phase 5 by design (R6); the
   deliverable is the harness + this assessment.
+
+## 2026-06-15 (later) — Database archetype as a config disposition (direction recorded; operator-prompted)
+
+The operator named a distinction the docs had blurred: there are **two classes of target database**,
+not one. **(1) On-prem SQL Server** — the migration team's own instance, which receives the emitted
+SSDT schema (`CREATE TABLE` / `ALTER`) AND hosts a database with the same schema + the migrated data
+(the `Logical` / B rendition); likely full DDL rights (operator to verify). **(2) Managed cloud SQL**
+— the J5-settled DML-only sink (`Physical` / A rendition; no ALTER / IDENTITY_INSERT / CREATE TABLE).
+These have materially different capability profiles, and the engine *already* branches on them — but
+the branch lives unevenly across a coarse binary `Grant` facet (`SchemaAndData | DataOnly`), a metadata
+`Rendition` facet, and a layer of **hardcoded cloud-shaped assumptions** (the client-side NDJSON
+journal exists *only because* the DML-only grant forbids the `CREATE TABLE` a sink-resident progress
+table would need; AssignedBySink is the reverse-leg default; `#`-temp staging; descent-only constraint
+handling).
+
+- **The direction.** Lift the target's capability **class** into one named, reusable **config
+  disposition** — an `Archetype` facet on `Environment` (sibling to `Grant` / `Rendition`) that
+  **expands** to a `CapabilityProfile` the pipeline reads instead of re-deciding per site. `FullRights`
+  (on-prem) ⇒ PreservedFromSource default, schema deploy, sink-resident resume, constraint bypass,
+  TRUNCATE. `ManagedDml` (cloud, the J5 profile) ⇒ AssignedBySink, client journal, capture-ladder
+  descent, child-first DELETE. The archetype **subsumes** `Grant` (which becomes a derived projection),
+  keeps `Rendition` orthogonal, and is **closed + total over the engine** (a new target class joins by
+  one DU case — the `ArtifactByKind` / `registered ⇔ executed` discipline applied to capability).
+- **Verify, don't trust (A44 — expressible ⇔ reachable).** The archetype is the operator's
+  *declaration*; the `CapabilitySurvey` *confirms* it against probed `fn_my_permissions` / write-probe
+  evidence, exactly as it reconciles the declared `Grant` today. A declared `FullRights` target missing
+  `CREATE TABLE` / `IDENTITY_INSERT`, or a `ManagedDml` target that unexpectedly permits them, is a
+  **named declared-vs-actual mismatch** — the J5 covenant (the disposition holds across same-class
+  instances) generalized from a one-time spike into a standing per-class gate. The J5 ledger is the
+  seed profile for `ManagedDml`; `REVERSE_LEG_OPERATOR_PROBE_SHEET.md` Part E (E1–E5: CREATE TABLE,
+  ALTER, IDENTITY_INSERT, schema parity, sink-resident progress — all validated against SQL Server 2022)
+  is the seed verification for `FullRights`.
+- **What it unlocks.** The on-prem path stops being forced into cloud-shaped assumptions and gains the
+  strategies its full grant permits (the highest-value: a **sink-resident progress table** retires the
+  Phase-3 address-drift/compaction hazards on this class; **PreservedFromSource** removes the entire
+  capture/remap/FK-repoint machinery when keys can be preserved). The cloud path stays byte-identical to
+  the J5-proven behavior.
+- **Status: design + assumptions recorded, not yet built.** The full design + the honest hardcoded-
+  assumption inventory (H1–H6) + the non-breaking slice plan (A: type + derive-from-Grant; B: survey
+  reconciliation; C: sink-resident resume fork; D: PreservedFromSource fork; E+: bypass/TRUNCATE) live
+  in **`DATABASE_ARCHETYPES.md`**. Slice A is byte-identical (the archetype defaults to *inferred from
+  the existing `Grant`*), so it can land without touching any current config. Sequenced behind the
+  real-wire verification (the on-prem profile must be probed before its forks are trusted).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23359,3 +23359,53 @@ composing them onto the streaming path and lifting two refusals.
   movement dry-run + row-grained progress (Phase 4), and the cutover gates (Phase 5) remain.
   Phase 2's exit test — "a reverse-leg move re-keys users by email with a pre-write orphan
   halt, witnessed" — is met.
+
+## 2026-06-15 (later) — Phase 3: harden resume + idempotency — force a journal on streaming execute; the journal-address-drift guard
+
+The charter's **Phase 3** buildable levers (`CHARTER_REVERSE_LEG_EXECUTION.md` Part IX). Both
+close a SILENT duplicate/re-run hazard with a NAMED refusal — the cardinal-sin discipline
+("a silent erasure is strictly worse than no claim," here a silent *duplication*).
+
+- **The duplicate-hazard close — force `--journal` on a streaming `--execute`
+  (`transfer.reverseLeg.streamingExecuteRequiresJournal`).** A journal-less streaming execute
+  has no idempotent envelope: any re-run re-streams and DOUBLES every AssignedBySink kind
+  (the G3 hazard, open whenever no journal is supplied). The CLI face now refuses that exact
+  shape by name and forces the operator to name a journal directory — making every streaming
+  execute resumable + idempotent by construction. The gate is the pure, total
+  `ReverseLegRealization.executeJournalGate` (Streaming-None × executeGated → refusal; DryRun,
+  journal-bearing, and the materialized G10 arm all pass), tested without a connection. The
+  ENGINE still supports journal-less execute (the test seam + the materialized arm); only the
+  production face forces it — so the existing engine witnesses are unchanged. This is "force a
+  journal," the smallest of the three lever options the charter named (force / default /
+  refuse) — chosen over defaulting because defaulting would guess a filesystem location and
+  silently change the write path; the named refusal is the honest, friction-light boundary.
+
+- **The journal-address-drift guard (`transfer.resume.journalAddressDrift`).** The journal is
+  addressed by the plan-marker digest (`transfer-<digest>.ndjson`), so a `planMarker`/schema
+  byte-change between a crashed run and its resume orphans the prior journal: THIS run's file
+  is absent, the prior is present under a different digest, and — unguarded — the run silently
+  starts fresh and re-streams (DOUBLING under AssignedBySink). The risk register named this
+  ("any byte change silently orphans journals"). `CaptureJournal.siblingJournalsUnderDrift`
+  detects the signature (own file absent + sibling `transfer-*.ndjson` present) and the
+  streaming execute refuses by name BEFORE any write rather than orphaning the prior journal.
+  Additive + fresh-run-only: a clean resume (own file present) and a true fresh run (empty
+  dir) both pass, so the resume / idempotent-re-run / source-drift witnesses are unchanged.
+  This does not re-address the journal (the digest filename stays — it preserves
+  multi-transfer-per-directory coexistence); it converts the *silence* into a named refusal,
+  which is the actual hazard.
+
+- **Witnessed.** Pure: `ReverseLegBoundaryTests` "Phase 3 gate" (executeJournalGate totality) +
+  "Phase 3 address-drift" (siblingJournalsUnderDrift signature). Docker:
+  `ReverseLegStreamingTests` "Phase 3 address-drift" — a stray journal orphans the run's own,
+  the execute refuses `transfer.resume.journalAddressDrift`, the sink stays untouched. Build
+  clean; 19 reverse-leg boundary+streaming tests green warm.
+
+- **STAGED, not built (the evidence discipline — IR/levers grow at the wake, not before).**
+  Two Phase-3 items remain deferred behind a wake the Docker harness cannot reach:
+  (1) **journal compaction** — resume loads the whole NDJSON into the index; ARMED, **wake =
+  any real resume > ~10M captured pairs** (`CaptureJournal.fs`); at Docker scale the index is
+  KB, so building compaction now would be a speculative scale-build with no witness.
+  (2) **live socket-drop reconnect/retry mid-transfer** (distinct from the built journal-replay
+  on re-run) — **needs a real dropped connection to prove**; it is a Phase-1 real-wire
+  co-requisite, not a Docker-witnessable lever. Both stay named with their wake; the built
+  levers above close the duplicate hazard that gated the rest.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,65 @@
+# Handoff addendum — 2026-06-15, REVERSE-LEG EXECUTION (Phases 2–5 landed) + THE OPERATOR PROBE PACKAGE — your job is to DECODE the operator's probe results (attached with this handoff) and drive each staged item to completion
+
+To the next agent.
+
+**Your mission in one sentence.** The reverse-leg data-load engine is built and witnessed at Docker
+scale through Phase 4; what remained was everything that needs the operator's real databases. The
+operator has now **run the probes and is bringing you the results** (attached beneath this handoff —
+the filled-in ledgers from `REVERSE_LEG_OPERATOR_PROBE_SHEET.md`, the `PHASE_1_REAL_WIRE_HARNESS.md`
+throughput bench, and the Part E archetype verdict). **Take those results and turn each "staged /
+gated" item into a built, witnessed one.** This letter is the decoder: result → what it unlocks →
+the slice to build.
+
+**Where you are standing.** Branch `claude/unruffled-diffie-801d9b`, 7 commits on top of the charter
+base (`74e9b597`). Read `CHARTER_REVERSE_LEG_EXECUTION.md` first (Part VII = code state; Part IX =
+the phase ladder with the ✅/⏳ status I left). Phases 2–4 are **built + warm-witnessed** (reconcile ∘
+streaming with the validate-user-map halt; force-journal + address-drift guard; the movement dry-run
+row-count preview). Phases 1/5 are operator/real-wire/CDC-gated — the harness + probe sheet are how
+they unblock. The three operator-facing companions are `REVERSE_LEG_OPERATOR_PROBE_SHEET.md`,
+`PHASE_1_REAL_WIRE_HARNESS.md`, `DATABASE_ARCHETYPES.md`.
+
+**The decoder — consume the attached results like this:**
+
+| Operator result (probe) | What it unlocks → your slice |
+|---|---|
+| **Part E archetype verdict** (E1 CREATE TABLE, E3 IDENTITY_INSERT) | **The biggest fork.** *FullRights* (both OK) ⇒ build `DATABASE_ARCHETYPES.md` Slice A (the `Archetype` type + `CapabilityProfile.of`, derived from `Grant` — byte-identical) **with its first consumer**: Slice C (sink-resident progress table — retires the Phase-3 journal hazards on-prem) and/or Slice D (PreservedFromSource — removes the whole capture/remap/FK-repoint path when keys can be preserved). *ManagedDml* (both denied) ⇒ the engine already ships this; declare it + move on. *Split* ⇒ treat each capability independently. **Do not build the archetype type with no consumer** (zero-consumer rule); build it the moment a fork needs it. |
+| **D1 throughput (P7b)** rows/sec vs floor | ≥ floor ⇒ record in DECISIONS (amend the ~271/~27k/~35.5k ladder) + proceed to the cutover gates. Materially < 20k ⇒ trigger an escape hatch *with a plan*: the 50k-chunk sweep, the **parallel wavefronts port** (reuse `Deploy.executeLeveledSeed`/`ParallelSafe` on the reverse leg — port, not build), or the sink-resident spill (sized by B2). |
+| **B1 row counts + B2 FK-target rows / `approx_keymap_MB`** | vs the transfer-host memory budget ⇒ resident remap (fast) **or** build the sink-resident keymap / server-side `UPDATE…JOIN` **spill** (DESIGNED-only today — this result is its wake). Also: if a real resume will exceed ~10M captured pairs, that is the wake for **journal compaction** (Phase 3 staged). |
+| **B3 orphan FK rows** | the expected drop count ⇒ set `--allow-drops` expectations / decide clean-vs-accept; confirm the exit-9 + `SkippedReferences` report matches. |
+| **B4 reconcile-key quality** (dup / null / casing of email) | dups ⇒ build a tiebreaker; nulls ⇒ those users hit the validate-user-map halt (expected); **casing mismatch ⇒ the reconcile matches raw strings (ordinal Map) — if source/sink email casing differs, build a normalization step** or the match silently misses. |
+| **A1–A5 schema shape** | the disposition mix + the refusal list. Composite-PK (A2) / no-PK (A1) / non-nullable cycle FK (A3) ⇒ each refuses by name — plan handling. A5 non-insertable columns ⇒ confirm the engine excludes them for those tables. |
+| **C1 object-scope DENY** | if any planned-write table is missing a permission ⇒ **promote the reserved Skip-stub** `ReverseLegBoundaryTests."object-scope DENY refused by name before any write"` (descend `Preflight.captureGrantEvidence` to table scope). |
+| **C3 triggers** | the capture-ladder descent map ⇒ confirm those descents appear in the run report (expected, not a regression); scrutinize any INSTEAD OF. |
+| **C4 CDC enabled?** | the verdict that **arms NM-73 auto-fallback** (Phase 5): CDC live ⇒ wire CDC-silence → EXCEPT automatic fallback (the manual override already ships). |
+| **C5 memory semaphore** | the chunk-size ceiling ⇒ pre-size `CaptureChunkSize` / drop-indexes-during-load to avoid the RESOURCE_SEMAPHORE stall. |
+| **C6 real-table write-probe** | if it errored ⇒ the exact constraint/trigger/permission to handle before a real run (the single most important pre-run fact). |
+| **E4 schema parity / shape drift** | if the rendered contract and live shape diverge ⇒ promote the reserved Skip-stub `ReverseLegBoundaryTests."B-drift refused by name"` (a named `transfer.sourceShapeDrift` preflight). |
+
+**Build discipline (the scars from this session — heed them).**
+1. **⚠️ Docker tests SILENTLY NO-OP on the Windows box.** `DockerDaemon.ensureRunning()` checks a
+   *Linux* socket, so every `EphemeralContainerFixture` test passes as a 0.4ms `()` no-op unless
+   `PROJECTION_MSSQL_CONN_STR` is set. Run them with
+   `$env:PROJECTION_MSSQL_CONN_STR="Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container; `scripts/warm-sql.sh conn` prints it) and **confirm via per-test TRX durations
+   (seconds, not ms)** — never trust the green count. This is survival-rule #12 in operational form.
+2. **`dotnet` is not on the bash PATH;** it lives at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe`.
+   Use PowerShell to build/test. Pure pools and Docker pools separately (CLAUDE.md §4.1).
+3. **Every refusal named; nothing silent.** Each new gate ships as a named `ValidationError` + a pure
+   witness; promote the reserved Skip-stubs rather than writing from zero; DECISIONS entry per slice.
+4. **The archetype is zero-consumer until its fork** — build the type *with* Slice C/D, not before
+   (the dead-algebra retirement precedent).
+
+**What NOT to redo (already built + witnessed, warm).** Reconcile ∘ streaming + the streaming
+validate-user-map halt (Phase 2); the force-journal + address-drift refusals (Phase 3); the streaming
+DryRun row-count preview (Phase 4). 62 reverse-leg + forward-reconcile Docker tests + 184 pure tests
+green for real against the warm container. The DECISIONS 2026-06-15 entries (Phases 2–5 + the
+archetype direction) are the substance; this letter only points.
+
+Hold the spine — name every refusal, count every crossing, and turn each probe result into a settled
+disposition.
+
+---
+
 # Handoff addendum — 2026-06-15, MIGRATION-CONTEXT WIRING — the data triumvirate is whole: the operator-curated Migration lane now has a real row source (JSON file → MigrationDependencyContext), threaded the same seam as Bootstrap, partition-disjoint, Docker-witnessed three lanes live
 
 To the next agent.

--- a/sidecar/projection/PHASE_1_REAL_WIRE_HARNESS.md
+++ b/sidecar/projection/PHASE_1_REAL_WIRE_HARNESS.md
@@ -1,0 +1,204 @@
+# Phase 1 — Real-Wire Harness & Estate Survey (operator-actionable)
+
+> **What this is.** The operator-runnable package for the one thing the engine cannot fake:
+> the real wire. It closes the charter's **Phase 1** (`CHARTER_REVERSE_LEG_EXECUTION.md` Part IX)
+> and is the prerequisite for the **Phase 5** cutover gates. Two parts: **(A)** the P7b throughput
+> bench (does the set-based streaming lane sustain the throughput floor against a real managed
+> OutSystems environment?), and **(B)** the estate survey SQL (the read-only probes that size the
+> remap, map the trigger lanes, and settle the residual J5 questions). Everything here is
+> **read-only or operator-gated** — the agent cannot run it; hand it to the operator.
+>
+> **Dated 2026-06-15.** Authored alongside Phases 2–4 (reconcile ∘ streaming, force-journal,
+> movement dry-run). The set-based streaming reconcile lane these measurements exercise is
+> **BUILT and witnessed at Docker scale**; this package is how it earns "trusted on the real wire."
+
+---
+
+## Part A — The P7b throughput bench
+
+**The question (the only load-bearing residual after the J5 run).** The shipped set-based
+streaming lane measured **~27k–35.5k rows/sec on loopback Docker** (`AUDIT_2026_06_10_REVERSE_LEG_DML_PROOF.md` §0).
+P7b asks: does it sustain the **throughput floor** (the figure `V2_DRIVER.md` / the audit fix
+for the cutover window) over a **real managed-environment wire**, worst-case all-FK-referenced shape?
+A real-wire bench materially **below 20k rows/sec re-opens** chunk-sizing, parallel per-table loading
+(the seed-lane level-parallel loader port), and the sink-resident spill — all named, none yet triggered.
+
+**The harness is the shipped engine, instrumented.** The streaming reverse leg already carries
+`Bench` probes on the hot loop (`Bench.scope` / `streamProbe`); a real run prints the rows/sec
+without new code. The operator procedure:
+
+1. **Pick a representative slice.** A single large FK-target table (the worst case for the resident
+   remap) at representative scale — ideally the largest OSUSR table the survey (Part B §1) finds, or a
+   capped slice of it. The streaming lane is whole-estate by design, but a single-table bench isolates
+   the per-row vs set-based cost P7b compares.
+2. **Run the streaming reverse leg, journaled, gated.** Against the real source (B, logical) → real
+   managed sink (A, physical):
+   ```
+   PROJECTION_ALLOW_EXECUTE=1 projection move <reverse-leg-flow> --go --streaming --journal <dir>
+   ```
+   `--streaming` selects the bounded-memory lane; `--journal <dir>` is now **required** for a streaming
+   execute (Phase 3 — the duplicate-hazard close), so the run is resumable + idempotent.
+3. **Read rows/sec from the bench output** (`-v` surfaces the bench table). The per-kind `load` stage
+   reports rows + elapsed; rows/sec = rows ÷ load-seconds. Cross-check against the per-chunk
+   `CaptureChunkSize = 50_000` cadence.
+4. **Compare to the floor.**
+   - **≥ floor:** Phase 1 throughput residual closed — record the figure in `DECISIONS.md` (amending the
+     `~271 / ~27k / ~35.5k` ladder) and proceed to the cutover gates (Phase 5).
+   - **materially < 20k:** trigger the escape hatches with a plan: (a) the **50k-chunk sweep** (the seed
+     lane vindicated 5k/10k batch at ~31k rows/sec; sweep `CaptureChunkSize`), (b) the **parallel
+     per-table wavefronts** (port `Deploy.executeLeveledSeed` / `ParallelSafe` to the reverse leg —
+     reuse, not build; gated on the cross-kind remap dependency), (c) the **sink-resident keymap /
+     server-side `UPDATE…JOIN` spill** (DESIGNED-only, gated on the FK-target row count from §2).
+5. **Watch for the warm-container memory-grant stall** (`RESOURCE_SEMAPHORE`): a bulk load that hangs
+   with zero rows is a memory-grant stall, NOT a throughput finding — diagnose via
+   `sys.dm_exec_query_memory_grants` + `…_resource_semaphores`, it is batch-size-independent.
+
+**Acceptance:** the throughput floor sustained over the real wire, or the escape hatches triggered
+**with a plan** (charter Phase 1 exit).
+
+---
+
+## Part B — The estate survey (read-only SQL)
+
+Run as the migration principal against the real managed sink (A). Every query is **read-only**
+(catalog views + `fn_my_permissions` + partition stats — no table scans, no writes). Replace the
+`OSUSR[_]%` pattern if the estate uses a different physical convention. Capture the **sanitized**
+results only (counts, shapes, verdicts — never table names / row data / logins) per the J5 covenant.
+
+### 1. Row counts — sizes the run and the spill decision
+
+```sql
+-- Exact per-table row counts WITHOUT a scan (partition stats).
+SELECT  s.name AS [schema], t.name AS [table], SUM(p.row_count) AS [rows]
+FROM    sys.dm_db_partition_stats p
+JOIN    sys.tables  t ON t.object_id = p.object_id
+JOIN    sys.schemas s ON s.schema_id = t.schema_id
+WHERE   p.index_id IN (0,1)           -- heap or clustered: the base rows
+  AND   t.name LIKE 'OSUSR[_]%'
+GROUP BY s.name, t.name
+ORDER BY [rows] DESC;
+```
+*Feeds:* the scale-shape decision (whole estate vs largest table), the P7b slice choice, and the
+operator decision "how many rows total."
+
+### 2. FK fan-in — sizes the resident packed remap (the ~40 B/entry ceiling)
+
+```sql
+-- (a) The FK edge map among OSUSR tables — referencing (table,col) -> referenced table.
+SELECT  rs.name AS ref_schema, rt.name AS referencing_table, rc.name AS referencing_col,
+        ts.name AS tgt_schema, tt.name AS referenced_table
+FROM    sys.foreign_keys fk
+JOIN    sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+JOIN    sys.tables   rt ON rt.object_id = fk.parent_object_id
+JOIN    sys.schemas  rs ON rs.schema_id = rt.schema_id
+JOIN    sys.columns  rc ON rc.object_id = fkc.parent_object_id AND rc.column_id = fkc.parent_column_id
+JOIN    sys.tables   tt ON tt.object_id = fk.referenced_object_id
+JOIN    sys.schemas  ts ON ts.schema_id = tt.schema_id
+WHERE   rt.name LIKE 'OSUSR[_]%' OR tt.name LIKE 'OSUSR[_]%'
+ORDER BY referenced_table, referencing_table;
+
+-- (b) Total rows living in FK-TARGET tables — the resident-remap RAM driver.
+--     Resident ceiling ~= 40 B * (rows in FK-target tables). Above the transfer-host
+--     memory budget, the sink-resident spill (DESIGNED-only) is the named next step.
+WITH fk_targets AS (SELECT DISTINCT referenced_object_id AS object_id FROM sys.foreign_keys)
+SELECT  SUM(p.row_count) AS fk_target_rows,
+        SUM(p.row_count) * 40 / 1024 / 1024 AS approx_remap_MB
+FROM    sys.dm_db_partition_stats p
+JOIN    fk_targets f ON f.object_id = p.object_id
+WHERE   p.index_id IN (0,1);
+```
+*Feeds:* resident remap vs sink-resident spill (the operator decision "how many rows in FK-target
+tables" + "transfer-host memory budget").
+
+### 3. P5 trigger map — the capture-ladder descent map
+
+```sql
+-- OSUSR tables carrying triggers. A trigger forces OUTPUT…INTO (the capture ladder
+-- descends StagedMergeOutput -> StagedMergeOutputInto on SQL error 334 automatically);
+-- this is the map of WHERE that descent will fire (so it is expected, not a surprise).
+SELECT  s.name AS [schema], t.name AS [table], tr.name AS [trigger],
+        tr.is_disabled, tr.is_instead_of_trigger
+FROM    sys.triggers tr
+JOIN    sys.tables  t ON t.object_id = tr.parent_id
+JOIN    sys.schemas s ON s.schema_id = t.schema_id
+WHERE   t.name LIKE 'OSUSR[_]%'
+ORDER BY t.name;
+```
+*Feeds:* confidence that the trigger-bearing tables are handled by the existing descent ladder; no
+code change expected — the map is for the run report, not a gate.
+
+### 4. G1 — object-scope DENY (the P1b residual)
+
+```sql
+-- Per-table effective permissions for the CURRENT principal (object scope).
+-- The J5 run settled the DATABASE-scope grant (SELECT/INSERT/UPDATE/DELETE, no ALTER).
+-- G1 is the residual: does any per-table DENY ESCAPE the DB grant? A table missing
+-- INSERT/UPDATE/DELETE/SELECT below has an object-scope restriction the DB grant hid.
+SELECT  s.name AS [schema], t.name AS [table], p.permission_name, p.state_desc
+FROM    sys.tables  t
+JOIN    sys.schemas s ON s.schema_id = t.schema_id
+CROSS APPLY sys.fn_my_permissions(QUOTENAME(s.name)+'.'+QUOTENAME(t.name),'OBJECT') p
+WHERE   t.name LIKE 'OSUSR[_]%'
+  AND   p.permission_name IN ('SELECT','INSERT','UPDATE','DELETE')
+ORDER BY t.name, p.permission_name;
+```
+*Feeds:* the reserved `ReverseLegBoundaryTests` Skip-stub ("object-scope DENY refused by name before
+any write"). If any planned-write table is missing a permission here, the preflight refinement (P1b —
+descend `Preflight.captureGrantEvidence` to table scope) is promoted; the agent's
+`transfer.insufficientGrant` gate is currently DATABASE-scope only.
+
+### 5. P10 — user directory (ReconciledByRule readability + email key)
+
+```sql
+-- The user directory the reverse-leg user re-key reconciles against (Phase 2).
+-- Confirms ReconciledByRule is available: a readable user table with an email column.
+SELECT  s.name AS [schema], t.name AS [table], c.name AS [column]
+FROM    sys.tables  t
+JOIN    sys.schemas s ON s.schema_id = t.schema_id
+JOIN    sys.columns c ON c.object_id = t.object_id
+WHERE  (t.name = 'OSSYS_USER' OR t.name LIKE 'OSUSR[_]%USER%')
+  AND   c.name LIKE '%EMAIL%'
+ORDER BY t.name, c.name;
+-- Then a read probe against the resolved table (confirms SELECT + a populated email):
+--   SELECT TOP 5 [Id],[Email] FROM <user table> WHERE [Email] IS NOT NULL;
+```
+*Feeds:* OPEN-7. Phase 2 built the reverse-leg user re-key (reconcile-by-email on the streaming
+arm); this confirms the real estate's user table is readable + email-keyed, so the operator can
+pass `--reconcile <userTable>:EMAIL` for real. (The Phase-2 reconcile reads the sink user inventory
+directly; no design-time discovery pass is needed.)
+
+### 6. CDC tracking (OPEN-3) — gates the NM-73 auto-fallback (Phase 5)
+
+```sql
+-- Is CDC enabled on the database / any OSUSR table?
+SELECT  name, is_cdc_enabled FROM sys.databases WHERE database_id = DB_ID();
+SELECT  s.name AS [schema], t.name AS [table]
+FROM    sys.tables  t
+JOIN    sys.schemas s ON s.schema_id = t.schema_id
+WHERE   t.name LIKE 'OSUSR[_]%' AND t.is_tracked_by_cdc = 1
+ORDER BY t.name;
+```
+*Feeds:* OPEN-3 / Phase 5. The J5 run proved transaction/lock semantics but NOT the CDC path on a
+real managed environment. This is the verdict that **arms the NM-73 EXCEPT auto-fallback** (today the
+manual `emission.dataVerification = ValidateBeforeApply` override is shipped; the automatic
+CDC-failure → EXCEPT fallback is deferred "until after J5" — i.e., until this verdict lands).
+
+---
+
+## Part C — Hand-off checklist
+
+For the operator, then back to the agent:
+
+- [ ] **§1 row counts** — the scale shape + the P7b slice choice.
+- [ ] **§2 FK fan-in** — `fk_target_rows` + `approx_remap_MB` vs the transfer-host memory budget
+      (decides resident remap vs the sink-resident spill).
+- [ ] **§3 trigger map** — expected capture-ladder descents (report-only).
+- [ ] **§4 G1** — any object-scope DENY (promotes the P1b preflight refinement if found).
+- [ ] **§5 P10** — the user table + email column (enables `--reconcile <userTable>:EMAIL` for real).
+- [ ] **§6 CDC** — the verdict that arms the NM-73 auto-fallback.
+- [ ] **Part A P7b** — rows/sec vs the floor (closes Phase 1, or triggers the escape hatches).
+
+When these land, the **Phase 5 cutover gates** become actionable: the production-shaped dry-run is
+the Phase-4 preview run against the real estate; the advisory→hard grant gate is the per-pair
+cutover wiring of `projection survey` (which already hard-stops on a blocked capability — exit 7);
+and the NM-73 auto-fallback arms on the §6 CDC verdict.

--- a/sidecar/projection/REVERSE_LEG_OPERATOR_PROBE_SHEET.md
+++ b/sidecar/projection/REVERSE_LEG_OPERATOR_PROBE_SHEET.md
@@ -1,0 +1,429 @@
+# Operator Probe Sheet — The Remaining Unknowns for the Reverse-Leg Data Load
+
+> **What this is.** A self-contained, runnable investigation sheet — modelled on the J5 capability
+> probe sheet — naming the facts about **your two databases** that the engine cannot determine on
+> its own. Each item is framed from the agent's side: *"here is something I cannot know without
+> your data; if you answer it, here is the specific engine outcome it unlocks, and here is exactly
+> how to find the answer."* The data-movement engine (two-phase, topologically-ordered, set-based
+> surrogate-capture with FK re-keying, bounded-memory streaming, chunk-resume, and reconcile-by-
+> business-key for the user directory) is **built and tested against mock data**; what it has never
+> seen is the **shape, scale, and grant posture of your real estate**. These probes settle that.
+>
+> **Generic by design.** Nothing here names a product, environment, or table — substitute your own.
+> Two databases are involved: the **SOURCE** (the system of record the data lives in today) and the
+> **TARGET** (where it is being loaded). Most probes are **read-only catalog queries**; the few
+> **WRITE-PROBES** are explicitly transactional and roll back — *nothing persists*.
+>
+> **How to use it.** (1) Fill the Binding Sheet (§0) once. (2) Run each probe against the database
+> it names (SOURCE / TARGET / BOTH). (3) Record the verdict in the Ledger (§5). Only the **verdicts**
+> need to travel back — never table names, row data, or credentials.
+
+---
+
+## §0 — Binding Sheet (resolve once, then substitute into every probe)
+
+| Placeholder | Meaning | Example |
+|---|---|---|
+| `{{ENTITY_LIKE}}` | A `LIKE` pattern matching the **business tables you intend to move** (so the surveys sweep them). Use `'%'` for "all user tables" and rely on the system-object exclusion already in each query, or a prefix/schema filter. | `'APP\_%' ESCAPE '\'` |
+| `{{SCHEMA}}` | Schema of a specific table under investigation. | `dbo` |
+| `{{TABLE}}` | A specific, representative business table (ideally the largest — see B1). | `Customer` |
+| `{{PK}}` | That table's primary-key column. | `Id` |
+| `{{USER_TABLE}}` | The table holding the **user / principal directory** (the reconcile target — the rows you do **not** re-import but re-key FKs to). | `User` |
+| `{{EMAIL}}` | The **business-key column** used to reconcile users across the two databases. | `Email` |
+| `{{CHILD}}` / `{{FK}}` / `{{PARENT}}` / `{{PARENT_PK}}` | A child table, its FK column, the parent table, and the parent's PK — for the orphan probe (B3). | `Order` / `CustomerId` / `Customer` / `Id` |
+
+> The agent's note: I derive the FK graph, dispositions, and load order **structurally** from the
+> schema — but only your data can tell me the **scale**, the **fidelity** (orphans, duplicate keys,
+> casing), and the **grant/runtime posture**. Those are the unknowns below.
+
+---
+
+## Part A — Schema shape *(determines the per-table strategy and the named refusals)*
+
+The engine classifies each table's identity strategy and decides whether a clean two-phase load is
+even possible. These probes tell me which strategy each table lands on and which tables I will
+**refuse by name** (so you hear it before the run, never after).
+
+### A1 — Is every business table's primary key a single IDENTITY (auto-number) column?
+- **What I can't know:** whether each table mints its own surrogate key (auto-number) or carries a
+  natural/business key.
+- **What it unlocks:** the **identity disposition** per table. A single IDENTITY PK ⇒ the sink mints
+  the key and I capture+remap it (the proven path). A non-IDENTITY PK ⇒ the source key must either be
+  preserved (which a DML-only grant forbids — see C1) **or** reconciled by a business rule; a table
+  here that is *not* the user directory is a table I currently cannot move and must flag.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table],
+          COUNT(ic.column_id)                                   AS pk_col_count,
+          MAX(CASE WHEN c.is_identity = 1 THEN 1 ELSE 0 END)    AS pk_is_identity
+  FROM    sys.tables   t
+  JOIN    sys.schemas  s  ON s.schema_id = t.schema_id
+  JOIN    sys.indexes  i  ON i.object_id = t.object_id AND i.is_primary_key = 1
+  JOIN    sys.index_columns ic ON ic.object_id = t.object_id AND ic.index_id = i.index_id
+  JOIN    sys.columns  c  ON c.object_id = t.object_id AND c.column_id = ic.column_id
+  WHERE   t.name LIKE '{{ENTITY_LIKE}}'
+  GROUP BY s.name, t.name
+  ORDER BY pk_col_count DESC, pk_is_identity;
+  ```
+- **Read-out:** `pk_col_count = 1, pk_is_identity = 1` → mint-and-remap (good). `pk_is_identity = 0`
+  → business-key table (flag unless it is the user directory). Any business table **absent from the
+  result entirely** has **no primary key** → I have no surrogate to capture; flag it.
+
+### A2 — Are there any composite (multi-column) primary keys?
+- **What I can't know:** whether any table keys on more than one column.
+- **What it unlocks:** the **`compositeSurrogateUnsupported` refusal**. Surrogate capture is
+  single-column; a composite key would be truncated, so I refuse rather than half-capture it. Knowing
+  the list lets us plan each (natural-key reconcile, or exclude) before the run.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table], COUNT(*) AS pk_columns
+  FROM    sys.indexes i
+  JOIN    sys.tables  t ON t.object_id = i.object_id
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  JOIN    sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+  WHERE   i.is_primary_key = 1 AND t.name LIKE '{{ENTITY_LIKE}}'
+  GROUP BY s.name, t.name
+  HAVING  COUNT(*) > 1
+  ORDER BY pk_columns DESC;
+  ```
+- **Read-out:** every row is a table I will refuse under mint-and-remap. Empty = clean.
+
+### A3 — What is the foreign-key graph, and which FK columns are nullable / self-referential?
+- **What I can't know:** the FK edges between your tables and whether each FK column is nullable —
+  the input to load ordering and cycle-breaking.
+- **What it unlocks:** the **load order** (topological), the **deferred-column** plan (nullable cycle
+  FKs are NULLed in phase 1, re-pointed in phase 2), and the **`unbreakableCycleFk` refusal** (a
+  **non-nullable** FK whose target is back inside its own dependency cycle cannot be satisfied by a
+  clean two-phase load).
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  rs.name AS ref_schema, rt.name AS referencing_table, rc.name AS referencing_col,
+          rc.is_nullable,
+          ts.name AS tgt_schema, tt.name AS referenced_table,
+          CASE WHEN rt.object_id = tt.object_id THEN 'self' ELSE 'cross' END AS edge_kind
+  FROM    sys.foreign_keys fk
+  JOIN    sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+  JOIN    sys.tables  rt ON rt.object_id = fk.parent_object_id
+  JOIN    sys.schemas rs ON rs.schema_id = rt.schema_id
+  JOIN    sys.columns rc ON rc.object_id = fkc.parent_object_id AND rc.column_id = fkc.parent_column_id
+  JOIN    sys.tables  tt ON tt.object_id = fk.referenced_object_id
+  JOIN    sys.schemas ts ON ts.schema_id = tt.schema_id
+  WHERE   rt.name LIKE '{{ENTITY_LIKE}}' OR tt.name LIKE '{{ENTITY_LIKE}}'
+  ORDER BY referenced_table, referencing_table;
+  ```
+- **Read-out:** a **non-nullable `self` edge** is an unbreakable self-cycle (refusal). For `cross`
+  edges I compute cycles myself — but a non-nullable FK participating in any mutual A→B→A pair is the
+  risk; hand me this edge list + nullability and I will tell you exactly which (if any) refuse.
+
+### A4 — Are there IDENTITY columns that are **not** the primary key?
+- **What I can't know:** whether any table has a natural PK *and* a separate auto-number column.
+- **What it unlocks:** the **IDENTITY-insert bracketing** decision. Writing any explicit value into an
+  IDENTITY column requires a privilege that a DML-only grant typically denies (C1); a non-PK IDENTITY
+  column means the row's INSERT touches that column and may be rejected. I need to know these tables to
+  confirm the column is sink-minted (omitted from the INSERT), not source-supplied.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table], c.name AS identity_col,
+          CASE WHEN ic.column_id IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key
+  FROM    sys.columns c
+  JOIN    sys.tables  t ON t.object_id = c.object_id
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  LEFT JOIN sys.indexes i ON i.object_id = t.object_id AND i.is_primary_key = 1
+  LEFT JOIN sys.index_columns ic
+         ON ic.object_id = t.object_id AND ic.index_id = i.index_id AND ic.column_id = c.column_id
+  WHERE   c.is_identity = 1 AND t.name LIKE '{{ENTITY_LIKE}}'
+  ORDER BY t.name;
+  ```
+- **Read-out:** `is_primary_key = 0` rows are natural-PK-plus-autonumber tables — confirm the
+  autonumber is sink-minted (so I omit it on INSERT) and the natural PK is what we key on.
+
+### A5 — Which columns are non-insertable (computed / generated / rowversion)?
+- **What I can't know:** whether any column is computed or system-generated and therefore must be
+  excluded from the INSERT column list.
+- **What it unlocks:** the **INSERT column list correctness**. Inserting into a computed or
+  `rowversion`/`timestamp` column raises an error; I must skip them. Knowing the set confirms the
+  generated column list is right for your tables.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table], c.name AS [column],
+          c.is_computed, ty.name AS data_type
+  FROM    sys.columns c
+  JOIN    sys.types   ty ON ty.user_type_id = c.user_type_id
+  JOIN    sys.tables  t  ON t.object_id = c.object_id
+  JOIN    sys.schemas s  ON s.schema_id = t.schema_id
+  WHERE   t.name LIKE '{{ENTITY_LIKE}}'
+    AND  (c.is_computed = 1 OR ty.name IN ('timestamp','rowversion'))
+  ORDER BY t.name;
+  ```
+- **Read-out:** every row is a column the load must omit. Empty = all columns are plain insertable.
+
+---
+
+## Part B — Data shape *(sizes the run and surfaces fidelity hazards)*
+
+These determine how much memory the run needs, how long it takes, and where the data itself will
+force a drop or an ambiguous match.
+
+### B1 — How many rows are in each table (and is the target already populated)?
+- **What I can't know:** the scale — total rows, per-table distribution, and whether the target is
+  blank or pre-loaded.
+- **What it unlocks:** the whole **run plan**: the throughput estimate, the bench slice (D1), the
+  memory ceiling (B2), and whether a re-run **appends** (a populated target is idempotent only via the
+  resume journal — which the engine now *requires* on a streaming execute) or needs a wipe first.
+- **Probe (run on BOTH — counts are scan-free via partition stats):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table], SUM(p.row_count) AS [rows]
+  FROM    sys.dm_db_partition_stats p
+  JOIN    sys.tables  t ON t.object_id = p.object_id
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  WHERE   p.index_id IN (0,1) AND t.name LIKE '{{ENTITY_LIKE}}'
+  GROUP BY s.name, t.name
+  ORDER BY [rows] DESC;
+  ```
+- **Read-out:** the SOURCE counts size the move; any non-zero TARGET count on a table you intend to
+  load means "append" semantics — confirm the journal discipline (or a wipe) so a re-run does not
+  duplicate.
+
+### B2 — How many rows live in FK-target tables (the resident key-map RAM ceiling)?
+- **What I can't know:** the total rows in tables that are pointed *at* by a foreign key — the only
+  rows whose minted keys I must hold in memory during the run.
+- **What it unlocks:** the **resident remap vs spill** decision. The in-memory key map costs ≈ 40
+  bytes per FK-target row; above your transfer host's memory budget, the run must switch to the
+  sink-resident / server-side spill strategy. This number, against your host RAM, makes that call.
+- **Probe (run on TARGET):**
+  ```sql
+  WITH fk_targets AS (SELECT DISTINCT referenced_object_id AS object_id FROM sys.foreign_keys)
+  SELECT  SUM(p.row_count)                       AS fk_target_rows,
+          SUM(p.row_count) * 40 / 1024 / 1024    AS approx_keymap_MB
+  FROM    sys.dm_db_partition_stats p
+  JOIN    fk_targets f ON f.object_id = p.object_id
+  WHERE   p.index_id IN (0,1);
+  ```
+- **Read-out:** `approx_keymap_MB` ≪ host RAM → resident map (fast path). Approaching/over → trigger
+  the spill design. Tell me `approx_keymap_MB` and your transfer-host memory budget.
+
+### B3 — How many rows reference a parent that does not exist (orphans)?
+- **What I can't know:** whether the source data carries FK values pointing at rows that aren't there
+  (a constraint that was disabled, or cross-system drift).
+- **What it unlocks:** the **drop set** and the **exit code**. The engine drops an orphan FK row,
+  names it, and exits non-zero (so a "complete" never hides vanished rows). Knowing the count up front
+  lets us decide: clean the source, or accept the loss explicitly. Run once per FK edge you care about.
+- **Probe (run on SOURCE):**
+  ```sql
+  SELECT COUNT_BIG(*) AS orphan_rows
+  FROM   {{SCHEMA}}.{{CHILD}} c
+  WHERE  c.{{FK}} IS NOT NULL
+    AND  NOT EXISTS (SELECT 1 FROM {{SCHEMA}}.{{PARENT}} p WHERE p.{{PARENT_PK}} = c.{{FK}});
+  ```
+- **Read-out:** `orphan_rows = 0` → no surprise drops on this edge. `> 0` → those rows will be dropped
+  + reported (non-zero exit); decide clean-vs-accept before the run.
+
+### B4 — Is the user reconcile key (email) unique, present, and consistently cased?
+- **What I can't know:** the quality of the business key I match users on across the two databases.
+- **What it unlocks:** the **user re-key fidelity**. Matching is by exact stored value: a **duplicate**
+  email makes the match ambiguous (I keep the first and surface the rest); a **missing** email makes
+  the user unmatchable (the pre-write halt fires unless you accept the drop); a **case difference**
+  between source and target breaks an exact match. This probe tells me whether the re-key will be clean
+  or needs a normalization/tiebreaker step first.
+- **Probe (run on BOTH):**
+  ```sql
+  -- duplicates (ambiguous match):
+  SELECT {{EMAIL}} AS email, COUNT(*) AS n
+  FROM   {{SCHEMA}}.{{USER_TABLE}}
+  WHERE  {{EMAIL}} IS NOT NULL
+  GROUP BY {{EMAIL}} HAVING COUNT(*) > 1 ORDER BY n DESC;
+
+  -- missing key + case-variation (raw vs lower-cased distinct counts):
+  SELECT  SUM(CASE WHEN {{EMAIL}} IS NULL OR LTRIM(RTRIM({{EMAIL}})) = '' THEN 1 ELSE 0 END) AS missing_email,
+          COUNT(DISTINCT {{EMAIL}})         AS distinct_raw,
+          COUNT(DISTINCT LOWER({{EMAIL}}))  AS distinct_lower
+  FROM    {{SCHEMA}}.{{USER_TABLE}};
+  ```
+- **Read-out:** duplicates present → plan a tiebreaker. `missing_email > 0` → those users halt the run
+  (or need `--allow-drops`). `distinct_raw > distinct_lower` → emails differ only by case → normalize,
+  or confirm the source and target store the same casing, before relying on the match.
+
+---
+
+## Part C — Capability, grant & runtime *(the J5 residuals + the load-time hazards)*
+
+What the principal is actually allowed to do, what the tables will do back, and what the engine the
+load runs against will tolerate at scale.
+
+### C1 — Does any table have an object-scope DENY that the database-scope grant hides?
+- **What I can't know:** whether a per-table permission overrides the broad grant (so a table refuses
+  a write mid-load instead of at preflight).
+- **What it unlocks:** the **pre-write grant gate's precision**. The engine checks the database-scope
+  grant today; an object-scope DENY would slip through and crash a partial load. If any exist, I
+  promote the preflight to table scope so the run refuses *before* writing.
+- **Probe (run on TARGET, as the migration principal):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table],
+          MAX(CASE WHEN p.permission_name='SELECT' THEN 1 ELSE 0 END) AS can_select,
+          MAX(CASE WHEN p.permission_name='INSERT' THEN 1 ELSE 0 END) AS can_insert,
+          MAX(CASE WHEN p.permission_name='UPDATE' THEN 1 ELSE 0 END) AS can_update,
+          MAX(CASE WHEN p.permission_name='DELETE' THEN 1 ELSE 0 END) AS can_delete
+  FROM    sys.tables  t
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  CROSS APPLY sys.fn_my_permissions(QUOTENAME(s.name)+'.'+QUOTENAME(t.name),'OBJECT') p
+  WHERE   t.name LIKE '{{ENTITY_LIKE}}'
+  GROUP BY s.name, t.name
+  ORDER BY can_insert, can_update, t.name;
+  ```
+- **Read-out:** any `can_insert`/`can_update`/`can_delete` = 0 on a table you intend to write is an
+  object-scope restriction → table-scope preflight required. All 1s → the database-scope check is
+  sufficient.
+
+### C2 — Is the user directory readable and email-keyed?
+- **What I can't know:** the physical name/shape of the table I reconcile users against, and whether
+  its email column is readable and populated.
+- **What it unlocks:** the **user re-key being available at all**. The reverse-leg re-key reads the
+  target's existing user inventory and matches by email; this confirms that table is selectable and the
+  key column exists and is non-empty.
+- **Probe (run on TARGET):**
+  ```sql
+  -- shape: the candidate user table + an email-like column
+  SELECT  s.name AS [schema], t.name AS [table], c.name AS [column]
+  FROM    sys.tables  t
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  JOIN    sys.columns c ON c.object_id = t.object_id
+  WHERE   t.name = '{{USER_TABLE}}' AND c.name LIKE '%{{EMAIL}}%'
+  ORDER BY c.name;
+  -- read probe: SELECT works + the key is populated
+  SELECT TOP 5 {{PK}}, {{EMAIL}} FROM {{SCHEMA}}.{{USER_TABLE}} WHERE {{EMAIL}} IS NOT NULL;
+  ```
+- **Read-out:** a returned column + non-empty rows → the re-key is available (pass `{{USER_TABLE}}:{{EMAIL}}`
+  as the reconcile rule). Empty/denied → the re-key cannot run; users must be matched another way.
+
+### C3 — Which tables carry triggers (and are any INSTEAD OF)?
+- **What I can't know:** where triggers sit — they change the form of the capture statement the engine
+  must use.
+- **What it unlocks:** the **capture-lane descent map**. A trigger forces the set-based capture to use
+  its `OUTPUT … INTO` form (the engine descends automatically on the relevant error); this is the map
+  of where that descent will fire, so it is *expected* in the run report, not a surprise. An **INSTEAD
+  OF** trigger is more serious — it can silently change what actually gets written.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  s.name AS [schema], t.name AS [table], tr.name AS [trigger],
+          tr.is_disabled, tr.is_instead_of_trigger
+  FROM    sys.triggers tr
+  JOIN    sys.tables  t ON t.object_id = tr.parent_id
+  JOIN    sys.schemas s ON s.schema_id = t.schema_id
+  WHERE   t.name LIKE '{{ENTITY_LIKE}}'
+  ORDER BY t.is_instead_of_trigger DESC, t.name;
+  ```
+- **Read-out:** `is_instead_of_trigger = 1` rows need scrutiny (they intercept the write). The rest are
+  the expected `OUTPUT … INTO` descents. Empty = the fast capture lane everywhere.
+
+### C4 — Is change-data-capture enabled on the database or any table?
+- **What I can't know:** whether the target tracks changes (which governs the idempotent-redeploy /
+  no-overwrite guarantee and the automatic conservative-verification fallback).
+- **What it unlocks:** **arming the auto-fallback** to the compare-before-apply verification mode. The
+  manual override already ships; the automatic "if change-tracking can't confirm silence, verify by
+  comparison" behaviour is deferred until this verdict lands.
+- **Probe (run on TARGET):**
+  ```sql
+  SELECT  name, is_cdc_enabled FROM sys.databases WHERE database_id = DB_ID();
+  SELECT  s.name AS [schema], t.name AS [table]
+  FROM    sys.tables  t JOIN sys.schemas s ON s.schema_id = t.schema_id
+  WHERE   t.name LIKE '{{ENTITY_LIKE}}' AND t.is_tracked_by_cdc = 1
+  ORDER BY t.name;
+  ```
+- **Read-out:** `is_cdc_enabled = 1` and/or tracked tables → the change-tracking path is live; I can
+  arm the auto-fallback. `0` / none → it stays on the manual override (the conservative default).
+
+### C5 — Will the target instance's memory grant admit a bulk load (the stall ceiling)?
+- **What I can't know:** the target instance's query-memory semaphore vs the memory a bulk insert's
+  internal sort will request — a mismatch makes a load **hang indefinitely** (not error), which looks
+  like a throughput problem but is a memory-grant stall.
+- **What it unlocks:** the **chunk-size / parallelism ceiling**. If the bulk grant can exceed the
+  big-query semaphore, I cap the chunk size or load against the table with its non-clustered indexes
+  disabled, rather than chase a phantom throughput regression.
+- **Probe (run on TARGET):**
+  ```sql
+  -- the standing semaphores (resource_semaphore_id 0 = default/large-query pool):
+  SELECT  resource_semaphore_id, max_target_memory_kb, target_memory_kb,
+          total_memory_kb, available_memory_kb
+  FROM    sys.dm_exec_query_resource_semaphores
+  WHERE   resource_semaphore_id IN (0,1);
+  -- AND, while a representative load is actually running, the live grant + any wait:
+  -- SELECT requested_memory_kb, granted_memory_kb, wait_time_ms, dop
+  -- FROM   sys.dm_exec_query_memory_grants ORDER BY requested_memory_kb DESC;
+  ```
+- **Read-out:** if a load shows `wait_time_ms` climbing with `granted_memory_kb` NULL (a request the
+  semaphore won't satisfy), that is the stall — reduce chunk size / drop indexes during load. Capture
+  the semaphore max so I can pre-size the chunk.
+
+### C6 — Confirm the AssignedBySink mint-capture-delete actually works on a real table *(WRITE-PROBE)*
+- **What I can't know:** whether a *real* target table — with its real triggers, constraints, and
+  defaults — admits the exact statement the engine uses to insert a row, read back the minted key, and
+  remove it. Mock tables proved the mechanism; this proves it on yours.
+- **What it unlocks:** **end-to-end confidence in the core loop** against a real table: identity minting
+  on INSERT, key capture via `OUTPUT`, trigger/constraint admission, and clean rollback — the four
+  things the whole load is built on.
+- **Probe (run on TARGET — transactional, rolls back; nothing persists):**
+  ```sql
+  BEGIN TRAN;
+    DECLARE @captured TABLE (pk BIGINT);
+    -- supply the table's NON-identity, non-computed columns and one valid row of values:
+    INSERT INTO {{SCHEMA}}.{{TABLE}} ( /* {{NON_PK_COLS}} */ )
+    OUTPUT INSERTED.{{PK}} INTO @captured
+    VALUES            ( /* {{ONE_VALID_ROW}} */ );
+
+    SELECT pk AS minted_key FROM @captured;            -- a value = INSERT + capture + triggers all pass
+    DELETE FROM {{SCHEMA}}.{{TABLE}} WHERE {{PK}} IN (SELECT pk FROM @captured);
+  ROLLBACK;                                             -- nothing persists; clean delete = the cleanup path holds
+  ```
+- **Read-out:** a `minted_key` row and a clean `DELETE` → the core loop works on a real table. An error
+  on INSERT names exactly which constraint/trigger/permission blocks it (the one thing I most need to
+  know before a real run). *(Optional: replace the `INSERT … OUTPUT` with the set-based `MERGE … WHEN
+  NOT MATCHED … OUTPUT INSERTED.{{PK}}, <source-key> INTO @map` form to prove the bulk capture lane on
+  the real table too; same transaction-rollback envelope.)*
+
+---
+
+## Part D — Throughput *(the one measurement, not a query)*
+
+### D1 — Does the set-based streaming lane sustain the throughput floor over the real wire?
+- **What I can't know:** the real rows/second over your actual network + instance, worst-case
+  all-FK-referenced shape. Every figure I have is loopback-local.
+- **What it unlocks:** the **go/no-go on the streaming lane as shipped**, and which escape hatch (if
+  any) to trigger — larger/swept chunk size, parallel per-table loading, or the server-side spill.
+- **Procedure (operator-run; the engine is already instrumented — no new code):**
+  1. Pick the largest FK-target table from B1 (the worst case for the key map), or a capped slice of it.
+  2. Run the streaming reverse-leg load against SOURCE → TARGET, **journaled** (a journal is required for
+     a streaming execute — it makes the run resumable + idempotent) and verbose:
+     `… move <flow> --go --streaming --journal <dir> -v`
+  3. Read rows/second from the bench output (rows ÷ load-seconds; cross-check against the 50,000-row
+     chunk cadence).
+- **Read-out:** at/above your cutover-window floor → ship the streaming lane. Materially below ~20k
+  rows/sec → tell me, and I trigger an escape hatch with a plan (chunk-size sweep, parallel wavefronts,
+  or the sink-resident spill — sized by B2). Watch for the C5 stall (a hang with zero rows is memory, not
+  throughput).
+
+---
+
+## §5 — Results ledger *(record verdicts here; only this needs to travel back)*
+
+| # | Probe | Verdict (generic — counts / yes-no / which-tables, never names or rows) | Engine consequence |
+|---|---|---|---|
+| A1 | identity disposition | | |
+| A2 | composite PKs | | |
+| A3 | FK graph + nullability | | |
+| A4 | non-PK identity cols | | |
+| A5 | non-insertable cols | | |
+| B1 | row counts (src/tgt) | | |
+| B2 | FK-target rows → keymap MB | | |
+| B3 | orphan FK rows | | |
+| B4 | reconcile-key quality | | |
+| C1 | object-scope DENY | | |
+| C2 | user directory / email | | |
+| C3 | triggers (+ INSTEAD OF) | | |
+| C4 | change-tracking enabled | | |
+| C5 | memory grant / semaphore | | |
+| C6 | real-table write-probe | | |
+| D1 | throughput rows/sec | | |
+
+**Then:** with A–C answered I finalize the per-table strategy, the refusal list, the memory/spill
+plan, and the reconcile plan; with D1 answered the streaming lane is go/no-go. Each answered row turns
+a "staged / gated" item in the charter into a settled one — that is the unlock.

--- a/sidecar/projection/REVERSE_LEG_OPERATOR_PROBE_SHEET.md
+++ b/sidecar/projection/REVERSE_LEG_OPERATOR_PROBE_SHEET.md
@@ -14,6 +14,15 @@
 > **TARGET** (where it is being loaded). Most probes are **read-only catalog queries**; the few
 > **WRITE-PROBES** are explicitly transactional and roll back — *nothing persists*.
 >
+> **There are two *classes* of TARGET** (and the engine must interact with each differently — see
+> `DATABASE_ARCHETYPES.md`): a **full-rights** database (on-prem SQL Server the migration team owns —
+> DDL + DML, receives the emitted schema and a copy of the migrated data) and a **managed-DML** database
+> (a platform-managed sink — DML-only, no DDL/`ALTER`/`IDENTITY_INSERT`). Parts A–D are
+> **archetype-agnostic** (they probe schema/data/capability shape regardless of class). **Part E**
+> determines *which archetype a target is* — because that single fact reshapes the identity strategy,
+> the resume mechanism, the schema-deploy lane, and the rollback channel. The managed-DML profile was
+> settled by the earlier capability spike; the full-rights profile is what Part E verifies.
+>
 > **How to use it.** (1) Fill the Binding Sheet (§0) once. (2) Run each probe against the database
 > it names (SOURCE / TARGET / BOTH). (3) Record the verdict in the Ledger (§5). Only the **verdicts**
 > need to travel back — never table names, row data, or credentials.
@@ -382,6 +391,114 @@ load runs against will tolerate at scale.
 
 ---
 
+## Part E — Target archetype *(which capability class is this target?)*
+
+This is the single fact that reshapes the most: whether the target is a **full-rights** database (DDL +
+DML — the on-prem schema+data home) or a **managed-DML** database (the platform sink the earlier spike
+settled — DML-only, sink-mints keys, no DDL). The managed-DML profile is known; these probes **verify
+the full-rights profile** and, by elimination, classify any target. Each answer flips a *bundle* of
+engine dispositions, not one knob (see `DATABASE_ARCHETYPES.md` §1–§2). Run on the **TARGET**, as the
+migration principal.
+
+### E1 — `CREATE TABLE` / DDL rights *(the keystone)*
+- **What I can't know:** whether the principal may create objects in the target.
+- **What it unlocks:** schema deploy (the `migrate-with-data` lane), a **sink-resident progress table**
+  for resume (durable + queryable + no filename↔digest coupling — strictly better than the client-side
+  journal), and persistent server-side staging. This one verdict is the primary full-rights vs
+  managed-DML fork.
+- **Probe** (`CREATE TABLE` is a *database*-scope permission — note the `'DATABASE'` securable class):
+  ```sql
+  SELECT HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'CREATE TABLE')     AS can_create_table,
+         HAS_PERMS_BY_NAME(DB_NAME(), 'DATABASE', 'CREATE PROCEDURE') AS can_create_proc;
+  -- Definitive (transactional — rolls back, nothing persists):
+  BEGIN TRAN;
+    CREATE TABLE dbo.__probe_create_rights (x INT);
+    SELECT 'CREATE TABLE OK' AS verdict;
+  ROLLBACK;
+  ```
+- **Read-out:** `can_create_table = 1` / the `CREATE` succeeds → **full-rights** (schema deploy +
+  sink-resident resume available). `0` / permission error → **managed-DML** (the client-side journal +
+  sink-minting path is required — the proven cloud profile).
+
+### E2 — `ALTER` rights *(constraint / trigger bypass, fast wipe)*
+- **What I can't know:** whether the principal may alter objects (disable constraints/triggers,
+  `TRUNCATE`).
+- **What it unlocks:** a **fast straight-load** path (`NOCHECK` constraints + disable triggers during the
+  load, instead of the capture-ladder descent) and `TRUNCATE`-based refresh (instead of child-first
+  `DELETE`).
+- **Probe (swap `{{SCHEMA}}` / `{{TABLE}}` for a representative table):**
+  ```sql
+  SELECT HAS_PERMS_BY_NAME(QUOTENAME('{{SCHEMA}}')+'.'+QUOTENAME('{{TABLE}}'),'OBJECT','ALTER')
+           AS can_alter_table;
+  ```
+- **Read-out:** `1` → constraint/trigger bypass + `TRUNCATE` available (the full-rights fast lane).
+  `0` → load through live constraints (the capture-ladder descent + child-first `DELETE` — the
+  managed-DML path).
+
+### E3 — `IDENTITY_INSERT` *(the identity-disposition fork)*
+- **What I can't know:** whether the principal may write explicit values into an auto-number column.
+- **What it unlocks:** **PreservedFromSource** — the source surrogate keys can be written *directly*, so
+  **no key capture, no remap, and no FK re-pointing are needed at all**. This is a dramatically simpler
+  and faster load than the sink-minting path; it is correct *only* if this is permitted.
+- **Probe (transactional — rolls back; swap `{{TABLE}}`/`{{PK}}` + one valid row):**
+  ```sql
+  BEGIN TRAN;
+    SET IDENTITY_INSERT {{SCHEMA}}.{{TABLE}} ON;
+    INSERT INTO {{SCHEMA}}.{{TABLE}} ({{PK}} /*, other required cols */)
+    VALUES            ( /* an explicit unused id */ /*, ... */);
+    SET IDENTITY_INSERT {{SCHEMA}}.{{TABLE}} OFF;
+    SELECT 'IDENTITY_INSERT OK' AS verdict;
+  ROLLBACK;
+  ```
+- **Read-out:** OK → **PreservedFromSource viable** (full-rights) — keys are preserved, FK values stay
+  valid, the whole capture/remap machinery is unnecessary. Denied (error 1088 / permission) →
+  **AssignedBySink** (the managed-DML path the engine ships). *A declared full-rights target that fails
+  this is a declared-vs-actual mismatch — surface it.*
+
+### E4 — Schema parity *(does the target host the same schema?)*
+- **What I can't know:** whether the on-prem target carries the same logical model as the source/cloud.
+- **What it unlocks:** confidence that the on-prem is the **same-schema home** (the verification
+  destination), and the structural input the post-load canary compares.
+- **Probe:**
+  ```sql
+  SELECT s.name AS [schema], t.name AS [table], c.name AS [column],
+         ty.name AS data_type, c.is_nullable, c.is_identity
+  FROM   sys.columns c
+  JOIN   sys.types   ty ON ty.user_type_id = c.user_type_id
+  JOIN   sys.tables  t  ON t.object_id = c.object_id
+  JOIN   sys.schemas s  ON s.schema_id = t.schema_id
+  WHERE  t.name LIKE '{{ENTITY_LIKE}}'
+  ORDER BY t.name, c.column_id;
+  ```
+- **Read-out:** diff this inventory against the emitted SSDT / the source rendition. Match (modulo the
+  rendition's name differences — compare by logical identity, not raw name) → the on-prem is the
+  same-schema home. The engine's canary does this exactly; this is the operator spot-check.
+
+### E5 — Sink-resident progress-table viability *(the resume upgrade)*
+- **What I can't know:** whether the target admits a small engine-owned bookkeeping table.
+- **What it unlocks:** a **sink-side resume checkpoint** — durable across a client crash, queryable
+  mid-run, and free of the client-journal's filename↔digest coupling (the Phase-3 address-drift and
+  compaction hazards simply do not exist on this archetype).
+- **Probe (transactional — rolls back; subsumes E1 + an INSERT):**
+  ```sql
+  BEGIN TRAN;
+    CREATE TABLE dbo.__progress_probe (kind SYSNAME, chunk_ix INT, committed_at DATETIME2);
+    INSERT INTO dbo.__progress_probe (kind, chunk_ix, committed_at) VALUES (N'probe', 0, SYSUTCDATETIME());
+    SELECT 'sink-resident progress OK' AS verdict;
+  ROLLBACK;
+  ```
+- **Read-out:** OK → the engine can checkpoint resume state **sink-side** (the full-rights upgrade).
+  Denied → the client-side journal is required (managed-DML) — which the engine already ships and
+  Phase 3 hardened.
+
+> **Classification rule.** E1 + E3 both **OK** ⇒ **full-rights** (and E2/E5 confirm the fast/durable
+> upgrades). E1 + E3 both **denied** ⇒ **managed-DML** (the J5 profile — declare it and the engine uses
+> the proven cloud path). A *split* result (e.g. `CREATE TABLE` yes but `IDENTITY_INSERT` no) is a
+> **distinct, valid archetype** — record it; the engine should treat each capability independently, not
+> assume the bundle.
+
+---
+
 ## Part D — Throughput *(the one measurement, not a query)*
 
 ### D1 — Does the set-based streaming lane sustain the throughput floor over the real wire?
@@ -422,6 +539,12 @@ load runs against will tolerate at scale.
 | C4 | change-tracking enabled | | |
 | C5 | memory grant / semaphore | | |
 | C6 | real-table write-probe | | |
+| E1 | CREATE TABLE / DDL | | |
+| E2 | ALTER rights | | |
+| E3 | IDENTITY_INSERT | | |
+| E4 | schema parity | | |
+| E5 | sink-resident progress | | |
+| — | **→ archetype verdict** | **full-rights / managed-DML / split** | drives the disposition bundle (`DATABASE_ARCHETYPES.md`) |
 | D1 | throughput rows/sec | | |
 
 **Then:** with A–C answered I finalize the per-table strategy, the refusal list, the memory/spill

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -841,6 +841,16 @@ let runReverseLegTransfer
         7
     else
 
+    // Phase 3 — the duplicate-hazard close (the charter's "small lever"): a
+    // journal-less streaming EXECUTE has no idempotent envelope, so refuse by
+    // name (the pure `executeJournalGate`) and force `--journal <dir>`.
+    match ReverseLegRealization.executeJournalGate realization executeGated with
+    | Some refusal ->
+        TtyRenderer.renderVoicedError refusal
+        dumpBench "transfer"
+        2
+    | None ->
+
     let sourceSub : Substrate =
         { Environment   = parseEnvironment "Source" None
           Role          = SubstrateRole.Source

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -778,19 +778,45 @@ let runReverseLegTransfer
     let collect = function Ok _ -> [] | Error es -> es
     let parsedSource = TransferSpec.parseConnectionSpec sourceSpec
     let parsedSink   = TransferSpec.parseConnectionSpec sinkSpec
-    let specErrors = collect parsedSource @ collect parsedSink
+    // Phase 2 (the charter): reconcile on the reverse leg is no longer
+    // refused — the User family re-keys by business key on the up-leg. The
+    // specs parse exactly as the forward face's; the named refusal that stood
+    // here is lifted (DECISIONS 2026-06-15 — reconcile ∘ reverse leg).
+    let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
+    let parsedUserMap : Result<TransferSpec.UserMapEntry list> =
+        match userMapPath with
+        | None -> Result.success []
+        | Some path ->
+            if not (System.IO.File.Exists path) then
+                Result.failureOf
+                    (ValidationError.create "transfer.userMap.fileMissing"
+                        (sprintf "user-map file '%s' not found." path))
+            else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+    let specErrors =
+        collect parsedSource @ collect parsedSink
+        @ (parsedReconciles |> List.collect collect)
+        @ collect parsedUserMap
     if not (List.isEmpty specErrors) then
         Console.Error.WriteLine "projection move (reverse leg): argument error:"
         printErrors Console.Error specErrors
         dumpBench "transfer"
         2
-    elif not (List.isEmpty reconcileSpecs) || Option.isSome userMapPath then
-        TtyRenderer.renderVoicedError
-            (ValidationError.create "transfer.reverseLeg.reconcileUnsupported"
-                "the B→A reverse leg is a straight load; reconciliation on the reverse leg is not yet supported (the reconcile + rename combination is the named follow-on).")
+    else
+
+    // Resolve the reconcile / user-map specs against the PHYSICAL sink
+    // contract (the rendition the reverse leg writes into; `findKindByTable`
+    // matches physical names, consistent with the forward face's live-read
+    // contract). A bad spec refuses by name before any connection opens.
+    let entries        = parsedReconciles |> List.map Result.value
+    let userMapEntries = Result.value parsedUserMap
+    let reconcile      = not (List.isEmpty entries) || not (List.isEmpty userMapEntries)
+    match TransferSpec.resolveAllReconciliation physicalSinkContract entries userMapEntries with
+    | Error es ->
+        Console.Error.WriteLine "projection move (reverse leg): reconcile resolution error:"
+        printErrors Console.Error es
         dumpBench "transfer"
         2
-    else
+    | Ok reconciliation ->
 
     // The realization SELECTOR (DECISIONS 2026-06-11): the engine chooses
     // the best realization the request admits — streaming whenever
@@ -823,7 +849,7 @@ let runReverseLegTransfer
         { Environment   = parseEnvironment "Sink" None
           Role          = SubstrateRole.Sink
           ConnectionRef = Result.value parsedSink }
-    match TransferConnections.create sourceSub sinkSub false with
+    match TransferConnections.create sourceSub sinkSub reconcile with
     | Error es ->
         Console.Error.WriteLine "projection move (reverse leg): apparatus invariant violation:"
         printErrors Console.Error es
@@ -835,18 +861,17 @@ let runReverseLegTransfer
     let runBody () =
         let result =
             match realization with
-            // NM-31: the streaming runner takes NO `allowDrops` — it is
-            // non-reconciling and offers no pre-write orphan halt (only the
-            // materialized arm threads `allowDrops` into the engine). For the
-            // streaming arm `allowDrops` reaches only the POST-write
-            // `narrateDropExit` below. This is a capability asymmetry, not a
-            // silent drop (FK orphans still surface + exit-9); see
-            // `ReverseLegRealization` / `runStreamingWithRenames`.
+            // Phase 2 (NM-31 closed on the streaming arm): both arms now thread
+            // `allowDrops` + `reconciliation` into the engine. A reconciling run
+            // takes the `validateUserMap` PRE-write orphan halt (AC-I5) on either
+            // arm; `allowDrops` downgrades it to the POST-write reported-drop path
+            // (`narrateDropExit`). A non-reconciling run carries an empty
+            // reconciliation, so the halt never fires (byte-identical straight load).
             | ReverseLegRealization.Streaming journal ->
-                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc journal connections logicalSourceContract physicalSinkContract)
+                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation)
                     .GetAwaiter().GetResult()
             | ReverseLegRealization.Materialized ->
-                (Transfer.runReverseLegThroughConnections mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract)
+                (Transfer.runReverseLegThroughConnections mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation)
                     .GetAwaiter().GetResult()
         match result with
         | Ok report ->

--- a/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
@@ -61,6 +61,31 @@ module CaptureJournal =
 
     let filePath (journal: CaptureJournal) : string = journal.FilePath
 
+    /// Phase 3 — the address-drift guard. The journal is addressed by the
+    /// plan-marker digest (`transfer-<digest>.ndjson`), so if the marker
+    /// changes between a crashed run and its resume — a `planMarker`/schema
+    /// byte-change — THIS run's file is absent yet the directory still holds
+    /// the prior run's `transfer-*.ndjson`. Left unguarded that silently
+    /// orphans the prior journal and starts fresh (re-doing, or under
+    /// AssignedBySink DOUBLING, committed work). This returns the sibling
+    /// journals that signal the drift: NON-EMPTY only when THIS journal's own
+    /// file is ABSENT (a would-be fresh run) AND other `transfer-*.ndjson`
+    /// exist beside it. Empty when the own file is present (a clean resume) or
+    /// the directory is genuinely empty (a true fresh run). The streaming
+    /// execute refuses by name on a non-empty result rather than orphaning
+    /// the prior journal — the silence the risk register names is killed.
+    let siblingJournalsUnderDrift (journal: CaptureJournal) : string list =
+        if File.Exists journal.FilePath then []
+        else
+            match Path.GetDirectoryName journal.FilePath with
+            | null | "" -> []
+            | dir when not (Directory.Exists dir) -> []
+            | dir ->
+                Directory.GetFiles(dir, "transfer-*.ndjson")
+                |> Array.filter (fun f -> not (System.String.Equals(f, journal.FilePath, System.StringComparison.OrdinalIgnoreCase)))
+                |> Array.sort
+                |> Array.toList
+
     /// Every journaled chunk, indexed by (kind root, chunk index). A
     /// missing or empty journal is an empty index (a fresh run).
     let load (journal: CaptureJournal) : Dictionary<string * int, ChunkRecord> =

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -24,22 +24,18 @@ open Projection.Targets.SSDT
 /// never a silent downgrade; a journal on an inadmissible combination
 /// likewise (the ledger belongs to the streaming realization).
 ///
-/// **NM-31 — the realizations are NOT drop-symmetric (capability
-/// asymmetry, NOT a silent drop).** The materialized arm threads
-/// `allowDrops` into the ENGINE: a reconciling run with unmatched
-/// orphans takes a PRE-WRITE halt (`validateUserMap` / `executeGate`,
-/// AC-I5 — the Sink stays untouched) gated on `allowDrops`. The
-/// streaming arm has NO reconcile leg (it is straight, non-reconciling
-/// Incremental), so it CANNOT offer a pre-write reconcile-orphan halt;
-/// `allowDrops` reaches only the run face's POST-write narration / exit
-/// (`narrateDropExit` — FK orphans surface as `SkippedReferences` + the
-/// exit-9 verdict AFTER the write). This is not a silent drop today —
-/// the streaming leg refuses reconcile up front, and its FK orphans are
-/// reported and exit-9'd — but the two arms are NOT interchangeable on
-/// the pre-write-halt capability, and `choose` presents them as if they
-/// were. Adding a pre-write halt to the streaming arm is the named
-/// follow-on (it needs a streaming reconcile leg); it is NOT attempted
-/// here.
+/// **NM-31 — CLOSED (Phase 2, 2026-06-15): the realizations are now
+/// drop-symmetric on the pre-write halt.** BOTH arms thread `allowDrops`
+/// + a reconciliation map into the ENGINE: a reconciling run with
+/// unmatched orphans takes a PRE-WRITE halt (`validateUserMap` /
+/// `executeGate`, AC-I5 — the Sink stays untouched) gated on
+/// `allowDrops`, whether realized streaming
+/// (`runStreamingReconcilingWithRenames`) or materialized (`runCore`'s
+/// reconcile leg). The streaming arm gained its reconcile leg (the named
+/// follow-on the prior note reserved), so `choose` no longer presents a
+/// false symmetry: a non-reconciling run carries an empty reconciliation
+/// (the halt never fires; FK orphans still surface POST-write as
+/// `SkippedReferences` + the exit-9 verdict via `narrateDropExit`).
 [<RequireQualifiedAccess>]
 type ReverseLegRealization =
     | Streaming of journalDirectory: string option
@@ -52,15 +48,12 @@ module ReverseLegRealization =
     /// realization or a NAMED refusal. The selector is deterministic from
     /// the request alone — testable without a connection.
     ///
-    /// **NM-31 caveat.** `choose` selects on admissibility (table subset /
-    /// resumable / emission), NOT on drop-halt capability. The two
-    /// realizations it returns are NOT symmetric on the pre-write orphan
-    /// halt: only `Materialized` threads `allowDrops` into a pre-write
-    /// engine halt (its reconcile leg); `Streaming` is non-reconciling, so
-    /// `allowDrops` reaches only post-write narration/exit. See the type
-    /// docstring above. The selector does not — and is not asked to —
-    /// reconcile that asymmetry; the streaming pre-write halt is a named
-    /// follow-on, not built here.
+    /// **NM-31 (closed).** `choose` selects on admissibility (table subset /
+    /// resumable / emission), NOT on drop-halt capability — and since Phase 2
+    /// it no longer needs to: both realizations carry the reconcile leg + the
+    /// `validateUserMap` pre-write halt (the streaming arm gained it), so the
+    /// arms are symmetric on the orphan halt. The selector picks the best
+    /// realization the request admits; reconcile rides whichever it picks.
     let choose
         (emission: EmissionMode)
         (resumable: bool)
@@ -1210,11 +1203,25 @@ module Transfer =
         (catalog: Catalog)
         (plan: DataLoadPlan)
         (journal: CaptureJournal option)
+        // Phase 2 (reconcile ∘ streaming) — the pre-built reconcile remap
+        // (Source→pre-existing-Sink surrogate, by the operator ruleset) and
+        // the kinds it reconciles. A reconciled kind is `ReconciledByRule`
+        // in `plan.Loads` (the sink already owns its rows): its phase-1
+        // insert is skipped, and every FK targeting it re-points through
+        // `reconcileRemap`. Empty / `Set.empty` is the straight-load path
+        // (byte-identical to the pre-reconcile streaming realization).
+        (reconcileRemap: SurrogateRemapContext)
+        (reconciledKinds: Set<SsKey>)
         : Task<Result<Map<SsKey, StreamedKind> * (SsKey * UnresolvedReference) list * LaneDescent list>> =
         let assignedBySinkKinds =
             plan.Loads
             |> List.choose (fun l -> if l.Disposition = IdentityDisposition.AssignedBySink then Some l.Kind else None)
             |> Set.ofList
+        // The FK-target set the re-point resolves against: AssignedBySink
+        // kinds (captured during the stream into the packed remap) UNION the
+        // reconciled kinds (matched before the stream into `reconcileRemap`).
+        // The two are disjoint by kind, so the combined lookup is unambiguous.
+        let remapTargetKinds = Set.union assignedBySinkKinds reconciledKinds
         let fkTargetKinds =
             Catalog.allKinds catalog
             |> List.collect (fun k -> k.References |> List.map (fun r -> r.TargetKind))
@@ -1222,17 +1229,28 @@ module Transfer =
         let remap = PackedSurrogateRemap.create ()
         let journalIndex = journal |> Option.map CaptureJournal.load
 
+        // The combined surrogate lookup: a target's assigned key is in the
+        // packed remap (AssignedBySink, stream-captured) OR the reconcile
+        // remap (ReconciledByRule, pre-matched). A kind lives in exactly one,
+        // so the fall-through never double-resolves.
+        let lookupAssigned (kindKey: SsKey) (sourceRaw: string) : string option =
+            match PackedSurrogateRemap.tryFind remap kindKey sourceRaw with
+            | Some assigned -> Some assigned
+            | None ->
+                SurrogateRemapContext.tryFindAssigned kindKey (SourceKey.ofString sourceRaw) reconcileRemap
+                |> Option.map AssignedKey.value
+
         // Q3: the re-point at the quantum grain — FK ordinals resolved
         // against the stream's renamed basis once per call (cheap; the
         // chunk behind it is 50k rows), cells re-pointed copy-on-write.
         let repoint (basis: RowBasis) (excluding: Set<Name>) (kind: Kind) (rows: RowQuantum list) : RemappedQuanta =
             let fkTargets =
-                SurrogateRemap.fkColumnsTargeting assignedBySinkKinds kind
+                SurrogateRemap.fkColumnsTargeting remapTargetKinds kind
                 |> Map.filter (fun col _ -> not (Set.contains col excluding))
             if Map.isEmpty fkTargets then { Rows = rows; Skipped = [] }
             else
                 SurrogateRemap.remapQuantumFksWith
-                    (PackedSurrogateRemap.tryFind remap)
+                    lookupAssigned
                     (SurrogateRemap.fkOrdinalsTargeting basis fkTargets)
                     rows
 
@@ -1348,6 +1366,13 @@ module Transfer =
             task {
                 match loads with
                 | [] -> return Result.success (totals, skips, descents)
+                | load :: rest when load.Disposition = IdentityDisposition.ReconciledByRule ->
+                    // Reconciled kinds skip the phase-1 insert — the sink
+                    // already owns their rows; only the FK re-point through
+                    // `reconcileRemap` (above) touches them. Counted as
+                    // loaded so the stage progress denominator stays whole.
+                    LogSink.recordStageProgress "load" (loaded + 1) loadTotal loadSw.ElapsedMilliseconds
+                    return! phase1 rest (loaded + 1) totals skips descents
                 | load :: rest ->
                     match Catalog.tryFindKind load.Kind catalog, Catalog.tryFindKind load.Kind ingestCatalog with
                     | Some kind, Some ingestKind ->
@@ -1426,7 +1451,9 @@ module Transfer =
                 match loads with
                 | [] -> return skips
                 | load :: rest ->
-                    if Set.isEmpty load.DeferredFkColumns then return! phase2 rest skips
+                    // Reconciled kinds are never inserted, so they have no
+                    // phase-2 deferred-FK re-stream either.
+                    if load.Disposition = IdentityDisposition.ReconciledByRule || Set.isEmpty load.DeferredFkColumns then return! phase2 rest skips
                     else
                         match Catalog.tryFindKind load.Kind catalog, Catalog.tryFindKind load.Kind ingestCatalog with
                         | Some kind, Some ingestKind ->
@@ -1467,34 +1494,41 @@ module Transfer =
             | RunAborted (refusal, None) -> return failwith refusal
         }
 
-    /// **The streaming realization** — bounded memory for the estate-scale
-    /// straight load (non-reconciling; Incremental semantics — the wipe and
-    /// reconcile envelopes stay on the materialized path). The optional
-    /// journal directory makes the run CHUNK-RESUMABLE: a journaled chunk
-    /// whose source fingerprint matches is skipped and its captured pairs
-    /// rebuild the remap; a fingerprint mismatch refuses by name
-    /// (`transfer.resume.sourceDrift`); a COMPLETED run re-runs as a full
-    /// skip — the streaming path's idempotent re-run (closing the G3
-    /// duplicate hazard whenever a journal is supplied). The resumed run's
-    /// report counts the resumed run's work; the journaled run reported its
-    /// own drops (exit-9 semantics are per-run). `DryRun` reports the plan
-    /// structure with zero counts — nothing is ingested.
+    /// **The streaming realization, reconcile-capable** — bounded memory for
+    /// the estate-scale load. The optional journal directory makes the run
+    /// CHUNK-RESUMABLE: a journaled chunk whose source fingerprint matches is
+    /// skipped and its captured pairs rebuild the remap; a fingerprint
+    /// mismatch refuses by name (`transfer.resume.sourceDrift`); a COMPLETED
+    /// run re-runs as a full skip — the streaming path's idempotent re-run
+    /// (closing the G3 duplicate hazard whenever a journal is supplied). The
+    /// resumed run's report counts the resumed run's work; the journaled run
+    /// reported its own drops (exit-9 semantics are per-run). `DryRun` reports
+    /// the plan structure (and the reconcile outcome — Unmatched/Ambiguous,
+    /// which `reconcileAgainstSink` reads read-only) with zero write counts.
     ///
-    /// **NM-31 — no `allowDrops` parameter, by construction.** This runner
-    /// is the straight, non-reconciling streaming realization: it has no
-    /// reconcile leg and therefore NO pre-write reconcile-orphan halt to
-    /// gate. FK orphans surface POST-write as `SkippedReferences` (the run
-    /// face's `narrateDropExit` applies `--allow-drops` to the exit code);
-    /// the materialized runner's pre-write `allowDrops` halt (AC-I5) has no
-    /// counterpart here. A streaming pre-write halt is the named follow-on,
-    /// gated on a streaming reconcile leg that does not yet exist.
-    let runStreamingWithRenames
+    /// **Phase 2 (the charter) — reconcile ∘ streaming + the validate-user-map
+    /// pre-write halt (closing NM-31 / N4 on the streaming arm).** When
+    /// `reconciliation` names kinds (the User family re-keyed by email), the
+    /// runner reconciles them against the sink BEFORE the stream (read-only):
+    /// each named kind's source rows are matched to the pre-existing sink rows
+    /// by the operator ruleset, producing the Source→Sink remap the stream
+    /// consults for every FK targeting a reconciled kind. The reconciled kinds
+    /// are `ReconciledByRule` (never re-imported — the sink owns them). The
+    /// `validateUserMap` gate then HALTS before any write if an orphan source
+    /// identity is unmatched (unless `--allow-drops`), so an unmapped user is a
+    /// pre-write refusal (`transfer.unmappedIdentities`), not a post-write
+    /// drop — the streaming counterpart of the materialized AC-I5 halt. An
+    /// empty `reconciliation` is the straight-load path (`allowDrops` inert,
+    /// the gate never fires), byte-identical to the pre-reconcile realization.
+    let runStreamingReconcilingWithRenames
         (mode: Mode)
         (allowCdc: bool)
+        (allowDrops: bool)
         (source: SqlConnection)
         (sink: SqlConnection)
         (sourceContract: Catalog)
         (sinkContract: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
         (journalDirectory: string option)
         : Task<Result<TransferReport>> =
         task {
@@ -1531,10 +1565,42 @@ module Transfer =
                 | Error es -> return Result.failure es
                 | Ok () ->
                     let topo = (TopologicalOrderPass.runWith TreatAsCycle sinkContract).Value
+                    let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+                    // Reconcile the named kinds against the sink (read-only,
+                    // safe in DryRun): ingest each reconciled kind's SOURCE
+                    // rows (re-pointed to the sink's names — the only kinds
+                    // materialized; the estate-scale bulk streams), and match
+                    // them to the pre-existing SINK rows by the operator
+                    // ruleset. The reverse leg's User population is small,
+                    // so this is bounded; the FK-target bulk never materializes.
+                    let! reconciledSourceRows =
+                        task {
+                            let mutable acc : Map<SsKey, StaticRow list> = Map.empty
+                            for KeyValue (kind, _) in reconciliation do
+                                match Catalog.tryFindKind kind sourceContract with
+                                | Some ingestKind ->
+                                    let! rows = AsyncStream.toList (Ingestion.streamKindRows source ingestKind)
+                                    acc <- Map.add kind (RenameProjection.repointRows renameMap rows) acc
+                                | None -> ()
+                            return acc
+                        }
+                    let! reconciled = reconcileAgainstSink sink sinkContract reconciliation reconciledSourceRows
                     // Structure only — order, dispositions, deferred columns;
                     // the rows STREAM at write time (the whole point).
-                    let plan = DataLoadPlan.build sinkContract topo Map.empty SurrogateRemapContext.empty
-                    let preWrite = if mode = Execute then executeGate sinkContract plan else None
+                    // `reclassifyReconciled` marks the reconciled kinds skip-
+                    // insert so the stream never re-imports a sink-owned row.
+                    let plan =
+                        DataLoadPlan.build sinkContract topo Map.empty SurrogateRemapContext.empty
+                        |> DataLoadPlan.reclassifyReconciled reconciledKinds
+                    // Pre-write gates (Execute only), precedence-ordered:
+                    // structural unsatisfiability first, then the validate-
+                    // user-map orphan halt (AC-I5 / NM-31 — now ON streaming).
+                    let preWrite =
+                        if mode = Execute then
+                            match executeGate sinkContract plan with
+                            | Some refusal -> Some refusal
+                            | None         -> validateUserMap allowDrops reconciled
+                        else None
                     match preWrite with
                     | Some refusal -> return Result.failureOf refusal
                     | None ->
@@ -1544,8 +1610,8 @@ module Transfer =
                                     { Mode                = mode
                                       Kinds               = reportKinds mode plan
                                       UnbreakableCycleFks = plan.UnbreakableCycleFks
-                                      UnmatchedIdentities = []
-                                      AmbiguousIdentities = []
+                                      UnmatchedIdentities = reconciled.Unmatched
+                                      AmbiguousIdentities = reconciled.Ambiguous
                                       SkippedReferences   = plan.SkippedReferences
                                       CaptureLaneDescents = []
                                       // Streaming DryRun: no G10 resumable replay.
@@ -1556,7 +1622,7 @@ module Transfer =
                             let journal =
                                 journalDirectory
                                 |> Option.map (fun dir -> CaptureJournal.create dir (planMarker sinkContract plan))
-                            match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal with
+                            match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds with
                             | Error es -> return Result.failure es
                             | Ok (totals, skips, descents) ->
                                 let kinds =
@@ -1573,8 +1639,8 @@ module Transfer =
                                         { Mode                = mode
                                           Kinds               = kinds
                                           UnbreakableCycleFks = plan.UnbreakableCycleFks
-                                          UnmatchedIdentities = []
-                                          AmbiguousIdentities = []
+                                          UnmatchedIdentities = reconciled.Unmatched
+                                          AmbiguousIdentities = reconciled.Ambiguous
                                           SkippedReferences   = skips
                                           CaptureLaneDescents = descents
                                           // Streaming-journal resume is per-run by
@@ -1585,21 +1651,42 @@ module Transfer =
                                           SyntheticUnsatisfiableFks = [] }
         }
 
+    /// The straight-load streaming realization — the non-reconciling default
+    /// (sibling-wrapper discipline: supplies the empty reconciliation +
+    /// inert `allowDrops` the caller did not name). FK orphans surface
+    /// POST-write as `SkippedReferences`; with no reconcile leg the validate-
+    /// user-map gate never fires. Byte-identical to the pre-Phase-2 runner.
+    let runStreamingWithRenames
+        (mode: Mode)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (sourceContract: Catalog)
+        (sinkContract: Catalog)
+        (journalDirectory: string option)
+        : Task<Result<TransferReport>> =
+        runStreamingReconcilingWithRenames mode allowCdc false source sink sourceContract sinkContract Map.empty journalDirectory
+
     /// The streaming reverse leg through the `TransferConnections`
     /// apparatus (D9) — the bounded-memory sibling of
     /// `runReverseLegThroughConnections` for the estate-scale B→A load.
     /// Both contracts arrive RENDERED from the one authored model
     /// (`CatalogRendition`); the optional journal directory makes the run
-    /// chunk-resumable. Straight load, Incremental semantics — the
-    /// reconcile / WipeAndLoad / table-subset combinations stay on the
-    /// materialized path (the CLI face refuses them by name).
+    /// chunk-resumable. Incremental semantics — the WipeAndLoad / table-
+    /// subset combinations stay on the materialized path (the CLI face
+    /// refuses them by name). **Phase 2: reconcile-capable** — a non-empty
+    /// `reconciliation` re-keys the named kinds (the User family by email)
+    /// with the `validateUserMap` pre-write halt (`allowDrops` gates it);
+    /// empty is the straight load.
     let runStreamingReverseLegThroughConnections
         (mode: Mode)
         (allowCdc: bool)
+        (allowDrops: bool)
         (journalDirectory: string option)
         (connections: TransferConnections)
         (logicalSourceContract: Catalog)
         (physicalSinkContract: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
         task {
             match! ConnectionResolver.openSubstrate connections.Source with
@@ -1610,7 +1697,7 @@ module Transfer =
                 | Error es -> return Result.failure es
                 | Ok sink ->
                     use sink = sink
-                    return! runStreamingWithRenames mode allowCdc source sink logicalSourceContract physicalSinkContract journalDirectory
+                    return! runStreamingReconcilingWithRenames mode allowCdc allowDrops source sink logicalSourceContract physicalSinkContract reconciliation journalDirectory
         }
 
     /// Run a *reconciling* Transfer — the operator's headline case
@@ -1770,8 +1857,14 @@ module Transfer =
     /// construction, the precondition the identity-matched repoint needs. The
     /// declared table subset resolves against the source contract by logical
     /// entity name (`Name` is rendition-invariant); the write options thread
-    /// the same emission/resumable envelope the peer transfer honors. Straight
-    /// load — the reconcile + rename combination is the named follow-on.
+    /// the same emission/resumable envelope the peer transfer honors.
+    /// **Phase 2: reconcile-capable** — a non-empty `reconciliation` re-keys
+    /// the named kinds (the User family by business key) through `runCore`'s
+    /// reconcile leg (the same AC-I5 pre-write halt the forward path uses);
+    /// empty is the straight load. The streaming sibling
+    /// (`runStreamingReverseLegThroughConnections`) is preferred for the
+    /// estate-scale combinations; this materialized arm carries the table-
+    /// subset / WipeAndLoad / G10-resumable cases the selector routes here.
     let runReverseLegThroughConnections
         (mode: Mode)
         (emission: EmissionMode)
@@ -1782,6 +1875,7 @@ module Transfer =
         (connections: TransferConnections)
         (logicalSourceContract: Catalog)
         (physicalSinkContract: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
         task {
             match CatalogDiff.between logicalSourceContract physicalSinkContract with
@@ -1801,7 +1895,7 @@ module Transfer =
                         | Error es -> return Result.failure es
                         | Ok sink ->
                             use sink = sink
-                            return! runCore mode allowCdc allowDrops source sink physicalSinkContract Map.empty (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet }
+                            return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet }
         }
 
     // -- 6.A.1: the drop-set is fail-loud, not exit-0 -----------------------

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -82,6 +82,22 @@ module ReverseLegRealization =
         elif admissible then Result.success (ReverseLegRealization.Streaming journalDirectory)
         else Result.success ReverseLegRealization.Materialized
 
+    /// Phase 3 — the duplicate-hazard gate (the charter's "small lever"). A
+    /// streaming realization with NO journal, run for real (`executeGated`),
+    /// has no idempotent envelope: any re-run re-streams and DOUBLES every
+    /// sink-minted (AssignedBySink) kind. This refuses that shape BY NAME so
+    /// the operator must supply `--journal <dir>` (making the run resumable +
+    /// idempotent by construction). Pure and total: a DryRun (not gated), a
+    /// journal-bearing stream, and the materialized arm (its own G10 envelope)
+    /// all pass. Tested without a connection.
+    let executeJournalGate (realization: ReverseLegRealization) (executeGated: bool) : ValidationError option =
+        match realization, executeGated with
+        | ReverseLegRealization.Streaming None, true ->
+            Some
+                (ValidationError.create "transfer.reverseLeg.streamingExecuteRequiresJournal"
+                    "a streaming --execute needs --journal <dir>: without it a re-run re-streams and DOUBLES every sink-minted kind (no idempotent envelope). Pass --journal <dir> to make the load resumable + idempotent.")
+        | _ -> None
+
 /// The Transfer orchestrator — `Compose`'s data-direction sibling. Binds
 /// the two legs of the adjunction across two substrates: `Ingestion`
 /// (Source → rows) then a Projection-onto-Sink realization (rows → Sink),
@@ -1622,6 +1638,23 @@ module Transfer =
                             let journal =
                                 journalDirectory
                                 |> Option.map (fun dir -> CaptureJournal.create dir (planMarker sinkContract plan))
+                            // Phase 3 — the address-drift guard: if THIS run's
+                            // journal file is absent but the directory holds a
+                            // prior run's journal under a different plan marker,
+                            // resuming would silently orphan it and DOUBLE
+                            // committed work. Refuse by name instead.
+                            let addressDrift =
+                                journal
+                                |> Option.map CaptureJournal.siblingJournalsUnderDrift
+                                |> Option.defaultValue []
+                            if not (List.isEmpty addressDrift) then
+                                return Result.failureOf
+                                    (ValidationError.create "transfer.resume.journalAddressDrift"
+                                        (sprintf
+                                            "the journal directory holds %d journal(s) under a DIFFERENT plan marker (e.g. %s) but none for this run — the plan changed since the journaled run, so resuming would silently re-stream and DOUBLE committed work. Clear the journal directory to reload from scratch, or restore the prior plan to resume."
+                                            (List.length addressDrift)
+                                            (addressDrift |> List.truncate 1 |> List.map (fun f -> System.IO.Path.GetFileName f |> nonNull) |> String.concat ", ")))
+                            else
                             match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds with
                             | Error es -> return Result.failure es
                             | Ok (totals, skips, descents) ->

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -1201,6 +1201,26 @@ module Transfer =
         { Ingested : int
           Written  : int }
 
+    /// Phase 4 — the movement DryRun row-count estimate. The streaming
+    /// realization ingests nothing on DryRun (the rows STREAM at write
+    /// time), so its preview reported zero rows-would-move; the operator
+    /// could not see "N rows would move" before committing. This is the
+    /// cheap exact count (`COUNT_BIG(*)` aggregate — one round-trip per
+    /// kind, no row scan) the streaming DryRun reports as `RowsIngested`,
+    /// the materialized DryRun's row count without the materialization. The
+    /// SQL is terminal text over a validated `TableId` (the file's
+    /// LINT-ALLOW boundary). `int` of the aggregate is faithful for the
+    /// preview surface (`KindOutcome.RowsIngested : int`).
+    let private countKindRows (cnn: SqlConnection) (kind: Kind) : Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <-
+                sprintf "SELECT COUNT_BIG(*) FROM [%s].[%s];"
+                    (TableId.schemaText kind.Physical) (TableId.tableText kind.Physical)
+            let! scalar = cmd.ExecuteScalarAsync()
+            return int (unbox<int64> scalar)
+        }
+
     /// The bounded-memory realization of the straight-load plan: per kind,
     /// the source streams in `CaptureChunkSize` chunks through
     /// rename-repoint → FK-repoint (deferred excluded) → the capture
@@ -1621,10 +1641,38 @@ module Transfer =
                     | Some refusal -> return Result.failureOf refusal
                     | None ->
                         if mode <> Execute then
+                            // Phase 4 — the movement DryRun preview. Estimate
+                            // each kind's rows-would-move with a cheap exact
+                            // COUNT (no ingestion): a reconciled kind moves
+                            // nothing (ReconciledByRule — the sink owns it), so
+                            // it previews 0; every other kind previews its
+                            // source count. RowsWritten stays 0 (a preview), and
+                            // the reconcile outcome (Unmatched / Ambiguous) rides
+                            // the same report — the rekey-map preview.
+                            let! previewKinds =
+                                task {
+                                    let mutable acc : KindOutcome list = []
+                                    for l in plan.Loads do
+                                        let! estimate =
+                                            task {
+                                                if l.Disposition = IdentityDisposition.ReconciledByRule then return 0
+                                                else
+                                                    match Catalog.tryFindKind l.Kind sourceContract with
+                                                    | Some srcKind -> return! countKindRows source srcKind
+                                                    | None -> return 0
+                                            }
+                                        acc <-
+                                            { Kind              = l.Kind
+                                              Disposition       = l.Disposition
+                                              RowsIngested      = estimate
+                                              DeferredFkColumns = l.DeferredFkColumns
+                                              RowsWritten       = 0 } :: acc
+                                    return List.rev acc
+                                }
                             return
                                 Result.success
                                     { Mode                = mode
-                                      Kinds               = reportKinds mode plan
+                                      Kinds               = previewKinds
                                       UnbreakableCycleFks = plan.UnbreakableCycleFks
                                       UnmatchedIdentities = reconciled.Unmatched
                                       AmbiguousIdentities = reconciled.Ambiguous

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -128,6 +128,44 @@ let ``selector: --journal on an inadmissible request refuses by name — the led
     | Error es -> Assert.Equal("transfer.reverseLeg.journalRequiresStreaming", (List.head es).Code)
     | Ok other -> Assert.Fail(sprintf "expected the journal refusal, got %A" other)
 
+// -- Phase 3: the duplicate-hazard gate + the journal-address-drift guard ------
+
+[<Fact>]
+let ``Phase 3 gate: a journal-less streaming EXECUTE refuses by name; DryRun / journal-bearing / materialized pass`` () =
+    let gate r e = Projection.Pipeline.ReverseLegRealization.executeJournalGate r e
+    // journal-less streaming, gated execute → the named refusal
+    match gate (Projection.Pipeline.ReverseLegRealization.Streaming None) true with
+    | Some err -> Assert.Equal("transfer.reverseLeg.streamingExecuteRequiresJournal", err.Code)
+    | None -> Assert.Fail "expected the streaming-execute-requires-journal refusal"
+    // the same shape as a DryRun (not gated) is exempt — nothing is written
+    Assert.True((gate (Projection.Pipeline.ReverseLegRealization.Streaming None) false).IsNone)
+    // a journal-bearing stream is idempotent-capable → passes
+    Assert.True((gate (Projection.Pipeline.ReverseLegRealization.Streaming (Some "/j")) true).IsNone)
+    // the materialized arm carries its own G10 envelope → passes
+    Assert.True((gate Projection.Pipeline.ReverseLegRealization.Materialized true).IsNone)
+
+// (The face wiring of `executeJournalGate` mirrors the already-face-tested
+// `streamingTablesUnsupported` refusal; the gate's logic is proven purely
+// above, env-var-free, so the face path is not re-tested with a global
+// PROJECTION_ALLOW_EXECUTE mutation that could flake concurrent suites.)
+
+[<Fact>]
+let ``Phase 3 address-drift: a sibling journal under a different marker signals drift; own-file-present or empty dir does not`` () =
+    let dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "rl-drift-" + System.Guid.NewGuid().ToString("N").Substring(0, 8))
+    try
+        let j = Projection.Pipeline.CaptureJournal.create dir "marker-A"
+        // a fresh dir holding only this (not-yet-written) journal → no drift
+        Assert.Empty(Projection.Pipeline.CaptureJournal.siblingJournalsUnderDrift j)
+        // a PRIOR run's journal under a different marker, our file still absent → drift
+        let stray = Projection.Pipeline.CaptureJournal.create dir "marker-B"
+        System.IO.File.WriteAllText(Projection.Pipeline.CaptureJournal.filePath stray, "")
+        Assert.NotEmpty(Projection.Pipeline.CaptureJournal.siblingJournalsUnderDrift j)
+        // once our OWN journal exists (a real resume), no drift
+        System.IO.File.WriteAllText(Projection.Pipeline.CaptureJournal.filePath j, "")
+        Assert.Empty(Projection.Pipeline.CaptureJournal.siblingJournalsUnderDrift j)
+    finally
+        if System.IO.Directory.Exists dir then System.IO.Directory.Delete(dir, true)
+
 [<Fact>]
 let ``streaming face: an explicit --streaming with --tables refuses at the face with exit 2`` () =
     let model = tinyModel

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -33,31 +33,55 @@ let private tinyModel : Catalog =
             IsActive = true; ExtendedProperties = [] } ] []
     |> Result.value
 
-// -- the CLI face's named reverse-leg refusal (live) --------------------------
+// -- the CLI face's reconcile spec handling (Phase 2: the refusal is LIFTED) ---
+//
+// The blanket `transfer.reverseLeg.reconcileUnsupported` refusal that stood
+// here is gone (DECISIONS 2026-06-15 — reconcile ∘ reverse leg). The face now
+// parses + resolves reconcile/user-map specs against the physical sink
+// contract exactly as the forward face does. A bad spec still refuses by name
+// (arg error, exit 2) BEFORE any connection opens; a good spec is ACCEPTED and
+// proceeds to the apparatus (the full re-key witness is the Docker
+// `ReverseLegStreamingTests` 'reconcile ∘ streaming' pair). The reverse-leg
+// physical rendition of `tinyModel`'s one kind is `OSUSR_B_CUSTOMER([ID])`.
 
 [<Fact>]
-let ``reverse-leg face: a reconcile spec is REFUSED BY NAME (transfer.reverseLeg.reconcileUnsupported, exit 2) — never a silent straight-load`` () =
+let ``reverse-leg face: a MALFORMED reconcile spec refuses by name (arg error, exit 2) before any connection opens`` () =
     let model = tinyModel
     let exit =
         RunFaces.runReverseLegTransfer
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [ "Customer=Email" ] None
+            [ "Customer" ] None   // no ':' — transfer.reconcile.specShape
             false true false EmissionMode.Incremental false false None [] []
     Assert.Equal(2, exit)
 
 [<Fact>]
-let ``reverse-leg face: a user-map is REFUSED BY NAME on the reverse leg (the rekey ∘ rendition composition is the named follow-on)`` () =
+let ``reverse-leg face: a reconcile spec naming an unknown table refuses by name (exit 2) before any connection opens`` () =
     let model = tinyModel
     let exit =
         RunFaces.runReverseLegTransfer
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [] (Some "user-map.csv")
+            [ "OSUSR_NOPE:ID" ] None   // table not in the contract — transfer.reconcile.tableNotFound
             false true false EmissionMode.Incremental false false None [] []
     Assert.Equal(2, exit)
+
+[<Fact>]
+let ``reverse-leg face: a WELL-FORMED resolvable reconcile spec is ACCEPTED (no longer refused) — it passes the spec gate and reaches the apparatus`` () =
+    let model = tinyModel
+    let exit =
+        RunFaces.runReverseLegTransfer
+            "env:L3B_SRC" "env:L3B_SINK"
+            (Projection.Pipeline.CatalogRendition.logical model)
+            (Projection.Pipeline.CatalogRendition.physical model)
+            [ "OSUSR_B_CUSTOMER:ID" ] None   // resolves to MatchByColumn (Id)
+            false true false EmissionMode.Incremental false false None [] []
+    // Past the parse/resolve gate the run reaches connection-opening, which
+    // fails on the unset env vars — a connection-class exit, NEVER the arg/
+    // resolve exit 2. The point: reconcile is no longer refused at the face.
+    Assert.NotEqual(2, exit)
 
 // -- the realization SELECTOR: the best admissible realization, chosen pure --
 
@@ -118,8 +142,14 @@ let ``streaming face: an explicit --streaming with --tables refuses at the face 
 
 // -- reserved follow-on contracts (Skip stubs with promotion triggers) --------
 
-[<Fact(Skip = "Reserved: the reconcile ∘ rendition composition — 'User reconciled by email on the up-leg' (the cloud-owns-its-users reverse leg). The CLI face refuses today (transfer.reverseLeg.reconcileUnsupported); promotion trigger: ReconciledByRule threaded through runReverseLegThroughConnections with rendition-aware business-key resolution, then this test seeds the cloud sink's own user inventory and asserts the up-leg re-keys every user FK without re-importing a user row (the PE-3 join witness on the reverse leg).")>]
-let ``RESERVED — reverse leg with ReconciledByRule: User reconciled by email on the up-leg, identities re-keyed, never re-imported`` () = ()
+// PROMOTED 2026-06-15 (Phase 2 — reconcile ∘ reverse leg): the reserved
+// "User reconciled by email on the up-leg, identities re-keyed, never
+// re-imported" contract is now the live Docker witness
+// `ReverseLegStreamingTests.``reconcile ∘ streaming: User reconciled by email
+// on the up-leg — identities re-keyed, never re-imported``` (+ the
+// `validate-user-map pre-write halt` sibling). It moved to the streaming
+// suite because it needs the seeded-sink fixture; this pure boundary file
+// keeps only the face-level spec-gate refusals above.
 
 [<Fact(Skip = "Reserved: the contract-vs-live-shape preflight — a column the rendered logical contract names but live B lacks dies today inside the ingest SELECT with a raw SqlException (pinned by ReverseLegCanaryTests 'B-drift'). Promotion trigger: a named transfer.sourceShapeDrift refusal lands (compare the rendered contract against the live INFORMATION_SCHEMA before any read); then this test drops a column from live B and asserts the named refusal replaces the raw crash.")>]
 let ``RESERVED — B-drift refused by name: the rendered contract is checked against live B's shape before any row is read`` () = ()

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
@@ -402,7 +402,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         let runLeg () =
                             Transfer.runReverseLegThroughConnections
                                 Transfer.Execute EmissionMode.WipeAndLoad false true false []
-                                connections logicalContract physicalContract
+                                connections logicalContract physicalContract Map.empty
 
                         let! firstR = runLeg ()
                         let first = ReverseLegFixtures.value firstR

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
@@ -173,6 +173,95 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     Assert.Equal(4, payment.RowsWritten)
                 })
 
+    // -- Phase 2 (the charter): reconcile ∘ streaming on the reverse leg ------
+    //
+    // The promoted ReverseLegBoundaryTests Skip-stub: the "cloud owns its
+    // users" up-leg. The sink is pre-seeded with its OWN Customer inventory
+    // (the User family); the reverse leg reconciles each source Customer to the
+    // pre-existing sink Customer BY EMAIL and re-keys every Customer FK to the
+    // sink surrogate — WITHOUT re-importing a Customer row (Customer is
+    // ReconciledByRule, phase-1 insert skipped). The PE-3 join witness, on the
+    // streaming reverse leg. `Customer` plays the User role (it carries Email).
+    member private _.reconcileCustomerByEmail : Map<SsKey, ReconciliationStrategy> =
+        Map.ofList
+            [ ReverseLegFixtures.kKey "Customer",
+              ReconciliationStrategy.MatchByColumn (ReverseLegFixtures.nm "Email") ]
+
+    [<Fact>]
+    member this.``reconcile ∘ streaming: User (Customer) reconciled by email on the up-leg — identities re-keyed, never re-imported`` () =
+        if not (ReverseLegFixtures.skipIfNoDocker "L3StreamReconcile") then () else
+        this.WithEstates "L3StreamReconcile" ReverseLegFixtures.seedClean
+            (fun src sink logicalContract physicalContract ->
+                task {
+                    // The cloud sink ALREADY owns its users — seed its Customer
+                    // inventory (sink-minted IDs 1,2), emails matching the source.
+                    do! Deploy.executeBatch sink
+                            "INSERT INTO [dbo].[OSUSR_L3_CUSTOMER] ([EMAIL]) VALUES (N'alice@x'),(N'bob@x');"
+
+                    let! reportR =
+                        Transfer.runStreamingReconcilingWithRenames
+                            Transfer.Execute true false src sink
+                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                    let report = ReverseLegFixtures.value reportR
+                    Assert.Empty(report.SkippedReferences)
+                    Assert.Empty(report.UnmatchedIdentities)
+
+                    // Customer is RECONCILED, never re-imported: still exactly the
+                    // two pre-seeded rows (a re-import would have doubled it to 4),
+                    // its report row ReconciledByRule with zero writes.
+                    let! customers = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_CUSTOMER]"
+                    Assert.Equal(2, customers)
+                    let customerKind = report.Kinds |> List.find (fun k -> k.Kind = ReverseLegFixtures.kKey "Customer")
+                    Assert.Equal(IdentityDisposition.ReconciledByRule, customerKind.Disposition)
+                    Assert.Equal(0, customerKind.RowsWritten)
+
+                    // No preserved source key anywhere (the sink mints; Customer
+                    // FKs re-point to the sink's pre-existing surrogates).
+                    let! preserved = ReverseLegFixtures.preservedKeyCount sink
+                    Assert.Equal(0, preserved)
+
+                    // Every Customer-FK edge lands on the sink's OWN users by
+                    // email — the re-key witness (Account→Customer, Invoice→Customer).
+                    let! (aAccCust, _, aInvCust, _, _) = ReverseLegFixtures.sinkEdgeJoins sink
+                    Assert.Equal<(string * string option) list>(
+                        [ ("acc-a1", Some "alice@x"); ("acc-a2", Some "alice@x"); ("acc-b1", Some "bob@x") ], aAccCust)
+                    Assert.Equal<(string * string option) list>(
+                        [ ("inv-1", Some "alice@x"); ("inv-2", None); ("inv-3", Some "bob@x") ], aInvCust)
+                })
+
+    [<Fact>]
+    member this.``validate-user-map pre-write halt: an unmatched source user refuses before any write (transfer.unmappedIdentities) — the sink stays untouched`` () =
+        if not (ReverseLegFixtures.skipIfNoDocker "L3StreamUserMapHalt") then () else
+        this.WithEstates "L3StreamUserMapHalt" ReverseLegFixtures.seedClean
+            (fun src sink logicalContract physicalContract ->
+                task {
+                    // The sink owns only ONE of the two users — bob@x is unmapped,
+                    // so the reverse-leg re-key has an orphan source identity.
+                    do! Deploy.executeBatch sink
+                            "INSERT INTO [dbo].[OSUSR_L3_CUSTOMER] ([EMAIL]) VALUES (N'alice@x');"
+
+                    let! reportR =
+                        Transfer.runStreamingReconcilingWithRenames
+                            Transfer.Execute true false src sink
+                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                    // AC-I5 / NM-31 on the streaming arm: a PRE-write refusal by
+                    // name, not a post-write drop.
+                    match reportR with
+                    | Error es ->
+                        Assert.True(
+                            es |> List.exists (fun e -> e.Code = "transfer.unmappedIdentities"),
+                            sprintf "expected transfer.unmappedIdentities, got %A" (es |> List.map (fun e -> e.Code)))
+                    | Ok _ -> Assert.Fail("expected the validate-user-map pre-write halt")
+
+                    // The sink is UNTOUCHED — the halt landed before any DML.
+                    let! accounts = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_ACCOUNT]"
+                    let! invoices = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_INVOICE]"
+                    let! payments = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_PAYMENT]"
+                    Assert.Equal(0, accounts)
+                    Assert.Equal(0, invoices)
+                    Assert.Equal(0, payments)
+                })
+
     [<Fact>]
     member this.``resume guard: source drift under the journal refuses by name (transfer.resume.sourceDrift) — never a silent re-run over changed data`` () =
         if not (ReverseLegFixtures.skipIfNoDocker "L3Drift") then () else

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
@@ -263,6 +263,34 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                 })
 
     [<Fact>]
+    member this.``Phase 3 address-drift: a streaming execute whose own journal is orphaned by a prior run's journal refuses by name (transfer.resume.journalAddressDrift) — never a silent re-run`` () =
+        if not (ReverseLegFixtures.skipIfNoDocker "L3AddrDrift") then () else
+        let journalDir = this.FreshJournalDir "addrdrift"
+        // A PRIOR run's journal under a DIFFERENT plan marker (a stray
+        // transfer-*.ndjson). This run's own marker resolves to a different
+        // filename, so its file is absent while the stray is present — the
+        // address-drift signature that, unguarded, silently re-streams.
+        System.IO.File.WriteAllText(
+            System.IO.Path.Combine(journalDir, "transfer-0000deadbeef0000.ndjson"), "")
+        this.WithEstates "L3AddrDrift" ReverseLegFixtures.seedClean
+            (fun src sink logicalContract physicalContract ->
+                task {
+                    let! reportR =
+                        Transfer.runStreamingWithRenames Transfer.Execute true src sink
+                            logicalContract physicalContract (Some journalDir)
+                    match reportR with
+                    | Error es ->
+                        Assert.True(
+                            es |> List.exists (fun e -> e.Code = "transfer.resume.journalAddressDrift"),
+                            sprintf "expected transfer.resume.journalAddressDrift, got %A" (es |> List.map (fun e -> e.Code)))
+                    | Ok _ -> Assert.Fail("expected the journal-address-drift refusal")
+
+                    // The refusal lands BEFORE any write — the sink is untouched.
+                    let! accounts = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_ACCOUNT]"
+                    Assert.Equal(0, accounts)
+                })
+
+    [<Fact>]
     member this.``resume guard: source drift under the journal refuses by name (transfer.resume.sourceDrift) — never a silent re-run over changed data`` () =
         if not (ReverseLegFixtures.skipIfNoDocker "L3Drift") then () else
         let journalDir = this.FreshJournalDir "drift"

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
@@ -262,6 +262,50 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     Assert.Equal(0, payments)
                 })
 
+    // -- Phase 4 (the charter): movement dry-run preview -----------------------
+    //
+    // The streaming realization ingests nothing on DryRun, so its preview used
+    // to report zero rows-would-move. Phase 4 estimates each kind's rows with a
+    // cheap exact COUNT (no row scan): a reconciled kind previews 0 (the sink
+    // owns it), the rest preview their source counts, and the reconcile outcome
+    // (Unmatched / Ambiguous) rides the same report — the rekey-map preview. A
+    // preview writes nothing.
+    [<Fact>]
+    member this.``Phase 4 dry-run preview: a streaming DryRun estimates rows-would-move per kind (reconciled kind previews 0) and writes nothing`` () =
+        if not (ReverseLegFixtures.skipIfNoDocker "L3DryRunPreview") then () else
+        this.WithEstates "L3DryRunPreview" ReverseLegFixtures.seedClean
+            (fun src sink logicalContract physicalContract ->
+                task {
+                    // Seed the sink's own users so the rekey preview shows a full match.
+                    do! Deploy.executeBatch sink
+                            "INSERT INTO [dbo].[OSUSR_L3_CUSTOMER] ([EMAIL]) VALUES (N'alice@x'),(N'bob@x');"
+
+                    let! reportR =
+                        Transfer.runStreamingReconcilingWithRenames
+                            Transfer.DryRun true false src sink
+                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                    let report = ReverseLegFixtures.value reportR
+                    Assert.Equal(Transfer.DryRun, report.Mode)
+
+                    let rowsOf k = report.Kinds |> List.find (fun x -> x.Kind = ReverseLegFixtures.kKey k)
+                    // The reconciled User kind previews 0 rows-would-move (ReconciledByRule).
+                    Assert.Equal(IdentityDisposition.ReconciledByRule, (rowsOf "Customer").Disposition)
+                    Assert.Equal(0, (rowsOf "Customer").RowsIngested)
+                    // The rest preview their EXACT source counts (no ingestion).
+                    Assert.Equal(3, (rowsOf "Account").RowsIngested)
+                    Assert.Equal(3, (rowsOf "Invoice").RowsIngested)
+                    Assert.Equal(4, (rowsOf "Payment").RowsIngested)
+                    // A preview writes nothing, and the rekey preview shows a full match.
+                    Assert.True(report.Kinds |> List.forall (fun x -> x.RowsWritten = 0))
+                    Assert.Empty(report.UnmatchedIdentities)
+
+                    // The sink is unchanged — only the 2 pre-seeded users, no movement.
+                    let! customers = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_CUSTOMER]"
+                    let! accounts  = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_ACCOUNT]"
+                    Assert.Equal(2, customers)
+                    Assert.Equal(0, accounts)
+                })
+
     [<Fact>]
     member this.``Phase 3 address-drift: a streaming execute whose own journal is orphaned by a prior run's journal refuses by name (transfer.resume.journalAddressDrift) — never a silent re-run`` () =
         if not (ReverseLegFixtures.skipIfNoDocker "L3AddrDrift") then () else


### PR DESCRIPTION
Drives the reverse-leg DML execution backlog (`CHARTER_REVERSE_LEG_EXECUTION.md` Part IX) from "engine proven on mock" through every buildable phase, and packages the rest for the operator. Built on the merged charter base (#612).

## Code (built + warm-witnessed against the `projection-mssql-warm` container)

- **Phase 2 — reconcile ∘ streaming on the reverse leg.** Lifts `transfer.reverseLeg.reconcileUnsupported`; the B→A up-leg re-keys users by email and re-points every FK to the sink's own users, **never re-importing a user row** (`reclassifyReconciled` → ReconciledByRule). Adds the `validate-user-map` pre-write halt to the **streaming** arm (NM-31 / N4 closed). Both arms reconcile through the engine — no silent reconcile loss. `runStreamingWithRenames` becomes a thin straight-load wrapper, so the existing witnesses are untouched.
- **Phase 3 — harden resume + idempotency.** Two silent duplication hazards become named refusals: `transfer.reverseLeg.streamingExecuteRequiresJournal` (forces `--journal` on a streaming execute — closes the G3 doubling by construction) and `transfer.resume.journalAddressDrift` (a marker/schema byte-change that orphans the prior journal now refuses instead of silently re-streaming). Compaction + live socket-drop reconnect staged with their wakes.
- **Phase 4 — movement dry-run.** The streaming DryRun now previews exact per-kind "N rows would move" via `COUNT_BIG(*)` (reconciled kind → 0; rekey-map preview rides along). The live ETA bar is staged (its denominator now exists).

New/updated witnesses (`ReverseLegStreamingTests`, `ReverseLegBoundaryTests`): reconcile-never-re-imported, the pre-write halt, the address-drift refusal, the dry-run preview, plus the pure gate/drift tests.

## Operator deliverables (Phases 1 & 5 are real-wire / CDC / cutover-governance gated — no R6-respecting code lever)

- **`REVERSE_LEG_OPERATOR_PROBE_SHEET.md`** — 16 generic, runnable probes naming the per-table unknowns the engine can't resolve itself (schema shape, data fidelity, capability, **target archetype**), each with what it unlocks + how to read it + a results ledger. All catalog SQL validated against SQL Server 2022.
- **`PHASE_1_REAL_WIRE_HARNESS.md`** — the P7b throughput-bench procedure + the estate-sizing survey.
- **`DATABASE_ARCHETYPES.md`** — the operator-prompted design: the target's capability **class** (on-prem full-rights vs managed-DML) as a first-class, **verified** config disposition that subsumes the coarse `Grant` facet; the honest hardcoded-assumption inventory (H1–H6); a non-breaking slice plan. Direction recorded, not built (slice A is byte-identical; the type stays zero-consumer until its fork).
- **Cutover-readiness assessment** (DECISIONS + charter Phase 5): the grant-gate hard-stop *mechanism* already exists (`projection survey` exits 7); the flip is per-pair cutover CI governance under the N=10-canary ladder — a speculative in-flow flip was deliberately **not** built (R6).

## Verification

- 62 reverse-leg + forward-reconcile Docker tests + 184 pure transfer/movement/reconciliation tests **green for real** (confirmed via per-test TRX durations against the warm container — the Windows `EphemeralContainerFixture` no-op trap is documented in the handoff). Full solution builds clean (dotnet 9.0.314).
- A DECISIONS.md entry per phase + the archetype direction; charter Part VII / IX / the named-gap index updated to match.

## Handoff

`HANDOFF.md` top letter is the decoder for the next agent: each operator probe result → what it unlocks → the slice to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)