### PR TITLE
Build the four archetype slices (A->C->S->B): capability class as a verified config disposition

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23696,3 +23696,191 @@ is the sequenced build plan.
   capability profile picking the safe mechanism per target. The work plan (`REVERSE_LEG_WORK_PLAN.md`)
   sequences Slice A (the type) → B (survey-verify) → C (the FullRights populate forks) → S (the
   reverse-leg `#`-temp spill), all on top of the already-shipped Phases 2–4 + NM-58.
+
+## 2026-06-15 (later) — Slice A BUILT: `Archetype` is a first-class config disposition (byte-identical foundation)
+
+The first of the four archetype slices (REVERSE_LEG_WORK_PLAN §3; `DATABASE_ARCHETYPES.md` §4/§6.1)
+is built and warm-witnessed. The capability CLASS of a target is now a named, closed, reusable
+config disposition — the foundation the populate forks (C), the at-scale spill (S), and the survey
+verification (B) all build on. **Nothing branches on it yet; the run is byte-identical.**
+
+- **What landed (all in `MovementSurface.fs`, Projection.Pipeline).**
+  - **`type Archetype = FullRights | ManagedDml`** — `[<RequireQualifiedAccess>]`, closed. `FullRights`
+    = the on-prem schema+data home (DDL + IDENTITY_INSERT, verified 2026-06-15); `ManagedDml` = the J5
+    managed DML-only sink. A new target class joins by ONE DU case (the `ArtifactByKind` /
+    `registered ⇔ executed` discipline applied to capability — total over the engine by construction).
+  - **`type CapabilityProfile`** + **`CapabilityProfile.of : Archetype -> CapabilityProfile`** — the
+    SINGLE expansion site, total over `Archetype`. Each capability is its OWN flag (`DdlPermitted`,
+    `IdentityInsert`, `ConstraintBypass`, `ResumeCheckpoint`, `WipeStrategy`, `IdentityDefault`,
+    derived `Grant`), NOT a bundle inferred from the label — so the survey (B) can flip an individual
+    probed flag for a SPLIT target (the on-prem `FullRights`-minus-DMV, §5) without re-classing the
+    whole archetype. The two new carrier DUs `ResumeKind` (`SinkResidentTable | ClientJournal`) and
+    `WipeKind` (`Truncate | ChildFirstDelete`) reify the resume/wipe dispositions C/S will read.
+  - **`Grant` becomes a derived projection** — `Archetype.grant : Archetype -> Grant` (`FullRights →
+    SchemaAndData`, `ManagedDml → DataOnly`) and its inverse `Archetype.ofGrant`. The two 2-element
+    sets are in bijection, so the round-trip holds both ways.
+  - **`Environment.Archetype : Archetype option`** facet, parsed from `projection.json`
+    (`"archetype": "full-rights" | "managed-dml"`; unknown = the named refusal
+    `cli.config.envArchetypeUnknown`). **Stored declared-only** (NOT eagerly inferred) — the design's
+    "default from `Grant`" is done LAZILY at read time via `Environment.effectiveArchetype` (declared
+    wins; else inferred from grant; no grant ⇒ `None`). This is the load-bearing choice: an
+    undeclared archetype renders no field, so **every existing config is byte-identical** AND
+    `parse ∘ render = id` holds without parse-time inference diverging from the round-trip generator.
+- **Why lazy-default over eager-infer (the refused alternative).** Inferring the archetype into the
+  stored field at parse time would have made `render` emit an `archetype` key for every grant-bearing
+  config (not byte-identical) and broken the A44 `parse ∘ render = id` property test (the generated
+  `Archetype = None` would parse back as `Some <inferred>`). The derived accessor keeps the field a
+  faithful image of the JSON and pushes the "default" to the consumer — exactly mirroring how
+  `Rendition`/`Grant` already store option-of-declared.
+- **Witness (pure, warm — 43 green: `ArchetypeTests` + `MovementIsomorphismTests` + `CapabilitySurvey*`).**
+  The work plan's named witness `(infer ∘ derive-grant)` round-trips BOTH ways
+  (`ofGrant ∘ grant = id`, `grant ∘ ofGrant = id`); `CapabilityProfile.of FullRights/ManagedDml` match
+  the confirmed verdicts (on-prem: DDL + IDENTITY_INSERT + sink-resident + TRUNCATE,
+  PreservedFromSource; cloud: none of those, sink-mints, client journal, child-first DELETE); the
+  derived `Grant` is a projection of the archetype; `effectiveArchetype` honors declared-over-inferred
+  and `None → None`; and the new facet round-trips through `parse ∘ render` across the full
+  reach × grant × rendition × **archetype** × store sweep (the A44 exhaustive pin, extended).
+- **Gate / refusal.** None at runtime (byte-identical). The only refusal is config-load:
+  `cli.config.envArchetypeUnknown` on a malformed `archetype` token (closed; never silently dropped).
+- **Net.** The disposition is named and verified-by-round-trip; consumers are next. Slice C (the
+  `FullRights` populate forks) and Slice S (the reverse-leg `#`-temp keymap spill) read the profile;
+  Slice B routes the survey through `archetype.Grant` and reconciles declared-vs-probed. The graph is
+  `A → {C, S, B}` and A is done.
+
+## 2026-06-15 (later) — Slice C BUILT: the `FullRights` populate forks (PreservedFromSource + sink-resident resume), live-wired + Docker-witnessed
+
+The highest-operator-value slice (REVERSE_LEG_WORK_PLAN §3 Slice C; DATABASE_ARCHETYPES.md §2/§6
+Slices C+D). On a `FullRights` sink the populate now uses the profile's better mechanisms; the
+`ManagedDml` cloud path stays **byte-identical to the J5-proven behavior**. Built end-to-end (the
+operator chose the full live-wire) and warm-witnessed (pure + Docker).
+
+- **C1 — the `PreservedFromSource` default fork (the headline unlock).** The single seam is the pure
+  `DataLoadPlan.build`: it now takes an `IdentityPolicy` (`Structural | PreferPreservedKeys`, new in
+  Core). `build = buildWith Structural` (`ofKind` — byte-identical). `buildWith PreferPreservedKeys`
+  writes the SOURCE key directly for IDENTITY PKs too ⇒ **every kind is `PreservedFromSource` ⇒ the
+  whole capture / surrogate-remap / FK-repoint machinery is skipped downstream by construction** (it
+  already branches on `AssignedBySink`). The realization needs ZERO changes: `PreservedFromSource`
+  already routes to `Bulk.copyRows`, whose `KeepIdentity` preserves the source surrogate — and
+  `KeepIdentity`'s implicit ALTER requirement is *exactly* what makes the fork correct only on a
+  `FullRights` sink (the DML-only cloud lacks it; the `copyRowsSinkMinted` lane stays its path). So
+  the fork is a one-line plan-build change with the engine's existing per-disposition machinery
+  carrying it the rest of the way.
+- **C2 — the resume chooser reads the archetype.** `ReverseLegRealization.choose` gained a
+  `sinkResidentResumeAvailable` flag. The cloud-shaped refusal "`--streaming` + `--resumable`: the
+  progress table needs CREATE TABLE the data grant forbids" was hardcoded; it now stands ONLY for a
+  `ManagedDml`/undeclared sink (byte-identical). A `FullRights` sink (CREATE TABLE permitted) **admits**
+  `--resumable` on the materialized G10 sink-resident-progress envelope instead of refusing — the
+  durable, queryable, filename↔digest-coupling-free checkpoint the on-prem class actually supports.
+- **The threading (the compile-order wall).** `TransferRun`/`MovementSpec`/`LoadOpts`/`PlanAction` all
+  compile BEFORE the `Archetype` vocabulary (`MovementSurface.fs`), so the archetype's engine-relevant
+  bits cross the boundary as a **Core** carrier `SinkLoadCapability { IdentityPolicy; SinkResidentResume }`.
+  `resolveFlowSpec` (the one site that sees both the sink `Environment` and `CapabilityProfile`)
+  projects it from `Environment.effectiveArchetype` (FullRights ⇒ `PreferPreservedKeys` +
+  sink-resident; else `structural`), threads it through `MovementSpec → LoadOpts → Program.fs →
+  RunFaces → MigrationRun/TransferRun → WriteOptions → runCore`. Every widely-called public Transfer
+  entry kept its signature byte-identical via additive `*With` variants (`runWithRenamesWith`,
+  `runReconcilingWithRenamesWith`, `runReverseLegThroughConnectionsWith`, `executeWithDataWith`,
+  `executeWithDataAndRecordWith`) — the old entries delegate with `Structural`, so the 60+ existing
+  test callers are untouched.
+- **Gate.** Only a `FullRights` sink takes the forks (its `CapabilityProfile.IdentityInsert` /
+  `DdlPermitted`); the probed-grant VERIFICATION that refuses a mis-declared FullRights lacking
+  IDENTITY_INSERT is Slice B's reconciliation (the declared archetype is trusted here; B confirms it).
+- **Witness.** PURE: `Slice C1: buildWith Structural = build` (byte-identical) and
+  `buildWith PreferPreservedKeys` flips the IDENTITY-PK to `PreservedFromSource` with **zero
+  AssignedBySink kinds remaining** (`DataLoadPlanTests`); `Slice C2` — FullRights admits
+  streaming+resumable as Materialized while ManagedDml still refuses by name (`ReverseLegBoundaryTests`).
+  DOCKER (warm, 13 green incl. the new cell, 35 s — real execution, not the silent-skip trap): the
+  full multi-kind reverse-leg graph run with `PreferPreservedKeys` PRESERVES every source key
+  (`preservedKeyCount = 12`, the exact INVERSE of the keystone's `= 0` under AssignedBySink minting),
+  drops nothing, and every FK edge's business-key join holds (`ReverseLegCanaryTests`). Broad pure
+  regression: 407 green, 0 failed.
+- **Net.** The on-prem populate stops being forced into the cloud-shaped capture/remap and gets the
+  keys-preserved + sink-resident-resume path its grant permits; the cloud path is byte-identical. The
+  fork lives at one pure seam and rides the engine's existing per-disposition branches.
+
+## 2026-06-15 (later) — Slice S BUILT: the at-scale keymap spill (`#`-temp + server-side `UPDATE…JOIN`), armed-but-inert + equivalence-witnessed
+
+The completeness/headroom slice (REVERSE_LEG_WORK_PLAN §3 Slice S; DATABASE_ARCHETYPES.md §1/§3 H3).
+The reverse leg's `AssignedBySink` keymap (source surrogate → sink-minted surrogate) is RESIDENT
+today (`PackedSurrogateRemap`, ~40 B/entry). **The 2026-06-15 sizing proves the resident map FITS at
+production** — 75 MB for the estate, ~4–8 GB extrapolated to 200 M FK-target rows, ≪ the 64 GB host —
+so this is **not a current necessity**; it ships **armed but inert**, the resident path byte-identical
+until the operator lowers the threshold or the estate outgrows it. Recorded as an operator-directed
+build-for-safety, not overstated.
+
+- **The spill mechanism (BUILT + Docker-equivalence-witnessed).** `KeymapSpill.fs` (`SqlKeymap`): a
+  session `#`-temp keymap table `(KindKey, SourceKey, AssignedKey)` (temp tables ARE permitted under
+  the DML-only grant — J5 P5) populated from captured pairs (`captureMany`, batched + parameterized,
+  keep-first via `WHERE NOT EXISTS`), and a set-based server-side **`UPDATE…JOIN`** re-point
+  (`repointJoin`) — the at-scale replacement for the resident per-row `tryFind` + per-row UPDATE
+  (a per-row SQL lookup against a spilled keymap would be N round-trips at 200 M; the set-based join
+  is the whole point). NVARCHAR keys so the store is TOTAL over the same shapes `PackedSurrogateRemap`
+  handles (integral fast path + non-integral fallback).
+- **The chooser (BUILT + pure-witnessed).** `KeymapResidence.choose : threshold option -> estimate ->
+  Resident | Spilled` — pure, total, testable without a connection (the `ReverseLegRealization.choose`
+  discipline). `None` threshold = unbounded = ALWAYS resident (the inert default, byte-identical);
+  `Some n` spills strictly above `n`. `describe` narrates the armed spill (no silent path change).
+- **Witness.** PURE (`KeymapSpillPure`): the chooser's inert default + threshold boundary + the
+  armed-spill narration. DOCKER (`KeymapSpillEquivalenceTests`, 983 ms — real execution, the
+  per-test-duration check, not the silent-skip trap): **the spilled `UPDATE…JOIN` re-point produces a
+  byte-identical sink state to the resident per-row re-point** over the same captured keymap and FK
+  rows — including leaving an unmatched FK (no captured target) untouched, exactly as the resident
+  path's no-capture row stands. This is the work plan's "spill-on vs resident → byte-identical sink
+  state" witness at the mechanism grain (the spill is observationally pure).
+- **Honest boundary (the named follow-on).** The spill is delivered as a real, witnessed, threshold-
+  armed mechanism, and the live streaming hot-loop is left UNTOUCHED (zero risk to the 62-Docker +
+  reconcile + journal baseline). The remaining live-cutover — having `writePlanStreaming` capture
+  AssignedBySink pairs DIRECTLY to the `#`-temp (bounding phase-1 RAM) and route the phase-2
+  deferred-FK re-point through `repointJoin` (with a per-kind source re-stream into a join-staging,
+  since deferred FKs are NULLed in phase-1) — is the named follow-on. It arms when the estate
+  approaches the RAM ceiling, which the sizing shows it will not at the confirmed 200 M scale. The
+  resident path (phase-1 capture + journal replay + per-row phase-2) stays the proven default; the
+  spill mechanism + chooser + threshold are the at-scale architecture, built and proven, ready to
+  wire when the number that would force it materializes.
+- **Net.** The one unbounded-RAM hole in the streaming path has a built, equivalence-proven,
+  threshold-gated answer — inert at today's scale, byte-identical, ready to arm. Not overstated: the
+  resident map fits; this is headroom.
+
+## 2026-06-15 (later) — Slice B BUILT: the survey VERIFIES the archetype (A44 — the J5 covenant generalized)
+
+The last archetype slice (REVERSE_LEG_WORK_PLAN §3 Slice B; DATABASE_ARCHETYPES.md §5/§6 Slice B).
+The declared archetype stops being a trusted label and becomes a **verified claim**: what the
+operator declares, the `CapabilitySurvey` confirms against probed `fn_my_permissions` evidence — the
+one-time J5 spike generalized into a standing, per-class gate. Pure-witnessed; byte-identical for every
+existing (undeclared-archetype) config.
+
+- **Part 1 — route the required-capability derivation through the archetype's derived grant.**
+  `CapabilitySurvey.requiredBy` (sink role) now reads `Environment.effectiveArchetype ∘ Archetype.grant`
+  instead of the raw `Grant` facet. **Byte-identical** for every config to date: an undeclared
+  archetype is inferred from `grant`, and `Archetype.grant ∘ Archetype.ofGrant = id` (Slice A's
+  round-trip), so the derived grant equals the hand-set one. An archetype-DECLARED sink derives its
+  grant from the class (the archetype subsumes `Grant`). Witnessed: an `archetype: full-rights` sink
+  yields the SAME required set as a `grant: schema+data` sink; `managed-dml` mirrors `data`.
+- **Part 2 — the declared-vs-probed archetype reconciliation.** `reconcileArchetype : Archetype ->
+  GrantEvidence -> ArchetypeFinding list` (pure, DB-free — the covenant is testable without a
+  connection). Findings are a closed DU surfaced as a REPORT FIELD (`EnvironmentReport.ArchetypeFindings`,
+  like `UserDirectory` — NOT a `Capability` variant, so the `required ⇔ surveyed` totality is
+  untouched), narrated via `advisoryLines` (R6 — a warning, never a gate):
+  - `RequiredCapabilityDenied` — a declared `FullRights` whose probe lacks CREATE TABLE or ALTER
+    (IDENTITY_INSERT): the engine would have assumed `PreservedFromSource` + a sink-resident checkpoint
+    the grant cannot support. A blocking-class mismatch, named.
+  - `SoftCapabilityAbsent` — the **on-prem `FullRights`-minus-DMV split** (observed 2026-06-15): full
+    DDL/DML present, `VIEW DATABASE PERFORMANCE STATE` absent. Classifies correctly as `FullRights`
+    with ONE probe degraded (the fast sizing probe falls to `COUNT_BIG`), NOT a misdeclaration — the
+    exact reason §5 carries each capability as its own verified flag, not a bundle inferred from the
+    label.
+  - `ForbiddenCapabilityPermitted` — a declared `ManagedDml` that UNEXPECTEDLY permits IDENTITY_INSERT
+    / CREATE TABLE: safer than declared (the simpler `PreservedFromSource` path is available), but a
+    divergence surfaced so the operator sees it.
+  - Runs ONLY on an EXPLICITLY declared archetype (an inferred one is not a claim to verify) and only
+    when the grant probe succeeded — so an undeclared place is byte-identical (no findings).
+- **Witness (pure, 31 green `CapabilitySurvey*` incl. the totality guard; 389 green across the touched
+  areas + the registry/axiom/pillar-9 guards).** Part 1's byte-identical routing; the four
+  reconciliation cases (FullRights clean / FullRights-missing-DDL mismatch / FullRights-minus-DMV split
+  / ManagedDml-permitting-IDENTITY_INSERT surfaced / ManagedDml-clean); and `advisoryLines` surfacing a
+  finding on an otherwise-unblocked place.
+- **Net.** The four archetype slices are complete (A → C → S → B). The capability class is a named,
+  closed, reusable disposition (A); the `FullRights` populate gets its keys-preserved + sink-resident
+  path (C); the at-scale spill is built, equivalence-proven, and armed-but-inert (S); and the declared
+  archetype is now a verified claim, not a trusted label (B). `expressible ⇔ reachable` holds for the
+  target's capability class.

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -157,11 +157,11 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // align — the original residual's premise, now honored structurally).
         needCatalog modelOssys model (fun cat ->
             withRun "projection reverse-leg" (fun () ->
-                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables surveyAdvisory))
+                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.SinkCapability surveyAdvisory))
     | PlanAction.MigrateWithData (model, modelOssys, sink, src, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
             withRun "projection migrate --with-data" (fun () ->
-                runMigrateWithData shapedCat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Store opts.Env)))
+                runMigrateWithData shapedCat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Store opts.Env opts.SinkCapability)))
     | PlanAction.SynthesizeAndLoad (model, modelOssys, profile, conn, opts, execute, modelSection) ->
         withRun "projection synth-load" (fun () -> runSyntheticLoad model modelOssys profile conn opts execute modelSection)
     | PlanAction.CaptureProfile (conn, out) -> runCaptureProfile conn out

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -787,6 +787,7 @@ let runReverseLegTransfer
     (streaming: bool)
     (journalDirectory: string option)
     (tables: string list)
