### PR TITLE
Reverse-leg: lock the two-flow / two-archetype model + the work plan (docs)

### DIFF
--- a/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
+++ b/sidecar/projection/CHARTER_REVERSE_LEG_EXECUTION.md
@@ -672,7 +672,11 @@ The mechanisms are built or already exist; what remains is operator governance (
 - **`REVERSE_LEG_OPERATOR_PROBE_SHEET.md`** — 16 generic, runnable probes naming the per-table unknowns
   (schema shape, data fidelity, capability, archetype) + the results ledger. All catalog SQL validated.
 - **`PHASE_1_REAL_WIRE_HARNESS.md`** — the P7b throughput-bench procedure + the estate-sizing survey.
+- **`NEXT_BUILD_INPUTS.sql`** — the two-flow input pack (keymap sizing + the on-prem archetype probe).
 - **`DATABASE_ARCHETYPES.md`** — the target capability-class design (the archetype as a config disposition).
+- **`REVERSE_LEG_WORK_PLAN.md`** — the locked two-flow / two-archetype model + the sequenced forward
+  slices (A archetype → C FullRights populate forks → S reverse-leg `#`-temp spill → B survey-verify),
+  on top of the shipped Phases 2–4 + NM-58. The current build plan (`DECISIONS.md` 2026-06-15).
 
 ## Risk register (carried from the discovery)
 

--- a/sidecar/projection/DATABASE_ARCHETYPES.md
+++ b/sidecar/projection/DATABASE_ARCHETYPES.md
@@ -223,6 +223,14 @@ verdicts: no ALTER, no IDENTITY_INSERT, AssignedBySink, SQL rollback); the probe
 *of the same class*, so verifying it once de-risks every same-class cutover — the original J5 thesis,
 now structural.
 
+> **Verified against the real estate (2026-06-15).** The two archetypes are no longer hypothetical:
+> the **on-prem** sink probed `FullRights`-minus-DMV (CREATE TABLE / ALTER / IDENTITY_INSERT /
+> sink-resident progress all permitted; `VIEW DATABASE PERFORMANCE STATE` denied — the predicted
+> split), and the **cloud** sink is `ManagedDml` (J5). And the engine genuinely writes to *both*
+> (Flow P populate on-prem via direct-connect `migrate` + emit-artifacts; Flow R reverse leg into the
+> cloud), so the per-sink-archetype mechanism is not academic — it is the daily operating reality. The
+> sequenced build is `REVERSE_LEG_WORK_PLAN.md`.
+
 ---
 
 ## §6 — Migration path (non-breaking slices)

--- a/sidecar/projection/DATABASE_ARCHETYPES.md
+++ b/sidecar/projection/DATABASE_ARCHETYPES.md
@@ -103,6 +103,20 @@ states intent **once** and the pipeline derives safe interaction:
    silent surprise mid-load.
 7. **The user-handling default.** `ManagedDml ⇒ ReconciledByRule` (the cloud owns its users — the
    Phase-2 reverse-leg re-key). `FullRights ⇒` preserve (same key space) unless reconcile is declared.
