### PR TITLE
THE VECTOR Wave 0 — honesty & fitness (M1′ · M2 · M16 · M15)

### DIFF
--- a/.github/workflows/analyzers-projection.yml
+++ b/.github/workflows/analyzers-projection.yml
@@ -1,0 +1,63 @@
+name: analyzers-projection
+
+# MOVE M15 (THE VECTOR, Wave 0 fitness) — promotes the custom
+# FSharp.Analyzers.SDK analyzer gate (`sidecar/projection/scripts/run-analyzers.sh`)
+# from opt-in/off-CI to a PR-blocking guardrail, mirroring the structure of
+# `lint-projection.yml` and `verifiability-projection.yml`.
+#
+# Today one analyzer ships (`Projection001NoUnsafeTimeInCore` — detects
+# `DateTime.Now` / `UtcNow` / `Guid.NewGuid` in `src/Projection.Core/`, the
+# determinism spine). The script builds the analyzer assembly + the consuming
+# projects, restores the pinned `fsharp-analyzers` tool, and runs the analyzer
+# against `Projection.Core`. As the analyzer set grows, the script's project
+# loop grows — this workflow needs no edit to track it.
+#
+# Unlike the two sibling guardrails (pure bash, no toolchain), this gate runs
+# `dotnet`, so it sets up the SDK explicitly:
+#   - .NET 9 (9.0.314) matches `sidecar/projection/global.json`'s pinned SDK
+#     (rollForward: disable), so the build uses the same compiler as local dev.
+#   - .NET 8 is also installed because the analyzer assembly + the
+#     `fsharp-analyzers` 0.30.0 tool target net8.0 (see
+#     `src/Projection.Analyzers/Projection.Analyzers.fsproj`); the tool's
+#     runtime must be present.
+#
+# NOTE — `scripts/perf-gate.sh` is DELIBERATELY NOT promoted here. The perf
+# gate's per-label timing verdict is only meaningful against a WARM, QUIET
+# host (the script itself soft-skips unless a warm SQL container is reachable);
+# a shared GitHub-hosted runner's CPU/IO contention voids the μ+σ timing
+# comparison (the script's own header documents the >2x cold/contended-host
+# inflation that false-trips the gate). Promote perf-gate to CI only behind a
+# DEDICATED / QUIET self-hosted runner (the named trigger), not a shared
+# ubuntu-latest — adding it here would be a flaky gate, not a fitness signal.
+
+on:
+  pull_request:
+    paths:
+      - 'sidecar/projection/**'
+      - '.github/workflows/analyzers-projection.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'sidecar/projection/**'
+
+jobs:
+  analyzers:
+    name: custom FSharp analyzers guardrail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET (9 SDK matching global.json + 8 runtime for the analyzer tool)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.314
+
+      - name: Run run-analyzers.sh
+        run: |
+          chmod +x sidecar/projection/scripts/run-analyzers.sh
+          sidecar/projection/scripts/run-analyzers.sh

--- a/sidecar/projection/AXIOMS.md
+++ b/sidecar/projection/AXIOMS.md
@@ -424,6 +424,13 @@ A test failure points at a specific axiom; a code reviewer can verify a
 pass against the law it claims to satisfy. The discipline costs nothing and
 pays compound interest.
 
+The `citationOf "<file>" "<name>"` cross-references in `AxiomTests.fs` are now
+guarded by a **live citation gate** (M16): the `` ``M16: every axiom citation
+resolves to a live File::Name in the tree`` `` Fact parses every `citationOf`
+call-site and asserts each cited `file::name` still exists on the tree — so a
+renamed or deleted cited test fails a test, retiring the former "verified-once
+by grep" debt.
+
 ---
 
 # V2 Amendments
@@ -759,15 +766,27 @@ The algebraic reasoning, not just the rule:
   (chapter-Cluster-B; H-003). Tests are property-based via FsCheck
   over arbitrary integer payloads (the laws are payload-agnostic).
 
-**Writer-monad trinity (chapter-Cluster-B finale; 2026-05-22).** A24
-amended characterizes three structurally-related writer carriers, each
-satisfying the chronological-bind law:
+**Writer-monad trinity (chapter-Cluster-B finale; 2026-05-22; corrected
+2026-06-04).** A24 amended originally characterized three
+structurally-related writer carriers. **Only the linear writer ships.**
+The branching `LineageTree<'a>` and the terminal `Certificate<'a>` were
+**retired 2026-06-04** (DECISIONS `2026-06-04 — Retire the speculative
+writer-trinity / optics-duo / Kleisli-product algebra`): both were
+defined + law-tested on symmetry rather than consumer demand, found
+**zero production callers**, and were deleted from `src/`. They are
+**documentation horizon, not code** — the bullets below stand as the
+recorded design space, not as shipped algebra. The witness for this is
+the retirement stubs in `AxiomTests.fs` (`H-009` multi-target fanout,
+`H-063` free-monad scheduling — both naming the 2026-06-04 retirement).
+A24's law itself is unaffected: it holds over the shipped carriers
+`Lineage`, `Diagnostics`, `LineageDiagnostics`, and `Pass` (above).
 
-- **`Lineage<'a>` — the linear writer.** Append-only trail; the
-  in-flight carrier every pass returns. A24 is the original law over
+- **`Lineage<'a>` — the linear writer (SHIPPED).** Append-only trail;
+  the in-flight carrier every pass returns. A24 is the original law over
   this shape.
 
-- **`LineageTree<'a>` — the branching writer** (H-005; the **free
+- **`LineageTree<'a>` — the branching writer (DOC-HORIZON; retired
+  2026-06-04, zero consumer)** (H-005; the **free
   monad over the labeled-list functor** applied to `Lineage<'a>`).
   Leaves are `Lineage<'a>` carriers; Forks are labeled lists of
   subtrees. A24 holds within each leaf AND across the substitution
@@ -776,25 +795,32 @@ satisfying the chronological-bind law:
   via the `prepend` primitive — preserving chronological ordering
   across the bind. The bind operation is the free-monad bind:
   recursive leaf-substitution that preserves Fork structure. Monad-law
-  preservation under the free-monad construction is standard;
-  property-tested in `LineageTests.fs::H-005 LineageTree monad: ...`.
+  preservation under the free-monad construction is standard; it *was*
+  property-tested before the 2026-06-04 retirement (no `LineageTree`
+  test exists today — the type and its tests were deleted as zero-consumer
+  algebra; this bullet is the recorded design space, not a live citation).
 
-- **`Certificate<'a>` — the terminal projection** (H-004). Structural
+- **`Certificate<'a>` — the terminal projection (DOC-HORIZON; retired
+  2026-06-04, zero consumer)** (H-004). Structural
   isomorphism with `Lineage<Diagnostics<'a>>` via `ofLineageDiagnostics`
   / `toLineageDiagnostics`. The role at the consumer boundary: a
   `Certificate<SsdtBundle>` is a value plus its witness chain, where
   the witness chain satisfies A24-amended by inheritance from the
   isomorphic dual-writer carrier.
 
-The trinity is closed: every writer-carrier role in the pipeline has
-a named type. A24-amended holds across all three.
+As shipped, the writer surface is a **linear writer only**: `Lineage`
+(plus its dual-writer stack `LineageDiagnostics`) is the one carrier
+role realized in `src/`. A24-amended holds over every shipped carrier;
+the branching and terminal siblings remain doc-horizon (above) until a
+real consumer materializes.
 
 **Future-extensibility note.** When a third writer is introduced (e.g.,
 a perf-trace writer separating `Bench` samples from `Lineage` events;
 a constraint-set writer for the typed `Tolerance` taxonomy), the
 amendment generalizes: stacking the new writer atop
 `LineageDiagnostics` inherits A24 by the same construction. New
-carriers similarly extend by stacking atop the trinity (e.g., a
+carriers similarly extend by stacking (e.g., were the doc-horizon
+`LineageTree` ever rebuilt against a real consumer, a
 `LineageTreeDiagnostics<'a>` would be `LineageTree<Diagnostics<'a>>`,
 inheriting branching + dual-writer chronology). The chapter-close
 ritual adds the new writer's monad-law triple in the same commit that

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23884,3 +23884,76 @@ existing (undeclared-archetype) config.
   path (C); the at-scale spill is built, equivalence-proven, and armed-but-inert (S); and the declared
   archetype is now a verified claim, not a trusted label (B). `expressible ⇔ reachable` holds for the
   target's capability class.
+
+## 2026-06-15 (later) — THE VECTOR Wave 0 BUILT: honesty & fitness (M1′ + M2 + M16 + M15 + count corrections)
+
+The first chapter of THE VECTOR (`THE_VECTOR.md` §7 / `THE_VECTOR_EXECUTION_KICKOFF.md` §8 Wave 0).
+**No new capability** — this wave only makes the engine tell the truth about itself and makes its
+guardrails un-rottable. The keystone (M1, Wave 1) builds on it; honesty before features. Orchestrated
+as a multi-agent workflow (worktree-isolated implementers, one adversarial verifier per move, an
+integrator); M1′+M2 was re-implemented by the integrator after its implementer hit a transient
+provider error, then independently verified (ACCEPT).
+
+- **M1′ — the two Decision-axis tolerances (the cheapest honesty correction in the codebase).** Added
+  `FkTrustUnreflected` + `UniquePromotionUnreflected` to the closed `ToleratedDivergence` DU, each
+  `@ladder … Decision OpenGap`. Before this, all 8 tolerances tagged Schema/Data — ZERO Decision — so
+  `matrix-status.sh` marked the **Decision axis `✅ faithful` by construction**, an over-claim: the
+  FK-trust sub-axis (`DecisionOverlay.NoCheckFk` → `WITH NOCHECK`; read back at `ReadSide.fs:1171`) and
+  the unique-promotion sub-axis (`DecisionOverlay.EnforceUnique`) are NOT reflected in the round-trip
+  comparator (`PhysicalForeignKey` has no trust field; `toPhysicalIndexes` ignores the overlay), and the
+  only live Decision witness covers nullability alone. The named-erasure law forbids a real erasure
+  absent from the closed set. **The matrix now drops Decision to `◑ L2-partial`** (L2 4/5 → 3/5) with no
+  script change — the generator under-claims. **Both auto-retire when M1 (Wave 1) lands.**
+- **M2 — name the silent `CreateTrigger` text-drop.** Added `TriggerBodyUnparsedDropped`
+  (`@ladder … Schema OpenGap`). `Render.fs` / `ScriptDomGenerate.fs` dropped an unparseable
+  `CreateTrigger` (`tryParseTriggerBody → None`, H-019) with a bare `()` justified by appeal to a canary
+  detector that does NOT cover the text path — the one **silent** named-erasure violation. (The `.dacpac`
+  path already refuses + names it, NM-24; only the text path was silent — the asymmetry this closes.)
+  The render site now emits an in-band marker comment naming the tolerance; the false justification is
+  removed. Witnessed by `DacpacEmitterTests` (M2: unparseable trigger named in-band, parseable trigger
+  carries no marker — discriminating).
+- **M16 — `citationOf` becomes a gated existence check; the matrix binds witnesses by Name.** The
+  `citationOf` helper in `AxiomTests.fs` was `ignore (file, name)` — the "verified-once-by-grep-at-first-
+  commit" debt. A new `[<Fact>]` (`M16: every axiom citation resolves to a live File::Name in the tree`)
+  parses every `citationOf "<file>" "<name>"` call-site and asserts each resolves on the tree (fails on a
+  drifted citation; verified non-vacuous by reproducing the failure against prose decoys). And
+  `matrix-status.sh` now binds each axis's L1/L3 witness by its **exact full test name** instead of a
+  loose substring grep (the old `data canary` substring could be satisfied by 8 tests; the named binding
+  by exactly one) — closing the substring-satisfaction hole. The open half of T-IV.
+- **M15 — architectural fitness functions in-assembly; the analyzer promoted to CI.** New
+  `ArchitectureFitnessTests.fs`: six reflection/registry Facts lifting the grep/bash guardrails into the
+  test assembly — the layer-dependency DAG (Core references nothing outward; Targets ⊥ Pipeline/Cli;
+  Adapters ⊥ Targets/Pipeline/Cli — lint Rules 20/21/22), every shipped emitter realizes the `Emitter`
+  port, every migrate-leg emitter is registered. `run-analyzers.sh` is promoted from opt-in/off-CI to a
+  PR-blocking gate (`.github/workflows/analyzers-projection.yml`, mirroring the lint/verifiability
+  workflows; .NET 9.0.314 + .NET 8 runtime for the analyzer tool). The analyzer gate runs green on this
+  tree. **`perf-gate.sh` is DELIBERATELY NOT promoted** — a shared CI runner's contention voids the μ+σ
+  timing verdict (survival-rule #13); deferred behind a dedicated/quiet self-hosted runner (the trigger).
+- **Count corrections.** Verified the canonical counts hold (112 citation sites, 42 Skip stubs, seven
+  emitter targets) and corrected the **writer "trinity" over-claim** in `AXIOMS.md`: `LineageTree` /
+  `Certificate` were retired 2026-06-04 (zero consumer, deleted from `src/`), so A24-amended now records
+  a **linear writer only** (`Lineage` + the `LineageDiagnostics` stack); the branching/terminal siblings
+  are doc-horizon, not shipped. A stale live citation to a non-existent `LineageTests.fs::H-005` was
+  neutralized to past tense.
+- **Pre-existing FS3511 fixed (drive-by, surfaced by this wave's Release-build check).** The landed
+  Slice S test (`KeymapSpillTests.fs`) carried `for … do` loops inside a `task { }` (one with an inner
+  `do!`) that fail Release compilation (FS3511) — pre-existing, never caught because CI runs
+  lint/verifiability (bash), not a Release build. Restructured to a synchronous `List.iter`/`List.choose`
+  + a single batched `do!` (survival-rule #5 extended; observationally identical — the test asserts final
+  FK state, not round-trip count). **Behavior verified on the warm container (Slice S equivalence test
+  green, 2 s — a real run, not a no-op).**
+- **Witness (all warm).** Debug + **Release** builds clean (0/0). Pure pool **3357 passed / 0 failed**.
+  Focused: `ToleranceTests` (eleven-variant closed-DU coverage + named-parseable + monotonicity props),
+  `SsdtExtendedPropertyEmissionTests` (the second exhaustive match site, count 8→11),
+  `ManifestUnsupportedTests` (the expected-names set), `DacpacEmitterTests` (M2 in-band marker),
+  `AxiomTests.M16` (citation gate), `ArchitectureFitnessTests` (all six M15 Facts), `KeymapSpill`
+  equivalence (Docker, warm) — all green and non-skipped. **`matrix-status.sh` regenerated** (gate=PASS;
+  rungs **L1/L2/L3 = 5/3/5**; tolerances **11, 5 open**; the `@ladder` cross-check passes — no untagged
+  variant). **`verifiability-gate.sh` clean** (exit 0; 79 live axioms; no phantom Bucket-A/B; a
+  pre-existing advisory WARN about 4 unbucketed deferrals, untouched by this wave).
+- **Exit criterion (Wave 0) — MET.** No green matrix cell is unfalsifiable-by-construction (Decision is
+  now honestly `◑ L2-partial`); every load-bearing layer/emitter guardrail is an in-assembly Fact; the
+  matrix binds witnesses by Name, not substring. The engine's "under-claims, never over-claims" guarantee
+  is restored on all five axes. **Next: Wave 1 (M1, the keystone) — `PhysicalForeignKey.IsTrusted` +
+  overlay-aware `PhysicalSchema.ofCatalogWith` + the decision-readback property, which auto-retires M1′
+  and turns Decision back to an earned faithful.**

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,61 @@
+# Handoff addendum — 2026-06-15, THE VECTOR WAVE 0 LANDED (honesty & fitness); your job is WAVE 1 — the keystone M1, which turns the honest tolerance back into an earned green
+
+To the next agent.
+
+**Your mission.** Build **Wave 1 — M1, the Decision-readback adjunction** (the single highest-leverage
+move in `THE_VECTOR.md`; §6 M1, §7 Wave 1; mechanics in `THE_VECTOR_UNABRIDGED.md` Part III). Wave 0
+just made the engine honest about the Decision axis; M1 makes it *true*. When M1 lands, **delete the
+two `@ladder … Decision OpenGap` tags** (`FkTrustUnreflected`, `UniquePromotionUnreflected`) — the
+generator auto-flips Decision back to faithful. Honesty first (done), then the theorem (you).
+
+**The move, precisely (the surfaces are scouted and the join keys confirmed).**
+1. Add `IsTrusted : bool` to `PhysicalForeignKey` (`src/Projection.Core/PhysicalSchema.fs`). A normally-
+   enforced FK is `true`; a `WITH NOCHECK` FK is `false`. The widened set-difference in
+   `PhysicalSchema.diff` picks the field up with **no comparator change**.
+2. Make `ofCatalog` overlay-aware **the way the SSDT emitter already is** — copy the
+   `statements`/`statementsWith` precedent (`SsdtDdlEmitter.fs:880-886`): add
+   `ofCatalogWith : DecisionOverlay -> Catalog -> PhysicalSchema` (the overlay-aware core) and keep
+   `ofCatalog c = ofCatalogWith DecisionOverlay.empty c`. This preserves **byte-identity at `empty`** and
+   every one of the ~30 existing `ofCatalog c` call sites — guard with the T1 goldens
+   (`GoldenEmissionTests`) and `AdjunctionLawTests`. Do NOT change `ofCatalog`'s signature.
+3. In `toPhysicalForeignKeys`, set `IsTrusted = r.IsConstraintTrusted && not (Set.contains r.SsKey overlay.NoCheckFk)`
+   (the source half reads the overlay; the readback half is overlay-`empty` and `r.IsConstraintTrusted`
+   is already recovered from `sys.foreign_keys.is_not_trusted` at **`ReadSide.fs:1171`** — the read leg is
+   free). In `toPhysicalIndexes`, set `IsUnique = IndexUniqueness.isUnique idx.Uniqueness || Set.contains idx.SsKey overlay.EnforceUnique`.
+   (`Reference.SsKey` matches `overlay.NoCheckFk`; `Index.SsKey` matches `overlay.EnforceUnique` — both confirmed.)
+4. Add the **decision-readback property**: emit a `WITH NOCHECK` FK via the overlay → deploy → ReadSide →
+   `ofCatalog` on the readback yields `IsTrusted = false`, and `ofCatalogWith overlay` on the source agrees
+   — the diff is empty; a *trusted* FK round-trips `IsTrusted = true`; the no-cheat case (emitter didn't
+   actually emit NOCHECK) shows a non-empty diff. This routes the recovered decision through the **general
+   comparator** instead of the bespoke nullability-only test (`CanaryRoundTripTests.fs` ~886). It is
+   **Docker-gated** — see the scar below; confirm a real duration, never the green count.
+
+**Exit criterion (Wave 1).** The live canary witnesses `NoCheckFk`/`EnforceUnique` survival through
+emit → deploy → read-back; the matrix's Decision cell is *showable*, not asserted, and flips back to
+`✅` when you delete the two Decision tolerances.
+
+**State.** Branch `claude/sleepy-lumiere-43d5c9`. Wave 0 is committed and green: Debug + **Release**
+clean; pure pool 3357/0; `matrix-status.sh` regenerated (L1/L2/L3 = 5/3/5; Decision `◑ L2-partial`;
+tolerances 11, 5 open); `verifiability-gate.sh` clean; the analyzer gate green and now CI-promoted. The
+2026-06-15 `DECISIONS` entry "THE VECTOR Wave 0 BUILT" is the substance; this letter points. After Wave 1,
+chapter-close and the PR carries Wave 0 + Wave 1 together.
+
+**Build-discipline scars (heed them — M1's witness is Docker-gated).**
+1. **⚠️ Docker tests SILENTLY NO-OP on this Windows box** unless `$env:PROJECTION_MSSQL_CONN_STR=
+   "Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container, currently up). They pass as ~0.4 ms `()` no-ops otherwise — **confirm via per-test
+   duration in seconds**, never the green count (survival-rule #12). M1's readback property is exactly such
+   a witness.
+2. `dotnet` is at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` (9.0.314; not on bash PATH) —
+   build/test via PowerShell; **never the pure + Docker pools in one `dotnet test`** (OOM). Build in
+   **Release too** before claiming done (Wave 0 found a pre-existing FS3511 only Release surfaces; CI runs
+   bash gates, not a Release compile).
+3. Default-empty overlay args **must preserve byte-identity at `empty`** — the goldens are the guard. Every
+   `AXIOMS.md` change carries its `AxiomTests.fs` witness in the same commit. Name every refusal; the
+   matrix under-claims by construction — keep it that way.
+
+---
+
 # Handoff addendum — 2026-06-15, BUILD THE ARCHETYPE SLICES — the model is locked, the inputs are confirmed, the plan is written; your job is to build Slice A → C → S → B per REVERSE_LEG_WORK_PLAN.md
 
 To the next agent.

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -10,10 +10,10 @@ _Derived from `tests/Projection.Tests/AxiomTests.fs` + `src/Projection.Core/Tole
 
 | Class | Meaning | Count |
 |---|---|---:|
-| Live | verified ("verified by …") or convention-enforced `[<Fact>]` | 78 |
+| Live | verified ("verified by …") or convention-enforced `[<Fact>]` | 79 |
 | Deferred C | weakness — `[<Fact(Skip … Bucket C …)>]` | 6 |
 | Deferred D | unnamed/unbacked — `[<Fact(Skip … Bucket D …)>]` | 1 |
-| **total axiom entries** | | **112** |
+| **total axiom entries** | | **113** |
 
 **Verifiability gate: `PASS`** — no deferral claims verified (no phantom Bucket-A/B); every deferral names its bucket.
 
@@ -27,14 +27,14 @@ witness covers the axis. The **Ladder** column is the honest weakest-rung summar
 
 | Axis | L1 witness | L2 faithful | L3 composed | Open tolerances | Ladder |
 |---|:--:|:--:|:--:|---|---|
-| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexOptionsUnreflected`, `CompositePkFkUnreflected` | ◑ L2-partial |
+| **Schema** | ✅ | ◑ L2-partial | ✅ | `IndexOptionsUnreflected`, `CompositePkFkUnreflected`, `TriggerBodyUnparsedDropped` | ◑ L2-partial |
 | **Data** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Identity** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Time** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
-| **Decision** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
+| **Decision** | ✅ | ◑ L2-partial | ✅ | `FkTrustUnreflected`, `UniquePromotionUnreflected` | ◑ L2-partial |
 
-**Rungs reached: L1 5/5 · L2 4/5 · L3 5/5.** Tolerance set:
-8 named, of which **2 open** (`OpenGap`). A cell cannot be
+**Rungs reached: L1 5/5 · L2 3/5 · L3 5/5.** Tolerance set:
+11 named, of which **5 open** (`OpenGap`). A cell cannot be
 hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance
 to be retired from `Tolerance.fs`. The generator under-claims; it never over-claims.
 
@@ -46,4 +46,4 @@ to be retired from `Tolerance.fs`. The generator under-claims; it never over-cla
 > L3 here is "a composition witness exists for the axis," not "faithful under every
 > spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
 
-_Self-reported · gate=PASS · L2 axioms live/C/D=78/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 8 (2 open)_
+_Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/3/5 of 5 · tolerances 11 (5 open)_

--- a/sidecar/projection/scripts/matrix-status.sh
+++ b/sidecar/projection/scripts/matrix-status.sh
@@ -85,28 +85,40 @@ open_for_axis() {
 }
 
 # --- T-I: the round-trip ladder matrix -------------------------------------
-# "Axis|round-trip-witness-substring|migrate(A B)-witness-substring". A rung is
-# VERIFIED iff a backtick-quoted test name containing the substring exists under
-# tests/ (matches `let ``...``` and `member _.``...``` forms). Axis names match
-# the `@ladder` axis tokens so the tolerance set joins by axis.
-cells='Schema|PhysicalSchema diff|one execute evolves
-Data|data canary|executeWithData migrates the sink schema
-Identity|reload preserves SsKey|migrate-with-data re-keys
-Time|replayTo genesis|the full A->B loop
-Decision|reproduces the DecisionOverlay|migrate refuses a NOT-NULL tightening'
+# "Axis|round-trip-witness-FULL-NAME|migrate(A B)-witness-FULL-NAME". A rung is
+# VERIFIED iff the EXACT, FULL backtick-quoted test name exists under tests/.
+# The binding is structural, not a loose substring: `witness_status` matches the
+# whole name bounded by its `` `` `` delimiters (fixed-string, so the name's
+# regex metacharacters — `(`, `;`, `—`, `→`, `?`, `/`, `.` — are literal), so a
+# witness can NOT be satisfied by an accidental substring hit on an unrelated
+# test (e.g. the bare `data canary` prefix matches eight Transfer tests; only the
+# named `data canary: multi-table FK chain …` test is the Data L1 witness). Each
+# name below was confirmed to resolve to exactly one test on the current tree, so
+# the regenerated matrix keeps the same verdicts (L1 5/5). Matches `let ``…``` and
+# `member _.``…``` forms alike. Axis names match the `@ladder` axis tokens so the
+# tolerance set joins by axis.
+cells='Schema|M3: V2-internal closure — programmatic Catalog round-trips through emit / deploy / read with empty PhysicalSchema diff|migrate A B canary: one execute evolves A→B across three channels; B reproduces B, data survives, re-run is idempotent
+Data|data canary: multi-table FK chain round-trips with empty PhysicalSchema diff|migrate canary: executeWithData migrates the sink schema then loads rows from the source
+Identity|Identity round-trip: reload preserves SsKey across emit / deploy / ReadSide|AC-X2: one-command migrate-with-data re-keys Order FKs to the Sink'"'"'s email-matched identity (fails for Map.empty)
+Time|Time round-trip (replay): replayTo genesis recovers the genesis catalog|6.D.1: the full A->B loop — migrate, record, then reconstruct reproduces B (durable round-trip)
+Decision|decision adjunction: emitted-then-read-back schema reproduces the DecisionOverlay|G9: migrate refuses a NOT-NULL tightening on NULL-bearing data via a pre-flight, before any ALTER'
 
 witness_status() {
-  local pat="$1"
-  if grep -rhE "\`\`[^\`]*${pat}" "$TESTS" >/dev/null 2>&1; then echo "VERIFIED"; else echo "OPEN"; fi
+  # Exact, anchored full-name binding: the test name must appear verbatim,
+  # bounded by its `` `` `` delimiters. Fixed-string (`grep -F`) so the name's
+  # regex metacharacters are literal; the leading/trailing `` `` `` anchors the
+  # match to a whole backtick-quoted name, defeating accidental substring hits.
+  local name="$1"
+  if grep -rhF "\`\`${name}\`\`" "$TESTS" >/dev/null 2>&1; then echo "VERIFIED"; else echo "OPEN"; fi
 }
 icon()    { case "$1" in VERIFIED) echo "✅";; *) echo "⬚";; esac; }
 
 l1n=0; l2n=0; l3n=0; counted=0; rows=""
-while IFS='|' read -r axis rtpat mgpat; do
+while IFS='|' read -r axis rtname mgname; do
   [ -z "$axis" ] && continue
   counted=$((counted+1))
-  l1=$(witness_status "$rtpat")
-  l3=$(witness_status "$mgpat")
+  l1=$(witness_status "$rtname")
+  l3=$(witness_status "$mgname")
   opens="$(open_for_axis "$axis")"
   [ "$l1" = "VERIFIED" ] && l1n=$((l1n+1))
   [ "$l3" = "VERIFIED" ] && l3n=$((l3n+1))

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -165,6 +165,63 @@ type ToleratedDivergence =
     /// @ladder DecimalScaleTolerated Data AcceptedFaithful
     | DecimalScaleTolerated
 
+    /// M1′ (THE VECTOR, Wave 0 honesty) — the **Decision-axis** round-trip
+    /// cannot observe whether an FK's *trust* decision survived. The engine's
+    /// `DecisionOverlay.NoCheckFk` records the references decided
+    /// `EnforceConstraint (ScriptWithNoCheck _)` (emit the FK but `WITH NOCHECK`,
+    /// i.e. untrusted), `SsdtDdlEmitter` emits the `WITH NOCHECK` clause, and the
+    /// read leg recovers `sys.foreign_keys.is_not_trusted` into
+    /// `Reference.IsConstraintTrusted` (`ReadSide.fs:1171`). But the canary's
+    /// comparison primitive `PhysicalForeignKey` carries **no trust field**, so
+    /// `PhysicalSchema.diff` is structurally blind to it: a NOCHECK decision that
+    /// failed to round-trip (emitted trusted, or read back trusted) yields an
+    /// EMPTY diff. The only live Decision witness today
+    /// (`CanaryRoundTripTests.fs` — "decision adjunction: emitted-then-read-back
+    /// schema reproduces the DecisionOverlay") covers only the *nullability*
+    /// sub-axis; its own docstring admits FK readback is unwitnessed. Without
+    /// this variant the matrix marks Decision ✅-faithful **by construction** (no
+    /// Decision tolerance exists to cap it) — an over-claim the named-erasure law
+    /// forbids: an erasure that is real but absent from the closed set means the
+    /// set is not closed over that axis. Named here so the Decision axis drops to
+    /// an honest ◑ L2-partial. **Retiring it:** M1 (Wave 1) — add `IsTrusted` to
+    /// `PhysicalForeignKey`, make `PhysicalSchema.ofCatalog` overlay-aware, and
+    /// route the recovered trust through the general comparator; deleting this
+    /// tag then auto-flips Decision back to faithful.
+    /// @ladder FkTrustUnreflected Decision OpenGap
+    | FkTrustUnreflected
+
+    /// M1′ (THE VECTOR, Wave 0 honesty) — the **Decision-axis** round-trip
+    /// cannot observe whether a *unique-index promotion* decision survived.
+    /// `DecisionOverlay.EnforceUnique` records the index keys the
+    /// `UniqueIndexPass` decided to promote to UNIQUE and the emitter writes a
+    /// UNIQUE index; but `PhysicalSchema.toPhysicalIndexes` derives `IsUnique`
+    /// from the catalog's static `idx.Uniqueness` **alone** — it never consults
+    /// the overlay — so an `EnforceUnique` decision the emitter applied is
+    /// invisible to `PhysicalSchema.diff` (unique-index readback is also outside
+    /// today's ReadSide scope boundary; see the nullability-only Decision
+    /// witness). The same over-claim as `FkTrustUnreflected`: a real Decision
+    /// erasure with no named surface. **Retiring it:** M1 (Wave 1) —
+    /// `toPhysicalIndexes` sets `IsUnique = isUnique || overlay.EnforceUnique`
+    /// and the readback closes; deleting this tag auto-flips Decision back.
+    /// @ladder UniquePromotionUnreflected Decision OpenGap
+    | UniquePromotionUnreflected
+
+    /// M2 (THE VECTOR, Wave 0 honesty) — a `Statement.CreateTrigger` whose
+    /// definition body fails to parse (`ScriptDomBuild.tryParseTriggerBody`
+    /// returns `None`, H-019) is dropped from the SSDT **text** artifact at
+    /// `Render.fs` / `ScriptDomGenerate.fs`. The drop was a bare `()` justified
+    /// by appeal to "the canary roundtrip surfaces regressions" — but no such
+    /// detector covers the text path, so the erasure was **silent**, the one
+    /// thing the named-erasure law forbids absolutely. (The `.dacpac` path
+    /// already refuses + names the dropped object, NM-24; only the text path was
+    /// silent — the asymmetry this variant closes.) Named here so the erasure is
+    /// *closed*; the render site now emits an in-band marker comment naming this
+    /// tolerance instead of vanishing. **Retiring it:** emit a trigger whose body
+    /// round-trips, or refuse at emit when it cannot parse (mirroring the
+    /// `.dacpac` path), so no faithful trigger is ever dropped from the text.
+    /// @ladder TriggerBodyUnparsedDropped Schema OpenGap
+    | TriggerBodyUnparsedDropped
+
     // **CommentMetadataUnreflected — RETIRED at chapter 4.1.A slice 8
     // (2026-05-17).** Column / table / index descriptions and extended
     // properties now emit as `EXEC sys.sp_addextendedproperty` calls
@@ -201,6 +258,9 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected       -> ToleratedDivergence.CompositePkFkUnreflected
         | ToleratedDivergence.CharAnsiPaddingTolerated       -> ToleratedDivergence.CharAnsiPaddingTolerated
         | ToleratedDivergence.DecimalScaleTolerated          -> ToleratedDivergence.DecimalScaleTolerated
+        | ToleratedDivergence.FkTrustUnreflected             -> ToleratedDivergence.FkTrustUnreflected
+        | ToleratedDivergence.UniquePromotionUnreflected     -> ToleratedDivergence.UniquePromotionUnreflected
+        | ToleratedDivergence.TriggerBodyUnparsedDropped     -> ToleratedDivergence.TriggerBodyUnparsedDropped
 
     /// Every empirically-grounded `ToleratedDivergence` variant.
     /// The closed-DU coverage test asserts this set has the same
@@ -224,6 +284,9 @@ module ToleratedDivergence =
                 coverage ToleratedDivergence.CompositePkFkUnreflected
                 coverage ToleratedDivergence.CharAnsiPaddingTolerated
                 coverage ToleratedDivergence.DecimalScaleTolerated
+                coverage ToleratedDivergence.FkTrustUnreflected
+                coverage ToleratedDivergence.UniquePromotionUnreflected
+                coverage ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
 
     /// Canonical string name for a divergence — the operator-facing token a
@@ -241,6 +304,9 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected     -> "CompositePkFkUnreflected"
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> "CharAnsiPaddingTolerated"
         | ToleratedDivergence.DecimalScaleTolerated        -> "DecimalScaleTolerated"
+        | ToleratedDivergence.FkTrustUnreflected           -> "FkTrustUnreflected"
+        | ToleratedDivergence.UniquePromotionUnreflected   -> "UniquePromotionUnreflected"
+        | ToleratedDivergence.TriggerBodyUnparsedDropped   -> "TriggerBodyUnparsedDropped"
 
     /// Parse a config token to its divergence, or `None` for an unrecognized
     /// token. Derived from `name` so the round-trip `name >> tryParse` is the

--- a/sidecar/projection/src/Projection.Targets.SSDT/Render.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/Render.fs
@@ -100,11 +100,23 @@ module Render =
             | Some fragment ->
                 sb.Append(ScriptDomGenerate.generateOne fragment).AppendLine() |> ignore
             | None ->
-                // `Blank` + `Comment` return None and are handled above.
-                // `CreateTrigger` also returns None when its definition
-                // fails to parse (H-019) — silently skipping is correct
-                // in that case (canary roundtrip surfaces regressions).
-                ()
+                // `Blank` + `Comment` + `BatchSeparator` are handled in the
+                // explicit arms above, so the only statement reaching this
+                // `None` is a `CreateTrigger` whose body failed to parse
+                // (`ScriptDomBuild.tryParseTriggerBody` → None, H-019). M2 (THE
+                // VECTOR, Wave 0): the prior bare `()` was a SILENT drop
+                // justified by appeal to a canary detector that does NOT cover
+                // the text path — the one named-erasure violation. Emit an
+                // in-band marker comment naming the closed tolerance
+                // `ToleratedDivergence.TriggerBodyUnparsedDropped` (Schema
+                // OpenGap) so the text artifact is honest, not silent; the
+                // `.dacpac` path refuses outright (NM-24). Static phrase only —
+                // the definition is not interpolated (static-phrase +
+                // structured-metadata discipline).
+                match s with
+                | CreateTrigger _ ->
+                    sb.Append("-- ").AppendLine("ToleratedDivergence.TriggerBodyUnparsedDropped: a CreateTrigger body failed to parse and was omitted from this SSDT text artifact (the .dacpac path refuses outright, NM-24).") |> ignore
+                | _ -> ()
 
     /// Fold a statement stream into a single SQL-text artifact. The
     /// canonical text realization of Π's output. Stream-aware bench

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomGenerate.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomGenerate.fs
@@ -200,9 +200,17 @@ module ScriptDomGenerate =
                 | Some fragment ->
                     sb.Append(generateOne fragment) |> ignore
                 | None ->
-                    // `Blank` / `Comment` return None and are handled
-                    // explicitly above. `CreateTrigger` also returns
-                    // None when the definition fails to parse (H-019);
-                    // silently skipping is intentional in that case.
-                    ()
+                    // `Blank` / `Comment` are handled explicitly above, so the
+                    // only statement reaching this `None` is a `CreateTrigger`
+                    // whose body failed to parse (H-019). M2 (THE VECTOR, Wave
+                    // 0): the prior bare `()` was a SILENT drop — the named-
+                    // erasure law forbids it. Emit an in-band marker comment
+                    // naming the closed tolerance
+                    // `ToleratedDivergence.TriggerBodyUnparsedDropped` (Schema
+                    // OpenGap) so this text path matches `Render.toSql` and the
+                    // `.dacpac` refusal (NM-24). Static phrase only.
+                    match stmt with
+                    | CreateTrigger _ ->
+                        sb.Append(commentLine "ToleratedDivergence.TriggerBodyUnparsedDropped: a CreateTrigger body failed to parse and was omitted from this SSDT text artifact (the .dacpac path refuses outright, NM-24).") |> ignore
+                    | _ -> ()
         sb.ToString()

--- a/sidecar/projection/tests/Projection.Tests/ArchitectureFitnessTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ArchitectureFitnessTests.fs
@@ -1,0 +1,356 @@
+module Projection.Tests.ArchitectureFitnessTests
+
+// ---------------------------------------------------------------------------
+// MOVE M15 (THE VECTOR, Wave 0 fitness) — architectural guardrails as
+// in-assembly Facts.
+//
+// The house convention->fitness pattern (CapabilitySurvey.reconcileArchetype /
+// CapabilityProfile.of) closes a law as: closed convention -> one total
+// expansion site -> derived projection -> round-trip / reconciliation finding.
+// Here the "convention" is the hexagonal layer DAG and the Emitter port; the
+// "fitness" is reflection over the in-assembly truth (the loaded assemblies +
+// the live registry), reconciled against the law derived from the actual
+// `.fsproj` ProjectReference graph.
+//
+// These Facts REPLACE the off-CI grep guardrails:
+//   - `scripts/lint-discipline.sh` Rules 20/21/22 (hexagonal-coupling, grep over
+//     `open Projection.X`) become the reflected layer-dependency DAG (Fact 1) —
+//     a STRONGER law: a grep sees only `open` statements, reflection sees the
+//     actual IL assembly references, so a coupling introduced via a
+//     fully-qualified type name (no `open`) — invisible to the grep — is caught.
+//   - the emitter-port contract (Fact 2) and the migrate-leg registry coverage
+//     (Fact 3) are reconciled against the live `RegisteredAllTransforms.all`.
+//
+// The test project references every Projection.* project transitively
+// (Core / Adapters.* / Targets.* / Pipeline / Cli) and is reflection-exempt
+// (`open System.Reflection` is banned in `src/` by lint Rule 17, not in
+// `tests/`), so it is the one place these in-assembly Facts can live.
+//
+// HONEST CAP (the prompt's optional Fact 4 — an analyzer-walker unit test —
+// is CUT, not silently dropped): `Projection.Analyzers` targets net8.0 and
+// pins FSharp.Core 9.0.201 + FSharp.Compiler.Service 43.9.201 +
+// FSharp.Analyzers.SDK 0.30.0 (see its `.fsproj` NU1608 note). The test
+// project targets net9.0 and rides the SDK's implicit FSharp.Core (9.0.30x).
+// Referencing the analyzer here would re-introduce exactly the FSharp.Core
+// version conflict that `.fsproj` note exists to avoid, and the SDK's
+// `walk`/`Context` surface is a net8 FCS type. The analyzer is instead
+// exercised end-to-end by `scripts/run-analyzers.sh`, which this move
+// PROMOTES to CI (`analyzers-projection.yml`). A net9-safe in-process walker
+// test is left for a future move that unifies the analyzer's TFM/FSharp.Core
+// with the test project (no cheap path today).
+// ---------------------------------------------------------------------------
+
+open System
+open System.Reflection
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+// ---------------------------------------------------------------------------
+// Shared reflection helpers.
+// ---------------------------------------------------------------------------
+
+/// The LOGICAL project name (the graph identity, matching the `.fsproj` file
+/// name) paired with the REAL IL assembly simple name to `Assembly.Load`.
+/// These coincide for every project EXCEPT `Projection.Cli`, whose `.fsproj`
+/// overrides `<AssemblyName>projection</AssemblyName>` (the shipped CLI binary
+/// is `projection.dll`). Reflection surfaces exactly this kind of build-detail
+/// drift — a grep over `open Projection.Cli` would never see it. Keeping the
+/// two identities distinct is what lets the law speak in logical project names
+/// while loading and normalizing against the real assembly names.
+let private projectionAssemblies : (string * string) list =
+    [ "Projection.Core",                           "Projection.Core"
+      "Projection.Adapters.Osm",                   "Projection.Adapters.Osm"
+      "Projection.Adapters.OssysSql",              "Projection.Adapters.OssysSql"
+      "Projection.Adapters.Sql",                   "Projection.Adapters.Sql"
+      "Projection.Targets.SSDT",                   "Projection.Targets.SSDT"
+      "Projection.Targets.Data",                   "Projection.Targets.Data"
+      "Projection.Targets.Json",                   "Projection.Targets.Json"
+      "Projection.Targets.Distributions",          "Projection.Targets.Distributions"
+      "Projection.Targets.OperationalDiagnostics", "Projection.Targets.OperationalDiagnostics"
+      "Projection.Pipeline",                       "Projection.Pipeline"
+      // The CLI's IL assembly simple name is `projection`, not `Projection.Cli`.
+      "Projection.Cli",                            "projection" ]
+
+let private projectionAssemblyNames : string list =
+    projectionAssemblies |> List.map fst
+
+/// Real-IL-simple-name -> logical-project-name (the inverse of the override
+/// above), so reflected references and loaded assemblies both speak the graph's
+/// logical vocabulary. The identity for all but the CLI; `projection` maps back
+/// to `Projection.Cli`.
+let private toLogicalName (ilSimpleName: string) : string =
+    projectionAssemblies
+    |> List.tryFind (fun (_, il) -> il = ilSimpleName)
+    |> Option.map fst
+    |> Option.defaultValue ilSimpleName
+
+let private loadProjectionAssembly (logicalName: string) : Assembly =
+    let ilName =
+        projectionAssemblies
+        |> List.tryFind (fun (logical, _) -> logical = logicalName)
+        |> Option.map snd
+        |> Option.defaultValue logicalName
+    Assembly.Load(AssemblyName(ilName))
+
+/// Is an IL assembly simple name one of OUR projection assemblies (in either
+/// the `Projection.*` spelling or the CLI's `projection` override)?
+let private isProjectionIlName (ilSimpleName: string) : bool =
+    (ilSimpleName.StartsWith("Projection.", StringComparison.Ordinal))
+    || (projectionAssemblies |> List.exists (fun (_, il) -> il = ilSimpleName))
+
+/// The Projection.* assemblies a given assembly DIRECTLY references in IL,
+/// reported in LOGICAL project names (`projection` normalized to
+/// `Projection.Cli`). `GetReferencedAssemblies` is the linker's view — direct
+/// references only; the compiler may elide an unused transitive reference,
+/// which is why the law below is "reflected ⊆ declared transitive closure",
+/// not equality.
+let private referencedProjectionNames (asm: Assembly) : Set<string> =
+    asm.GetReferencedAssemblies()
+    |> Array.choose (fun an ->
+        match an.Name with
+        | null -> None
+        | n when isProjectionIlName n -> Some (toLogicalName n)
+        | _ -> None)
+    |> Set.ofArray
+
+// ---------------------------------------------------------------------------
+// Fact 1 — the layer-dependency DAG (replaces lint Rules 20/21/22).
+// ---------------------------------------------------------------------------
+
+/// The DECLARED direct-dependency edges — read straight off each project's
+/// `.fsproj` ProjectReference list (the single source of truth for the layer
+/// graph). This map IS the law: derive the allowed edges from what the build
+/// graph actually declares, so the Fact is precise rather than a hand-guessed
+/// approximation. `Core -> {}` is the keystone: Core depends on nothing
+/// outward (the pure-core spine).
+let private declaredDirectEdges : Map<string, Set<string>> =
+    [ "Projection.Core",                          Set.empty
+      "Projection.Adapters.Osm",                  set [ "Projection.Core" ]
+      "Projection.Adapters.OssysSql",             set [ "Projection.Core"; "Projection.Adapters.Osm" ]
+      "Projection.Adapters.Sql",                  set [ "Projection.Core" ]
+      "Projection.Targets.SSDT",                  set [ "Projection.Core" ]
+      "Projection.Targets.Data",                  set [ "Projection.Core"; "Projection.Targets.SSDT" ]
+      "Projection.Targets.Json",                  set [ "Projection.Core" ]
+      "Projection.Targets.Distributions",         set [ "Projection.Core" ]
+      "Projection.Targets.OperationalDiagnostics", set [ "Projection.Core" ]
+      "Projection.Pipeline",
+        set [ "Projection.Core"
+              "Projection.Adapters.Osm"; "Projection.Adapters.OssysSql"; "Projection.Adapters.Sql"
+              "Projection.Targets.SSDT"; "Projection.Targets.Json"; "Projection.Targets.Distributions"
+              "Projection.Targets.Data"; "Projection.Targets.OperationalDiagnostics" ]
+      "Projection.Cli",
+        set [ "Projection.Core"; "Projection.Adapters.Sql"; "Projection.Pipeline"; "Projection.Targets.SSDT" ] ]
+    |> Map.ofList
+
+/// Transitive closure of the declared edges — the set of every project a given
+/// project may LEGITIMATELY reference (directly or via a chain). A reflected IL
+/// reference outside this set is a real layer violation (a regression).
+let private allowedTransitive (root: string) : Set<string> =
+    let rec walk (seen: Set<string>) (frontier: string list) : Set<string> =
+        match frontier with
+        | [] -> seen
+        | x :: rest when Set.contains x seen -> walk seen rest
+        | x :: rest ->
+            let direct = Map.tryFind x declaredDirectEdges |> Option.defaultValue Set.empty
+            walk (Set.add x seen) (rest @ (Set.toList direct))
+    // Closure of the DEPENDENCIES of `root` (root itself excluded — a project
+    // does not "reference itself").
+    let directOfRoot = Map.tryFind root declaredDirectEdges |> Option.defaultValue Set.empty
+    walk Set.empty (Set.toList directOfRoot)
+
+[<Fact>]
+let ``M15: the layer-dependency DAG holds (Core depends on nothing outward)`` () =
+    // Each loaded assembly's actual IL Projection.* references must be a SUBSET
+    // of the closure the declared `.fsproj` graph permits. This is the
+    // reflected, stronger form of lint Rules 20/21/22: the grep sees only
+    // `open` statements; `GetReferencedAssemblies` sees every real coupling,
+    // including ones introduced by a fully-qualified name with no `open`.
+    let violations =
+        projectionAssemblyNames
+        |> List.collect (fun name ->
+            let asm = loadProjectionAssembly name
+            let allowed = allowedTransitive name
+            let actual = referencedProjectionNames asm
+            Set.difference actual allowed
+            |> Set.toList
+            |> List.map (fun bad -> sprintf "%s -> %s" name bad))
+
+    Assert.True(
+        List.isEmpty violations,
+        sprintf
+            "Layer-DAG violation(s) — an assembly references a Projection.* assembly the declared .fsproj graph forbids: %s"
+            (String.concat "; " violations))
+
+[<Fact>]
+let ``M15: Core references no outward Projection assembly (the pure-core keystone)`` () =
+    // The keystone stated as its own Fact (the most load-bearing edge of the
+    // DAG, and the strongest of lint Rule 20). Core is the sink of the
+    // dependency graph: nothing it ships may reach an adapter / target /
+    // pipeline / cli assembly.
+    let core = loadProjectionAssembly "Projection.Core"
+    let outward = referencedProjectionNames core
+    Assert.True(
+        Set.isEmpty outward,
+        sprintf
+            "Projection.Core must reference NO other Projection.* assembly (pure-core spine); found: %s"
+            (outward |> Set.toList |> String.concat ", "))
+
+[<Fact>]
+let ``M15: no Targets assembly references Pipeline or Cli (horizontal siblings, lint Rule 21)`` () =
+    // Targets are horizontal siblings under Core; none may reach UP into
+    // Pipeline or Cli. (Targets.Data -> Targets.SSDT is a DECLARED sibling
+    // edge — permitted by the .fsproj graph — so this Fact bans only the
+    // upward Pipeline/Cli reach, exactly as lint Rule 21 does.)
+    let forbidden = set [ "Projection.Pipeline"; "Projection.Cli" ]
+    let violations =
+        projectionAssemblyNames
+        |> List.filter (fun n -> n.StartsWith("Projection.Targets.", StringComparison.Ordinal))
+        |> List.collect (fun name ->
+            let actual = referencedProjectionNames (loadProjectionAssembly name)
+            Set.intersect actual forbidden
+            |> Set.toList
+            |> List.map (fun bad -> sprintf "%s -> %s" name bad))
+    Assert.True(
+        List.isEmpty violations,
+        sprintf "Targets must not reference Pipeline/Cli; found: %s" (String.concat "; " violations))
+
+[<Fact>]
+let ``M15: no Adapters assembly references any Targets or Pipeline or Cli (lint Rule 22)`` () =
+    // Adapters sit beside Targets under Core (raw rowset/JSON -> Catalog); none
+    // may reach a Targets emitter, Pipeline, or Cli. (Adapters.OssysSql ->
+    // Adapters.Osm is a DECLARED adapter edge — permitted — so this Fact bans
+    // only the cross-plane reach into Targets/Pipeline/Cli, as lint Rule 22.)
+    let isForbidden (n: string) =
+        n.StartsWith("Projection.Targets.", StringComparison.Ordinal)
+        || n = "Projection.Pipeline"
+        || n = "Projection.Cli"
+    let violations =
+        projectionAssemblyNames
+        |> List.filter (fun n -> n.StartsWith("Projection.Adapters.", StringComparison.Ordinal))
+        |> List.collect (fun name ->
+            referencedProjectionNames (loadProjectionAssembly name)
+            |> Set.filter isForbidden
+            |> Set.toList
+            |> List.map (fun bad -> sprintf "%s -> %s" name bad))
+    Assert.True(
+        List.isEmpty violations,
+        sprintf "Adapters must not reference Targets/Pipeline/Cli; found: %s" (String.concat "; " violations))
+
+// ---------------------------------------------------------------------------
+// Fact 2 — every shipped emitter realizes the Emitter port.
+// ---------------------------------------------------------------------------
+//
+// `Emitter<'element>` (Projection.Core/Types.fs) is the port:
+//   `Catalog -> Result<ArtifactByKind<'element>, EmitError>`.
+// "Realizes the port" has two halves, both checked here:
+//   (a) STATIC — the shipped emitter values are bound through the `Emitter<_>`
+//       type abbreviation below. If any drifts off the port shape (a new
+//       Profile/Diff parameter, a non-`Result` codomain), THIS FILE STOPS
+//       COMPILING — a build-green failure of the witness, the strongest signal.
+//   (b) RUNTIME — each port value, applied to the empty Catalog, yields the
+//       port codomain `Result<ArtifactByKind<_>, EmitError>` (a real value,
+//       Ok or Error, never a throw). A regression that made an emitter partial
+//       on the empty Catalog (an unhandled exn) fails the assertion.
+
+/// The shipped emitters that expose the canonical `Emitter<'element>` port
+/// (Catalog-only, `Result<ArtifactByKind<_>, EmitError>` codomain). The
+/// sibling-Π emitters (`DistributionsEmitter` = `EmitterWithProfile`,
+/// `RefactorLogEmitter` = `EmitterOverDiff`, the Data-axis emitters whose
+/// wider `Profile`/options arguments don't fit the bare port) are the
+/// A18-amended variants — covered by Fact 3's registry-coverage law, not by
+/// this bare-port realization. The static `: Emitter<_>` annotations are the
+/// compile-time port-conformance proof.
+let private ssdtPort : Emitter<Projection.Targets.SSDT.SsdtDdlEmitter.SsdtFile> =
+    Projection.Targets.SSDT.SsdtDdlEmitter.emitSlices
+
+let private jsonPort : Emitter<System.Text.Json.Nodes.JsonNode> =
+    Projection.Targets.Json.JsonEmitter.emitSlices
+
+[<Fact>]
+let ``M15: every shipped emitter realizes the Emitter port`` () =
+    let emptyCatalog : Catalog = { Modules = []; Sequences = [] }
+
+    // The port values, erased to a uniform probe shape: each takes the empty
+    // Catalog and must produce a `Result<ArtifactByKind<_>, EmitError>` (Ok or
+    // Error). The codomain is asserted by matching the Result; an unhandled
+    // throw escapes and fails the Fact.
+    let probeOk (name: string) (run: Catalog -> bool) =
+        // `run` collapses the port result to a bool only AFTER confirming the
+        // codomain is a real `Result` value (the match is total over Result).
+        Assert.True(run emptyCatalog, sprintf "emitter '%s' did not return the Emitter-port codomain" name)
+
+    probeOk "ssdtDdlEmitter" (fun c ->
+        match ssdtPort c with
+        | Ok _ | Error _ -> true)
+
+    probeOk "jsonEmitter" (fun c ->
+        match jsonPort c with
+        | Ok _ | Error _ -> true)
+
+    // The registry's view must AGREE that these realize-the-port emitters are
+    // present at the Emitter stage — the static port binding and the live
+    // registry cannot disagree on what an emitter is.
+    let registeredEmitterNames =
+        RegisteredAllTransforms.all
+        |> List.filter (fun rt -> rt.StageBinding = Emitter)
+        |> List.map (fun rt -> rt.Name)
+        |> Set.ofList
+    for portName in [ "ssdtDdlEmitter"; "jsonEmitter" ] do
+        Assert.True(
+            Set.contains portName registeredEmitterNames,
+            sprintf "port-realizing emitter '%s' is not registered at the Emitter stage" portName)
+
+// ---------------------------------------------------------------------------
+// Fact 3 — every migrate-leg emitter is registered.
+// ---------------------------------------------------------------------------
+//
+// The migrate leg's emit phase is the registry-driven `Compose.emitSteps`
+// fold (Pipeline) surfaced into `RegisteredAllTransforms.all`. `registered ⇔
+// executed` holds for that stage BY CONSTRUCTION (each EmitStep projects its
+// own `Metadata`); this Fact is the standing witness that the canonical
+// migrate-leg emitter set has not silently dropped a member. Each name here
+// is a transform the migrate leg actually executes (SsdtDdlEmitter +
+// JsonEmitter + DistributionsEmitter via Compose.emitSteps; DacpacEmitter +
+// StaticPopulationEmitter as the conditional schema/data realizers; the
+// operator-UX projections Remediation / Summary / SuggestConfig).
+
+[<Fact>]
+let ``M15: every migrate-leg emitter is registered`` () =
+    let registeredEmitterNames =
+        RegisteredAllTransforms.all
+        |> List.filter (fun rt -> rt.StageBinding = Emitter)
+        |> List.map (fun rt -> rt.Name)
+        |> Set.ofList
+
+    // The canonical migrate-leg emitter roster (the names the emit phase
+    // actually fires; see `Compose.emitSteps` + the conditional
+    // schema/data/dacpac emitters in `RegisteredAllTransforms.all`). A drop or
+    // rename of any one — the exact regression lint could never see, since a
+    // grep over `open` says nothing about registry membership — fails here.
+    let expectedMigrateLegEmitters =
+        set [ "ssdtDdlEmitter"
+              "jsonEmitter"
+              "distributionsEmitter"
+              "remediationEmitter"
+              "summaryFormatter"
+              "suggestConfigEmitter"
+              "dacpacEmitter"
+              "staticPopulationEmitter" ]
+
+    let missing = Set.difference expectedMigrateLegEmitters registeredEmitterNames
+    Assert.True(
+        Set.isEmpty missing,
+        sprintf
+            "migrate-leg emitter(s) not registered at the Emitter stage: %s (registered: %s)"
+            (missing |> Set.toList |> String.concat ", ")
+            (registeredEmitterNames |> Set.toList |> String.concat ", "))
+
+    // And the dual direction: the registry must validate (the registered set is
+    // a real, uniquely-named, rationale-complete registry — not a bag of
+    // strings), so the coverage claim above is anchored on a sound registry.
+    match TransformRegistry.create RegisteredAllTransforms.all with
+    | Ok _ -> ()
+    | Error es ->
+        let codes = es |> List.map (fun e -> e.Code) |> String.concat ", "
+        Assert.Fail(sprintf "RegisteredAllTransforms.all does not validate; codes: %s" codes)

--- a/sidecar/projection/tests/Projection.Tests/AxiomTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/AxiomTests.fs
@@ -33,6 +33,8 @@ module Projection.Tests.AxiomTests
 // (when the citation is a string). The string form is the cheap audit
 // trail; direct delegations are the structural form.
 
+open System.IO
+open System.Text.RegularExpressions
 open Xunit
 open Projection.Core
 open Projection.Tests.Fixtures
@@ -53,10 +55,110 @@ let private citationOf (testFilePath: string) (testName: string) : unit =
     // The structural form would be to call the cited test directly,
     // but xUnit doesn't expose backtick-quoted test names as callable
     // F# values. The audit-trail discipline is "every cited test must
-    // exist at the named file::name" — the test names below were
-    // verified via `grep -rE 'let \`\`AN: ...' tests/Projection.Tests/`
-    // at AxiomTests.fs's first commit.
+    // exist at the named file::name". This was once a verified-once debt
+    // (a `grep` at AxiomTests.fs's first commit); it is now a LIVE GATE —
+    // see ``M16: every axiom citation resolves to a live File::Name in the
+    // tree`` below, which parses THIS file's `citationOf` call-sites and
+    // asserts each cited `file::name` exists on the tree. A drifted
+    // citation now fails a test, not a forgotten grep.
     ignore (testFilePath, testName)
+
+// ---------------------------------------------------------------------------
+// M16 — the citation gate. `citationOf` is the cheap string-typed audit trail,
+// but until M16 nothing enforced that the strings still resolve: a renamed or
+// deleted cited test would leave a `citationOf` call-site pointing at a ghost
+// (the "verified-once" debt — checked by grep at first commit, then never
+// again). This Fact retires that debt. It parses AxiomTests.fs itself,
+// extracts every `citationOf "<file>" "<name>"` pair, and asserts — for each —
+// that the referenced file exists under the projection root AND contains a
+// backtick-quoted test (`let ``<name>``` or `member _.``<name>``) by that
+// exact name. A drifted citation fails M16; the tree stays green because every
+// current citation resolves (110 pairs at this commit).
+// ---------------------------------------------------------------------------
+
+/// Walk up from the running test assembly to the projection root — the
+/// directory that contains `tests/Projection.Tests/AxiomTests.fs`. Mirrors
+/// the findUp idiom in MatrixLadderTests.fs (tolerant of any build depth:
+/// Debug/Release, net9.0) and the `Option.ofObj` null-discipline the
+/// Nullable-enabled test project requires.
+let private projectionRoot : string =
+    let sentinel = Path.Combine("tests", "Projection.Tests", "AxiomTests.fs")
+    let rec findUp (dir: DirectoryInfo option) : string option =
+        match dir with
+        | None -> None
+        | Some d ->
+            if File.Exists(Path.Combine(d.FullName, sentinel)) then Some d.FullName
+            else findUp (Option.ofObj d.Parent)
+    let start =
+        System.Reflection.Assembly.GetExecutingAssembly().Location
+        |> Path.GetDirectoryName
+        |> Option.ofObj
+        |> Option.map (fun d -> DirectoryInfo d)
+    match findUp start with
+    | Some root -> root
+    | None ->
+        // Fail loud rather than skip: AxiomTests.fs is committed at a fixed
+        // path under the projection root, so its absence above the test
+        // assembly is a real regression, not an environment gap.
+        failwith "projection root not found above the test assembly — expected tests/Projection.Tests/AxiomTests.fs"
+
+/// Every `citationOf "<file>" "<name>"` call-site pair, parsed from the
+/// source of AxiomTests.fs. The two string literals are matched across the
+/// optional newline the file uses between the path and the name argument.
+/// The definition site (`let private citationOf`) has no string-literal
+/// arguments, so the regex naturally skips it; the result is exactly the
+/// call-sites.
+let private parsedCitations () : (string * string) list =
+    let raw = File.ReadAllText(Path.Combine(projectionRoot, "tests", "Projection.Tests", "AxiomTests.fs"))
+    // Drop full-line comments before parsing. The `citationOf` token also
+    // appears in prose inside this file's own comments (e.g. the `citationOf
+    // "<file>" "<name>"` example just above) — a real call-site is never on a
+    // `//`-prefixed line, so stripping comment lines removes those decoys
+    // without touching any genuine call-site. (A call-site's path/name
+    // arguments may sit on their own lines, but none of those lines is a
+    // comment.) Replacing comment lines with blanks preserves line offsets.
+    let source =
+        raw.Split('\n')
+        |> Array.map (fun line -> if line.TrimStart().StartsWith("//") then "" else line)
+        |> String.concat "\n"
+    // `citationOf` then two double-quoted literals (file, then name). Citation
+    // names carry no embedded escaped quotes, so a simple non-quote run is a
+    // faithful and total parse of the literal.
+    let rx = Regex("citationOf\\s+\"([^\"]+)\"\\s+\"([^\"]+)\"")
+    [ for m in rx.Matches(source) -> (m.Groups.[1].Value, m.Groups.[2].Value) ]
+
+[<Fact>]
+let ``M16: every axiom citation resolves to a live File::Name in the tree`` () =
+    // Parse our own call-sites and prove each cited test still exists. This is
+    // the executable form of the "every cited test must exist at the named
+    // file::name" discipline — drift fails here, on the current tree, instead
+    // of rotting silently behind a one-time grep.
+    let citations = parsedCitations ()
+    // Guard: the parse must find the citation corpus (a refactor that broke the
+    // regex would otherwise vacuously pass with zero assertions).
+    Assert.True(
+        citations.Length >= 100,
+        sprintf "M16 parsed only %d citationOf call-sites — expected the full corpus (>=100). The regex or the call-site shape drifted." citations.Length)
+
+    let failures =
+        citations
+        |> List.choose (fun (relFile, testName) ->
+            let path = Path.Combine(projectionRoot, relFile.Replace('/', Path.DirectorySeparatorChar))
+            if not (File.Exists path) then
+                Some (sprintf "MISSING FILE  %s :: %s" relFile testName)
+            else
+                let content = File.ReadAllText path
+                // The cited test is a backtick-quoted member: `let ``Name``` or
+                // `member _.``Name```. Either form contains the literal ``<name>``.
+                let needle = "``" + testName + "``"
+                if content.Contains needle then None
+                else Some (sprintf "MISSING TEST  %s :: %s" relFile testName))
+
+    Assert.True(
+        List.isEmpty failures,
+        sprintf
+            "M16 citation gate: %d of %d cited tests no longer resolve on the tree (a drifted citation):\n%s"
+            failures.Length citations.Length (String.concat "\n" failures))
 
 // ===========================================================================
 // Group A — Identity (A1–A5)

--- a/sidecar/projection/tests/Projection.Tests/DacpacEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DacpacEmitterTests.fs
@@ -160,6 +160,30 @@ let ``NM-24: DacpacEmitter.emit still succeeds for a catalog whose trigger body 
     Assert.NotEmpty bytes
 
 // ---------------------------------------------------------------------------
+// M2 (THE VECTOR, Wave 0 honesty) — the SSDT TEXT path is the sibling of the
+// NM-24 .dacpac refusal. The .dacpac path REFUSES an unparseable CreateTrigger;
+// the text path cannot refuse (`Render.toText` is a total fold to a string), so
+// it names the drop IN-BAND. The formerly-silent bare `()` at Render.fs /
+// ScriptDomGenerate.fs is now an honest marker comment naming the closed
+// tolerance `ToleratedDivergence.TriggerBodyUnparsedDropped` — a dropped trigger
+// leaves a trace in the script instead of vanishing.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``M2: an unparseable CreateTrigger is named in-band in the SSDT text, not silently dropped`` () =
+    // Same unparseable body as the NM-24 .dacpac witness; here through the text
+    // render fold. Pre-M2 this produced an empty emission (the silent drop).
+    let unparseable = Render.toText [ Statement.CreateTrigger "THIS IS NOT VALID TSQL @@ )(" ]
+    Assert.Contains("TriggerBodyUnparsedDropped", unparseable)
+    // DISCRIMINATING: a well-formed trigger renders its real CREATE TRIGGER and
+    // carries NO marker — so the test is not trivially always-true.
+    let parseable =
+        Render.toText
+            [ Statement.CreateTrigger
+                "CREATE TRIGGER [dbo].[trgWidget] ON [dbo].[WIDGET] AFTER INSERT AS BEGIN SET NOCOUNT ON END" ]
+    Assert.DoesNotContain("TriggerBodyUnparsedDropped", parseable)
+
+// ---------------------------------------------------------------------------
 // Content-equality via DacFx round-trip — slice α T1 amendment for binary
 // emitters. Per `DECISIONS 2026-05-11 — Chapter 3.x DacpacEmitter open`
 // commitment 3: same Catalog → DacFx model contains same Table objects

--- a/sidecar/projection/tests/Projection.Tests/KeymapSpillTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/KeymapSpillTests.fs
@@ -83,16 +83,30 @@ type KeymapSpillEquivalenceTests(fixture: EphemeralContainerFixture) =
                     // (the essence of the streaming phase2Chunks loop): tryFind the
                     // FK's source value, UPDATE that row. An unmatched FK is left.
                     let remap = PackedSurrogateRemap.create ()
-                    for (s, a) in pairs do PackedSurrogateRemap.capture (SsKey.synthesizedComposite "OS_TEST" [ "Account" ] |> Result.value) s a remap
-                    let kKey = SsKey.synthesizedComposite "OS_TEST" [ "Account" ] |> Result.value
+                    // FS3511 (Release): a `for … do` loop inside `task { }` defeats
+                    // the task CE's static state-machine reduction (the second loop's
+                    // inner `do!` is the hard case). Survival-rule #5's remedy extended:
+                    // drive the synchronous capture with List.iter, and collapse the
+                    // async re-point to a synchronously-built statement list executed
+                    // in ONE batched `do!` — observationally identical (the test
+                    // asserts final FK state, not round-trip count). This pre-existing
+                    // pattern surfaced under THE VECTOR Wave 0's Release-build check
+                    // (the branch CI runs lint/verifiability, not a Release compile).
+                    let acctKey = SsKey.synthesizedComposite "OS_TEST" [ "Account" ] |> Result.value
+                    pairs |> List.iter (fun (s, a) -> PackedSurrogateRemap.capture acctKey s a remap)
+                    let kKey = acctKey
                     let! residentRows = fkState cnn "[dbo].[T_resident]"
-                    for (id, fk) in residentRows do
-                        match fk with
-                        | Some v ->
-                            match PackedSurrogateRemap.tryFind remap kKey (string v) with
-                            | Some assigned -> do! Deploy.executeBatch cnn (sprintf "UPDATE [dbo].[T_resident] SET [FK] = %s WHERE [ID] = %d;" assigned id)
-                            | None -> ()
-                        | None -> ()
+                    let residentUpdates =
+                        residentRows
+                        |> List.choose (fun (id, fk) ->
+                            match fk with
+                            | Some v ->
+                                PackedSurrogateRemap.tryFind remap kKey (string v)
+                                |> Option.map (fun assigned ->
+                                    sprintf "UPDATE [dbo].[T_resident] SET [FK] = %s WHERE [ID] = %d;" assigned id)
+                            | None -> None)
+                    if not (List.isEmpty residentUpdates) then
+                        do! Deploy.executeBatch cnn (String.concat " " residentUpdates)
 
                     // SPILLED re-point — capture the SAME pairs to the session
                     // #-temp keymap, then ONE server-side UPDATE…JOIN per kind.

--- a/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
@@ -49,6 +49,9 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
     // two representation-only tolerances (Char/Decimal) that do not fire CDC.
     // NM-17 (2026-06-14) RETIRED the four NM-16 kind-facet diff-erasure
     // tolerances (now a real `KindFacet` diff channel in `CatalogDiff`).
+    // M1′ + M2 (THE VECTOR, Wave 0, 2026-06-15) added the two Decision-axis
+    // tolerances (FkTrustUnreflected / UniquePromotionUnreflected) +
+    // TriggerBodyUnparsedDropped (the named CreateTrigger text-render drop).
     let result = Unsupported.compute () |> Set.ofList
     let expected =
         Set.ofList
@@ -56,10 +59,13 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
               "CompositePkFkUnreflected"
               "DecimalScaleTolerated"
               "EmptyTextNormalizedToNull"
+              "FkTrustUnreflected"
               "HeaderCommentsOmitted"
               "IndexOptionsUnreflected"
               "PostDeployForeignKeysSplit"
-              "StaticPopulationsUnreflected" ]
+              "StaticPopulationsUnreflected"
+              "TriggerBodyUnparsedDropped"
+              "UniquePromotionUnreflected" ]
     Assert.Equal<Set<string>> (expected, result)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -251,6 +251,7 @@
     <Compile Include="SkeletonPurityTests.fs" />
     <Compile Include="PillarNineTests.fs" />
     <Compile Include="RegisteredAllTransformsBidirectionalTests.fs" />
+    <Compile Include="ArchitectureFitnessTests.fs" />
     <Compile Include="RegistryDigestRoundTripTests.fs" />
     <Compile Include="SsdtExtendedPropertyEmissionTests.fs" />
     <Compile Include="NullabilityRulesTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -199,11 +199,17 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
         | ToleratedDivergence.CompositePkFkUnreflected     -> ()
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> ()
         | ToleratedDivergence.DecimalScaleTolerated        -> ()
+        | ToleratedDivergence.FkTrustUnreflected           -> ()
+        | ToleratedDivergence.UniquePromotionUnreflected   -> ()
+        | ToleratedDivergence.TriggerBodyUnparsedDropped   -> ()
     // AC-D6 (NEITHER→HELD) added the two representation-only tolerances;
     // NM-28 (2026-06-14) added CompositePkFkUnreflected; NM-17 (2026-06-14)
     // RETIRED the four NM-16 kind-facet diff-erasure tolerances (now a real
-    // `KindFacet` diff channel), dropping the count from 12 to 8.
-    Assert.Equal(8, Set.count ToleratedDivergence.allKnown)
+    // `KindFacet` diff channel), dropping the count from 12 to 8. M1′ + M2
+    // (THE VECTOR, Wave 0, 2026-06-15) added the two Decision-axis tolerances
+    // (FkTrustUnreflected / UniquePromotionUnreflected) + TriggerBodyUnparsedDropped,
+    // raising the count to 11.
+    Assert.Equal(11, Set.count ToleratedDivergence.allKnown)
 
 // ---------------------------------------------------------------------------
 // NM-70 (WP5) — the identity-annotation emit | omit gate.

--- a/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
@@ -39,6 +39,9 @@ type ToleratedDivergenceGen =
                 ToleratedDivergence.CompositePkFkUnreflected
                 ToleratedDivergence.CharAnsiPaddingTolerated
                 ToleratedDivergence.DecimalScaleTolerated
+                ToleratedDivergence.FkTrustUnreflected
+                ToleratedDivergence.UniquePromotionUnreflected
+                ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
         |> Arb.fromGen
 
@@ -57,7 +60,7 @@ let ``Tolerance.permissive is not strict`` () =
     Assert.False (Tolerance.isStrict Tolerance.permissive)
 
 [<Fact>]
-let ``Closed-DU coverage: ToleratedDivergence.allKnown contains twelve variants (NM-28 CompositePkFkUnreflected added)`` () =
+let ``Closed-DU coverage: ToleratedDivergence.allKnown contains eleven variants (M1prime Decision + M2 trigger added)`` () =
     // Per the closed-DU expansion empirical-test discipline (`DECISIONS
     // 2026-05-13`): when a new ToleratedDivergence variant lands, this
     // count assertion fires until allKnown is extended. The companion
@@ -86,7 +89,13 @@ let ``Closed-DU coverage: ToleratedDivergence.allKnown contains twelve variants 
     // **NM-17 (2026-06-14):** back to 8 — the four NM-16 kind-facet
     // diff-erasure tolerances are RETIRED (now a real `KindFacet` diff
     // channel in `CatalogDiff`, not an erased tolerance).
-    Assert.Equal (8, Set.count ToleratedDivergence.allKnown)
+    // **M1′ + M2 (THE VECTOR, Wave 0, 2026-06-15):** 11 — the two Decision-axis
+    // tolerances `FkTrustUnreflected` + `UniquePromotionUnreflected` name the
+    // FK-trust / unique-promotion sub-axes the round-trip comparator cannot yet
+    // observe (over-claim correction — Decision drops to ◑ L2-partial; both
+    // auto-retire when M1 lands), and `TriggerBodyUnparsedDropped` names the
+    // formerly-silent CreateTrigger text-render drop (Schema OpenGap).
+    Assert.Equal (11, Set.count ToleratedDivergence.allKnown)
 
 [<Fact>]
 let ``Tolerance.ofSet round-trips through divergences`` () =
@@ -271,6 +280,32 @@ let ``AC-D6: a representation-tolerant environment passes Char/Decimal divergenc
     Assert.True(Tolerance.tolerates ToleratedDivergence.DecimalScaleTolerated tolerant)
     Assert.False(Tolerance.tolerates ToleratedDivergence.CharAnsiPaddingTolerated strict)
     Assert.False(Tolerance.tolerates ToleratedDivergence.DecimalScaleTolerated strict)
+
+// ---------------------------------------------------------------------------
+// M1′ + M2 (THE VECTOR, Wave 0 honesty) — the three new tolerances are named,
+// parseable, and present in the closed set. The two Decision-axis tolerances
+// (FkTrustUnreflected / UniquePromotionUnreflected) name the FK-trust and
+// unique-promotion sub-axes the round-trip comparator cannot yet observe — so
+// matrix-status.sh drops Decision from an over-claimed ✅-faithful to ◑
+// L2-partial (their `@ladder … Decision OpenGap` tags are cross-checked by the
+// generator). TriggerBodyUnparsedDropped names the formerly-silent CreateTrigger
+// text-render drop. All three auto-flip / retire when their fix lands (M1 / a
+// faithful trigger round-trip).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``M1prime + M2: the three new tolerances are named, parseable, and in allKnown`` () =
+    // DISCRIMINATING: each must be in the closed set AND round-trip through the
+    // operator-facing token surface (name ⇒ tryParse). A mislabeled-but-wrong
+    // implementation that dropped one from `allKnown`/`name` would fail here.
+    for d in [ ToleratedDivergence.FkTrustUnreflected
+               ToleratedDivergence.UniquePromotionUnreflected
+               ToleratedDivergence.TriggerBodyUnparsedDropped ] do
+        Assert.True(Set.contains d ToleratedDivergence.allKnown, sprintf "%A must be in allKnown" d)
+        Assert.Equal<ToleratedDivergence option>(Some d, ToleratedDivergence.tryParse (ToleratedDivergence.name d))
+    Assert.Equal("FkTrustUnreflected", ToleratedDivergence.name ToleratedDivergence.FkTrustUnreflected)
+    Assert.Equal("UniquePromotionUnreflected", ToleratedDivergence.name ToleratedDivergence.UniquePromotionUnreflected)
+    Assert.Equal("TriggerBodyUnparsedDropped", ToleratedDivergence.name ToleratedDivergence.TriggerBodyUnparsedDropped)
 
 // ---------------------------------------------------------------------------
 // matchedResidual — the per-run residual the canary collector resolves


### PR DESCRIPTION
## THE VECTOR — Wave 0: honesty & fitness

First chapter of [THE VECTOR](sidecar/projection/THE_VECTOR.md) (§7 / `THE_VECTOR_EXECUTION_KICKOFF.md` §8). **No new capability** — this wave only makes the projection engine tell the truth about itself and makes its guardrails un-rottable. Honesty before the keystone (M1, Wave 1, handed off). The governing rule the engine holds itself to: *the generator under-claims, never over-claims* — and Wave 0 restores that on all five round-trip axes.

### The honesty correction, concretely

The self-verification matrix (`scripts/matrix-status.sh` → `NORTH_STAR.matrix.generated.md`) marked the **Decision axis `✅ faithful`** — but the only live Decision witness covers nullability alone; the FK-trust and unique-promotion sub-axes are not reflected in the round-trip comparator. With zero Decision-tagged tolerances, the matrix had no way to mark the gap, so "Decision faithful" was unfalsifiable-by-construction.

| Axis | Before | After |
|---|---|---|
| **Decision** | `✅ faithful` / `✅ L3` (over-claim) | `◑ L2-partial` — open: `FkTrustUnreflected`, `UniquePromotionUnreflected` |
| **Schema** | `◑ L2-partial` (2 open) | `◑ L2-partial` (+ `TriggerBodyUnparsedDropped` — named, not silent) |

Rungs: **L1/L2/L3 = 5/3/5** (L2 was 4/5). Tolerance set: **11, 5 open**.

### What changed

- **M1′ — name the Decision-axis erasure.** Added `FkTrustUnreflected` + `UniquePromotionUnreflected` to the closed `ToleratedDivergence` DU (`@ladder … Decision OpenGap`). Drops Decision to an honest `◑ L2-partial` with no script change. **Both auto-retire when M1 (Wave 1) lands.**
- **M2 — name the silent `CreateTrigger` text-drop.** Added `TriggerBodyUnparsedDropped` (`@ladder … Schema OpenGap`). `Render.fs` / `ScriptDomGenerate.fs` dropped an unparseable `CreateTrigger` with a bare `()` justified by a canary detector that doesn't cover the text path. The render site now emits an in-band marker comment naming the tolerance; the false justification is gone. (The `.dacpac` path already refused + named it, NM-24 — only the text path was silent. This closes that asymmetry.)
- **M16 — `citationOf` becomes a gated existence check; the matrix binds witnesses by Name.** A new `AxiomTests` Fact parses every `citationOf "<file>" "<name>"` call-site and asserts each resolves in the tree (retires the "verified-once-by-grep-at-first-commit" debt; verified to *fail* on a drifted citation). `matrix-status.sh` now binds each axis's L1/L3 witness by its **exact full test name** instead of a loose substring, closing the substring-satisfaction hole.
- **M15 — architectural fitness functions in-assembly; analyzer → CI.** New `ArchitectureFitnessTests.fs`: six reflection/registry Facts lifting the grep/bash guardrails (layer-dependency DAG = lint Rules 20/21/22, emitter-port shape, migrate-leg registration). `scripts/run-analyzers.sh` promoted to a PR-blocking gate (`.github/workflows/analyzers-projection.yml`). `perf-gate.sh` **deliberately not** promoted — shared-runner contention voids the timing verdict (survival-rule #13); deferred behind a dedicated/quiet runner.
- **Count corrections.** Verified the canonical counts hold (112 citations, 42 Skips, seven emitter targets); corrected the writer-"trinity" over-claim in `AXIOMS.md` to **linear writer only** (`LineageTree`/`Certificate` were retired 2026-06-04, zero consumer) and neutralized a stale citation to a non-existent test.

### Reviewer notes

- **A pre-existing Release-only FS3511** in the landed Slice S test (`KeymapSpillTests.fs` — `for … do` inside `task { }`) surfaced under this wave's Release-build check (branch CI runs bash gates, never a Release compile). Fixed as a labeled drive-by (synchronous `List.iter`/`List.choose` + one batched `do!`; behavior-preserving) and **verified on the warm container** (Slice S equivalence green, 2 s — a real run, not a no-op).
- **The new CI workflow (`analyzers-projection.yml`) is unvalidated on an actual GitHub runner** (can't run CI locally), but the underlying analyzer gate runs green on the tree — it's a fail-loud guardrail, not flaky.
- `verifiability-gate.sh` emits a pre-existing advisory WARN about 4 unbucketed deferrals — untouched by this wave, not a phantom (gate exits 0).
- Orchestrated as a multi-agent workflow (worktree-isolated implementers + an adversarial verifier per move). M1′+M2's implementer hit a transient provider error; it was re-implemented by the integrator and independently verified (ACCEPT). The closed-DU forcing function then caught two further exhaustive-match sites — the discipline working.

### Verification (all warm)

- Debug **and Release** builds clean (0 warnings / 0 errors).
- Pure test pool: **3357 passed / 0 failed**.
- `matrix-status.sh` regenerated — gate=PASS; rungs 5/3/5; tolerances 11 (5 open); `@ladder` cross-check passes (no untagged variant).
- `verifiability-gate.sh` exit 0; `run-analyzers.sh` green.
- Each move adversarially verified; every witness confirmed a live, non-vacuous green test.

### Not in this PR

**Wave 1 — M1 (the keystone):** `PhysicalForeignKey.IsTrusted` + overlay-aware `ofCatalogWith` + the Docker-gated decision-readback property, which auto-retires M1′ and turns Decision back to an earned `✅`. The full spec is scouted and waiting in the `HANDOFF.md` top letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