+    (sinkCapability: SinkLoadCapability)
     (surveyAdvisory: string list)
     : int =
     let collect = function Ok _ -> [] | Error es -> es
@@ -838,7 +839,7 @@ let runReverseLegTransfer
     // path for the combinations streaming does not yet support. An
     // explicit --streaming on an inadmissible combination refuses BY
     // NAME, never a silent downgrade.
-    match ReverseLegRealization.choose emission resumable tables streaming journalDirectory with
+    match ReverseLegRealization.choose emission resumable tables streaming journalDirectory sinkCapability.SinkResidentResume with
     | Error errors ->
         errors |> List.iter TtyRenderer.renderVoicedError
         dumpBench "transfer"
@@ -895,7 +896,7 @@ let runReverseLegTransfer
                 (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation)
                     .GetAwaiter().GetResult()
             | ReverseLegRealization.Materialized ->
-                (Transfer.runReverseLegThroughConnections mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation)
+                (Transfer.runReverseLegThroughConnectionsWith sinkCapability.IdentityPolicy mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation)
                     .GetAwaiter().GetResult()
         match result with
         | Ok report ->
@@ -1879,7 +1880,7 @@ let runMigrateExecute (target: Catalog) (connSpec: string) (declaration: LossDec
 /// AC-I5 `validate-user-map` pre-write halt gates first; absent, it is a
 /// straight load. Schema is fail-loud + minimum-viable; the data leg runs
 /// only if the schema verified.
-let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string) (reconcileSpecs: string list) (userMapPath: string option) (declaration: LossDeclaration) (allowCdc: bool) (storePath: string option) (envLabel: string option) : int =
+let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string) (reconcileSpecs: string list) (userMapPath: string option) (declaration: LossDeclaration) (allowCdc: bool) (storePath: string option) (envLabel: string option) (sinkCapability: SinkLoadCapability) : int =
     if System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE" <> "1" then
         TtyRenderer.renderVoicedError (ValidationError.create "gate.intent" "PROJECTION_ALLOW_EXECUTE is not set in the environment.")
         dumpBench "migrate"
@@ -1988,7 +1989,7 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
                                             | Ok tl ->
                                                 let at = System.DateTimeOffset.UtcNow
                                                 let! recorded =
-                                                    MigrationRun.executeWithDataAndRecord declaration Transfer.Execute allowCdc
+                                                    MigrationRun.executeWithDataAndRecordWith sinkCapability.IdentityPolicy declaration Transfer.Execute allowCdc
                                                         sinkSourceA target reconciliation store tl env at None dataSource sink
                                                 match recorded with
                                                 | Ok (o, chain) ->
@@ -2000,7 +2001,7 @@ let runMigrateWithData (target: Catalog) (sinkSpec: string) (sourceSpec: string)
                                                 | Error e -> return reportMigrationError e
                                         | None ->
                                         let! outcome =
-                                            MigrationRun.executeWithData declaration Transfer.Execute allowCdc
+                                            MigrationRun.executeWithDataWith sinkCapability.IdentityPolicy declaration Transfer.Execute allowCdc
                                                 sinkSourceA target reconciliation dataSource sink
                                         match outcome with
                                         | Ok o when o.Schema.Verified ->

--- a/sidecar/projection/src/Projection.Core/DataLoadPlan.fs
+++ b/sidecar/projection/src/Projection.Core/DataLoadPlan.fs
@@ -78,7 +78,16 @@ module DataLoadPlan =
     /// Transfer's "this kind is reconciled, skip its insert" —
     /// compose on top via `reclassifyReconciled` (Transfer-side
     /// concern; emit-side realizations don't need to call it).
-    let build
+    ///
+    /// Slice C1 — the disposition default is selected by an `IdentityPolicy`:
+    /// `buildWith` carries it; `build` fixes it to `Structural` (byte-identical).
+    /// A `PreferPreservedKeys` policy (a `FullRights` sink permitting
+    /// IDENTITY_INSERT) writes the source key directly for IDENTITY PKs too,
+    /// so the whole capture/remap/FK-repoint machinery is skipped downstream
+    /// (it already branches on `PreservedFromSource`). `reclassifyReconciled`
+    /// still composes on top.
+    let buildWith
+        (policy: IdentityPolicy)
         (catalog: Catalog)
         (topo: TopologicalOrder)
         (rawRowsByKind: Map<SsKey, StaticRow list>)
@@ -103,7 +112,7 @@ module DataLoadPlan =
                     let remapped = substitute k raw
                     let load =
                         { Kind              = key
-                          Disposition       = IdentityDisposition.ofKind k
+                          Disposition       = IdentityDisposition.byPolicy policy k
                           DeferredFkColumns = TopologicalOrder.deferredFkColumns members k
                           Rows              = remapped.Rows }
                     let owned = remapped.Skipped |> List.map (fun u -> key, u)
@@ -131,6 +140,18 @@ module DataLoadPlan =
         { Loads               = loads
           UnbreakableCycleFks = unbreakable
           SkippedReferences   = skipped }
+
+    /// The structural-policy build — `ofKind` from the PK shape, byte-identical
+    /// to every path before Slice C. The emit-side realizations and the
+    /// ManagedDml/undeclared transfer paths call this; only a `FullRights` sink
+    /// reaches `buildWith IdentityPolicy.PreferPreservedKeys`.
+    let build
+        (catalog: Catalog)
+        (topo: TopologicalOrder)
+        (rawRowsByKind: Map<SsKey, StaticRow list>)
+        (remap: SurrogateRemapContext)
+        : DataLoadPlan =
+        buildWith IdentityPolicy.Structural catalog topo rawRowsByKind remap
 
     /// Override the disposition of the reconciled kinds to
     /// `ReconciledByRule` and zero their `Rows` (the rows already

--- a/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
+++ b/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
@@ -67,6 +67,40 @@ type IdentityDisposition =
     | PreservedFromSource
     | ReconciledByRule
 
+/// The identity-disposition POLICY a plan-build applies (DATABASE_ARCHETYPES.md
+/// §2.1; REVERSE_LEG_WORK_PLAN Slice C1). `Structural` is the default — `ofKind`
+/// from the PK shape (byte-identical to every path to date). `PreferPreservedKeys`
+/// is the FullRights fork: the sink permits IDENTITY_INSERT, so write the SOURCE
+/// surrogate directly even for an IDENTITY PK — no capture, no remap, no FK
+/// re-point (the dramatically simpler load that `Bulk.copyRows`'s `KeepIdentity`
+/// realizes; its implicit ALTER requirement is exactly what gates it to a
+/// `FullRights` sink). Core cannot see the Pipeline `Archetype`; this policy is
+/// the projection of `CapabilityProfile.IdentityInsert` that crosses the
+/// assembly boundary into the engine.
+[<RequireQualifiedAccess>]
+type IdentityPolicy =
+    | Structural
+    | PreferPreservedKeys
+
+/// The sink-capability inputs the data-load ENGINE (Core / early-Pipeline)
+/// consumes, projected from the Pipeline `CapabilityProfile` at flow resolution.
+/// Core (and `TransferRun`, which compiles before the `Archetype` vocabulary)
+/// cannot see `CapabilityProfile`, so the two engine-relevant bits cross the
+/// compile boundary as this record: the identity-disposition policy (C1) and
+/// whether a sink-resident progress table is available for resume (C2 — the
+/// `ReverseLegRealization.choose` chooser reads it). `structural` is the
+/// byte-identical default (every existing caller).
+type SinkLoadCapability =
+    { IdentityPolicy     : IdentityPolicy
+      SinkResidentResume : bool }
+
+[<RequireQualifiedAccess>]
+module SinkLoadCapability =
+    /// The default: structural disposition + no sink-resident resume — the
+    /// byte-identical pre-Slice-C behavior (a ManagedDml or undeclared sink).
+    let structural : SinkLoadCapability =
+        { IdentityPolicy = IdentityPolicy.Structural; SinkResidentResume = false }
+
 [<RequireQualifiedAccess>]
 module IdentityDisposition =
 
@@ -81,6 +115,19 @@ module IdentityDisposition =
             |> List.exists (fun a -> a.IsPrimaryKey && a.IsIdentity)
         if pkIsIdentity then IdentityDisposition.AssignedBySink
         else IdentityDisposition.PreservedFromSource
+
+    /// Classify a kind under an `IdentityPolicy` (Slice C1). `Structural` is
+    /// `ofKind` (byte-identical). `PreferPreservedKeys` writes the source key
+    /// directly for EVERY kind — an IDENTITY PK becomes `PreservedFromSource`
+    /// (viable because the `FullRights` sink permits IDENTITY_INSERT, so the
+    /// source surrogate is preserved via `KeepIdentity`); a business PK was
+    /// already `PreservedFromSource`. `ReconciledByRule` still composes on top
+    /// via `reclassifyReconciled` (the operator's reconcile choice, applied after
+    /// the build default — `byPolicy` never returns it, exactly as `ofKind`).
+    let byPolicy (policy: IdentityPolicy) (kind: Kind) : IdentityDisposition =
+        match policy with
+        | IdentityPolicy.Structural          -> ofKind kind
+        | IdentityPolicy.PreferPreservedKeys -> IdentityDisposition.PreservedFromSource
 
     /// NM-26 — the SINGLE-SOURCED `SET IDENTITY_INSERT` bracketing
     /// predicate shared by every data emitter (`StaticPopulationEmitter`,

--- a/sidecar/projection/src/Projection.Pipeline/CapabilitySurvey.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CapabilitySurvey.fs
@@ -129,8 +129,16 @@ module CapabilitySurvey =
             | FlowSource.Env _ -> set [ Reads ]
             | FlowSource.Model | FlowSource.Synthetic _ | FlowSource.NoData -> Set.empty
         | SubstrateRole.Sink ->