+8. **The keymap-spill mechanism (added 2026-06-15 — the direction-clarification insight).** The
+   resident packed remap (~40 B/FK-target-row) overflows at estate scale (≈ 8 GB at 200M), so a spill
+   is needed — but *which* spill is archetype-determined, NOT one build:
+   - `PreservedFromSource` sink (FullRights + IDENTITY_INSERT) ⇒ **no keymap at all** (keys written
+     directly; the spill question disappears).
+   - `AssignedBySink` + `CREATE TABLE` (FullRights without IDENTITY_INSERT) ⇒ a **persistent
+     sink-resident keymap table** + server-side `UPDATE…JOIN`.
+   - `AssignedBySink` + no `CREATE TABLE` (`ManagedDml` — the reverse-leg cloud sink) ⇒ a **session
+     `#`-temp keymap** (temp tables ARE permitted under DML — J5 P5) + server-side `UPDATE…JOIN`, or a
+     client-side disk-backed map. The charter's "sink-resident spill" must not be read as "always a
+     persistent table" — on the cloud it is the `#`-temp form.
+   This is the sharpest case for the archetype being first-class: the spill chooser must *read* the
+   sink's capability profile, because the same "200M won't fit in RAM" problem has three different
+   correct answers depending on the class.
 
 ---
 

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23638,3 +23638,31 @@ direction is load-bearing.
   AssignedBySink. Part 2 (archetype) run on the **on-prem** (Flow P's sink) → its CREATE TABLE /
   IDENTITY_INSERT decide whether Flow P even has a keymap and which spill it would use. Builds are
   HELD until these land — building a spill now risks building the wrong one of the three mechanisms.
+
+## 2026-06-15 (later) — Confirmed: on-prem = FullRights(-minus-DMV); cloud sink is EMPTY; the codebase's job is the reverse leg
+
+Operator confirmations that close the archetype unknowns and lock the data topology.
+
+- **On-prem archetype = `FullRights`** (verified, not just declared): `CREATE TABLE`, `ALTER` on
+  `[dbo].[<table>]`, `SELECT/INSERT/UPDATE/DELETE`, **`IDENTITY_INSERT`**, and a **sink-resident
+  progress table** all permitted — minus **`VIEW DATABASE PERFORMANCE STATE`** (the earlier DMV gap).
+  So the on-prem is precisely the `FullRights`-minus-DMV split the §5 archetype note predicted. Part 2
+  is **answered**; nothing more to probe on the on-prem.
+- **The keystone topology fact: the cloud managed instance will NOT hold the estate data.** The estate
+  data is populated **into the on-prem** (by an upstream process), and the codebase then runs **the
+  last leg = the reverse leg = on-prem → cloud**. So:
+  - The **estate data lives on the on-prem** — which means the keymap sizing (`NEXT_BUILD_INPUTS.sql`
+    Part 1) must run on the **on-prem via the `COUNT_BIG` fallback (1c)** (DMV-denied there); the
+    cloud-DMV path is moot (no data on the cloud yet). *(Corrects the prior entry's "size on the cloud".)*
+  - The **reverse-leg sink = the (empty) cloud = `ManagedDml`** (J5): `AssignedBySink` (mints; no
+    `IDENTITY_INSERT`), so the keymap is needed, and the spill is the **`#`-temp** form (no CREATE
+    TABLE on the cloud). `PreservedFromSource` is dead on the cloud sink regardless of the on-prem's
+    IDENTITY_INSERT.
+  - The on-prem's `FullRights` is the **source** side of the reverse leg (read-only) — so it does NOT
+    change the reverse-leg sink's mechanism. Its forks (`PreservedFromSource`, sink-resident resume —
+    Slice C/D) are in scope **only if the codebase also WRITES INTO the on-prem** (a populate flow). The
+    open scope question: does this engine populate the on-prem, or only read it for the reverse leg?
+- **Net:** the reverse-leg path + its `#`-temp keymap spill are the codebase's confirmed job and are
+  fully scoped (mechanism determined; only the sizing/RAM-budget set the spill trigger). The on-prem
+  `FullRights` forks await the populate-scope answer. Still needed: Part 1c on the on-prem (FK-target
+  AssignedBySink row count) + the transfer-host RAM budget.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23601,3 +23601,40 @@ they settle, and the one CODE change they demanded.
   fix). The disposition mix (AssignedBySink for identity tables; preserve/reconcile for reference
   tables; deferred nullable cycle FKs; conditional user reconcile) is decided. The DMV gap + the 200M
   scale (spill / compaction wakes) are the named next items.
