### PR TITLE
docs(projection): reconcile THE_VECTOR against main + add execution kickoff

### DIFF
--- a/sidecar/projection/THE_VECTOR.md
+++ b/sidecar/projection/THE_VECTOR.md
@@ -4,7 +4,9 @@
 
 > **Companion.** This is the executive edition. The full annals — all nine lenses with their sixty-one
 > methodologies, the complete construct catalogue, the three adversarial verdicts, and the entire 123-row ranked
-> recommendation table — are in [`THE_VECTOR_UNABRIDGED.md`](THE_VECTOR_UNABRIDGED.md).
+> recommendation table — are in [`THE_VECTOR_UNABRIDGED.md`](THE_VECTOR_UNABRIDGED.md). **To *execute* this plan,**
+> see [`THE_VECTOR_EXECUTION_KICKOFF.md`](THE_VECTOR_EXECUTION_KICKOFF.md) — the operational contract (read order ·
+> environment scars · surface map · the gated wave plan).
 >
 > **What this is.** A planning masterwork: given the engine's concerns, the effective methodologies of
 > improvement that ameliorate the *quality of its execution* in service of the larger flows its verbs and
@@ -28,9 +30,67 @@
 >
 > **One standing fact for this reading.** The Reverse-Leg DML execution backlog is treated as **done** — the
 > movement engine (streaming, `CaptureJournal`, MERGE-OUTPUT sink-minting, packed surrogate remap,
-> `MigrationRun.execute`) is shipped, even where the tree does not yet reflect it. The interesting question is
+> `MigrationRun.execute`) has since **landed on `main`** (Phases 2–5, 2026-06-15) — the bracket is now realized in code, with a new *database-archetype* model alongside it; see the **Reconciliation addendum** immediately below. The interesting question is
 > not *build it* but *what its completion has now made ready to cash* — and, sharper, *what it has now made it
 > possible to corrupt in silence.*
+
+---
+
+## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
+
+> Written against `db01c23d`; `main` has since advanced 19 commits (PR #613 — this study — among them, now
+> merged). The reconciliation is **focused, and the core is intact.** Per the house amendment discipline this is
+> recorded as a dated note, not a silent rewrite of the body.
+
+**Still valid, verified byte-for-byte.** The keystone and every honesty finding hold: `PhysicalSchema.fs`
+(`PhysicalForeignKey` still has no `IsTrusted`; `ofCatalog` still takes no `DecisionOverlay`), `Tolerance.fs`
+(still exactly 8 variants, all `@ladder` Schema/Data — zero Decision/Identity/Time), `NORTH_STAR.matrix.generated.md`
+(still L1 5/5 · L2 4/5), and `AXIOMS.md`/`AxiomTests.fs` (no drift) are unchanged on main; the counts (112
+citations, 42 Skips, seven emitter targets) stand. **M1 (the keystone) is still unbuilt and still the
+highest-leverage move; Wave 0's honesty moves are still unbuilt and still first.**
+
+**The reverse leg is no longer a bracket — it landed (Phases 2–5).** What the standing-fact note treated as "done
+even though the tree won't reflect it" is now realized in code, and two claims move:
+
+- **NM-31 is CLOSED.** The streaming write engine gained a real reconcile leg
+  (`TransferRun.runStreamingReconcilingWithRenames` + the streaming `validateUserMap` pre-write halt, AC-I5
+  sink-untouched); `ReverseLegRealization.choose` now honors `--resumable` via `sinkResidentResumeAvailable`. The
+  "streaming arm has no reconcile leg / `choose` presents a false symmetry" claim (§2.3) is **retired** — its
+  docstrings now read "NM-31 — CLOSED." *The two-write-engine duplication itself still stands — Phase 2 added
+  capability, it did not unify the engines, so that compression candidate holds.*
+- **Resume / idempotency / dry-run hardened** (Phase 3: a streaming `--execute` without `--journal` is refused by
+  name; a journal-address-drift guard. Phase 4: a `COUNT_BIG` DryRun row-count preview). *This makes `M3` (the
+  real-wire swept change-algebra proof) more ready than the study assumed: the real inverse leg now exists **and
+  is hardened + witnessed** (reconcile + resume + dry-run), so the in-process→on-substrate promotion is a backend
+  swap, not a build.*
+
+**A new disposition the study did not anticipate: the database *archetype*.** `DATABASE_ARCHETYPES.md` +
+`MovementSurface.fs` introduce `Archetype = FullRights | ManagedDml` — the target's *capability class* lifted from
+scattered implicit behaviors into one closed DU that expands at a single total site (`CapabilityProfile.of`), with
+`Grant` demoted to a *derived projection* (`Archetype.grant ∘ ofGrant = id`, round-tripped) and reconciled against
+probed evidence (`CapabilitySurvey.reconcileArchetype → ArchetypeFinding`). It bears on the study two ways:
+
+- It **partially retires the Permissions inverse-space finding** (§5.1 / `C1.F3` — "permissions are *gated* but
+  not an axis"): the capability *disposition* is now typed, declared, projected, round-tripped, and verified. *The
+  residual gap stands:* grants/roles/RLS as projected/diffed Catalog **content** are still absent — the archetype
+  names *what the engine may do to a target*, not *what grants live on its objects*.
+- It is a **worked example of Convergence 3** (convention → typed disposition, §3.2): exactly the move the study
+  recommends, executed independently on the capability axis — closed DU + one total expansion site + a round-trip
+  law + a reconciliation finding. The thesis is being lived — and `CapabilityProfile.of` is now the **in-repo
+  precedent to copy** for `M4` (`ConstraintState`) and the Kind-V fitness functions (closed DU → one total
+  expansion site → derived projection → round-trip law → reconciliation finding).
+
+**Minor cited-detail drift.** NM-58 added `Reconciliation.ReconciledIdentity.AmbiguousTargetKeys` (blank-key
+exclusion + duplicate-target tiebreaker), surfaced as `TransferReport.AmbiguousTargetMatchKeys`. No axiom or
+tolerance drift.
+
+**Landed, at rest — not a concurrent track.** The archetype slices (A → C → S → B, per `REVERSE_LEG_WORK_PLAN.md`
++ the 2026-06-15 `DECISIONS.md` entries) are **merged and idle**; there is no in-flight program to coordinate
+with, so the VECTOR roadmap proceeds freely. They matter here only as **landed precedent**: they sit on surfaces
+largely disjoint from this study's (`MovementSurface`/`TransferRun`/`KeymapSpill` vs `PhysicalSchema`/`Tolerance`/
+the matrix), and where a VECTOR move does touch a surface the archetype work recently extended (`SurrogateRemap.fs`
+now carries `IdentityPolicy`; `CapabilitySurvey.fs` now carries `reconcileArchetype`), read that file's current
+shape first so the change composes with the landed work.
 
 ---
 