+            // Slice B — route through the ARCHETYPE's derived grant
+            // (`Environment.effectiveArchetype` ∘ `Archetype.grant`) instead of
+            // the raw `Grant` facet. Byte-identical for every existing config:
+            // an undeclared archetype is inferred from `grant`, and
+            // `Archetype.grant ∘ Archetype.ofGrant = id`, so the derived grant
+            // equals the hand-set one. An archetype-DECLARED sink derives its
+            // grant from the class (the archetype subsumes `Grant`).
             let targetGrant =
-                Map.tryFind flow.To config.Environments |> Option.bind (fun e -> e.Grant)
+                Map.tryFind flow.To config.Environments
+                |> Option.bind (fun e -> Environment.effectiveArchetype e |> Option.map Archetype.grant)
             sinkCapabilities targetGrant flow.From
 
     /// The (environment, role) bindings a flow exercises: its `to` is the Sink;
@@ -165,6 +173,65 @@ module CapabilitySurvey =
         |> Set.toList
         |> List.filter (fun c -> not (Capability.surveyedBy c evidence))
         |> List.sortBy Capability.permissionOf
+
+    /// Slice B — a declared-vs-probed ARCHETYPE finding (A44; the J5 covenant
+    /// generalized from a one-time spike into a standing per-class gate). The
+    /// declared archetype's `CapabilityProfile` says what the engine will ASSUME;
+    /// the probed grant says what is ACTUAL. A divergence is surfaced BY NAME,
+    /// never trusted blindly. Closed so the surfacing is total.
+    type ArchetypeFinding =
+        /// The declared archetype REQUIRES this capability but the probe denies
+        /// it — the engine would assume a path the grant cannot support (a
+        /// declared `FullRights` lacking CREATE TABLE / IDENTITY_INSERT would
+        /// have chosen `PreservedFromSource` + a sink-resident checkpoint).
+        | RequiredCapabilityDenied of capability: string
+        /// The declared archetype FORBIDS this capability but the probe permits
+        /// it — safer-than-declared, but a divergence the operator should see (a
+        /// `ManagedDml` sink that UNEXPECTEDLY permits IDENTITY_INSERT means the
+        /// simpler `PreservedFromSource` path is actually available).
+        | ForbiddenCapabilityPermitted of capability: string
+        /// An INDEPENDENTLY-GRANTABLE capability the archetype expects but that is
+        /// absent WITHOUT re-classing the archetype — the named SPLIT (the on-prem
+        /// `FullRights`-minus-DMV, observed 2026-06-15; DATABASE_ARCHETYPES.md §5):
+        /// surfaced + degrade-the-one-probe, NOT a refusal. This is exactly why
+        /// `CapabilityProfile` carries each capability as its own verified flag.
+        | SoftCapabilityAbsent of capability: string
+
+    // The database-scope permission names the archetype reconciliation probes.
+    // `ALTER` is the IDENTITY_INSERT viability proxy (IDENTITY_INSERT requires
+    // ALTER on the table — probe sheet E3); `VIEW DATABASE PERFORMANCE STATE` is
+    // the DMV-read the fast sizing probes need (the on-prem split, B1/B2).
+    let private createTablePermission = "CREATE TABLE"
+    let private identityInsertPermission = "ALTER"
+    let private dmvReadPermission = "VIEW DATABASE PERFORMANCE STATE"
+
+    /// Reconcile the DECLARED archetype against the probed grant (Slice B). Pure
+    /// + DB-free, so the J5 covenant is testable without a connection. A
+    /// `FullRights` declaration REQUIRES CREATE TABLE + IDENTITY_INSERT (a denial
+    /// is a blocking mismatch) and EXPECTS DMV-read — but DMV-read is
+    /// independently grantable, so its absence is the surfaced split, not a
+    /// refusal. A `ManagedDml` declaration FORBIDS CREATE TABLE + IDENTITY_INSERT
+    /// (their presence is surfaced — safer-than-declared). Deterministic order.
+    let reconcileArchetype (declared: Archetype) (grant: Preflight.GrantEvidence) : ArchetypeFinding list =
+        let has p = Preflight.coversPermissionAtDatabaseScope p grant
+        match declared with
+        | Archetype.FullRights ->
+            [ if not (has createTablePermission)   then yield RequiredCapabilityDenied createTablePermission
+              if not (has identityInsertPermission) then yield RequiredCapabilityDenied (identityInsertPermission + " (IDENTITY_INSERT)")
+              if not (has dmvReadPermission)        then yield SoftCapabilityAbsent dmvReadPermission ]
+        | Archetype.ManagedDml ->
+            [ if has createTablePermission   then yield ForbiddenCapabilityPermitted createTablePermission
+              if has identityInsertPermission then yield ForbiddenCapabilityPermitted (identityInsertPermission + " (IDENTITY_INSERT)") ]
+
+    /// The operator-facing line for one archetype finding (the advisory surface).
+    /// The finding TYPE already implies the class — `RequiredCapabilityDenied`
+    /// arises only for a declared `FullRights`, `ForbiddenCapabilityPermitted`
+    /// only for `ManagedDml` — so the line needs no separate class argument.
+    let describeFinding (finding: ArchetypeFinding) : string =
+        match finding with
+        | RequiredCapabilityDenied cap     -> sprintf "archetype mismatch — the declared class REQUIRES %s but the probe DENIES it (the engine would assume a path this grant cannot support)" cap
+        | ForbiddenCapabilityPermitted cap -> sprintf "archetype divergence — the declared class FORBIDS %s but the probe PERMITS it (safer than declared — a simpler path is available)" cap
+        | SoftCapabilityAbsent cap         -> sprintf "archetype split — %s absent (an independently-grantable capability; that one probe degrades, the class is unchanged)" cap
 
     /// The survey's verdict for one environment.
     type EnvironmentReport =
@@ -203,6 +270,14 @@ module CapabilitySurvey =
             /// (`CapabilitySurveyTotalityTests`). `absent` for a place with no
             /// live address (nothing probed).
             UserDirectory : ReadSide.UserDirectoryProbe
+            /// Slice B — the declared-vs-probed ARCHETYPE reconciliation findings,
+            /// computed ONLY when the place EXPLICITLY declares an `archetype`
+            /// (an inferred archetype is not a claim to verify). Empty for an
+            /// undeclared place (byte-identical to the pre-Slice-B survey) or a
+            /// place whose grant probe failed. A REPORT FIELD (like
+            /// `UserDirectory`), not a `Capability` variant — surfaced via
+            /// `advisoryLines`, so the `required ⇔ surveyed` totality is untouched.
+            ArchetypeFindings : ArchetypeFinding list
         }
 
     /// Does a report name a *blocked* capability — a connected place that is
@@ -227,7 +302,11 @@ module CapabilitySurvey =
     /// and PROCEEDS regardless (the advisory never changes an exit).
     let advisoryLines (reports: EnvironmentReport list) : string list =
         let blockedReports = reports |> List.filter blocked
-        if List.isEmpty blockedReports then []
+        // Slice B — places whose DECLARED archetype diverged from the probe.
+        // Independent of `blocked` (a place can be fully covered yet carry a
+        // FullRights-minus-DMV split, or a safer-than-declared ManagedDml).
+        let findingReports = reports |> List.filter (fun r -> not (List.isEmpty r.ArchetypeFindings))
+        if List.isEmpty blockedReports && List.isEmpty findingReports then []
         else
             [ yield "Advisory — capability survey found environment(s) that may not be able to do what this run asks (proceeding anyway; this is a warning, not a gate):"
               for r in blockedReports do
@@ -236,7 +315,12 @@ module CapabilitySurvey =
                   elif r.GrantUnreadable then
                       yield sprintf "  %s: grant unreadable (coverage unverified)" r.Name
                   else
-                      yield sprintf "  %s: missing %s" r.Name (r.Missing |> List.map Capability.text |> String.concat ", ") ]
+                      yield sprintf "  %s: missing %s" r.Name (r.Missing |> List.map Capability.text |> String.concat ", ")
+              // The declared-vs-probed archetype reconciliation (the J5 covenant
+              // generalized) — surfaced, never a gate; the run proceeds (R6).
+              for r in findingReports do
+                  for f in r.ArchetypeFindings do
+                      yield sprintf "  %s: %s" r.Name (describeFinding f) ]
 
     /// Probe ONE environment (boundary): reachability, the required-vs-actual
     /// reconciliation, the CDC axis. A `Bundle` / `Docker` place has no live
@@ -249,7 +333,8 @@ module CapabilitySurvey =
                 { Name = env.Name; Grant = env.Grant; Required = required
                   Connected = false; Reachable = false; Missing = []; GrantUnreadable = false; CdcTracked = false
                   CdcProbeFailed = false
-                  UserDirectory = ReadSide.UserDirectoryProbe.absent }
+                  UserDirectory = ReadSide.UserDirectoryProbe.absent
+                  ArchetypeFindings = [] }
             match env.Access with
             | Access.Bundle _ | Access.Docker -> return baseReport
             | Access.Direct connRef ->
@@ -274,6 +359,14 @@ module CapabilitySurvey =
                             match grantEv with
                             | Ok ev   -> reconcile required ev, false
                             | Error _ -> [], true
+                        // Slice B — the archetype reconciliation runs ONLY on an
+                        // EXPLICITLY declared archetype (the operator's claim to
+                        // verify) and only when the grant probe succeeded; an
+                        // inferred/undeclared place is byte-identical (no findings).
+                        let archetypeFindings =
+                            match env.Archetype, grantEv with
+                            | Some declared, Ok ev -> reconcileArchetype declared ev
+                            | _ -> []
                         // NM-54 — a failed CDC probe is NOT "no CDC"; it is an
                         // UNVERIFIED axis. Carry it as `CdcProbeFailed` (mirroring
                         // `GrantUnreadable`) so the survey surfaces the unreadable
@@ -287,7 +380,8 @@ module CapabilitySurvey =
                                 Connected = true; Reachable = true
                                 Missing = missing; GrantUnreadable = grantUnreadable
                                 CdcTracked = cdcTracked; CdcProbeFailed = cdcProbeFailed
-                                UserDirectory = userDir }
+                                UserDirectory = userDir
+                                ArchetypeFindings = archetypeFindings }
                     with _ -> return { baseReport with Connected = true }
         }
 

--- a/sidecar/projection/src/Projection.Pipeline/KeymapSpill.fs
+++ b/sidecar/projection/src/Projection.Pipeline/KeymapSpill.fs
@@ -1,0 +1,127 @@
+namespace Projection.Pipeline
+
+// LINT-ALLOW-FILE-MUTATION: BCL SqlCommand surfaces (CommandText, Parameters)
+//   and a function-local StringBuilder accumulator while batching the INSERT;
+//   the mutation is contained per call. The SQL identifiers (table/column) come
+//   from validated `TableId` / `Render.quote`; the value (`KindKey`) is
+//   PARAMETERIZED — no string-built value injection.
+
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Projection.Core
+open Projection.Targets.SSDT
+
+/// Slice S — the at-scale keymap SPILL (REVERSE_LEG_WORK_PLAN §3 Slice S;
+/// DATABASE_ARCHETYPES.md §1 staging / §3 H3). The reverse leg's `AssignedBySink`
+/// keymap (source surrogate → sink-minted surrogate) is RESIDENT today
+/// (`PackedSurrogateRemap`, ~40 B/entry). The 2026-06-15 sizing proves it FITS:
+/// 75 MB for the estate, ~4–8 GB extrapolated to the 200 M production FK-target
+/// count — ≪ the 64 GB host. So this is a **completeness + headroom** build,
+/// **ARMED BUT INERT**: the resident path is byte-identical until the operator
+/// lowers the threshold (or the estate grows past it). When armed, the keymap
+/// spills to a session `#`-temp table (temp tables ARE permitted under the
+/// DML-only grant — J5 P5) and the phase-2 FK re-point becomes a set-based
+/// server-side `UPDATE…JOIN` instead of the resident per-row `tryFind` + UPDATE.
+
+/// Where the keymap lives — resident (the in-RAM `PackedSurrogateRemap`) or
+/// spilled (a session `#`-temp table). Closed so the chooser and every consumer
+/// are TOTAL over it (a third backend joins by one DU case).
+[<RequireQualifiedAccess>]
+type KeymapResidence =
+    | Resident
+    | Spilled
+
+[<RequireQualifiedAccess>]
+module KeymapResidence =
+
+    /// Pure + total — choose residence from the configurable RAM threshold (the
+    /// maximum keymap assignments to keep resident) and the estimated assignment
+    /// count. `None` threshold = unbounded = ALWAYS `Resident` (the inert default,
+    /// byte-identical to every reverse leg to date). A `Some n` threshold spills
+    /// once the estimate EXCEEDS it. Testable without a connection — the selector
+    /// is deterministic from the request alone (the `ReverseLegRealization.choose`
+    /// discipline).
+    let choose (threshold: int option) (estimatedAssignments: int) : KeymapResidence =
+        match threshold with
+        | None   -> KeymapResidence.Resident
+        | Some n -> if estimatedAssignments > n then KeymapResidence.Spilled else KeymapResidence.Resident
+
+    /// The operator-facing one-line reason, narrated when the spill arms (never a
+    /// silent path change — the no-silent-drop discipline applied to the spill).
+    let describe (residence: KeymapResidence) (threshold: int option) (estimate: int) : string =
+        match residence, threshold with
+        | KeymapResidence.Resident, None      -> sprintf "keymap resident (%d assignments; no spill threshold set)" estimate
+        | KeymapResidence.Resident, Some n     -> sprintf "keymap resident (%d assignments ≤ threshold %d)" estimate n
+        | KeymapResidence.Spilled,  Some n     -> sprintf "keymap SPILLED to a session #-temp table (%d assignments > threshold %d); phase-2 re-point is a server-side UPDATE…JOIN" estimate n
+        | KeymapResidence.Spilled,  None       -> sprintf "keymap SPILLED (%d assignments)" estimate
+
+/// The spilled keymap: a session `#`-temp table `(KindKey, SourceKey,
+/// AssignedKey)` populated as `AssignedBySink` chunks capture, and a server-side
+/// `UPDATE…JOIN` re-point. NVARCHAR keys so the store is TOTAL over the same
+/// shapes `PackedSurrogateRemap` handles (the integral fast path AND the
+/// non-integral fallback — never a dropped capture on an exotic identity raw).
+[<RequireQualifiedAccess>]
+module SqlKeymap =
+
+    /// The session keymap table name — a `#`-temp (session-scoped, dropped on
+    /// connection close). tempdb rights are implicit for every principal, so the
+    /// lane fits the DML-only `grant: data` envelope (the cloud `ManagedDml` sink).
+    [<Literal>]
+    let TableName = "#projection_keymap_spill"
+
+    /// Create the session keymap table (idempotent within a session: a resumed
+    /// run re-uses it). PK `(KindKey, SourceKey)` enforces the keep-first
+    /// invariant at insert (the `INSERT…WHERE NOT EXISTS` guard below).
+    let createTable (cnn: SqlConnection) : Task<unit> =
+        Deploy.executeBatch cnn
+            (sprintf
+                "IF OBJECT_ID('tempdb..%s') IS NULL CREATE TABLE [%s] (KindKey NVARCHAR(450) NOT NULL, SourceKey NVARCHAR(450) NOT NULL, AssignedKey NVARCHAR(450) NOT NULL, CONSTRAINT [PK_keymap_spill] PRIMARY KEY (KindKey, SourceKey));"
+                TableName TableName)
+
+    /// Capture a kind's `(source raw → assigned raw)` pairs into the session
+    /// table — KEEP-FIRST on a duplicate source (the `PackedSurrogateRemap`
+    /// invariant), realized by the `WHERE NOT EXISTS` guard so a re-captured
+    /// source keeps its first binding. Batched + parameterized (the `KindKey` /
+    /// keys are VALUES, never string-built into the SQL). A blank source/assigned
+    /// is skipped (a NULL key is inserted, never captured — mirrors `capture`).
+    let captureMany (cnn: SqlConnection) (kindKey: string) (pairs: (string * string) list) : Task<unit> =
+        task {
+            let valid = pairs |> List.filter (fun (s, a) -> s <> "" && a <> "")
+            for batch in valid |> List.chunkBySize 500 do
+                if not (List.isEmpty batch) then
+                    use cmd = cnn.CreateCommand()
+                    let sb = System.Text.StringBuilder()
+                    sb.Append(sprintf "INSERT INTO [%s] (KindKey, SourceKey, AssignedKey) SELECT v.SourceKey0, v.SourceKey1, v.SourceKey2 FROM (VALUES " TableName) |> ignore
+                    batch |> List.iteri (fun i (src, asg) ->
+                        if i > 0 then sb.Append(",") |> ignore
+                        sb.Append(sprintf "(@k%d,@s%d,@a%d)" i i i) |> ignore
+                        cmd.Parameters.AddWithValue(sprintf "@k%d" i, box kindKey) |> ignore
+                        cmd.Parameters.AddWithValue(sprintf "@s%d" i, box src) |> ignore
+                        cmd.Parameters.AddWithValue(sprintf "@a%d" i, box asg) |> ignore)
+                    sb.Append(sprintf ") AS v(SourceKey0, SourceKey1, SourceKey2) WHERE NOT EXISTS (SELECT 1 FROM [%s] e WHERE e.KindKey = v.SourceKey0 AND e.SourceKey = v.SourceKey1);" TableName) |> ignore
+                    cmd.CommandText <- sb.ToString()
+                    let! _ = cmd.ExecuteNonQueryAsync()
+                    ()
+            return ()
+        }
+
+    /// The set-based phase-2 re-point — re-point a sink table's FK column from
+    /// the SOURCE surrogate it currently holds to the captured ASSIGNED surrogate
+    /// in ONE server-side statement (the at-scale replacement for the resident
+    /// per-row `tryFind` + per-row UPDATE). The `CONVERT(NVARCHAR…)` matches the
+    /// keymap's text keys to the FK column whatever its physical type; the inner
+    /// join leaves an unmatched FK value untouched (the resident path's
+    /// no-capture row is likewise left as-is, the named phase-2 erasure).
+    let repointJoin (cnn: SqlConnection) (sinkTable: TableId) (kindKey: string) (fkColumn: string) : Task<unit> =
+        task {
+            let qualified =
+                Render.tableQualified { Schema = sinkTable.Schema; Table = sinkTable.Table; Catalog = None }
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <-
+                sprintf
+                    "UPDATE s SET s.%s = k.AssignedKey FROM %s s JOIN [%s] k ON k.KindKey = @kind AND k.SourceKey = CONVERT(NVARCHAR(450), s.%s);"
+                    (Render.quote fkColumn) qualified TableName (Render.quote fkColumn)
+            cmd.Parameters.AddWithValue("@kind", box kindKey) |> ignore
+            let! _ = cmd.ExecuteNonQueryAsync()
+            return ()
+        }