+
+## 2026-06-15 (later) — Direction clarified: TWO flows, two sinks; the keymap-spill mechanism is archetype-determined
+
+The operator flagged a Source/Target conflation worth fixing precisely. Resolved: there are **two
+load flows**, and the builds are **sink-centric** (a "sink" = the DB the engine writes into), so the
+direction is load-bearing.
+
+- **Flow R — the reverse leg / "up-leg" (on-prem → cloud).** The charter's subject. **Sink = the
+  cloud managed env** (A/Physical), `ManagedDml` (J5: mints keys, no CREATE TABLE / ALTER /
+  IDENTITY_INSERT). Source = on-prem (B/Logical), read-only. Grounded in `MovementSurface.fs`'s
+  Rendition doc ("Physical … A — the up-leg sink; Logical … B — the legacy reverse leg's source").
+- **Flow P — populate / extract (cloud → on-prem).** **Sink = the on-prem SQL Server.** Archetype
+  UNKNOWN (`NEXT_BUILD_INPUTS.sql` Part 2 probes it). The operator's probe framing (Source=cloud,
+  Target=on-prem) is this flow — the *opposite* of the reverse leg, which is why it read as a
+  conflation. The DMV gap they found is on this sink.
+
+- **The design nuance this surfaces — the keymap-spill MECHANISM is itself archetype-driven** (a new
+  H-row for `DATABASE_ARCHETYPES.md` §2). The resident packed remap (~40 B/FK-target-row) overflows at
+  200M (≈ 8 GB), so a spill is needed — but *which* spill depends on the sink's archetype:
+  - **`PreservedFromSource` sink** (FullRights on-prem with IDENTITY_INSERT): **no keymap at all** —
+    keys are written directly; the spill question disappears for Flow P if the on-prem permits it.
+  - **`AssignedBySink` + CREATE TABLE** (FullRights on-prem without IDENTITY_INSERT): a **persistent
+    sink-resident keymap table** + server-side `UPDATE…JOIN` (the charter's named "sink-resident spill").
+  - **`AssignedBySink` + no CREATE TABLE** (the `ManagedDml` cloud — Flow R's sink): a persistent
+    sink table is **forbidden**, so the spill must be a **session `#`-temp keymap** (temp tables ARE
+    permitted under the DML grant — J5 P5) + server-side `UPDATE…JOIN`, OR a client-side disk-backed
+    map. The charter's "sink-resident spill" must NOT be read as "always a persistent table"; on the
+    cloud it is the `#`-temp form.
+  So the spill is **not one build** — it is per-archetype. This is exactly why the archetype must be a
+  first-class disposition the spill chooser reads (`DATABASE_ARCHETYPES.md`), not an assumption.
+
+- **What I need, re-mapped (`NEXT_BUILD_INPUTS.sql` relabelled for both flows):** Part 1 (keymap
+  sizing — the estate FK-target AssignedBySink row count, same data both sides) run on the **cloud**
+  (DMV works) + the host RAM budget → sizes Flow R's keymap and Flow P's IFF the on-prem is
+  AssignedBySink. Part 2 (archetype) run on the **on-prem** (Flow P's sink) → its CREATE TABLE /
+  IDENTITY_INSERT decide whether Flow P even has a keymap and which spill it would use. Builds are
+  HELD until these land — building a spill now risks building the wrong one of the three mechanisms.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23666,3 +23666,33 @@ Operator confirmations that close the archetype unknowns and lock the data topol
   fully scoped (mechanism determined; only the sizing/RAM-budget set the spill trigger). The on-prem
   `FullRights` forks await the populate-scope answer. Still needed: Part 1c on the on-prem (FK-target
   AssignedBySink row count) + the transfer-host RAM budget.
+
+## 2026-06-15 (later) — Sizing + dual on-prem-write CONFIRMED; the two-flow / two-archetype model locked; the work plan
+
+The last operator inputs. The model is now fully determined and recorded; `REVERSE_LEG_WORK_PLAN.md`
+is the sequenced build plan.
+
+- **Keymap sizing (estate-data on-prem, the reverse-leg source).** **2.0 M** key-map-shaped rows
+  (FK-target, single-IDENTITY-PK) ⇒ **75 MB** resident packed remap (~37.5 B/row); **3.5 M** all-`dbo`
+  rows ⇒ **134 MB**. Transfer host = **64 GB RAM**. **The resident map fits comfortably even
+  extrapolated to production (~200 M ⇒ ~4–8 GB ≪ 64 GB).** So the spill is **NOT forced by the
+  numbers** — it is a *completeness* build (it closes the one unbounded-RAM hole in the otherwise
+  bounded-memory streaming path) and *headroom* (estates/hosts beyond this one). **Operator decision:
+  build the at-scale spill anyway, to be safe** — recorded as a conscious build-ahead-of-the-wake, with
+  a **configurable trigger defaulted inert at current scale** so it is armed + witnessed, not dead code.
+- **Dual on-prem-write CONFIRMED — Flow P IS a codebase job.** The engine writes into the on-prem two
+  ways: **(a) direct-connect** — the engine connects and applies data live (a `migrate` command,
+  diff-based, no schema change); **(b) emit-artifacts** — export SSDT + data, the operator deploys the
+  SSDT + static seeds + applies the data. So the on-prem-as-sink (`FullRights`) forks are **in scope**:
+  `PreservedFromSource` (write source keys directly via IDENTITY_INSERT — **no keymap** for the populate
+  flow) and **sink-resident resume** (CREATE TABLE permitted). This closes the open scope question.
+- **The two-flow / two-archetype model — LOCKED, and it validates the archetype design.** The codebase
+  writes to **two different sink classes**, so the per-sink mechanism MUST be archetype-driven:
+  - **Flow P — populate the on-prem** (direct-connect `migrate` OR emit-artifacts). Sink = on-prem =
+    **`FullRights`-minus-DMV**. Mechanism: `PreservedFromSource` (no keymap) + sink-resident resume.
+  - **Flow R — the reverse leg** (on-prem → cloud). Sink = empty cloud = **`ManagedDml`**. Mechanism:
+    `AssignedBySink` + keymap + `#`-temp spill + client-side journal.
+  This is the real-estate proof of `DATABASE_ARCHETYPES.md`: one engine, two sink archetypes, the
+  capability profile picking the safe mechanism per target. The work plan (`REVERSE_LEG_WORK_PLAN.md`)
+  sequences Slice A (the type) → B (survey-verify) → C (the FullRights populate forks) → S (the
+  reverse-leg `#`-temp spill), all on top of the already-shipped Phases 2–4 + NM-58.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,4 +1,65 @@
-# Handoff addendum — 2026-06-15, REVERSE-LEG EXECUTION (Phases 2–5 landed) + THE OPERATOR PROBE PACKAGE — your job is to DECODE the operator's probe results (attached with this handoff) and drive each staged item to completion
+# Handoff addendum — 2026-06-15, BUILD THE ARCHETYPE SLICES — the model is locked, the inputs are confirmed, the plan is written; your job is to build Slice A → C → S → B per REVERSE_LEG_WORK_PLAN.md
+
+To the next agent.
+
+**Your mission.** Build the four sequenced slices in **`REVERSE_LEG_WORK_PLAN.md`** — there is nothing
+left to discover; the operator's real-estate facts are all in, the model is locked, and the plan names
+each slice's mechanism, gate, and exit-test witness. Read `REVERSE_LEG_WORK_PLAN.md` first, then the
+2026-06-15 `DECISIONS.md` entries (they are the substance; the plan points). Then build, warm-witness,
+and write one DECISIONS entry per slice.
+
+**The locked model (what every slice assumes).** One engine, **two flows, two sink archetypes** — the
+real estate proved the archetype-as-config-disposition design:
+- **Flow P — populate the on-prem** (the engine writes in two ways: direct-connect `migrate` + emit
+  SSDT/data artifacts). Sink = on-prem = **`FullRights`-minus-DMV** (verified: CREATE TABLE, ALTER,
+  IDENTITY_INSERT, sink-resident progress; no `VIEW DATABASE PERFORMANCE STATE`). ⇒ `PreservedFromSource`
+  (no keymap) + sink-resident resume.
+- **Flow R — the reverse leg** (on-prem → the *empty* cloud it fills). Sink = cloud = **`ManagedDml`**
+  (J5). ⇒ `AssignedBySink` + keymap + the `#`-temp spill + client journal.
+- **Sizing:** estate-data on-prem = 2.0 M key-map-shaped rows (75 MB) / 3.5 M all-`dbo` (134 MB); host
+  = 64 GB. The resident map **fits even at ~200 M (~4–8 GB ≪ 64 GB)** — so **Slice S (the spill) is a
+  completeness/headroom build, not a current necessity**: ship it **armed-but-inert** (configurable
+  threshold, default off, byte-identical today). Do not overstate its need; the operator chose it for
+  scale-safety, recorded as a build-ahead-of-the-wake.
+
+**The slices (build order A → C → S → B; the graph is A → {C, S, B}).**
+1. **A — the `Archetype` config type** + `CapabilityProfile.of` + `Environment.Archetype` (default
+   inferred from `Grant`, byte-identical). Pure round-trip witness. The foundation; nothing branches yet.
+2. **C — the FullRights populate forks** (highest value): `PreservedFromSource` (write source keys
+   directly, *no* capture/remap) + sink-resident resume, gated on a `FullRights` sink; `ManagedDml`
+   keeps AssignedBySink + journal byte-identical. Docker witness: keys preserved on FullRights, old path
+   on ManagedDml.
+3. **S — the reverse-leg `#`-temp keymap spill** (armed scale-safety): a session `#`-temp keymap (temp
+   tables ARE permitted under DML — J5 P5) + server-side `UPDATE…JOIN` for phase-2, above a configurable
+   threshold. Equivalence canary: spill-on vs resident → **byte-identical** sink state.
+4. **B — the survey verifies the archetype** (A44; least urgent — the verdicts are known): route
+   `CapabilitySurvey` through `archetype.Grant` + declared-vs-probed reconciliation, so a
+   `FullRights`-minus-DMV surfaces as a named split.
+
+**What is SHIPPED — do not redo.** Phases 2–4 + NM-58 (reconcile ∘ streaming + the validate-user-map
+halt; force-journal + journal-address-drift refusals; the DryRun row-count preview; the reconcile-key
+robustness — blank-key exclusion + duplicate-target tiebreaker). 62 Docker + 184 pure green warm. The
+operator package (`REVERSE_LEG_OPERATOR_PROBE_SHEET.md`, `PHASE_1_REAL_WIRE_HARNESS.md`,
+`NEXT_BUILD_INPUTS.sql`) and the design (`DATABASE_ARCHETYPES.md`).
+
+**Build-discipline scars (heed them).**
+1. **⚠️ Docker tests SILENTLY NO-OP on this Windows box** unless `$env:PROJECTION_MSSQL_CONN_STR=
+   "Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container). They pass as 0.4 ms `()` no-ops otherwise — **confirm via per-test TRX
+   durations (seconds, not ms)**, never the green count (survival-rule #12).
+2. `dotnet` is at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` (not on bash PATH) — build/
+   test via PowerShell; never the pure + Docker pools in one `dotnet test` (CLAUDE.md §4.1).
+3. **The archetype is total-over-the-engine** (closed DU, one `CapabilityProfile.of` site — the
+   `ArtifactByKind` discipline); `Grant` becomes a *derived* projection. Named refusals + a witness +
+   a DECISIONS entry per slice; promote the reserved Skip-stubs where they fit.
+
+**State.** Branch `claude/reverse-leg-execution-phases-2-5`, **PR #614** (open against `main`). Worktree
+at `sidecar/projection/.claude/worktrees/unruffled-diffie-801d9b`. Read the work plan, build the slices,
+keep the books balanced.
+
+---
+
+## Handoff addendum — 2026-06-15, REVERSE-LEG EXECUTION (Phases 2–5 landed) + THE OPERATOR PROBE PACKAGE — your job is to DECODE the operator's probe results (attached with this handoff) and drive each staged item to completion
 
 To the next agent.
 

--- a/sidecar/projection/NEXT_BUILD_INPUTS.sql
+++ b/sidecar/projection/NEXT_BUILD_INPUTS.sql
@@ -8,20 +8,35 @@
      {{ENTITY_LIKE}}  a LIKE pattern matching your entity tables (e.g. 'APP\_%' ESCAPE '\', or '%')
      {{SCHEMA}}.{{TABLE}}  one representative IDENTITY-PK entity table (for the ALTER/IDENTITY probes)
 
+   TWO FLOWS, TWO SINKS (a "sink" = the DB the engine WRITES INTO):
+     Flow R — REVERSE LEG / up-leg (on-prem -> cloud): sink = the cloud managed env.
+              Already characterised: ManagedDml (J5 — sink mints keys, no CREATE TABLE /
+              ALTER / IDENTITY_INSERT). No new archetype probe needed for this sink.
+     Flow P — POPULATE / extract (cloud -> on-prem): sink = the on-prem SQL Server.
+              UNKNOWN archetype — Part 2 probes it (FullRights vs ...). If FullRights +
+              IDENTITY_INSERT, this flow uses PreservedFromSource (NO keymap at all).
+
    WHAT EACH PART UNLOCKS
-     Part 1  -> the sink-resident keymap SPILL sizing (resident vs spill decision at 200M)
-     Part 2  -> the ARCHETYPE verdict for the on-prem target (Slice A + the C/D forks)
-     (verify-data needs NOTHING new: the engine counts via COUNT_BIG, not DMVs, so it
-      already works on the DMV-denied target — no input required, no build required.)
+     Part 1 -> the keymap SPILL sizing. The keymap holds ~40 B per AssignedBySink (single-
+               IDENTITY-PK) FK-target row being inserted. It is the SAME estate data on both
+               renditions, so run Part 1 on whichever DB has DMV access (your CLOUD/managed).
+               This count sizes Flow R's keymap (cloud sink mints -> always AssignedBySink),
+               and Flow P's keymap IFF the on-prem sink turns out AssignedBySink (Part 2).
+               NOTE: Flow R's sink is the cloud, which forbids CREATE TABLE — so its spill is
+               a SESSION '#'-temp keymap + server-side UPDATE...JOIN, not a persistent table.
+     Part 2 -> the on-prem ARCHETYPE (Flow P's sink): CREATE TABLE / ALTER / IDENTITY_INSERT /
+               sink-resident-progress. Drives Slice A + the C/D forks for the populate flow.
+     (verify-data needs NOTHING new: the engine counts via COUNT_BIG, not DMVs, so it already
+      works on the DMV-denied on-prem — no input required, no build required.)
    ============================================================================= */
 
 
 /* -----------------------------------------------------------------------------
-   PART 1 — KEYMAP SPILL SIZING
-   Run on the SOURCE (the database rows are READ from). The resident key-map holds
-   ~40 bytes PER ROW of each AssignedBySink (single-IDENTITY-PK) table that is also
-   a foreign-key TARGET — those are the only minted keys with a downstream consumer.
-   Sum(rows) * 40 = the resident RAM ceiling; compare to the transfer-host budget.
+   PART 1 — KEYMAP SPILL SIZING  (run on whichever DB has DMV access — your CLOUD/managed)
+   The resident key-map holds ~40 bytes PER ROW of each AssignedBySink (single-IDENTITY-PK)
+   table that is also a foreign-key TARGET — those are the only minted keys with a downstream
+   consumer. It is the SAME estate data on both renditions, so the count is direction-agnostic;
+   measure it where the DMV works. Sum(rows) * 40 = the resident RAM ceiling vs the host budget.
    ----------------------------------------------------------------------------- */
 
 -- 1a — the set of AssignedBySink FK-target tables (catalog only; no DMV needed).
@@ -43,7 +58,7 @@ WHERE  t.name LIKE '{{ENTITY_LIKE}}'
 ORDER BY t.name;
 --> PASTE BACK: the table count (how many such tables). Names not needed.
 
--- 1b — DMV sizing (use on the MANAGED source, where the DMV is granted).
+-- 1b — DMV sizing (run on the CLOUD/managed DB, where the DMV is granted — the on-prem lacks it).
 WITH fk_targets AS (SELECT DISTINCT referenced_object_id AS oid FROM sys.foreign_keys),
      identity_pk AS (
         SELECT t.object_id AS oid
@@ -85,8 +100,10 @@ WHERE  t.name LIKE '{{ENTITY_LIKE}}';
 
 
 /* -----------------------------------------------------------------------------
-   PART 2 — ON-PREM ARCHETYPE VERDICT  (run on the ON-PREM TARGET as the principal)
-   Settles the FullRights vs managed-DML fork that drives Slice A + the C/D forks.
+   PART 2 — ON-PREM ARCHETYPE VERDICT  (run on the ON-PREM SQL Server — Flow P's SINK)
+   The cloud sink (Flow R) is already J5 = ManagedDml; this probes the OTHER sink, the
+   on-prem the populate flow writes into. Settles FullRights vs ... — which drives Slice A
+   + the C/D forks for the populate flow (and whether it uses PreservedFromSource, no keymap).
    The write-probes are transactional and ROLL BACK — nothing persists.
    ----------------------------------------------------------------------------- */
 SET NOCOUNT ON;

--- a/sidecar/projection/REVERSE_LEG_WORK_PLAN.md
+++ b/sidecar/projection/REVERSE_LEG_WORK_PLAN.md
@@ -1,0 +1,127 @@
+# Work Plan — Archetype-driven movement at scale (the locked model + the forward slices)
+
+> **What this is.** The sequenced build plan that follows from the operator's confirmed real-estate
+> facts (2026-06-15). It sits on top of the shipped Phases 2–4 + NM-58 (the reverse-leg engine,
+> reconcile, idempotency, dry-run, reconcile-robustness) and drives the **archetype-as-config-
+> disposition** design (`DATABASE_ARCHETYPES.md`) to built+witnessed, plus the **at-scale keymap
+> spill**. Canonical decisions live in `DECISIONS.md` (2026-06-15 entries); this is the plan.
+
+---
+
+## 1 — The locked model (what every slice below assumes)
+
+**One engine, two load flows, two sink archetypes** — the real topology that validates the archetype
+design:
+
+| | **Flow P — populate the on-prem** | **Flow R — the reverse leg ("last leg")** |
+|---|---|---|
+| Direction | (source) → **on-prem** | **on-prem** → (cloud) |
+| Sink (written into) | **on-prem SQL Server** | **cloud managed env** (empty; this flow fills it) |
+| Sink archetype | **`FullRights`-minus-DMV** (verified: CREATE TABLE, ALTER, IDENTITY_INSERT, sink-resident progress; no `VIEW DATABASE PERFORMANCE STATE`) | **`ManagedDml`** (J5: mints keys; no CREATE TABLE / ALTER / IDENTITY_INSERT) |
+| How the engine writes | **direct-connect `migrate`** (live, diff-based, no schema change) **and** **emit-artifacts** (SSDT + static seeds + data, operator-applied) | the live streaming reverse-leg transfer (shipped) |
+| Identity disposition | **`PreservedFromSource`** (IDENTITY_INSERT) ⇒ **no keymap** | **`AssignedBySink`** ⇒ keymap (mints + remap) |
+| Resume mechanism | **sink-resident progress table** (CREATE TABLE) | client-side NDJSON journal + the **`#`-temp keymap spill** |
+
+**Sizing (estate-data on-prem = the reverse-leg source):** 2.0 M key-map-shaped rows (FK-target,
+single-IDENTITY-PK) ⇒ **75 MB** resident remap; 3.5 M all-`dbo` ⇒ 134 MB. Host = **64 GB**. The
+resident map **fits even at production ~200 M (~4–8 GB ≪ 64 GB)** — so the spill (Slice S) is a
+**completeness + headroom** build, not a current necessity; it ships **armed but inert** (configurable
+threshold defaulted off at this scale). This is an operator-directed build-for-safety, recorded as such.
+
+---
+
+## 2 — Already shipped (do not redo)
+
+Phases 2–4 + NM-58, all warm-witnessed (62 Docker + 184 pure green): reconcile ∘ streaming + the
+validate-user-map pre-write halt; force-journal + journal-address-drift refusals; the movement
+DryRun row-count preview; the reconcile-key robustness (blank-key exclusion + duplicate-target
+tiebreaker). Plus the operator package (`REVERSE_LEG_OPERATOR_PROBE_SHEET.md`,
+`PHASE_1_REAL_WIRE_HARNESS.md`, `NEXT_BUILD_INPUTS.sql`) and the design (`DATABASE_ARCHETYPES.md`).
+
+---
+
+## 3 — The forward slices (sequenced)
+
+Each: **goal · mechanism · gate · witness (the exit test) · depends-on**. Build order: **A → C → S → B**
+(A is the foundation; C is the highest near-term value — the direct-connect populate; S is the
+scale-safety; B is the verification, valuable but least urgent since the verdicts are already known).
+
+### Slice A — the `Archetype` config disposition *(foundation; byte-identical)*
+- **Goal.** Add `type Archetype = FullRights | ManagedDml` + `CapabilityProfile.of : Archetype ->
+  CapabilityProfile` (the disposition bundle, §1) + an optional `Environment.Archetype` facet parsed
+  from `projection.json`, **defaulting to inferred-from-`Grant`** (`SchemaAndData→FullRights`,
+  `DataOnly→ManagedDml`).
+- **Mechanism.** Closed DU; `Grant` becomes a *derived* projection of the archetype; `CapabilityProfile.of`
+  is the single expansion site (total over the DU — the `ArtifactByKind` discipline). Nothing branches
+  on it yet (the survey routing in B is the first consumer).
+- **Gate.** None — existing configs are byte-identical (archetype inferred from their `Grant`).
+- **Witness (pure).** `(infer ∘ derive-grant)` round-trips; `CapabilityProfile.of FullRights` /
+  `ManagedDml` match the confirmed verdicts (on-prem: DDL+IDENTITY_INSERT+sink-resident; cloud: none).
+- **Depends on.** Nothing.
+
+### Slice C — the `FullRights` populate forks *(Flow P; the highest operator value)*
+- **Goal.** On a `FullRights` sink (the on-prem), the populate flow uses the profile's better mechanisms:
+  - **C1 — `PreservedFromSource` default** (IDENTITY_INSERT permitted): write source keys directly —
+    **no key capture, no remap, no FK re-point** (the dramatically simpler + faster load). The
+    direct-connect `migrate`-into-on-prem path.
+  - **C2 — sink-resident progress resume** (CREATE TABLE permitted): checkpoint resume state in a
+    sink-side table — durable, queryable, free of the client-journal's filename↔digest coupling.
+- **Mechanism.** The identity-disposition default + the resume chooser read `archetype` /
+  `CapabilityProfile` instead of assuming the cloud shape. `ManagedDml` (cloud) keeps `AssignedBySink`
+  + the client journal unchanged.
+- **Gate.** Only a `FullRights` sink takes these forks; verified against the probed grant (Slice B) so
+  a mis-declared FullRights that lacks IDENTITY_INSERT refuses rather than mis-loading.
+- **Witness (Docker).** A populate into a `FullRights` sink preserves source keys (zero remap, joins
+  hold) and checkpoints sink-side; the same into a `ManagedDml` sink keeps the AssignedBySink + journal
+  path byte-identical.
+- **Depends on.** A.
+
+### Slice S — the reverse-leg `#`-temp keymap spill *(Flow R; the at-scale architecture)*
+- **Goal.** Close the one unbounded-RAM hole in the bounded-memory streaming path: when the keymap
+  would exceed a configurable threshold, spill it off-heap.
+- **Mechanism.** The spill chooser reads the sink archetype + the threshold. For the `ManagedDml` cloud
+  sink: a **session `#`-temp keymap table** (temp tables ARE permitted under DML — J5 P5) populated as
+  AssignedBySink chunks capture, and a **server-side `UPDATE…JOIN`** for the phase-2 FK re-point
+  (replacing the resident `PackedSurrogateRemap` lookup). For a `FullRights` AssignedBySink sink, the
+  same but a persistent table (rare — FullRights usually takes `PreservedFromSource`, no keymap).
+- **Gate.** Above the configurable RAM threshold — **defaulted inert at current scale** (75 MB ≪ 64 GB),
+  so the resident path is byte-identical today; the spill arms when the operator lowers the threshold
+  or the estate grows.
+- **Witness (Docker).** An equivalence canary: the same leg with the threshold forced LOW (spill on) vs
+  default (resident) produces **byte-identical** sink state + joins — the spill is observationally pure.
+- **Depends on.** A. (The largest slice; the operator-directed scale-safety build.)
+
+### Slice B — the survey *verifies* the archetype *(the J5 covenant, generalized)*
+- **Goal.** Make the declared archetype a *verified* claim (A44 — expressible ⇔ reachable).
+- **Mechanism.** Route `CapabilitySurvey.requiredOf` through `archetype.Grant` (identical results — the
+  derivation is exact); add the declared-vs-probed **archetype** reconciliation over the new capability
+  flags (CREATE TABLE, IDENTITY_INSERT, DMV-read).
+- **Gate.** A declared `FullRights` sink missing a probed capability is a **named mismatch** — e.g. the
+  on-prem's absent DMV-read is reported as `FullRights`-minus-DMV (a *split*, surfaced, not a
+  misdeclaration); a `ManagedDml` sink that unexpectedly permits IDENTITY_INSERT is surfaced too.
+- **Witness.** A `FullRights`-declared sink with a denied capability surfaces the named gap; the
+  on-prem's real `FullRights`-minus-DMV classifies correctly.
+- **Depends on.** A. (Least urgent — the verdicts are already known; this makes them *enforced*.)
+
+---
+
+## 4 — Dependencies & open inputs
+
+- **Dependency graph:** `A → {C, S, B}` (C, S, B independent of each other).
+- **No build is blocked.** Every archetype verdict + the sizing + the dual-write scope are confirmed.
+  The only *optional* outstanding number is the production (200 M) FK-target count — not needed to
+  build (the resident map fits; the spill is threshold-driven), only to confirm the resident headroom,
+  which the 75 MB → ~4–8 GB extrapolation already establishes against 64 GB.
+- **Discipline carried:** named refusals + a witness + a `DECISIONS.md` entry per slice; promote the
+  reserved Skip-stubs where they fit; build/test warm (set `PROJECTION_MSSQL_CONN_STR`; verify Docker
+  tests ran via per-test TRX durations — the Windows no-op trap).
+
+---
+
+## 5 — One-line summary
+
+> The estate proved the design: one engine writing to two sink classes (`FullRights` on-prem,
+> `ManagedDml` cloud). Build the archetype as a first-class disposition (A), give the FullRights
+> populate its simpler keys-preserved + sink-resident-resume path (C), arm the bounded-memory spill for
+> the reverse leg at scale (S), and make the declared archetype a verified claim (B) — each a named,
+> witnessed slice on top of the shipped reverse-leg engine.


### PR DESCRIPTION
Docs-only, on top of the merged #614. Captures the operator's confirmed real-estate facts, locks the load model, and lays out the forward build plan. No code changes.

## What it records

- **Direction clarified — two flows, two sinks** (the builds are sink-centric):
  - **Flow P** — populate the on-prem (direct-connect `migrate` + emit-artifacts). Sink = on-prem = **FullRights-minus-DMV** (verified: CREATE TABLE / ALTER / IDENTITY_INSERT / sink-resident progress; no `VIEW DATABASE PERFORMANCE STATE`). → PreservedFromSource (no keymap) + sink-resident resume.
  - **Flow R** — the reverse leg (on-prem → the empty cloud it fills). Sink = cloud = **ManagedDml** (J5). → AssignedBySink + keymap + `#`-temp spill + client journal.
- **Sizing:** estate-data on-prem = 2.0M key-map-shaped rows (75MB) / 3.5M all-dbo (134MB), host 64GB → the resident map fits even at ~200M (~4–8GB ≪ 64GB). So the spill is a **completeness/headroom** build (armed-but-inert), not a current necessity — recorded honestly as an operator-directed build-ahead-of-the-wake.
- **The keymap-spill mechanism is archetype-determined** (a design insight): PreservedFromSource → no keymap; AssignedBySink + CREATE TABLE → persistent sink-resident table; AssignedBySink + no CREATE TABLE (the cloud) → session `#`-temp keymap + server-side `UPDATE…JOIN`.

## What it adds

- **`REVERSE_LEG_WORK_PLAN.md`** (new) — the locked model + the sequenced forward slices: A (archetype type) → C (FullRights populate forks) → S (reverse-leg `#`-temp spill) → B (survey-verify), each with mechanism / gate / witness / deps, on top of the shipped Phases 2–4 + NM-58.
- **`NEXT_BUILD_INPUTS.sql`** relabelled for both flows; **`DATABASE_ARCHETYPES.md`** verified-against-the-real-estate banner + the spill-by-archetype disposition; **`DECISIONS.md`** entries for the direction, the confirmations, and the locked model; charter companions updated; **`HANDOFF.md`** top letter = build the archetype slices.

The real estate validates the archetype-as-config-disposition design: one engine writing to two sink classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)