@@ -259,7 +319,7 @@ will show the *fix* the chorus first proposed for it was wrong; the genuine resi
 only. Second, **two near-identical write engines** (`writePlan` materialized-with-reconcile vs
 `writePlanStreaming` bounded-memory-no-reconcile) duplicate the two-phase orchestration across row carriers — a
 clean compression candidate, and the reason the streaming arm cannot yet offer the sink-untouched guarantee
-(NM-31). Third, **`compose` recomputes `between` twice**, discarding the channel structure it already holds —
+(NM-31 — **closed 2026-06-15**; the streaming arm now has a reconcile leg, see the Reconciliation addendum). Third, **`compose` recomputes `between` twice**, discarding the channel structure it already holds —
 an O(N log N) re-derivation where a true torsor `+` would patch the channels (§4 picks this up).
 
 ### 2.4 Policy, the decision algebra, and the silent fifth column

--- a/sidecar/projection/THE_VECTOR_EXECUTION_KICKOFF.md
+++ b/sidecar/projection/THE_VECTOR_EXECUTION_KICKOFF.md
@@ -1,0 +1,207 @@
+# THE VECTOR — Execution Kickoff
+
+### The operational contract for implementing the treatise (for the next agent + its agent teams)
+
+> **What this is.** The executable companion to `THE_VECTOR.md` (executive) and `THE_VECTOR_UNABRIDGED.md` (full
+> annals). Those two derive *what* to do and *why*; this one is *how to run it*: the read order, the environment
+> scars, the guardrails, the surface map, the orchestration shape, the per-move definition of done, and the gated
+> wave plan. Read the two treatises (their `Reconciliation addendum — 2026-06-15` first), then this.
+>
+> **You are authorized to orchestrate.** This task is explicit opt-in to multi-agent orchestration: **author and
+> run `Workflow`s** (one per wave or move-cluster) with teams of subagents. (If a session reminder says ultracode
+> is off, treat *this authorization* as the standing opt-in for the VECTOR work.) Do not re-derive the analysis —
+> it is done, adversarially verified, and gated. Implement from the specs.
+
+---
+
+## §0 — The situation (read this first)
+
+- **The core analysis is intact and verified on `main` (2026-06-15).** The keystone surfaces are unchanged:
+  `PhysicalSchema.fs` (`PhysicalForeignKey` has no `IsTrusted`; `ofCatalog` takes no `DecisionOverlay`),
+  `Tolerance.fs` (exactly 8 variants, all `@ladder` Schema/Data — zero Decision/Identity/Time),
+  `NORTH_STAR.matrix.generated.md` (L1 5/5 · L2 4/5), `AXIOMS.md`/`AxiomTests.fs` (no drift). The counts hold
+  (112 citations, 42 Skips, seven emitter targets). **Every move below is still live.**
+- **The reverse-leg DML engine has landed** (Phases 2–5, merged): NM-31 closed (the streaming arm has a reconcile
+  leg), resume/idempotency/dry-run hardened. *Build on it, not it.* It makes **`M3`** (the real-wire swept proof)
+  more ready than the treatise assumed — the real inverse leg now exists and is witnessed.
+- **The database-archetype work has landed and is at rest** (`Archetype = FullRights | ManagedDml`,
+  `CapabilityProfile.of`, `KeymapSpill.fs`, `reconcileArchetype`). **It is NOT a concurrent program** — there is
+  no in-flight track to coordinate with, and you may edit any surface freely. It matters to you two ways: (1) as a
+  **precedent to copy** (§4), and (2) because two files it extended overlap a VECTOR move — read their current
+  shape before editing (§5).
+
+## §1 — Read order (≈45 min, before any code)
+
+1. `KICKOFF.md` — the five-minute brief.
+2. `THE_VECTOR.md` + `THE_VECTOR_UNABRIDGED.md`, **addendum first**, then §6/§7 (executive) or Parts VII/VIII
+   (unabridged): the toolbox (M1–M20) and the gated wave roadmap.
+3. `THE_USE_CASE_ONTOLOGY.md` — the target index (the move alphabet, the laws T12–T16 + A43).
+4. `AXIOMS.md` + `tests/Projection.Tests/AxiomTests.fs` — run
+   `dotnet test --filter "FullyQualifiedName~AxiomTests"`; do not trust restated counts anywhere.
+5. `DECISIONS.md` — the operating-disciplines index + the **Active deferrals** index + the 2026-06-15 entries.
+6. `CLAUDE.md` §4 (survival rules) + §5 (the load-bearing commitments).
+7. `DATABASE_ARCHETYPES.md` §1–§2 — the precedent you will copy for `M4`/`M15`.
+
+## §2 — Environment & build discipline (the scars that will bite you today)
+
+- **⚠️ Docker tests SILENTLY NO-OP on this Windows box.** `DockerDaemon.ensureRunning()` checks a *Linux* socket,
+  so every `EphemeralContainerFixture` test passes as a ~0.4 ms `()` no-op **unless** the warm-container conn is
+  set: `$env:PROJECTION_MSSQL_CONN_STR="Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+  (`scripts/warm-sql.sh conn` prints it). **Confirm via per-test TRX durations in seconds, never the green count**
+  (this is survival-rule #12 in operational form). The keystone (`M1`) and `M3` have Docker-gated witnesses — this
+  *will* matter.
+- **`dotnet` is not on the bash PATH** — it lives at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe`.
+  Build and test via **PowerShell**.
+- **Never run the pure + Docker pools in one `dotnet test`** — it OOM-kills the host. Use `scripts/test.sh`
+  (`fast` / `docker` / `canary` / `focus <name>` / `all`). **CDC test classes use `IsolatedContainerFixture`**
+  (`sp_cdc_enable_db` flips instance-wide state — never on the warm container).
+- The scripts you will lean on: `scripts/test.sh`, `scripts/warm-sql.sh`, `scripts/matrix-status.sh` (regenerates
+  `NORTH_STAR.matrix.generated.md`), `scripts/verifiability-gate.sh` (the phantom-coverage gate),
+  `scripts/run-analyzers.sh`, `scripts/perf-gate.sh`. Each is its own documentation.
+- **FS3511 in Release**: no `let rec` / tuple-`let!` / tuple-pattern-`for` inside `task { }` — hoist helpers,
+  bind single values. **`[<Literal>]` only on CLR primitives** (`[<Literal>] decimal` detonates at module load).
+  At any `{ X.create … with … }` site, **count the fields** — omitted fields silently inherit ctor defaults with
+  no warning.
+- **A perf-gate verdict is VOID if anything else runs on the host** — run it solo before believing a regression,
+  and re-record the baseline only with a DECISIONS amendment.
+
+## §3 — Non-negotiable guardrails (hard constraints)
+
+- **Honesty before features.** Execute **Wave 0 first.** Never build atop an over-claim.
+- **Every `AXIOMS.md` change carries its `AxiomTests.fs` witness in the same commit.** Every new erasure is a
+  closed-DU `ToleratedDivergence` variant with its `@ladder` tag — never a silent drop.
+- **Pure core** (zero I/O, no clock, no `Task`/`Async`, no module-level mutable except `Bench`); **A18** (Π never
+  takes `Policy`); **typed-AST-first** (no `StringBuilder` for SQL/JSON/XML); **determinism is constructed** (sort
+  by `SsKey`; byte-identical output is T1). Any curried-prefix `DecisionOverlay`/overlay argument **defaults to
+  `empty` and must preserve byte-identity at `empty`** — guard with the existing T1 goldens (`GoldenEmissionTests`).
+- **IR-grows-under-evidence: do NOT build the deferred moves** (§10). A feature that is not a corollary of the
+  adjunction with a fired trigger is the wrong feature.
+- **Total decisions, named refusals, downgrades never silent.** The cutover-safety commitments (R6, the T-30/T-15
+  ladder, V1 stays warm) do not loosen.
+
+## §4 — The landed precedent to copy
+
+The archetype work just demonstrated the exact discipline several VECTOR moves require — copy it rather than
+inventing a shape:
+
+- **For `M4` (`ConstraintState` DU) and the `M15` fitness functions — copy `CapabilityProfile.of`.** The archetype
+  is a **closed DU** that **expands at one total site** (`CapabilityProfile.of` in `MovementSurface.fs`) into a
+  per-capability bundle, with the coarse legacy facet (`Grant`) demoted to a **derived projection**
+  (`Archetype.grant ∘ ofGrant = id`, round-tripped in `ArchetypeTests.fs`) and **reconciled against probed
+  evidence** (`CapabilitySurvey.reconcileArchetype → ArchetypeFinding`). That is precisely the move `M4` makes for
+  `(HasDbConstraint, IsConstraintTrusted)` → `ConstraintState`, and the shape `M15`'s in-assembly Facts should
+  take. The pattern, end to end, is in the repo now.
+- **For `M1` (the keystone) — copy the curried-overlay-defaulting-to-`empty` discipline.** The SSDT emitter is
+  already overlay-curried and byte-identical at `DecisionOverlay.empty` (slice-2.2 T1 test). Symmetrize the
+  *reader-side* projection (`PhysicalSchema.ofCatalog`) the same way: `ofCatalog : DecisionOverlay -> Catalog ->
+  PhysicalSchema`, default `empty`, byte-identical guard. `ReadSide.fs:1171` already recovers `is_not_trusted` —
+  the read leg is free.
+- **For the private-ctor / closed-DU laws generally** — the house derive-macro (`private` + smart ctor +
+  `[<RequireQualifiedAccess>]`) is enumerated in `CONSTELLATION.md` §9.8.9; `ArtifactByKind` and now `Archetype`
+  are the worked examples.
+
+## §5 — Surface map (which files each move touches)
+
+Most moves are on surfaces disjoint from the recently-landed work, so you can fan out freely. The **only two files
+to read in their current shape before editing** (because the archetype work extended them) are flagged ⚠.
+
+| Move(s) | Primary surfaces |
+|---|---|
+| `M1` keystone | `Projection.Core/PhysicalSchema.fs`, `Projection.Targets.SSDT/PhysicalSchemaReader.fs`; tests `CanaryRoundTripTests.fs` / `DecisionEmissionTests.fs` / `AdjunctionLawTests.fs` |
+| `M1′` / `M2` tolerances | `Projection.Core/Tolerance.fs`, `Projection.Targets.SSDT/Render.fs` (the `CreateTrigger` skip), `Projection.Core/CanaryResidual.fs`; regen via `scripts/matrix-status.sh` |
+| `M3` swept proof | `tests/.../CatalogCodecTests.fs` (`catalogGen → genCatalogPair`), a new property file, `AxiomTests.fs` |
+| `M7`/`M11`/`M12`/`M13` algebra | `Projection.Core/CatalogDiff.fs` |
+| `M5` digest | `Projection.Core/VersionedPolicy.fs` |
+| `M8` JSON seam | `Projection.Targets.Json/*`, a shared writer helper in Core or `Targets.Json` |
+| `M9` binding algebra | `Projection.Pipeline/*Binding.fs`, `Pipeline.fs` |
+| `M6` `[<Struct>]` surrogate keys ⚠ | `Projection.Core/SurrogateRemap.fs` — **now also carries `IdentityPolicy`/`SinkLoadCapability` (archetype Slice C); read it first** |
+| `M15`/`M17` fitness + totality ⚠ | `tests/Projection.Tests/`, `Projection.Analyzers/`, `scripts/run-analyzers.sh`, CI config; `Projection.Pipeline/CapabilitySurvey.fs` — **now also carries `reconcileArchetype`/`ArchetypeFinding`; read it first** |
+| `M16` citation gate + matrix binding | `AxiomTests.fs`, `scripts/matrix-status.sh`, `scripts/verifiability-gate.sh`, `AXIOMS.md`/`PRODUCT_AXIOMS.md` |
+| `M18` `toJson` | `Projection.Pipeline/ReportRun.fs`, a JSON codec in `Targets.Json` |
+| `M4` `ConstraintState` | `Projection.Core/Catalog.fs` + the catalog codec — **behind the persisted-state-migration story** |
+| `M14` `Traversal` | `Projection.Core/Optics.fs`, `Catalog.fs` — **gated on the compile-order split** |
+
+## §6 — Orchestration shape (per wave)
+
+1. **Scout** the wave's moves against live code (one read-only pass): confirm each move's surfaces, the exact
+   witness test it must turn green, and whether that witness is pure or Docker-gated.
+2. **Fan out** the **independent** moves to implementer agents, each in its **own git worktree**
+   (`isolation: "worktree"`) so parallel edits never conflict. **Serialize** moves that share a file (e.g. the
+   several `CatalogDiff.fs` moves `M7`/`M11`/`M12`/`M13`; the `Tolerance.fs` moves `M1′`/`M2`).
+3. **Adversarially verify** each move as it lands — the same discipline that built the treatise: build green
+   (warm, per §2) + the **named witness test green** + `scripts/matrix-status.sh` regenerated + `verifiability-
+   gate.sh` clean. Default the verifier to skeptical; a move is done only when its witness is a live green test or
+   a regenerated artifact, **never a judgment**.
+4. **Wave-close** (one integrator agent): merge the worktrees, run the relevant suite warm, perform the
+   chapter-close ritual (§7), and confirm the wave's exit criterion.
+
+## §7 — Per-move definition of done + the chapter-close ritual
+
+**A move is done when** all hold: (a) the named **witness test is live and green** (and its citation is registered
+so `M16`'s gate will check it); (b) the build is clean in Release; (c) if it added/changed an axiom, the
+`AxiomTests.fs` entry is in the **same commit**; (d) if it added an erasure, a closed `ToleratedDivergence` variant
++ `@ladder` tag exists and `scripts/matrix-status.sh` regenerated the matrix; (e) `verifiability-gate.sh` is clean;
+(f) if it touched a `Bench`-labelled hot path, the perf-gate is green (run solo).
+
+**The chapter-close ritual (per wave):** regenerate the matrix and confirm the intended cell moved (or is honestly
+capped); write the `AXIOMS.md`/`Tolerance.fs` amendments and a `DECISIONS.md` entry naming the wave; **prepend** a
+forward-looking top letter to `HANDOFF.md` (never overwrite); update `CLAUDE.md` only if a Tier-1 surface changed
+ownership; and re-verify the survival list. Then pause and report (§9).
+
+## §8 — The waves (Part VIII of the treatise — in order, gate between them)
+
+- **Wave 0 — Honesty & fitness** *(all S/M, no new capability; protects everything after).* `M1′`
+  (`DecisionNotReadBack`/`FkTrustUnreflected` tolerance) · `M2` (name the silent `CreateTrigger` drop) · `M16`
+  (`citationOf` existence gate + structural matrix binding) · `M15` (in-assembly fitness Facts; promote
+  `run-analyzers.sh` + the perf-gate to CI) · the count corrections (112/42/seven targets/linear-writer-only).
+  **Exit:** no green matrix cell is unfalsifiable-by-construction; the guardrails are in-assembly.
+- **Wave 1 — The keystone.** `M1` (`PhysicalForeignKey.IsTrusted` + overlay-aware `PhysicalSchema.ofCatalog` + the
+  decision-readback property; read leg free at `ReadSide.fs:1171`). **Auto-retires `M1′`.** **Exit:** the live
+  canary witnesses `NoCheckFk`/`EnforceUnique` survival.
+- **Wave 2 — Reversible algebra & real-wire proof.** `M11` (triangle-inequality theorem) · `M13` (drop the
+  vestigial `Result` on `between`) · `M12` (the ~3-line groupoid `inverse`) · `M3` (`genCatalogPair` + swept T16,
+  in-process backend first; the landed reverse leg supplies the real backend) · `M20` (transactionality
+  honest-naming half: `GateLabel.MidWriteNotProtected` + the pure gate — **not** the deferred live wrapper).
+  **Exit:** the groupoid laws green; the change algebra property-swept; the destructive failure mode a named refusal.
+- **Wave 3 — Compression & idiom.** `M7` (diff `ChannelSpec`) · `M8` (`JsonDocumentWriter` seam) · `M9` (FsToolkit
+  `validation { }` bindings + close the model-read/live divergence) · `M17` (totality functor) · `M6` (`[<Struct>]`
+  on `SourceKey`/`AssignedKey`, measure-then-promote) · `M19` (`[<Measure>] row`) · the `Changed → Reshaped`
+  rename. **Exit:** the descriptor-duplication retired; the riskiest config seam closed.
+- **Wave 4 — Corollary cashes & gated deepenings.** `M18` (`ChangeManifest.toJson`) · `M14` (`Traversal` optic —
+  only after the compile-order split is resolved) · `M4` (`ConstraintState` DU — **behind the persisted-state-
+  migration story**: name NM-34 as the store-codec contract; gate every serialized-form change) · `M5` (digest
+  projection). **Exit:** the CDC-norm machine-queryable; the store-migration checklist active.
+
+## §9 — The first move, and the cadence
+
+**Make `M1′ + M2` first** — the two cheapest moves (a handful of closed-DU variants). They cost almost nothing and
+immediately stop the engine over-claiming on three of five axes, restoring the one guarantee the whole epistemic
+spine rests on (*the generator under-claims, never over-claims*). Then **`M1`**, the real cash, which turns the
+honest tolerance back to an earned green. Honesty first, then the theorem.
+
+**Cadence:** treat each wave as a chapter — run its workflow, integrate, run the chapter-close ritual, then
+**pause and report** with the green-test/artifact evidence and the updated `HANDOFF.md` top letter before opening
+the next wave. Stay in the loop; do not silently chain all five waves.
+
+## §10 — Deferred-with-trigger (do NOT build)
+
+Honor the treatise's moat verbatim:
+
+| Deferred | Re-open trigger |
+|---|---|
+| Full `SchemaMove` unification | a real divergence between the four move enumerations fires (do only the zero-risk `Changed → Reshaped` rename) |
+| The live atomic `BEGIN TRAN` wrapper | the managed-login grant survey resolves (per `Preflight.fs`) |
+| `TighteningStrategy` descriptor (`M10`) | a fifth tightening intervention, or a divergence between the four |
+| DACPAC reader / second `Ingest` source | a second catalog source materializes |
+| Policy-version plane → Episode | a cross-run digest-comparison need + `M5` (digest stability) |
+| `LineageTree` consumer | a pass that genuinely branches its lineage materializes |
+| Permissions as a projected **content** axis | a flow must *publish* grants (the eject) — note the *capability* disposition already landed via the archetype |
+| Docker N≥20 real-wire FsCheck sweep | coverage-guided fixtures **or** an N≥20 container pool |
+| `EmitError` split into layer-scoped types | a second consumer needs the layer distinction |
+| Dead FK-config retirement | a DECISIONS amendment names the V1-parity obligation discharged |
+| ReadSide flat-synthesis change | an authored-schema *attribute* round-trip is shown to fail (then the fix is per-attribute extended-property emission, `M-equivalent L3.M6`, **not** changing the flat fallback) |
+
+---
+
+*Hold the spine. Name every refusal, count every crossing, and leave the books balanced. The treatise is the
+destination; this is the order of the steps.*

--- a/sidecar/projection/THE_VECTOR_UNABRIDGED.md
+++ b/sidecar/projection/THE_VECTOR_UNABRIDGED.md
@@ -23,9 +23,72 @@
 >
 > **The standing fact for this reading.** The Reverse-Leg DML execution backlog is treated as **done** — the
 > movement engine (streaming, `CaptureJournal`, MERGE-OUTPUT sink-minting, packed surrogate remap,
-> `MigrationRun.execute`) is shipped, even where the tree does not yet reflect it. The interesting question is
+> `MigrationRun.execute`) has since **landed on `main`** (Phases 2–5, 2026-06-15) — the bracket is now realized in code, with a new *database-archetype* model alongside it; see the **Reconciliation addendum** immediately below. The interesting question is
 > not *build it* but *what its completion has now made ready to cash* — and, sharper, *what it has now made it
 > possible to corrupt in silence.*