--- a/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationRun.fs
@@ -670,7 +670,12 @@ module MigrationRun =
     /// (identity-matched, never ordinal) before the write. A no-renames diff
     /// yields an empty rename map ⇒ identity repoint ⇒ byte-identical to the
     /// straight load.
-    let executeWithData
+    /// Slice C1 — the policy-bearing migrate-with-data: a `FullRights` sink
+    /// threads `IdentityPolicy.PreferPreservedKeys` so the populate preserves
+    /// source keys (no capture/remap). `executeWithData` fixes `Structural`
+    /// (byte-identical; the existing callers + the ManagedDml shape).
+    let executeWithDataWith
+        (identityPolicy: IdentityPolicy)
         (declaration: LossDeclaration)
         (mode: Transfer.Mode)
         (allowCdc: bool)
@@ -694,16 +699,28 @@ module MigrationRun =
                         // derives from `CatalogDiff.between sinkSource target`; a
                         // no-renames diff repoints by identity (== the straight load).
                         if Map.isEmpty reconciliation then
-                            Transfer.runWithRenames mode allowCdc dataSource sink sinkSource target
+                            Transfer.runWithRenamesWith identityPolicy mode allowCdc dataSource sink sinkSource target
                         else
                             // allowDrops = false: enforce the AC-I5 pre-write validate-user-map
                             // halt on the reconciling migrate-with-data path (the reconcile+migrate
                             // composition, AC-I7, is the follow-on; --allow-drops flows here then).
-                            Transfer.runReconcilingWithRenames mode allowCdc dataSource sink sinkSource target reconciliation
+                            Transfer.runReconcilingWithRenamesWith identityPolicy mode allowCdc dataSource sink sinkSource target reconciliation
                     match transferResult with
                     | Ok report -> return Ok { Schema = schema; Transfer = report }
                     | Error es -> return Error (DataTransferFailed es)
         }
+
+    let executeWithData
+        (declaration: LossDeclaration)
+        (mode: Transfer.Mode)
+        (allowCdc: bool)
+        (sinkSource: Catalog)
+        (target: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        (dataSource: SqlConnection)
+        (sink: SqlConnection)
+        : System.Threading.Tasks.Task<Result<MigrationDataOutcome, MigrationError>> =
+        executeWithDataWith IdentityPolicy.Structural declaration mode allowCdc sinkSource target reconciliation dataSource sink
 
     /// **X5 — the in-place migrate-with-data, MEASURED and RECORDED.** The
     /// protein P-6 chain is `migrate-schema → Move-data → Measure-CDC →
@@ -722,7 +739,8 @@ module MigrationRun =
     /// `record` (coordinate from `nextCoordinate`), so the timeline carries the
     /// data-plane observation. Additive — `execute` (and its G9 gate) and
     /// `executeWithData` are untouched.
-    let executeWithDataAndRecord
+    let executeWithDataAndRecordWith
+        (identityPolicy: IdentityPolicy)
         (declaration: LossDeclaration)
         (mode: Transfer.Mode)
         (allowCdc: bool)
@@ -752,9 +770,9 @@ module MigrationRun =
                     // A5 — the data source is at A (`sinkSource`); re-point rows
                     // A→B through the rename-aware Transfer (see `executeWithData`).
                     if Map.isEmpty reconciliation then
-                        Transfer.runWithRenames mode allowCdc dataSource sink sinkSource target
+                        Transfer.runWithRenamesWith identityPolicy mode allowCdc dataSource sink sinkSource target
                     else
-                        Transfer.runReconcilingWithRenames mode allowCdc dataSource sink sinkSource target reconciliation
+                        Transfer.runReconcilingWithRenamesWith identityPolicy mode allowCdc dataSource sink sinkSource target reconciliation
                 match transferResult with
                 | Error es -> return Error (DataTransferFailed es)
                 | Ok report ->
@@ -769,3 +787,20 @@ module MigrationRun =
                         | Ok chain -> return Ok ({ Schema = schema; Transfer = report }, chain)
                         | Error e -> return Error (ExecutionFailed (sprintf "data load succeeded but recording the episode failed: %A" e))
         }
+
+    let executeWithDataAndRecord
+        (declaration: LossDeclaration)
+        (mode: Transfer.Mode)
+        (allowCdc: bool)
+        (sinkSource: Catalog)
+        (target: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        (path: string)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        (refactorLogRef: string option)
+        (dataSource: SqlConnection)
+        (sink: SqlConnection)
+        : System.Threading.Tasks.Task<Result<MigrationDataOutcome * EpisodicLifecycle, MigrationError>> =
+        executeWithDataAndRecordWith IdentityPolicy.Structural declaration mode allowCdc sinkSource target reconciliation path timeline environment at refactorLogRef dataSource sink

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -141,6 +141,10 @@ type MovementSpec =
         Store       : string option
         /// Environment label for the timeline / episode.
         Env         : string option
+        /// Slice C — the sink's capability-derived engine inputs, set by
+        /// `resolveFlowSpec` from the target environment's effective `Archetype`.
+        /// `structural` default (byte-identical); only a `FullRights` sink forks.
+        SinkCapability : SinkLoadCapability
         Commit      : bool
     }
 
@@ -171,6 +175,7 @@ module MovementSpec =
             Scale       = None
             Store       = None
             Env         = None
+            SinkCapability = SinkLoadCapability.structural
             Commit      = false
         }
 
@@ -299,6 +304,11 @@ type LoadOpts =
         Seed        : uint64 option
         /// D8 — the synthesis volume factor; honored on the synthetic load only.
         Scale       : decimal option
+        /// Slice C — the sink's capability-derived engine inputs (the identity
+        /// policy + sink-resident-resume availability), projected from the sink
+        /// `Environment`'s effective `Archetype` at flow resolution. `structural`
+        /// = the byte-identical default (a ManagedDml or undeclared sink).
+        SinkCapability : SinkLoadCapability
     }
 
 /// The engine face a parsed `Intent` routes to, named with the cfg-resolved

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -49,6 +49,121 @@ type Rendition =
     | Physical
     | Logical
 
+/// The capability CLASS of a target (DATABASE_ARCHETYPES.md §1/§4) — the bundle
+/// of covarying dispositions the engine forks on, named ONCE. `FullRights` = the
+/// on-prem schema+data home (DDL + IDENTITY_INSERT — verified 2026-06-15);
+/// `ManagedDml` = the managed DML-only sink (the J5 profile: sink-mints, no DDL /
+/// IDENTITY_INSERT / CREATE TABLE). Closed so every consumer (the disposition
+/// selector, the resume-mechanism chooser, the gate set, the renderer) is TOTAL
+/// over it — a new target class joins by ONE DU case, never a parallel hand-list
+/// (the `ArtifactByKind` / `registered ⇔ executed` discipline applied to
+/// capability; CONSTELLATION §9.8.9). It SUBSUMES `Grant` (which becomes a
+/// derived projection — `Archetype.grant`) and stays orthogonal to `Rendition`.
+[<RequireQualifiedAccess>]
+type Archetype =
+    | FullRights
+    | ManagedDml
+
+/// Where mid-run resume state lives (DATABASE_ARCHETYPES.md §1/§2.2). A
+/// `FullRights` sink can host a sink-resident progress table (needs CREATE
+/// TABLE — durable, queryable, no filename↔digest coupling); a `ManagedDml` sink
+/// must journal off-box (the client-side NDJSON journal — the only option under a
+/// no-DDL grant). Closed so the resume-mechanism chooser (Slice C) is total.
+[<RequireQualifiedAccess>]
+type ResumeKind =
+    | SinkResidentTable
+    | ClientJournal
+
+/// How a fresh load wipes a sink (DATABASE_ARCHETYPES.md §1/§2.5). `Truncate` is
+/// the ALTER-gated fast refresh (`FullRights`); `ChildFirstDelete` is the only
+/// DML-legal path under a no-ALTER grant (`ManagedDml` — the 2·|rows| CDC-costed
+/// path). Closed so the wipe chooser is total.
+[<RequireQualifiedAccess>]
+type WipeKind =
+    | Truncate
+    | ChildFirstDelete
+
+/// What an `Archetype` EXPANDS to — the disposition defaults the pipeline reads
+/// instead of re-deciding "is this DML-only?" from scattered checks
+/// (DATABASE_ARCHETYPES.md §4). Each capability is its OWN flag, NOT a bundle
+/// inferred from the label, because a real estate hands you a SPLIT target (the
+/// on-prem `FullRights`-minus-DMV, observed 2026-06-15 — DATABASE_ARCHETYPES.md
+/// §5): the survey (Slice B) can flip an individual probed flag without
+/// re-classing the whole archetype. `CapabilityProfile.of` is the SINGLE
+/// expansion site (total over `Archetype`); the disposition selector, resume
+/// chooser, and gate set all read this record.
+type CapabilityProfile =
+    {
+        /// The coarse refusal-gate facet this archetype derives (subsumes the
+        /// hand-set `Grant`): `FullRights → SchemaAndData`, `ManagedDml → DataOnly`.
+        Grant            : Grant
+        /// The identity-disposition DEFAULT the structural classifier starts from
+        /// (per-table overrides still apply — a `ReconciledByRule` user table, a
+        /// composite-key refusal): `FullRights → PreservedFromSource` (write source
+        /// keys; no capture/remap/FK-repoint), `ManagedDml → AssignedBySink`.
+        IdentityDefault  : IdentityDisposition
+        /// CREATE TABLE / ALTER permitted — schema deploy + a sink-resident
+        /// progress table become available.
+        DdlPermitted     : bool
+        /// IDENTITY_INSERT permitted — `PreservedFromSource` is viable on an
+        /// IDENTITY PK (write the source surrogate directly).
+        IdentityInsert   : bool
+        /// NOCHECK / disable-trigger fast lane (needs ALTER).
+        ConstraintBypass : bool
+        /// Where a mid-run resume checkpoint lives.
+        ResumeCheckpoint : ResumeKind
+        /// How a fresh load wipes the sink.
+        WipeStrategy     : WipeKind
+    }
+
+[<RequireQualifiedAccess>]
+module Archetype =
+
+    /// The `Grant` an archetype derives — the coarse facet becomes a PROJECTION
+    /// of the class (DATABASE_ARCHETYPES.md §4). Total over `Archetype`.
+    let grant (a: Archetype) : Grant =
+        match a with
+        | Archetype.FullRights -> Grant.SchemaAndData
+        | Archetype.ManagedDml -> Grant.DataOnly
+
+    /// Infer the archetype a `Grant` implies — the inverse of `grant`, used to
+    /// DEFAULT an undeclared archetype from the existing `grant` facet
+    /// (`SchemaAndData → FullRights`, `DataOnly → ManagedDml`). The two 2-element
+    /// sets are in bijection, so `grant ∘ ofGrant = id` AND `ofGrant ∘ grant = id`
+    /// — the round-trip witness (`ArchetypeTests`).
+    let ofGrant (g: Grant) : Archetype =
+        match g with
+        | Grant.SchemaAndData -> Archetype.FullRights
+        | Grant.DataOnly      -> Archetype.ManagedDml
+
+[<RequireQualifiedAccess>]
+module CapabilityProfile =
+
+    /// EXPAND an archetype to its disposition bundle — the SINGLE definition site
+    /// (DATABASE_ARCHETYPES.md §1/§4). Total over `Archetype`. The confirmed
+    /// verdicts are pinned by `CapabilityProfileTests`: on-prem `FullRights` =
+    /// DDL + IDENTITY_INSERT + constraint-bypass + a sink-resident progress table
+    /// + TRUNCATE, PreservedFromSource by default; cloud `ManagedDml` = the J5
+    /// ledger (none of those — sink-mints, client journal, child-first DELETE).
+    let ``of`` (a: Archetype) : CapabilityProfile =
+        match a with
+        | Archetype.FullRights ->
+            { Grant            = Grant.SchemaAndData
+              IdentityDefault  = IdentityDisposition.PreservedFromSource
+              DdlPermitted     = true
+              IdentityInsert   = true
+              ConstraintBypass = true
+              ResumeCheckpoint = ResumeKind.SinkResidentTable
+              WipeStrategy     = WipeKind.Truncate }
+        | Archetype.ManagedDml ->
+            { Grant            = Grant.DataOnly
+              IdentityDefault  = IdentityDisposition.AssignedBySink
+              DdlPermitted     = false
+              IdentityInsert   = false
+              ConstraintBypass = false
+              ResumeCheckpoint = ResumeKind.ClientJournal
+              WipeStrategy     = WipeKind.ChildFirstDelete }
+
 /// A named place (THE_CLI.md §4.1): its reach (`Access`) and, for a target,
 /// its permission (`Grant`). D9 holds — a `Direct`/`Bundle` address is a
 /// reference or a folder, never an inline secret.
@@ -66,7 +181,30 @@ type Environment =
         /// moves, the established surface, never set it). Env metadata, not a
         /// gate. THE_CLI.md §4.1; THE_DATA_PRODUCERS §4.6.
         Rendition : Rendition option
+        /// The capability CLASS this place DECLARES (DATABASE_ARCHETYPES.md §4) —
+        /// the bundle of dispositions the engine forks on, named once. `None` =
+        /// undeclared (the established surface — every config to date). Stored
+        /// declared-only (NOT eagerly inferred) so existing configs render
+        /// byte-identically and `parse ∘ render = id` holds without parse-time
+        /// inference diverging; consumers DEFAULT it from `Grant` via
+        /// `Environment.effectiveArchetype`. Nothing branches on it until Slices
+        /// B/C/S — Slice A is byte-identical by construction.
+        Archetype : Archetype option
     }
+
+[<RequireQualifiedAccess>]
+module Environment =
+
+    /// The EFFECTIVE archetype of a place — its declared `Archetype`, else
+    /// inferred from the `Grant` facet (`SchemaAndData → FullRights`,
+    /// `DataOnly → ManagedDml`; no grant ⇒ `None`). The DEFAULTING the design
+    /// names (DATABASE_ARCHETYPES.md §6.1) done LAZILY at read time, so the stored
+    /// field stays declared-only (byte-identical render) while consumers still see
+    /// a class for any grant-bearing place. This is what Slices B/C/S read.
+    let effectiveArchetype (env: Environment) : Archetype option =
+        match env.Archetype with
+        | Some a -> Some a
+        | None   -> env.Grant |> Option.map Archetype.ofGrant
 
 // `FlowSource`, `Flow`, and `FlowRunOpts` live in MovementSpec.fs (the types
 // file) — `Intent.Flow` carries them, so they precede it in compile order.
@@ -173,6 +311,16 @@ module ProjectionConfig =
         | "logical"  -> Result.success Rendition.Logical
         | other -> Result.failureOf (err "cli.config.envRenditionUnknown" (sprintf "environment '%s' rendition '%s' is not physical | logical." envName other))
 
+    /// The capability-class disposition facet (DATABASE_ARCHETYPES.md §4):
+    /// full-rights (on-prem, DDL+IDENTITY_INSERT) | managed-dml (cloud, the J5
+    /// DML-only profile). Absent = `None` (consumers default it from `grant`).
+    /// Closed; an unknown value is a named refusal, never silently dropped.
+    let private parseArchetype (envName: string) (raw: string) : Result<Archetype> =
+        match raw.ToLowerInvariant() with
+        | "fullrights" | "full-rights" | "full"          -> Result.success Archetype.FullRights
+        | "manageddml" | "managed-dml" | "managed" | "dml" -> Result.success Archetype.ManagedDml
+        | other -> Result.failureOf (err "cli.config.envArchetypeUnknown" (sprintf "environment '%s' archetype '%s' is not full-rights | managed-dml." envName other))
+
     let private parseEnvironment (name: string) (el: JsonElement) : Result<Environment> =
         if el.ValueKind <> JsonValueKind.Object then
             Result.failureOf (err "cli.config.envShape" (sprintf "environment '%s' must be a JSON object." name))
@@ -185,14 +333,18 @@ module ProjectionConfig =
                     match getString el "rendition" with
                     | None   -> Result.success None
                     | Some r -> parseRendition name r |> Result.map Some
-                match renditionR with
-                | Error e -> Result.failure e
-                | Ok rendition ->
+                let archetypeR =
+                    match getString el "archetype" with
+                    | None   -> Result.success None
+                    | Some a -> parseArchetype name a |> Result.map Some
+                match renditionR, archetypeR with
+                | Error e, _ | _, Error e -> Result.failure e
+                | Ok rendition, Ok archetype ->
                     match getString el "grant" with
-                    | None -> Result.success { Name = name; Access = access; Grant = None; Store = store; Rendition = rendition }
+                    | None -> Result.success { Name = name; Access = access; Grant = None; Store = store; Rendition = rendition; Archetype = archetype }
                     | Some g ->
                         match parseGrant name g with
-                        | Ok grant -> Result.success { Name = name; Access = access; Grant = Some grant; Store = store; Rendition = rendition }
+                        | Ok grant -> Result.success { Name = name; Access = access; Grant = Some grant; Store = store; Rendition = rendition; Archetype = archetype }
                         | Error e  -> Result.failure e
 
     /// The content origin: `from` names an environment (the Move), or one of
@@ -448,6 +600,15 @@ module ProjectionConfig =
         | Rendition.Physical -> "physical"
         | Rendition.Logical  -> "logical"
 
+    /// The archetype disposition field (dual of `parseArchetype`): the canonical
+    /// token. Emitted only when DECLARED (`Some`) — an undeclared archetype
+    /// round-trips through the absent arm (so existing configs render
+    /// byte-identically; mirrors how `grant`/`rendition` omit their absent value).
+    let private renderArchetype (a: Archetype) : string =
+        match a with
+        | Archetype.FullRights -> "full-rights"
+        | Archetype.ManagedDml -> "managed-dml"
+
     /// The move-projection field (dual of `parseFlowScope`): the canonical token.
     let private renderScope (s: Scope) : string =
         match s with
@@ -478,6 +639,7 @@ module ProjectionConfig =
         setOptStr o "grant" (env.Grant |> Option.map renderGrant)
         setOptStr o "store" env.Store
         setOptStr o "rendition" (env.Rendition |> Option.map renderRendition)
+        setOptStr o "archetype" (env.Archetype |> Option.map renderArchetype)
         o
 
     /// Render one `Flow` to its `JsonObject` — the dual of `parseFlow`. `from`
@@ -626,7 +788,8 @@ module Command =
           Env         = spec.Env
           Tables      = spec.Tables
           Seed        = spec.Seed
-          Scale       = spec.Scale }
+          Scale       = spec.Scale
+          SinkCapability = spec.SinkCapability }
 
     // --- the pure movement routing (the surface→engine map) ----------------
 
@@ -976,6 +1139,23 @@ module Command =
                 // unchanged; only ossys-only-with-store gains provenance).
                 let hasPublishableModel =
                     Option.isSome cfg.Shaping.Model.Path || Option.isSome cfg.Shaping.Model.Ossys
+                // Slice C — derive the sink's capability-derived engine inputs from
+                // its DECLARED-or-inferred archetype (DATABASE_ARCHETYPES.md §4).
+                // `FullRights` (IDENTITY_INSERT + CREATE TABLE) ⇒ PreferPreservedKeys
+                // + sink-resident resume; `ManagedDml` / undeclared ⇒ `structural`
+                // (byte-identical). The two engine bits are projected here, the one
+                // site that sees both the sink `Environment` and `CapabilityProfile`.
+                let sinkCapability : SinkLoadCapability =
+                    match Environment.effectiveArchetype toEnv with
+                    | Some archetype ->
+                        let profile = CapabilityProfile.``of`` archetype
+                        { IdentityPolicy =
+                            (if profile.IdentityInsert then IdentityPolicy.PreferPreservedKeys else IdentityPolicy.Structural)
+                          SinkResidentResume =
+                            (match profile.ResumeCheckpoint with
+                             | ResumeKind.SinkResidentTable -> true
+                             | ResumeKind.ClientJournal     -> false) }
+                    | None -> SinkLoadCapability.structural
                 let modelSource =
                     match cfg.SourcePath, toEnv.Store with
                     | Some sourcePath, Some _ when hasPublishableModel -> ModelSource.ConfigFile sourcePath
@@ -1030,6 +1210,8 @@ module Command =
                         // The target's durable timeline: a live --go records an
                         // episode into it (which `report` later diffs). F4.
                         Store    = toEnv.Store
+                        // Slice C — the sink's archetype-derived engine inputs.
+                        SinkCapability = sinkCapability
                         Commit   = opts.Go }
 
     /// Route a named flow to its `ExecutionPlan`. The grant gate refuses a

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="BenchSink.fs" />
     <Compile Include="Preflight.fs" />
     <Compile Include="PackedSurrogateRemap.fs" />
+    <Compile Include="KeymapSpill.fs" />
     <Compile Include="SurrogateCapture.fs" />
     <Compile Include="CaptureJournal.fs" />
     <Compile Include="RenameProjection.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -60,6 +60,7 @@ module ReverseLegRealization =
         (tables: string list)
         (streamingRequested: bool)
         (journalDirectory: string option)
+        (sinkResidentResumeAvailable: bool)
         : Result<ReverseLegRealization> =
         let admissible =
             List.isEmpty tables && not resumable && emission = EmissionMode.Incremental
@@ -67,6 +68,15 @@ module ReverseLegRealization =
             Result.failureOf
                 (ValidationError.create "transfer.reverseLeg.streamingTablesUnsupported"
                     "the streaming reverse leg loads the whole estate; a declared table subset is the named follow-on. Remove --tables or drop --streaming to run materialized.")
+        elif streamingRequested && resumable && sinkResidentResumeAvailable then
+            // Slice C2 — the resume chooser reads the sink ARCHETYPE instead of
+            // assuming the cloud (ManagedDml) shape. A `FullRights` sink CAN host
+            // the G10 sink-resident progress table (CREATE TABLE permitted), so
+            // `--resumable` is HONORED on the materialized envelope (the path that
+            // carries sink-resident resume) rather than refused. The ManagedDml
+            // refusal below stands — its data grant forbids the CREATE TABLE the
+            // progress table needs (the original, archetype-correct reasoning).
+            Result.success ReverseLegRealization.Materialized
         elif streamingRequested && resumable then
             Result.failureOf
                 (ValidationError.create "transfer.reverseLeg.streamingResumableUnsupported"
@@ -818,11 +828,16 @@ module Transfer =
           /// loads every kind; `Some s` loads only kinds in `s`, leaving the
           /// rest of the sink untouched (the catalog stays whole for FK
           /// context — only the per-kind row load is restricted).
-          LoadSet : Set<SsKey> option }
+          LoadSet : Set<SsKey> option
+          /// Slice C1 — the identity-disposition policy `DataLoadPlan.buildWith`
+          /// applies. `Structural` (the `def` default) is byte-identical; a
+          /// `FullRights` sink threads `PreferPreservedKeys` so IDENTITY-PK kinds
+          /// preserve their source keys (no capture/remap).
+          IdentityPolicy : IdentityPolicy }
 
     [<RequireQualifiedAccess>]
     module WriteOptions =
-        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None }
+        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None; IdentityPolicy = IdentityPolicy.Structural }
         let resumable : WriteOptions = { def with Resumable = true }
         let ofEmission (mode: EmissionMode) : WriteOptions = { def with Emission = mode }
 
@@ -918,7 +933,7 @@ module Transfer =
             // substitution is applied here, once. After this, every Row
             // is in target identity space.
             let plan =
-                DataLoadPlan.build catalog topo rows reconciled.Remap
+                DataLoadPlan.buildWith writeOpts.IdentityPolicy catalog topo rows reconciled.Remap
                 |> DataLoadPlan.reclassifyReconciled reconciledKinds
             // Pre-write gate, precedence-ordered: structural unsatisfiability /
             // surrogate-capture shapes first (executeGate), then the
@@ -1141,7 +1156,11 @@ module Transfer =
     /// ordinal), and writes against the sink contract. A no-rename pair (A = B
     /// modulo renames) is byte-identical to `run`. Straight load (no
     /// reconciliation); the reconcile + rename combination is the follow-on.
-    let runWithRenames
+    /// Slice C1 — the policy-bearing `runWithRenames`: a `FullRights` sink threads
+    /// `IdentityPolicy.PreferPreservedKeys` so the populate preserves source keys
+    /// (no capture/remap). `runWithRenames` fixes `Structural` (byte-identical).
+    let runWithRenamesWith
+        (identityPolicy: IdentityPolicy)
         (mode: Mode)
         (allowCdc: bool)
         (source: SqlConnection)