+
+---
+
+## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
+
+> Written against `db01c23d`; `main` has since advanced 19 commits (PR #613 — this study — among them, now
+> merged). The reconciliation is **focused, and the core is intact.** Per the house amendment discipline this is
+> recorded as a dated note, not a silent rewrite of the body.
+
+**Still valid, verified byte-for-byte.** The keystone and every honesty finding hold: `PhysicalSchema.fs`
+(`PhysicalForeignKey` still has no `IsTrusted`; `ofCatalog` still takes no `DecisionOverlay`), `Tolerance.fs`
+(still exactly 8 variants, all `@ladder` Schema/Data — zero Decision/Identity/Time), `NORTH_STAR.matrix.generated.md`
+(still L1 5/5 · L2 4/5), and `AXIOMS.md`/`AxiomTests.fs` (no drift) are unchanged on main; the counts (112
+citations, 42 Skips, seven emitter targets) stand. **M1 (the keystone) is still unbuilt and still the
+highest-leverage move; Wave 0's honesty moves are still unbuilt and still first.**
+
+**The reverse leg is no longer a bracket — it landed (Phases 2–5).** What the standing-fact note treated as "done
+even though the tree won't reflect it" is now realized in code, and two claims move:
+
+- **NM-31 is CLOSED.** The streaming write engine gained a real reconcile leg
+  (`TransferRun.runStreamingReconcilingWithRenames` + the streaming `validateUserMap` pre-write halt, AC-I5
+  sink-untouched); `ReverseLegRealization.choose` now honors `--resumable` via `sinkResidentResumeAvailable`. The
+  "streaming arm has no reconcile leg / `choose` presents a false symmetry" claim (§II.3) is **retired** — its
+  docstrings now read "NM-31 — CLOSED." *The two-write-engine duplication itself still stands — Phase 2 added
+  capability, it did not unify the engines, so that compression candidate (§V.1-adjacent) holds.*
+- **Resume / idempotency / dry-run hardened** (Phase 3: a streaming `--execute` without `--journal` is refused by
+  name; a journal-address-drift guard. Phase 4: a `COUNT_BIG` DryRun row-count preview). *This makes `M3` (the
+  real-wire swept change-algebra proof) more ready than the study assumed: the real inverse leg now exists **and
+  is hardened + witnessed** (reconcile + resume + dry-run), so the in-process→on-substrate promotion is a backend
+  swap, not a build.*
+
+**A new disposition the study did not anticipate: the database *archetype*.** `DATABASE_ARCHETYPES.md` +
+`MovementSurface.fs` introduce `Archetype = FullRights | ManagedDml` — the target's *capability class* lifted from
+scattered implicit behaviors into one closed DU that expands at a single total site (`CapabilityProfile.of`) to a
+per-capability bundle (`DdlPermitted`, `IdentityInsert`, `ResumeCheckpoint`, `WipeStrategy`…), with `Grant`
+demoted to a *derived projection* (`Archetype.grant ∘ ofGrant = id`, round-tripped in `ArchetypeTests.fs`) and
+reconciled against probed evidence (`CapabilitySurvey.reconcileArchetype → ArchetypeFinding`). The keymap-spill
+mechanism (`KeymapSpill.fs`) is archetype-determined (shipped armed-but-inert). It bears on the study two ways:
+
+- It **partially retires the Permissions inverse-space finding** (§VI.1 / `C1.F3` — "permissions are *gated* but
+  not an axis"): the capability *disposition* is now typed, declared (`Environment.Archetype` in
+  `projection.json`), projected, round-tripped, and verified — no longer "just a gate." *The residual gap stands:*
+  grants/roles/RLS as projected/diffed Catalog **content** (a `Grant` facet in the IR, `GRANT` in the `Statement`
+  DU, permission readback) are still absent — the archetype names *what the engine may do to a target*, not *what
+  grants live on its objects*.
+- It is a **worked example of Convergence 3** (convention → typed disposition, §IV.1): exactly the move the study
+  recommends, executed independently on the capability axis — closed DU + one total expansion site + a round-trip
+  law + a reconciliation finding. The thesis is being lived — and `CapabilityProfile.of` is now the **in-repo
+  precedent to copy** for `M4` (`ConstraintState`) and the Kind-V fitness functions (closed DU → one total
+  expansion site → derived projection → round-trip law → reconciliation finding).
+
+**Minor cited-detail drift.** NM-58 added `Reconciliation.ReconciledIdentity.AmbiguousTargetKeys` (blank-key
+exclusion + duplicate-target tiebreaker), surfaced as `TransferReport.AmbiguousTargetMatchKeys` — cite it if you
+enumerate the reconcile-report fields (Appendix C / §II.3). `ReverseLegRealization.choose` gained a
+`sinkResidentResumeAvailable` parameter. No axiom or tolerance drift.
+
+**Landed, at rest — not a concurrent track.** The archetype slices (A → C → S → B, per `REVERSE_LEG_WORK_PLAN.md`
++ the 2026-06-15 `DECISIONS.md` entries) are **merged and idle**; there is no in-flight program to coordinate
+with, so the VECTOR roadmap proceeds freely. They matter here only as **landed precedent**: they sit on surfaces
+largely disjoint from this study's (`MovementSurface`/`TransferRun`/`KeymapSpill` vs `PhysicalSchema`/`Tolerance`/
+the matrix), and where a VECTOR move does touch a surface the archetype work recently extended (`SurrogateRemap.fs`
+now carries `IdentityPolicy`; `CapabilitySurvey.fs` now carries `reconcileArchetype`), read that file's current
+shape first so the change composes with the landed work.
 
 ---
 