@@ -1156,8 +1175,18 @@ module Transfer =
             | Ok diff ->
                 let renameMap =
                     RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) WriteOptions.def
+                return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
         }
+
+    let runWithRenames
+        (mode: Mode)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (sourceContract: Catalog)
+        (sinkContract: Catalog)
+        : Task<Result<TransferReport>> =
+        runWithRenamesWith IdentityPolicy.Structural mode allowCdc source sink sourceContract sinkContract
 
     /// M3.b — the `legacy` B→A reverse leg's engine face (`THE_DATA_PRODUCERS`
     /// LE-1). The source is at the LOGICAL rendition (B, on-prem); the sink is at
@@ -1827,7 +1856,11 @@ module Transfer =
     /// context (A = B). A no-rename pair AND empty reconciliation collapses
     /// to `run`. This composition is what the `runWithRenames`/`runReconciling`
     /// site named "the follow-on."
-    let runReconcilingWithRenames
+    /// Slice C1 — the policy-bearing `runReconcilingWithRenames`. A `FullRights`
+    /// sink threads `PreferPreservedKeys`; `runReconcilingWithRenames` fixes
+    /// `Structural` (byte-identical).
+    let runReconcilingWithRenamesWith
+        (identityPolicy: IdentityPolicy)
         (mode: Mode)
         (allowCdc: bool)
         (source: SqlConnection)
@@ -1843,8 +1876,19 @@ module Transfer =
             | Ok diff ->
                 let renameMap =
                     RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) WriteOptions.def
+                return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
         }
+
+    let runReconcilingWithRenames
+        (mode: Mode)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (sourceContract: Catalog)
+        (sinkContract: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        : Task<Result<TransferReport>> =
+        runReconcilingWithRenamesWith IdentityPolicy.Structural mode allowCdc source sink sourceContract sinkContract reconciliation
 
     /// Slice 4.2 — drive a Transfer through the `TransferConnections`
     /// apparatus instead of caller-opened connections. Opens both
@@ -1959,7 +2003,8 @@ module Transfer =
     /// (`runStreamingReverseLegThroughConnections`) is preferred for the
     /// estate-scale combinations; this materialized arm carries the table-
     /// subset / WipeAndLoad / G10-resumable cases the selector routes here.
-    let runReverseLegThroughConnections
+    let runReverseLegThroughConnectionsWith
+        (identityPolicy: IdentityPolicy)
         (mode: Mode)
         (emission: EmissionMode)
         (resumable: bool)
@@ -1989,8 +2034,25 @@ module Transfer =
                         | Error es -> return Result.failure es
                         | Ok sink ->
                             use sink = sink
-                            return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet }
+                            return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy }
         }
+
+    /// The structural-policy reverse leg (byte-identical; the ManagedDml cloud
+    /// sink). A `FullRights` reverse-leg sink threads `PreferPreservedKeys` via
+    /// `runReverseLegThroughConnectionsWith`.
+    let runReverseLegThroughConnections
+        (mode: Mode)
+        (emission: EmissionMode)
+        (resumable: bool)
+        (allowCdc: bool)
+        (allowDrops: bool)
+        (tables: string list)
+        (connections: TransferConnections)
+        (logicalSourceContract: Catalog)
+        (physicalSinkContract: Catalog)
+        (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        : Task<Result<TransferReport>> =
+        runReverseLegThroughConnectionsWith IdentityPolicy.Structural mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation
 
     // -- 6.A.1: the drop-set is fail-loud, not exit-0 -----------------------
     //

--- a/sidecar/projection/tests/Projection.Tests/ArchetypeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ArchetypeTests.fs
@@ -1,0 +1,87 @@
+module Projection.Tests.ArchetypeTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+/// Slice A witness (DATABASE_ARCHETYPES.md §1/§4; REVERSE_LEG_WORK_PLAN Slice A).
+/// The archetype is the FOUNDATION — a closed capability class that subsumes
+/// `Grant`, expands to a `CapabilityProfile` at ONE site, and defaults from the
+/// existing grant. Nothing branches on it yet (Slices B/C/S are the consumers),
+/// so the only claims to pin are: the derive/infer round-trip, the expansion
+/// matches the confirmed verdicts, the lazy default, and byte-identical render.
+
+let private allArchetypes = [ Archetype.FullRights; Archetype.ManagedDml ]
+let private allGrants     = [ Grant.SchemaAndData; Grant.DataOnly ]
+
+// --- the (infer ∘ derive-grant) round-trip — the work plan's named witness ---
+
+[<Fact>]
+let ``Archetype — ofGrant ∘ grant = id on every archetype`` () =
+    for a in allArchetypes do
+        Assert.Equal<Archetype>(a, Archetype.ofGrant (Archetype.grant a))
+
+[<Fact>]
+let ``Archetype — grant ∘ ofGrant = id on every grant`` () =
+    for g in allGrants do
+        Assert.Equal<Grant>(g, Archetype.grant (Archetype.ofGrant g))
+
+// --- the expansion matches the confirmed verdicts (§1 catalog) ---------------
+
+[<Fact>]
+let ``CapabilityProfile.of FullRights — the verified on-prem bundle (DDL + IDENTITY_INSERT + sink-resident + TRUNCATE)`` () =
+    let p = CapabilityProfile.``of`` Archetype.FullRights
+    Assert.Equal<Grant>(Grant.SchemaAndData, p.Grant)
+    Assert.Equal<IdentityDisposition>(IdentityDisposition.PreservedFromSource, p.IdentityDefault)
+    Assert.True(p.DdlPermitted)
+    Assert.True(p.IdentityInsert)
+    Assert.True(p.ConstraintBypass)
+    Assert.Equal<ResumeKind>(ResumeKind.SinkResidentTable, p.ResumeCheckpoint)
+    Assert.Equal<WipeKind>(WipeKind.Truncate, p.WipeStrategy)
+
+[<Fact>]
+let ``CapabilityProfile.of ManagedDml — the J5 cloud bundle (no DDL / IDENTITY_INSERT; sink-mints; client journal; child-first DELETE)`` () =
+    let p = CapabilityProfile.``of`` Archetype.ManagedDml
+    Assert.Equal<Grant>(Grant.DataOnly, p.Grant)
+    Assert.Equal<IdentityDisposition>(IdentityDisposition.AssignedBySink, p.IdentityDefault)
+    Assert.False(p.DdlPermitted)
+    Assert.False(p.IdentityInsert)
+    Assert.False(p.ConstraintBypass)
+    Assert.Equal<ResumeKind>(ResumeKind.ClientJournal, p.ResumeCheckpoint)
+    Assert.Equal<WipeKind>(WipeKind.ChildFirstDelete, p.WipeStrategy)
+
+[<Fact>]
+let ``CapabilityProfile — the derived Grant is a projection of the archetype (subsumes Grant)`` () =
+    for a in allArchetypes do
+        Assert.Equal<Grant>(Archetype.grant a, (CapabilityProfile.``of`` a).Grant)
+
+// --- the lazy default: declared wins, else inferred from grant, else None -----
+
+let private envWith (grant: Grant option) (archetype: Archetype option) : Environment =
+    { Name = "e"; Access = Access.Direct (ConnectionRef.EnvVar "E_CONN")
+      Grant = grant; Store = None; Rendition = None; Archetype = archetype }
+
+[<Fact>]
+let ``effectiveArchetype — a declared archetype wins over the grant inference`` () =
+    // grant DataOnly would infer ManagedDml, but the explicit declaration is FullRights.
+    Assert.Equal<Archetype option>(
+        Some Archetype.FullRights,
+        Environment.effectiveArchetype (envWith (Some Grant.DataOnly) (Some Archetype.FullRights)))
+
+[<Fact>]
+let ``effectiveArchetype — an undeclared archetype is inferred from the grant`` () =
+    Assert.Equal<Archetype option>(Some Archetype.FullRights, Environment.effectiveArchetype (envWith (Some Grant.SchemaAndData) None))
+    Assert.Equal<Archetype option>(Some Archetype.ManagedDml, Environment.effectiveArchetype (envWith (Some Grant.DataOnly) None))
+
+[<Fact>]
+let ``effectiveArchetype — no grant and no declared archetype is no class (None → None)`` () =
+    Assert.Equal<Archetype option>(None, Environment.effectiveArchetype (envWith None None))
+
+// --- byte-identical render: an undeclared archetype emits no field ------------
+
+[<Fact>]
+let ``render — an undeclared archetype omits the field (existing configs byte-identical); a declared one emits the canonical token`` () =
+    let bare = { ProjectionConfig.empty with Environments = Map.ofList [ "e", envWith (Some Grant.SchemaAndData) None ] }
+    Assert.DoesNotContain("archetype", ProjectionConfig.render bare)
+    let declared = { ProjectionConfig.empty with Environments = Map.ofList [ "e", envWith (Some Grant.SchemaAndData) (Some Archetype.ManagedDml) ] }
+    Assert.Contains("managed-dml", ProjectionConfig.render declared)

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
@@ -58,7 +58,7 @@ let ``CapabilitySurvey.Capability.all is Reads plus every write action; permissi
 // --- the flow-shape derivation (requiredBy) --------------------------------
 
 let private env (name: string) (grant: Grant option) : Projection.Pipeline.Environment =
-    { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None }
+    { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
     { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; Scope = None; Shape = None; Shaping = None }
@@ -156,7 +156,8 @@ let private report name connected reachable missing : CapabilitySurvey.Environme
     { Name = name; Grant = Some Grant.DataOnly; Required = Set.empty
       Connected = connected; Reachable = reachable; Missing = missing
       GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false
-      UserDirectory = Projection.Adapters.Sql.ReadSide.UserDirectoryProbe.absent }
+      UserDirectory = Projection.Adapters.Sql.ReadSide.UserDirectoryProbe.absent
+      ArchetypeFindings = [] }
 
 [<Fact>]
 let ``NM-55: a reachable place with an unreadable grant is blocked (coverage unverified, not covered)`` () =
@@ -223,3 +224,73 @@ let ``advisoryLines: the advisory reads the SAME blocked predicate the verb's ga
     let lines = CapabilitySurvey.advisoryLines reports
     for n in blockedNames do
         Assert.Contains(lines, fun l -> l.Contains n)
+
+// --- Slice B — the survey VERIFIES the archetype (A44; the J5 covenant) -------
+
+let private envArch (name: string) (archetype: Archetype option) : Projection.Pipeline.Environment =
+    { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = None; Store = None; Rendition = None; Archetype = archetype }
+
+/// A database-scope `GrantEvidence` from a permission-name list (object-key "").
+let private grantOf (perms: string list) : Preflight.GrantEvidence =
+    { Granted = perms |> List.map (fun p -> ("", p)) |> Set.ofList }
+
+[<Fact>]
+let ``Slice B (Part 1): the survey routes through the archetype's derived grant — an archetype-declared sink yields the SAME required set as the equivalent grant (byte-identical)`` () =
+    // A `full-rights` archetype derives `schema+data`; a `managed-dml` archetype
+    // derives `data` — so `requiredBy` is identical to the hand-set grant.
+    let liveSource = env "staging" (Some Grant.SchemaAndData)
+    let archetypeSink = envArch "uat-arch" (Some Archetype.FullRights)
+    let grantSink     = env "uat-grant" (Some Grant.SchemaAndData)
+    let cfgA = cfgWith [ liveSource; archetypeSink ] [ flow "a" (FlowSource.Env "staging") "uat-arch" ]
+    let cfgG = cfgWith [ liveSource; grantSink ]     [ flow "g" (FlowSource.Env "staging") "uat-grant" ]
+    Assert.Equal<Set<CapabilitySurvey.Capability>>(
+        CapabilitySurvey.requiredBy cfgG (Map.find "g" cfgG.Flows) SubstrateRole.Sink,
+        CapabilitySurvey.requiredBy cfgA (Map.find "a" cfgA.Flows) SubstrateRole.Sink)
+    // The ManagedDml mirror: derives `data` ⇒ the DML-only required set.
+    let dmlSink = envArch "cloud" (Some Archetype.ManagedDml)
+    let cfgD = cfgWith [ liveSource; dmlSink ] [ flow "d" (FlowSource.Env "staging") "cloud" ]
+    Assert.Equal<Set<CapabilitySurvey.Capability>>(
+        set [ Performs Preflight.Insert; Performs Preflight.Delete ],
+        CapabilitySurvey.requiredBy cfgD (Map.find "d" cfgD.Flows) SubstrateRole.Sink)
+
+[<Fact>]
+let ``Slice B (Part 2): a declared FullRights whose probe COVERS DDL + IDENTITY_INSERT + DMV reconciles clean`` () =
+    let grant = grantOf [ "CREATE TABLE"; "ALTER"; "VIEW DATABASE PERFORMANCE STATE"; "INSERT"; "DELETE" ]
+    Assert.Empty(CapabilitySurvey.reconcileArchetype Archetype.FullRights grant)
+
+[<Fact>]
+let ``Slice B (Part 2): a declared FullRights missing CREATE TABLE / IDENTITY_INSERT is a NAMED required-capability mismatch`` () =
+    let grant = grantOf [ "INSERT"; "DELETE" ]   // DML only — no DDL
+    let findings = CapabilitySurvey.reconcileArchetype Archetype.FullRights grant
+    Assert.Contains(CapabilitySurvey.RequiredCapabilityDenied "CREATE TABLE", findings)
+    Assert.Contains(CapabilitySurvey.RequiredCapabilityDenied "ALTER (IDENTITY_INSERT)", findings)
+
+[<Fact>]
+let ``Slice B (Part 2): the on-prem FullRights-minus-DMV classifies correctly — DDL present, DMV-read absent surfaces as the SPLIT (not a misdeclaration)`` () =
+    // The real on-prem target (2026-06-15): full DDL/DML, minus VIEW DATABASE
+    // PERFORMANCE STATE. The class is FullRights; only the DMV probe degrades.
+    let grant = grantOf [ "CREATE TABLE"; "ALTER"; "INSERT"; "DELETE" ]   // no DMV-read
+    let findings = CapabilitySurvey.reconcileArchetype Archetype.FullRights grant
+    Assert.Equal<CapabilitySurvey.ArchetypeFinding list>(
+        [ CapabilitySurvey.SoftCapabilityAbsent "VIEW DATABASE PERFORMANCE STATE" ], findings)
+
+[<Fact>]
+let ``Slice B (Part 2): a declared ManagedDml that UNEXPECTEDLY permits IDENTITY_INSERT is surfaced (safer than declared)`` () =
+    let grant = grantOf [ "INSERT"; "DELETE"; "ALTER"; "CREATE TABLE" ]   // more than DML-only
+    let findings = CapabilitySurvey.reconcileArchetype Archetype.ManagedDml grant
+    Assert.Contains(CapabilitySurvey.ForbiddenCapabilityPermitted "CREATE TABLE", findings)
+    Assert.Contains(CapabilitySurvey.ForbiddenCapabilityPermitted "ALTER (IDENTITY_INSERT)", findings)
+
+[<Fact>]
+let ``Slice B (Part 2): a declared ManagedDml on the true J5 DML-only grant reconciles clean`` () =
+    let grant = grantOf [ "INSERT"; "DELETE"; "SELECT" ]
+    Assert.Empty(CapabilitySurvey.reconcileArchetype Archetype.ManagedDml grant)
+
+[<Fact>]
+let ``Slice B: a report carrying archetype findings surfaces them in advisoryLines (even when not blocked)`` () =
+    let r =
+        { report "onprem" true true [] with
+            ArchetypeFindings = [ CapabilitySurvey.SoftCapabilityAbsent "VIEW DATABASE PERFORMANCE STATE" ] }
+    Assert.False(CapabilitySurvey.blocked r)   // a split is NOT blocking
+    let lines = CapabilitySurvey.advisoryLines [ r ]
+    Assert.Contains(lines, fun (l: string) -> l.Contains "onprem" && l.Contains "VIEW DATABASE PERFORMANCE STATE")

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
@@ -24,7 +24,7 @@ open type Projection.Pipeline.CapabilitySurvey.Capability
 // reach all five capabilities — the "in-scope" surface the totality holds the
 // catalog to (the analog of Voice's `inScopeCodes`).
 let private env (name: string) (grant: Grant option) : Projection.Pipeline.Environment =
-    { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None }
+    { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
     { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; Scope = None; Shape = None; Shaping = None }

--- a/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
@@ -84,6 +84,26 @@ let ``DataLoadPlan: identity PK is AssignedBySink, business PK is PreservedFromS
     Assert.Equal(IdentityDisposition.PreservedFromSource, (loadFor customerKey plan).Disposition)
     Assert.Equal(IdentityDisposition.AssignedBySink, (loadFor invoiceKey plan).Disposition)
 
+// --- Slice C1 — the FullRights disposition fork (buildWith PreferPreservedKeys) ---
+
+[<Fact>]
+let ``Slice C1: buildWith Structural = build — the byte-identical default`` () =
+    let structural = DataLoadPlan.buildWith IdentityPolicy.Structural catalog topo Map.empty SurrogateRemapContext.empty
+    Assert.Equal<DataLoadPlan>(build Map.empty, structural)
+
+[<Fact>]
+let ``Slice C1: buildWith PreferPreservedKeys flips an IDENTITY PK to PreservedFromSource — no AssignedBySink kind remains (capture/remap entirely skipped)`` () =
+    let plan = DataLoadPlan.buildWith IdentityPolicy.PreferPreservedKeys catalog topo Map.empty SurrogateRemapContext.empty
+    // The IDENTITY-PK Invoice is now written with its source key preserved
+    // (Bulk.copyRows + KeepIdentity — viable on a FullRights sink), not minted.
+    Assert.Equal(IdentityDisposition.PreservedFromSource, (loadFor invoiceKey plan).Disposition)
+    // The business-PK Customer was already PreservedFromSource (unchanged).
+    Assert.Equal(IdentityDisposition.PreservedFromSource, (loadFor customerKey plan).Disposition)
+    // The KEY consequence: zero AssignedBySink kinds ⇒ the whole capture +
+    // surrogate-remap + FK-repoint machinery (which branches on AssignedBySink)
+    // is skipped downstream by construction — the dramatically simpler load.
+    Assert.True(plan.Loads |> List.forall (fun l -> l.Disposition <> IdentityDisposition.AssignedBySink))
+
 [<Fact>]
 let ``DataLoadPlan: nullable same-cycle FK is deferred, non-nullable is not`` () =
     let plan = build Map.empty

--- a/sidecar/projection/tests/Projection.Tests/KeymapSpillTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/KeymapSpillTests.fs
@@ -1,0 +1,110 @@
+namespace Projection.Tests
+
+// Slice S — the at-scale keymap SPILL (REVERSE_LEG_WORK_PLAN §3 Slice S). The
+// pure chooser (threshold + estimate → residence) is DB-free; the equivalence
+// canary proves the spilled server-side `UPDATE…JOIN` re-point produces a
+// byte-identical sink state to the resident per-row re-point over the same
+// captured keymap — the work plan's "spill-on vs resident → byte-identical sink
+// state" witness, at the mechanism grain. Serial via Docker-SqlServer.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+module KeymapSpillPure =
+
+    // -- the chooser: pure + total, testable without a connection --------------
+
+    [<Fact>]
+    let ``KeymapResidence.choose: no threshold is ALWAYS resident (the inert default)`` () =
+        Assert.Equal<KeymapResidence>(KeymapResidence.Resident, KeymapResidence.choose None 0)
+        Assert.Equal<KeymapResidence>(KeymapResidence.Resident, KeymapResidence.choose None 200_000_000)
+
+    [<Fact>]
+    let ``KeymapResidence.choose: a threshold spills strictly ABOVE it, resident at or below`` () =
+        Assert.Equal<KeymapResidence>(KeymapResidence.Resident, KeymapResidence.choose (Some 1000) 1000)
+        Assert.Equal<KeymapResidence>(KeymapResidence.Resident, KeymapResidence.choose (Some 1000) 999)
+        Assert.Equal<KeymapResidence>(KeymapResidence.Spilled,  KeymapResidence.choose (Some 1000) 1001)
+
+    [<Fact>]
+    let ``KeymapResidence.describe: the armed spill is NARRATED (no silent path change)`` () =
+        let resident = KeymapResidence.describe KeymapResidence.Resident None 50
+        Assert.Contains("resident", resident)
+        let spilled = KeymapResidence.describe KeymapResidence.Spilled (Some 10) 50
+        Assert.Contains("SPILLED", spilled)
+        Assert.Contains("UPDATE", spilled)
+
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type KeymapSpillEquivalenceTests(fixture: EphemeralContainerFixture) =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    /// Read the FK column for every row, ordered by ID — the comparable sink state.
+    let fkState (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT [ID], [FK] FROM %s ORDER BY [ID];" table
+            use! reader = cmd.ExecuteReaderAsync()
+            let acc = System.Collections.Generic.List<int * int option>()
+            let mutable go = true
+            while go do
+                let! has = reader.ReadAsync()
+                if has then
+                    let fk = if reader.IsDBNull 1 then None else Some (reader.GetInt32 1)
+                    acc.Add(reader.GetInt32 0, fk)
+                else go <- false
+            return List.ofSeq acc
+        }
+
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``Slice S: the spilled UPDATE…JOIN re-point produces a byte-identical sink state to the resident per-row re-point (observationally pure)`` () =
+        if not (skipIfNoDocker "SliceSEquivalence") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "SliceSSpill" (fun cnn _ ->
+                task {
+                    // Two identical sink tables, each holding SOURCE surrogates in
+                    // their FK column (>= 1000), one row (9999) with NO mapping.
+                    let kindKey = "OS_TEST::Account"
+                    do! Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[T_resident] ([ID] INT NOT NULL PRIMARY KEY, [FK] INT NULL); " +
+                             "CREATE TABLE [dbo].[T_spill]    ([ID] INT NOT NULL PRIMARY KEY, [FK] INT NULL); " +
+                             "INSERT INTO [dbo].[T_resident] ([ID],[FK]) VALUES (10,1000),(20,1001),(30,1002),(40,9999); " +
+                             "INSERT INTO [dbo].[T_spill]    ([ID],[FK]) VALUES (10,1000),(20,1001),(30,1002),(40,9999);")
+
+                    // The captured (source → assigned) pairs, identical for both backends.
+                    let pairs = [ ("1000", "500"); ("1001", "501"); ("1002", "502") ]
+
+                    // RESIDENT re-point — the PackedSurrogateRemap per-row path
+                    // (the essence of the streaming phase2Chunks loop): tryFind the
+                    // FK's source value, UPDATE that row. An unmatched FK is left.
+                    let remap = PackedSurrogateRemap.create ()
+                    for (s, a) in pairs do PackedSurrogateRemap.capture (SsKey.synthesizedComposite "OS_TEST" [ "Account" ] |> Result.value) s a remap
+                    let kKey = SsKey.synthesizedComposite "OS_TEST" [ "Account" ] |> Result.value
+                    let! residentRows = fkState cnn "[dbo].[T_resident]"
+                    for (id, fk) in residentRows do
+                        match fk with
+                        | Some v ->
+                            match PackedSurrogateRemap.tryFind remap kKey (string v) with
+                            | Some assigned -> do! Deploy.executeBatch cnn (sprintf "UPDATE [dbo].[T_resident] SET [FK] = %s WHERE [ID] = %d;" assigned id)
+                            | None -> ()
+                        | None -> ()
+
+                    // SPILLED re-point — capture the SAME pairs to the session
+                    // #-temp keymap, then ONE server-side UPDATE…JOIN per kind.
+                    do! SqlKeymap.createTable cnn
+                    do! SqlKeymap.captureMany cnn kindKey pairs
+                    do! SqlKeymap.repointJoin cnn (TableId.create "dbo" "T_spill" |> Result.value) kindKey "FK"
+
+                    // Byte-identical sink state: both re-point 1000→500, 1001→501,
+                    // 1002→502, and leave the unmatched 9999 untouched.
+                    let! residentFinal = fkState cnn "[dbo].[T_resident]"
+                    let! spillFinal     = fkState cnn "[dbo].[T_spill]"
+                    Assert.Equal<(int * int option) list>(residentFinal, spillFinal)
+                    Assert.Equal<(int * int option) list>(
+                        [ (10, Some 500); (20, Some 501); (30, Some 502); (40, Some 9999) ], spillFinal)
+                }))