@@ -366,7 +429,7 @@ realization with a chunk-resume `CaptureJournal`, and CDC capture count as the d
 | `ChannelDiff<'change>` | `CatalogDiff.fs:62` | the one generic carrier (Added/Removed/Renamed/Changed) behind all five channels — four byte-identical records collapsed into one |
 | `Migration.plan / applyTo` | `Migration.fs` | the plan-time view + the pure T16 master equation; the `LossDeclaration` gate ranges over the complete `SchemaLoss` enumeration |
 | `MigrationRun.execute / executeWithData` | `MigrationRun.fs` | live `migrate A B`: emit→preflight→deploy→canary, `sp_rename`+ALTER minimum-viable touches, read-back B' and verify |
-| `Transfer.runCore` + `writePlan` / `writePlanStreaming` | `TransferRun.fs` | the data-direction adjunction leg; the two realizations (materialized-with-reconcile vs streaming-no-reconcile, NM-31) |
+| `Transfer.runCore` + `writePlan` / `writePlanStreaming` | `TransferRun.fs` | the data-direction adjunction leg; the two realizations (materialized vs streaming — both now reconcile-capable, NM-31 **closed 2026-06-15**) |
 | `SurrogateRemap` (`SourceKey`/`AssignedKey`, `remapRowFksWith`) | `SurrogateRemap.fs` | the generic identity-crossing carrier, A40-harmonized over an injected lookup |
 | `CaptureJournal` | `CaptureJournal.fs` | the client-side chunk-resume ledger; resume replays journaled pairs; drift refuses by name |
 | `ReadSide.read` | `ReadSide.fs` | the Ingest leg — best-effort, synthesizes attribute SsKeys, defaults V2-IR-only axes |
@@ -384,7 +447,7 @@ source a rename changes the key and lands in `Removed + Added` rather than `Rena
 *kind* identity from the V2.SsKey extended property, but attribute SsKeys still re-synthesize — so the residue is
 at the **attribute grain only** (§IV.3 will show why the chorus's first fix for this was wrong). Second, **two
 near-identical write engines** duplicate the two-phase orchestration across row carriers — a clean compression
-candidate, and the reason the streaming arm cannot yet offer the sink-untouched guarantee (NM-31). Third,
+candidate. (It was also the reason the streaming arm could not yet offer the sink-untouched guarantee — **NM-31, now closed 2026-06-15**; see the Reconciliation addendum.) Third,
 **`compose` recomputes `between` twice**, discarding the channel structure it already holds — an O(N log N)
 re-derivation where a true torsor `+` would patch the channels (Part V picks this up).
 


### PR DESCRIPTION
## Reconcile THE VECTOR against main + add the execution kickoff

A follow-up to #613 (the amelioration treatise, now merged). `main` advanced 19 commits since the docs were written; this PR reconciles them and adds the operational contract for implementation.

### The headline: the core analysis is intact, verified byte-for-byte
The keystone surfaces are **unchanged on main** — `PhysicalSchema.fs` (`PhysicalForeignKey` still has no `IsTrusted`; `ofCatalog` takes no `DecisionOverlay`), `Tolerance.fs` (8 variants, all `@ladder` Schema/Data), `NORTH_STAR.matrix.generated.md` (L1 5/5 · L2 4/5), `AXIOMS.md`/`AxiomTests.fs`, and the counts (112 citations, 42 Skips, seven targets). **M1 (the keystone) and Wave 0 (honesty) remain unbuilt and highest-leverage.**

### What moved (a dated `Reconciliation addendum` in both docs — amendment, not silent rewrite)
- **NM-31 CLOSED.** The streaming write arm gained a real reconcile leg (Phase 2) — the "streaming can't offer the sink-untouched guarantee" claim is retired; the relevant `(NM-31)` mentions are marked closed inline.
- **Resume / idempotency / dry-run hardened** (Phases 3–4) → makes **M3** (the real-wire swept change-algebra proof) *more ready* than the study assumed: the real inverse leg now exists and is witnessed, so the in-process→on-substrate promotion is a backend swap, not a build.
- **The database-archetype model landed** (`Archetype = FullRights | ManagedDml`, `CapabilityProfile.of`). It **partially retires the Permissions inverse-space finding** (`C1.F3` — the capability *disposition* is now typed, projected, round-tripped, and verified; the grants-as-Catalog-*content* axis remains absent), and it is a **worked example of the convention→typed-disposition thesis** — now the **in-repo precedent to copy** for `M4` (`ConstraintState`) and the Kind-V fitness functions.

### New: `THE_VECTOR_EXECUTION_KICKOFF.md`
The operational contract for the implementation agent and its teams: read order, the environment scars (Docker tests silently no-op without `PROJECTION_MSSQL_CONN_STR`; the `dotnet` path; never the pure+Docker pools in one run), the non-negotiable guardrails, the landed precedent to copy, a **per-move surface map** (the two files to read-current-shape-first because the archetype work extended them), the per-wave orchestration shape (worktree-isolated fan-out → adversarial verify → chapter-close), and the gated wave plan (**Wave 0 honesty first, then the keystone**). The archetype work is **landed and at rest** — no concurrent program, so the implementation proceeds freely.

### Notes for review
- Documentation only — **no code changes**.
- Diff against `main` is the single reconciliation commit (three files); the original treatise is already merged via #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