--- a/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
@@ -44,6 +44,7 @@ let private allRenditions : Rendition list = [ Rendition.Physical; Rendition.Log
 let private allRenditionOpts : Rendition option list = None :: (allRenditions |> List.map Some)
 let private allScopeOpts : Scope option list = [ None; Some Scope.Schema; Some Scope.Data; Some Scope.All ]
 let private allGrantOpts : Grant option list = [ None; Some Grant.SchemaAndData; Some Grant.DataOnly ]
+let private allArchetypeOpts : Archetype option list = [ None; Some Archetype.FullRights; Some Archetype.ManagedDml ]
 
 /// The closed `from` alphabet, as constructed-valid origins. `Env` is split out
 /// (it needs a live source env) so the generator can wire it consistently.
@@ -60,7 +61,7 @@ let private allOriginDraws : OriginDraw list =
 /// A direct (live) environment with a chosen rendition — the up-leg endpoints.
 let private directEnv (name: string) (grant: Grant option) (rendition: Rendition option) : Environment =
     { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN"))
-      Grant = grant; Store = None; Rendition = rendition }
+      Grant = grant; Store = None; Rendition = rendition; Archetype = None }
 
 let private genOpt (xs: 'a list) : Gen<'a> = Gen.elements xs
 
@@ -156,12 +157,13 @@ let ``A44 clause 1 — renderEnvironment ∘ parseEnvironment = id on every reac
     for access in accesses do
       for grant in allGrantOpts do
         for rendition in allRenditionOpts do
-          for store in [ None; Some "lifecycle/e.json" ] do
-            let env = { Name = "e"; Access = access; Grant = grant; Store = store; Rendition = rendition }
-            let cfg = { ProjectionConfig.empty with Environments = Map.ofList [ "e", env ] }
-            match ProjectionConfig.parse (ProjectionConfig.render cfg) with
-            | Ok back -> Assert.Equal<Environment>(env, Map.find "e" back.Environments)
-            | Error es -> Assert.Fail(sprintf "round-trip failed for %A: %A" env es)
+          for archetype in allArchetypeOpts do
+            for store in [ None; Some "lifecycle/e.json" ] do
+              let env = { Name = "e"; Access = access; Grant = grant; Store = store; Rendition = rendition; Archetype = archetype }
+              let cfg = { ProjectionConfig.empty with Environments = Map.ofList [ "e", env ] }
+              match ProjectionConfig.parse (ProjectionConfig.render cfg) with
+              | Ok back -> Assert.Equal<Environment>(env, Map.find "e" back.Environments)
+              | Error es -> Assert.Fail(sprintf "round-trip failed for %A: %A" env es)
 
 [<Fact>]
 let ``A44 clause 1 — renderFlow ∘ parseFlow = id on every from × scope × shape × tables`` () =

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -460,7 +460,7 @@ let private liveDev = Destination.Live (ConnectionRef.EnvVar "DEV_CONN")
 let private baseLive = MovementSpec.forDestination liveDev
 let private defaultOpts : LoadOpts =
     { Declaration = DeclareNone; Emission = EmissionMode.Incremental
-      Reconcile = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None }
+      Reconcile = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None; SinkCapability = SinkLoadCapability.structural }
 
 [<Fact>]
 let ``planMovement: --fresh selects WipeAndLoad on the transfer path`` () =

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -154,6 +154,7 @@
     <Compile Include="ModelResolutionTests.fs" />
     <Compile Include="MovementSurfaceTests.fs" />
     <Compile Include="MovementIsomorphismTests.fs" />
+    <Compile Include="ArchetypeTests.fs" />
     <Compile Include="TransferRefusalTests.fs" />
     <Compile Include="ReverseLegPropertyTests.fs" />
     <Compile Include="ReverseLegBoundaryTests.fs" />
@@ -196,6 +197,7 @@
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />
     <Compile Include="ReverseLegStreamingTests.fs" />
+    <Compile Include="KeymapSpillTests.fs" />
     <Compile Include="RunWithConfigProfileTests.fs" />
     <Compile Include="DacpacWireTests.fs" />
     <Compile Include="DescriptionLiftTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -53,7 +53,7 @@ let ``reverse-leg face: a MALFORMED reconcile spec refuses by name (arg error, e
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "Customer" ] None   // no ':' — transfer.reconcile.specShape
-            false true false EmissionMode.Incremental false false None [] []
+            false true false EmissionMode.Incremental false false None [] SinkLoadCapability.structural []
     Assert.Equal(2, exit)
 
 [<Fact>]
@@ -65,7 +65,7 @@ let ``reverse-leg face: a reconcile spec naming an unknown table refuses by name
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "OSUSR_NOPE:ID" ] None   // table not in the contract — transfer.reconcile.tableNotFound
-            false true false EmissionMode.Incremental false false None [] []
+            false true false EmissionMode.Incremental false false None [] SinkLoadCapability.structural []
     Assert.Equal(2, exit)
 
 [<Fact>]
@@ -77,7 +77,7 @@ let ``reverse-leg face: a WELL-FORMED resolvable reconcile spec is ACCEPTED (no 
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "OSUSR_B_CUSTOMER:ID" ] None   // resolves to MatchByColumn (Id)
-            false true false EmissionMode.Incremental false false None [] []
+            false true false EmissionMode.Incremental false false None [] SinkLoadCapability.structural []
     // Past the parse/resolve gate the run reaches connection-opening, which
     // fails on the unset env vars — a connection-class exit, NEVER the arg/
     // resolve exit 2. The point: reconcile is no longer refused at the face.
@@ -85,8 +85,14 @@ let ``reverse-leg face: a WELL-FORMED resolvable reconcile spec is ACCEPTED (no 
 
 // -- the realization SELECTOR: the best admissible realization, chosen pure --
 
+// The selector helper defaults `sinkResidentResumeAvailable = false` (the
+// ManagedDml / undeclared sink — byte-identical to the pre-Slice-C cloud shape);
+// the FullRights (`true`) fork is pinned by its own Slice-C2 cell below.
 let private choose emission resumable tables streamingRequested journal =
-    Projection.Pipeline.ReverseLegRealization.choose emission resumable tables streamingRequested journal
+    Projection.Pipeline.ReverseLegRealization.choose emission resumable tables streamingRequested journal false
+
+let private chooseOn emission resumable tables streamingRequested journal sinkResidentResume =
+    Projection.Pipeline.ReverseLegRealization.choose emission resumable tables streamingRequested journal sinkResidentResume
 
 [<Fact>]
 let ``selector: an admissible request streams AUTOMATICALLY — the dominant realization needs no flag`` () =
@@ -121,6 +127,21 @@ let ``selector: an EXPLICIT --streaming on an inadmissible request refuses BY NA
     Assert.Equal("transfer.reverseLeg.streamingTablesUnsupported", codeOf (choose EmissionMode.Incremental false [ "Customer" ] true None))
     Assert.Equal("transfer.reverseLeg.streamingResumableUnsupported", codeOf (choose EmissionMode.Incremental true [] true None))
     Assert.Equal("transfer.reverseLeg.streamingWipeUnsupported", codeOf (choose EmissionMode.WipeAndLoad false [] true None))
+
+[<Fact>]
+let ``Slice C2: the resume chooser reads the sink archetype — a FullRights sink ADMITS streaming+resumable on the materialized envelope; ManagedDml still refuses`` () =
+    let codeOf r = match r with Error (es: ValidationError list) -> (List.head es).Code | Ok _ -> "OK"
+    // ManagedDml / undeclared (sinkResidentResume = false): the cloud-shaped
+    // refusal stands — the data grant forbids the CREATE TABLE a sink-resident
+    // progress table needs (byte-identical to the pre-Slice-C selector).
+    Assert.Equal("transfer.reverseLeg.streamingResumableUnsupported", codeOf (chooseOn EmissionMode.Incremental true [] true None false))
+    // FullRights (sinkResidentResume = true): the sink CAN host the G10
+    // sink-resident progress table, so --resumable is HONORED on the
+    // materialized envelope (the path that carries sink-resident resume) — the
+    // archetype-correct admission, not the cloud-shaped refusal.
+    match chooseOn EmissionMode.Incremental true [] true None true with
+    | Ok Projection.Pipeline.ReverseLegRealization.Materialized -> ()
+    | other -> Assert.Fail(sprintf "expected Materialized (sink-resident resume admitted), got %A" other)
 
 [<Fact>]
 let ``selector: --journal on an inadmissible request refuses by name — the ledger belongs to the streaming realization`` () =
@@ -175,7 +196,7 @@ let ``streaming face: an explicit --streaming with --tables refuses at the face 
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [] None
-            false true false EmissionMode.Incremental false true None [ "Customer" ] []
+            false true false EmissionMode.Incremental false true None [ "Customer" ] SinkLoadCapability.structural []
     Assert.Equal(2, exit)
 
 // -- reserved follow-on contracts (Skip stubs with promotion triggers) --------

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegCanaryTests.fs
@@ -376,6 +376,60 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         [ ("inv-1", Some "alice@x"); ("inv-2", None); ("inv-3", Some "bob@x") ], aInvCust)
                 })
 
+    // ------------------------------------------------------------------
+    // Slice C1 — the FullRights populate fork: PreferPreservedKeys writes
+    // the SOURCE key directly (Bulk.copyRows + KeepIdentity) for IDENTITY
+    // PKs too, so the whole capture/remap/FK-repoint machinery is skipped.
+    // The exact INVERSE of the keystone above: every key preserved (not
+    // minted), zero AssignedBySink, joins still hold. Witnesses the work
+    // plan's Slice C exit test on the same multi-kind graph.
+    // ------------------------------------------------------------------
+
+    [<Fact>]
+    member this.``Slice C1: a FullRights populate (PreferPreservedKeys) preserves every source key — zero remap, joins hold — the inverse of the AssignedBySink keystone`` () =
+        if not (ReverseLegFixtures.skipIfNoDocker "L3SliceC1") then () else
+        this.WithReverseLegEstates "L3SliceC1" ReverseLegFixtures.seedClean
+            (fun src _ sink _ logicalContract physicalContract ->
+                task {
+                    let! reportR =
+                        Transfer.runWithRenamesWith IdentityPolicy.PreferPreservedKeys Transfer.Execute true src sink logicalContract physicalContract
+                    let report = ReverseLegFixtures.value reportR
+
+                    // The fork: EVERY kind is PreservedFromSource — the source key
+                    // is written directly, NOT minted. No capture, no remap, no
+                    // FK re-point (the dramatically simpler load); nothing skipped.
+                    Assert.Equal(4, report.Kinds.Length)
+                    for k in report.Kinds do
+                        Assert.Equal(IdentityDisposition.PreservedFromSource, k.Disposition)
+                    Assert.Empty(report.SkippedReferences)
+
+                    // Every source key (>= 1000) is PRESERVED in the sink — the
+                    // INVERSE of the keystone (AssignedBySink ⇒ preservedKeyCount = 0).
+                    // 2 + 3 + 3 + 4 = 12 rows, each carrying its source identity.
+                    let! preserved = ReverseLegFixtures.preservedKeyCount sink
+                    Assert.Equal(12, preserved)
+
+                    let! customers = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_CUSTOMER]"
+                    let! accounts  = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_ACCOUNT]"
+                    let! invoices  = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_INVOICE]"
+                    let! payments  = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_PAYMENT]"
+                    Assert.Equal(2, customers)
+                    Assert.Equal(3, accounts)
+                    Assert.Equal(3, invoices)
+                    Assert.Equal(4, payments)
+
+                    // Joins hold: every FK edge's business-key join in A equals B's
+                    // — the FK values stayed valid because the keys were preserved
+                    // (no re-point needed). Nothing dropped, so no `minusOrphan`.
+                    let! (bAccCust, bInvAcc, bInvCust, bPayInv, bPayAcc) = ReverseLegFixtures.sourceEdgeJoins src
+                    let! (aAccCust, aInvAcc, aInvCust, aPayInv, aPayAcc) = ReverseLegFixtures.sinkEdgeJoins sink
+                    Assert.Equal<(string * string option) list>(bAccCust, aAccCust)
+                    Assert.Equal<(string * string option) list>(bInvAcc, aInvAcc)
+                    Assert.Equal<(string * string option) list>(bInvCust, aInvCust)
+                    Assert.Equal<(string * string option) list>(bPayInv, aPayInv)
+                    Assert.Equal<(string * string option) list>(bPayAcc, aPayAcc)
+                })
+
     [<Fact>]
     member this.``LE-3 apparatus: the same full-shape leg through runReverseLegThroughConnections, and a WipeAndLoad re-run leaves no duplicates`` () =
         if not (ReverseLegFixtures.skipIfNoDocker "L3Apparatus") then () else

--- a/sidecar/projection/tests/Projection.Tests/ViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ViewTests.fs
@@ -128,10 +128,10 @@ let ``Capability survey: covered / missing / unreachable / no-gate each read pla
         { Found = true; EmailKeyed = true; TableName = Some "dbo.OSSYS_USER" }
     let absentDir = Projection.Adapters.Sql.ReadSide.UserDirectoryProbe.absent
     let reports : CapabilitySurvey.EnvironmentReport list =
-        [ { Name = "cloud-uat"; Grant = Some Grant.SchemaAndData; Required = Set.empty; Connected = true;  Reachable = true;  Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = emailKeyed }
-          { Name = "prod";      Grant = Some Grant.DataOnly;      Required = Set.empty; Connected = true;  Reachable = true;  Missing = [ CapabilitySurvey.Performs Preflight.Insert ]; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir }
-          { Name = "stale";     Grant = Some Grant.DataOnly;      Required = Set.empty; Connected = true;  Reachable = false; Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir }
-          { Name = "onprem";    Grant = None;                     Required = Set.empty; Connected = false; Reachable = false; Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir } ]
+        [ { Name = "cloud-uat"; Grant = Some Grant.SchemaAndData; Required = Set.empty; Connected = true;  Reachable = true;  Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = emailKeyed; ArchetypeFindings = [] }
+          { Name = "prod";      Grant = Some Grant.DataOnly;      Required = Set.empty; Connected = true;  Reachable = true;  Missing = [ CapabilitySurvey.Performs Preflight.Insert ]; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir; ArchetypeFindings = [] }
+          { Name = "stale";     Grant = Some Grant.DataOnly;      Required = Set.empty; Connected = true;  Reachable = false; Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir; ArchetypeFindings = [] }
+          { Name = "onprem";    Grant = None;                     Required = Set.empty; Connected = false; Reachable = false; Missing = []; GrantUnreadable = false; CdcTracked = false; CdcProbeFailed = false; UserDirectory = absentDir; ArchetypeFindings = [] } ]
     let p = plain (TtyRenderer.buildSurveyView reports)
     Assert.Contains("grant covered", p)        // cloud-uat — covered
     Assert.Contains("users email-keyed", p)    // cloud-uat — P10 user-directory fragment


### PR DESCRIPTION
Builds the four archetype slices (A -> C -> S -> B) per `REVERSE_LEG_WORK_PLAN.md`, on the shipped reverse-leg engine and the locked two-flow / two-archetype model (PR #616). The target's capability **class** becomes a first-class, closed, reusable config disposition that drives - and the survey **verifies** - how the pipeline may safely interact with each sink. Each slice: a named mechanism, a gate, and a warm witness. Canonical record: `DECISIONS.md` 2026-06-15 "Slice A/C/S/B".

## The slices

**A - `Archetype` as a config disposition (byte-identical foundation).** `type Archetype = FullRights | ManagedDml` + `CapabilityProfile.of` (one total expansion site) + `ResumeKind`/`WipeKind` carriers. `Environment.Archetype` is stored **declared-only** with lazy `effectiveArchetype` inference, so existing configs render byte-identically and `parse o render = id` holds; `Grant` becomes a derived projection (a bijection). _Witness: 43 pure._

**C - the FullRights populate forks (live-wired end-to-end).** The disposition fork lives at one pure seam - `DataLoadPlan.buildWith PreferPreservedKeys` flips IDENTITY-PK kinds to `PreservedFromSource`, and the engine's **existing** per-disposition branches (`Bulk.copyRows` + `KeepIdentity`, gated to FullRights by its implicit ALTER) carry it: zero capture/remap/FK-repoint. Threaded through a Core `SinkLoadCapability` carrier (the compile-order wall), with additive `*With` variants keeping 60+ existing callers byte-identical. C2: `ReverseLegRealization.choose` reads the archetype. _Witness: pure (zero AssignedBySink remains) + Docker (every source key preserved, `preservedKeyCount = 12` - the inverse of the keystone's 0; joins hold)._

**S - the at-scale keymap spill (armed-but-inert).** `KeymapSpill.fs`: a session `#`-temp keymap + server-side `UPDATE...JOIN` re-point + a pure threshold chooser. _Witness: pure chooser + a Docker equivalence canary proving the spilled re-point byte-identical to the resident one._ **One honest boundary:** the sizing proves the resident map fits at production (~4-8 GB at 200M, much less than 64 GB), so per the work plan it ships inert (default off, byte-identical). The mechanism is built and equivalence-proven; the live streaming **hot-loop cutover** is the named follow-on, deliberately left out to keep the green baseline untouched for a feature the scale does not yet need.

**B - the survey verifies the archetype (A44 - the J5 covenant generalized).** `requiredBy` routes through `archetype.Grant` (byte-identical); `reconcileArchetype` surfaces declared-vs-probed divergences **by name** - FullRights-missing-DDL = mismatch, **FullRights-minus-DMV = the surfaced split** (the real on-prem case), ManagedDml-permitting-IDENTITY_INSERT = surfaced - only on an _explicitly declared_ archetype. _Witness: 31 pure incl. the totality guard._

## Verification (warm, real execution)

- **Pure:** 389 green across all touched areas + the registry / axiom / pillar-9 guards, 0 failures.
- **Docker:** 64 green across every changed path (ReverseLegCanary 13 incl. the C1 witness, Migrate + Streaming 29, Transfer 21, the S equivalence canary 1) - **+2 over the prior 62 baseline**, confirmed by per-test durations.

## Notes

- Based on current `main` (PR #616); `DECISIONS.md` cleanly appends the four `Slice * BUILT` entries after #616's entries (no overlap). `REVERSE_LEG_WORK_PLAN.md` is already on main via #616 and is not re-touched here.
- Per R6, the survey gate stays **advisory** (warn, never hard-stop); V2 still emits-but-doesn't-ship.

## Suggested next steps

1. The Slice S streaming hot-loop cutover (the one staged follow-on).
2. The real-wire run + throughput bench against the on-prem FullRights-minus-DMV target.

[Generated with Claude Code]
