### PR TITLE
THE VECTOR Waves 0+1: honesty (M1′/M2/M16/M15) + the keystone M1 (Decision-readback adjunction)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -23957,3 +23957,87 @@ provider error, then independently verified (ACCEPT).
   is restored on all five axes. **Next: Wave 1 (M1, the keystone) — `PhysicalForeignKey.IsTrusted` +
   overlay-aware `PhysicalSchema.ofCatalogWith` + the decision-readback property, which auto-retires M1′
   and turns Decision back to an earned faithful.**
+
+---
+
+## 2026-06-15 (later still) — THE VECTOR Wave 1 BUILT: M1, the keystone — the Decision-readback adjunction (the honest tolerance becomes an earned green)
+
+The second chapter of THE VECTOR (`THE_VECTOR.md` §6 M1 / §7 Wave 1; mechanics in `THE_VECTOR_UNABRIDGED.md`
+Part III). Wave 0 made the Decision axis **honest** (`◑ L2-partial`, two named tolerances); Wave 1 makes it
+**true** — it routes the recovered FK-trust and unique-promotion decisions through the *general*
+`PhysicalSchema.diff` comparator, so the matrix's Decision cell is *showable*, not asserted. Built **inline**
+(a single coupled move with a Docker witness; worktree-isolated fan-out would have cost more in cold builds
+than it saved — Waves 2–3 are the fan-out waves). Ships with Wave 0 in **one PR** (Wave 0 was committed but
+never merged; this branch fast-forwarded onto it).
+
+- **M1 — `PhysicalForeignKey.IsTrusted` + the overlay-aware projection.** Added `IsTrusted : bool` to the
+  closed `PhysicalForeignKey` record (both construction sites fixed: `PhysicalSchema.toPhysicalForeignKeys`
+  and `PhysicalSchemaReader.toPhysicalForeignKeys`; `ReadSide`'s internal `FkRow`/`FkCoordinates` carry
+  `IsNotTrusted` and are a different record, untouched). `PhysicalSchema.ofCatalog` became overlay-aware the
+  way the SSDT emitter already is (the `statements`/`statementsWith` precedent): a new
+  `ofCatalogWith : DecisionOverlay -> Catalog -> PhysicalSchema` is the core, and `ofCatalog c =
+  ofCatalogWith DecisionOverlay.empty c` — **byte-identical at `empty`** (the ~30 call sites and the read-back
+  leg are unchanged). `toPhysicalForeignKeys` sets `IsTrusted = r.IsConstraintTrusted && not (Set.contains
+  r.SsKey overlay.NoCheckFk)`; `toPhysicalIndexes` sets `IsUnique = isUnique || Set.contains idx.SsKey
+  overlay.EnforceUnique` — each mirrors the emitter's own predicate (`untrustedFkAlters` / `indexStatements`),
+  so the source projection and the `ReadSide`-recovered read-back agree on the decision (the read leg recovers
+  `sys.foreign_keys.is_not_trusted` at `ReadSide.fs:1171` and `sys.indexes.is_unique` via `readIndexes`).
+- **Compile-order move (the only structural change).** `PhysicalSchema.fs` moved in `Projection.Core.fsproj`
+  from compile-order ~58 to just after `DecisionOverlay.fs` (~94), since `ofCatalogWith` now consumes
+  `DecisionOverlay` (whose `ofComposeState` depends on `ComposeState` + the strategy DUs, deep in the chain —
+  so `DecisionOverlay` could not move up). Dependency-safe: no Core file references `PhysicalSchema` *in code*
+  before its new slot (Coordinates / CatalogDiff / Catalog / Tolerance / CanaryResidual cite it in docstrings
+  only). Verified by a clean Debug **and** Release build.
+- **The decision-readback witness (Docker, real — not a no-op).** New
+  `CanaryRoundTripTests."M1 (decision-readback adjunction): NoCheckFk + EnforceUnique survive emit / deploy /
+  read-back through PhysicalSchema.diff"`. One overlay carries both intents (`NoCheckFk(ref)` +
+  `EnforceUnique(idx)`); emit → deploy → read-back, then **two arms**: (1) AGREEMENT — `ofCatalogWith overlay
+  source` ≡ `ofCatalog readback` on the FK-trust and index-uniqueness axes (empty diff); (2) FALSIFIABILITY —
+  *without* the overlay reflection (`ofCatalog source`) the SAME read-back DIVERGES on exactly those axes,
+  proving the comparator is no longer blind (the precise over-claim M1′ named — before M1 both diffs were
+  empty). Confirmed green at a **real ~3.0 s duration** (TRX-verified, not the 0.4 ms soft-skip) against the
+  warm container.
+- **M1′ retired — per-axis, honestly, both proven.** Both Decision tolerances were retired only after the
+  Docker witness proved both sub-axes round-trip: `FkTrustUnreflected` (FK trust via `NoCheckFk`) AND
+  `UniquePromotionUnreflected` (unique promotion via `EnforceUnique` — `ReadSide` recovers `is_unique`, proven
+  by the witness, not taken on faith). The closed-DU cascade in reverse, 11 → 9 variants: `Tolerance.fs` (DU +
+  `coverage` + `allKnown` + `name`, replaced by a retirement comment per the dead-algebra precedent),
+  `ToleranceTests.fs` (generator + the 11→9 count + the `M1prime + M2` named test rewritten to M2-only),
+  `SsdtExtendedPropertyEmissionTests.fs` (match arms + count), `ManifestUnsupportedTests.fs` (the expected-names
+  set). Deleting the two `@ladder … Decision OpenGap` tags is the honesty mechanism: `matrix-status.sh`
+  **auto-flips Decision from `◑ L2-partial` to `✅ faithful` / `✅ L3`** with no script change. The matrix now
+  reads **rungs L1/L2/L3 = 5/4/5** (L2 was 3/5), **tolerances 9, 3 open** (the three remaining Schema OpenGaps:
+  `IndexOptionsUnreflected`, `CompositePkFkUnreflected`, `TriggerBodyUnparsedDropped`). The `@ladder`
+  cross-check passes (no untagged/orphan variant). Also corrected the generator's stale caveat (the "3-axis
+  Decision adjunction, debrief G12" is now witnessed, so it left the *unwitnessed* example list).
+- **Caught a latent Wave 0 red (the full-pure-pool lesson).** `MatrixLadderTests."D1: exactly two tolerances
+  are open"` pins the matrix open-gap count by reading the committed matrix. Wave 0 added three OpenGap
+  tolerances (matrix → "5 open") but did **not** update this test (still "2 open"), so it was red since Wave 0 —
+  the full pure pool surfaces it; a focused run would not. Updated to "exactly **three**" / `"3 open"` (the
+  honest post-M1 count) with the full M1′→M1 history in the comment. (This is why the pure-pool count is now an
+  honest 3357/0, matching Wave 0's *claimed* figure for the first time.)
+- **A real divergence M1 surfaced (named, scoped, flagged — NOT silenced).** With FK trust now in the
+  comparator, two `TransferCanaryTests` (`multi-table FK chain` + `deferred self-referential FK`) failed: the
+  rendered diff showed the *only* divergence is FK trust — source `trusted=true` (inline FK), sink
+  `trusted=false`. Cause: `Transfer.Execute` bulk-loads via `SqlBulkCopy` WITHOUT `CHECK_CONSTRAINTS` (the
+  high-throughput path), which SQL Server records by marking the sink's FKs `is_not_trusted = 1`. The FK
+  *structure*, columns, rows, and indexes all round-trip. This is the keystone working — a previously-invisible
+  trust divergence is now visible. **Resolution (in-scope):** the transfer canary witnesses DATA +
+  SCHEMA-STRUCTURE fidelity, so it normalizes the trust bit on both sides before comparing
+  (`TransferCanaryFixtures.trustNormalizedFks` — a precise exclusion: only `IsTrusted` is normalized, so a
+  genuine *structural* FK divergence still fails; the `isSchemaEqual`-ignores-rows precedent). FK-trust
+  round-trip is witnessed on the schema surface (the M1 canary above). **OPEN QUESTION for the operator /
+  transfer-path owner:** should `Transfer.Execute` re-validate FKs (`WITH CHECK CHECK CONSTRAINT`) after the
+  bulk load to re-trust the sink — trading load throughput for trust fidelity at the reverse leg's
+  hundreds-of-millions-of-rows scale? Deferred to the operator; not decided here.
+- **Witness (all green).** Debug + **Release** builds clean (0/0). Pure pool **3357 passed / 0 failed** (210
+  skip). **Docker pool 244 / 244** (incl. the M1 decision-readback canary, the transfer canaries, and the
+  bulk-load scale tests — `ReverseLegScale` / `GeneratorScale` / `DacpacPublishEquivalence`). Byte-identity
+  guards (`GoldenEmissionTests` + `AdjunctionLawTests`) green. `matrix-status.sh` regenerated (gate=PASS;
+  Decision `✅`; L2 4/5; tolerances 9, 3 open; `@ladder` cross-check passes). `verifiability-gate.sh` exit 0.
+- **Exit criterion (Wave 1) — MET.** The live canary witnesses `NoCheckFk` / `EnforceUnique` survival through
+  emit → deploy → read-back **through the general comparator**; the Decision cell is *showable*, not asserted,
+  and has flipped to an earned `✅ L3`. The fifth column is true. **Next: Wave 2 (the fan-out wave) — the
+  `CatalogDiff.fs` trio (M11 → M13 → M12, one serialized implementer — shared file), plus M3 and M20 (each its
+  own surface, parallel). Drive it as a Workflow: worktree-isolated implementers + one adversarial verifier per
+  move + one integrator owning the build/matrix/gates.**

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,69 @@
+# Handoff addendum — 2026-06-15, THE VECTOR WAVE 1 LANDED (the keystone M1 — the Decision axis is now an EARNED green); your job is WAVE 2 — the fan-out wave, and this time you ORCHESTRATE IT WITH A WORKFLOW
+
+To the next agent.
+
+**Your mission.** Build **Wave 2** of `THE_VECTOR.md` — five moves, cleanly partitionable, and the **first
+fan-out wave**. Wave 0 (honesty) and Wave 1 (the keystone) were single coupled moves done inline; Wave 2 is
+where worktree isolation finally pays. **Drive it as a `Workflow`** (the operator asked for this explicitly):
+worktree-isolated implementers, **one adversarial verifier per move**, and **one integrator** who alone owns
+the build / matrix / gates. Read `THE_VECTOR.md` §6 (the move catalog) + §7 (the wave roadmap) first; the moves
+below are the partition.
+
+**The five moves and how they partition (this is the workflow's shape).**
+1. **The `CatalogDiff.fs` trio — M11 → M13 → M12 — ONE serialized implementer** (shared file; they conflict if
+   parallel). M11 = the triangle-inequality law on `between`; M13 = drop the `Result` on `between` (it is total);
+   M12 = the groupoid inverse (`between a b` ∘ `between b a` = id). Order matters: M11, then M13, then M12.
+2. **M3 — `genCatalogPair` + the swept property** (its own surface — a generator + a property test). Independent;
+   runs parallel to the trio.
+3. **M20 — `GateLabel.MidWriteNotProtected` + the pure gate** (`Preflight.fs`). Independent; parallel.
+   So: **3 worktree implementers** (trio / M3 / M20) → **3 adversarial verifiers** (one each) → **1 integrator**
+   who cherry-picks/integrates, runs the one authoritative build, regenerates the matrix, and runs the gates.
+   Have implementers **commit to their worktree branch** and integrate via cherry-pick — NOT text-diff-apply
+   (Windows diffs lack the trailing newline `git apply` wants; that bit Wave 0).
+
+**What is DONE — do not redo (Wave 0 + Wave 1, both in this PR).** Wave 0: M1′ + M2 + M16 + M15 + count
+corrections (the honesty wave). Wave 1 (the 2026-06-15 "THE VECTOR Wave 1 BUILT" DECISIONS entry is the
+substance — read it): `PhysicalForeignKey.IsTrusted`; overlay-aware `PhysicalSchema.ofCatalogWith` (with
+`ofCatalog = ofCatalogWith empty`, byte-identical); the Docker decision-readback canary (agreement +
+falsifiability, ~3 s real); **M1′ retired** (both Decision tolerances, per-axis, proven); the matrix flipped
+**Decision → `✅ L3`, L2 4/5, tolerances 9 (3 open)**. The honest machine's fifth column is now true.
+
+**One open question Wave 1 surfaced and DEFERRED to the operator (do not silently decide it).** M1's new FK
+`IsTrusted` field revealed that `Transfer.Execute` bulk-loads via `SqlBulkCopy` WITHOUT `CHECK_CONSTRAINTS`,
+leaving the sink's FKs **untrusted** (`is_not_trusted = 1`) while the source is trusted. The transfer canary now
+normalizes the trust bit by name (`TransferCanaryFixtures.trustNormalizedFks` — a precise exclusion; structure
+still compared) and FK-trust round-trip is witnessed on the schema surface. **The question for the operator:**
+should the transfer re-validate FKs (`WITH CHECK CHECK CONSTRAINT`) after load to re-trust the sink, trading
+throughput for trust fidelity at hundreds-of-millions-of-rows scale? It's flagged in DECISIONS; surface it.
+
+**Build-discipline scars (heed them — they all bit this session).**
+1. **⚠️ Docker tests SILENTLY NO-OP on this Windows box** unless `$env:PROJECTION_MSSQL_CONN_STR=
+   "Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container, up). Confirm a **real per-test duration in seconds** via the TRX, never the green count.
+2. **⚠️ Run bash scripts from the WORKTREE, not the main checkout.** `cd`-ing to
+   `C:/Users/danny/code/outsystems-ddl-exporter/sidecar/projection` lands in the MAIN checkout (a *different*
+   branch); `matrix-status.sh` then reads the wrong `Tolerance.fs` and overwrites the main checkout's matrix.
+   Run scripts by absolute path into the worktree: `bash "<worktree>/sidecar/projection/scripts/<x>.sh"`. (The
+   Bash tool resets cwd to the worktree root each call, so a bare `scripts/...` from there is also fine.)
+3. `dotnet` lives at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` (9.0.314; not on bash PATH).
+   Build/test via PowerShell, or `export PATH="/c/Users/danny/AppData/Local/Microsoft/dotnet:$PATH"` for
+   `scripts/test.sh`. **Never the pure + Docker pools in one `dotnet test`** (OOM) — use `test.sh fast` /
+   `docker`. Build **Release** too before claiming done (only it catches FS3511).
+4. **Run the FULL pure pool, not a focused subset** — Wave 0 left `MatrixLadderTests."exactly two tolerances are
+   open"` red (it never updated the count when it added OpenGaps), and only the full pool surfaces it. A change
+   to a comparison primitive (`PhysicalSchema`, `CatalogDiff`) ripples through every canary — run the **full
+   Docker pool** after it (244/244 is the bar), not just `~Canary`.
+5. **Closed-DU edits cascade — grep first, fix all sites, build once.** `M13` (drop `Result` on `between`)
+   changes every `CatalogDiff.between` call site; `grep -rn "CatalogDiff.between" src tests` before you touch it.
+
+**State.** Branch `claude/wizardly-wing-f7fb26`, Wave 0 + Wave 1 committed (this branch fast-forwarded onto
+Wave 0's commit `a71bdc34`, which was committed but **never merged to main** — the PR carries both). After
+Wave 2, chapter-close and extend the same PR (or open the Wave-2 PR atop it per the operator's call). Hold the
+spine: name every refusal, count every crossing, leave the books balanced — and this time, let the workflow
+carry the fan-out.
+
+---
+
 # Handoff addendum — 2026-06-15, THE VECTOR WAVE 0 LANDED (honesty & fitness); your job is WAVE 1 — the keystone M1, which turns the honest tolerance back into an earned green
 
 To the next agent.

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -31,19 +31,21 @@ witness covers the axis. The **Ladder** column is the honest weakest-rung summar
 | **Data** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Identity** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 | **Time** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
-| **Decision** | ✅ | ◑ L2-partial | ✅ | `FkTrustUnreflected`, `UniquePromotionUnreflected` | ◑ L2-partial |
+| **Decision** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 
-**Rungs reached: L1 5/5 · L2 3/5 · L3 5/5.** Tolerance set:
-11 named, of which **5 open** (`OpenGap`). A cell cannot be
+**Rungs reached: L1 5/5 · L2 4/5 · L3 5/5.** Tolerance set:
+9 named, of which **3 open** (`OpenGap`). A cell cannot be
 hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance
 to be retired from `Tolerance.fs`. The generator under-claims; it never over-claims.
 
 > **Witness/tolerance-present ≠ feature-complete.** L2 here is "no open *named*
 > tolerance on the axis." Silent drops with no named surface (the cross-schema FK
-> filter, debrief G4) and unwitnessed sub-axes (the 3-axis Decision adjunction,
-> debrief G12) are NOT auto-detected — they have no machine surface yet, and are
-> tracked in `DEBRIEF_2026_06_02` until E2/F2 give them a named diagnostic/witness.
+> filter, debrief G4) are NOT auto-detected — they have no machine surface yet, and are
+> tracked in `DEBRIEF_2026_06_02` until a named diagnostic/witness lands. The 3-axis
+> Decision adjunction (debrief G12) IS now witnessed — M1 (THE VECTOR Wave 1) routes
+> FK-trust + unique-promotion through the general `PhysicalSchema.diff` comparator,
+> so the Decision axis is honestly faithful, not asserted.
 > L3 here is "a composition witness exists for the axis," not "faithful under every
 > spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
 
-_Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/3/5 of 5 · tolerances 11 (5 open)_
+_Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 9 (3 open)_

--- a/sidecar/projection/THE_VECTOR.md
+++ b/sidecar/projection/THE_VECTOR.md
@@ -36,11 +36,31 @@
 
 ---
 
+## Build addendum — 2026-06-15 (Wave 0 + Wave 1 BUILT — the keystone landed)
+
+> The study below is now partly **executed**, not just proposed. Per the house dated-note discipline, this
+> supersedes the "still unbuilt" claim in the reconciliation addendum that follows.
+>
+> - **Wave 0 (honesty) — BUILT.** M1′ + M2 + M16 + M15 + count corrections. `Tolerance.fs` gained the two
+>   Decision tolerances; the matrix dropped Decision to `◑ L2-partial`. (DECISIONS 2026-06-15 "THE VECTOR Wave 0
+>   BUILT".)
+> - **Wave 1 — M1, the keystone — BUILT.** `PhysicalForeignKey.IsTrusted` + overlay-aware
+>   `PhysicalSchema.ofCatalogWith` (with `ofCatalog = ofCatalogWith empty`, byte-identical) route the FK-trust
+>   (`NoCheckFk`) and unique-promotion (`EnforceUnique`) decisions through the general comparator; a Docker
+>   decision-readback canary (agreement + falsifiability, ~3 s real) witnesses it; M1′ retired (both tolerances,
+>   per-axis, proven). **The matrix's Decision cell is now an EARNED `✅ L3`** (L2 4/5; tolerances 9, 3 open).
+>   So §2.4's "silent fifth column" and §2.5's "unfalsifiable by construction" are **closed for the Decision
+>   axis**: it is now *showable*, not asserted. (DECISIONS 2026-06-15 "THE VECTOR Wave 1 BUILT".)
+> - **Still ahead.** Waves 2–3 (the fan-out waves: the `CatalogDiff` trio M11/M13/M12, M3, M20, then M7/M8/M9/
+>   M17/M6/M19). The §6 move catalog stands for those.
+
 ## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
 
 > Written against `db01c23d`; `main` has since advanced 19 commits (PR #613 — this study — among them, now
 > merged). The reconciliation is **focused, and the core is intact.** Per the house amendment discipline this is
-> recorded as a dated note, not a silent rewrite of the body.
+> recorded as a dated note, not a silent rewrite of the body. **(Superseded in part by the Build addendum above:
+> M1 and Wave 0 are no longer unbuilt — the "still unbuilt / still 8 variants / no `IsTrusted`" facts below were
+> true on main at the time of writing and are now overtaken by Wave 0 + Wave 1.)**
 
 **Still valid, verified byte-for-byte.** The keystone and every honesty finding hold: `PhysicalSchema.fs`
 (`PhysicalForeignKey` still has no `IsTrusted`; `ofCatalog` still takes no `DecisionOverlay`), `Tolerance.fs`

--- a/sidecar/projection/scripts/matrix-status.sh
+++ b/sidecar/projection/scripts/matrix-status.sh
@@ -181,9 +181,11 @@ open_count=$(printf '%s\n' "$ladder_tags" | awk '$3=="OpenGap"' | grep -c . || t
   echo
   echo "> **Witness/tolerance-present ≠ feature-complete.** L2 here is \"no open *named*"
   echo "> tolerance on the axis.\" Silent drops with no named surface (the cross-schema FK"
-  echo "> filter, debrief G4) and unwitnessed sub-axes (the 3-axis Decision adjunction,"
-  echo "> debrief G12) are NOT auto-detected — they have no machine surface yet, and are"
-  echo "> tracked in \`DEBRIEF_2026_06_02\` until E2/F2 give them a named diagnostic/witness."
+  echo "> filter, debrief G4) are NOT auto-detected — they have no machine surface yet, and are"
+  echo "> tracked in \`DEBRIEF_2026_06_02\` until a named diagnostic/witness lands. The 3-axis"
+  echo "> Decision adjunction (debrief G12) IS now witnessed — M1 (THE VECTOR Wave 1) routes"
+  echo "> FK-trust + unique-promotion through the general \`PhysicalSchema.diff\` comparator,"
+  echo "> so the Decision axis is honestly faithful, not asserted."
   echo "> L3 here is \"a composition witness exists for the axis,\" not \"faithful under every"
   echo "> spanning axis\" (T-VI atomicity/permissions ride the debrief until cluster A names them)."
   echo

--- a/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
+++ b/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
@@ -39,7 +39,8 @@ namespace Projection.Core
 ///   - `Columns`: set of `(schema, table, column, type, nullable,
 ///     isPrimaryKey)` tuples.
 ///   - `ForeignKeys`: set of `(srcSchema, srcTable, srcCol,
-///     tgtSchema, tgtTable, tgtCol)` tuples (Session B addition).
+///     tgtSchema, tgtTable, tgtCol, isTrusted)` tuples (Session B addition;
+///     `isTrusted` is THE VECTOR Wave 1 / M1's Decision-axis trust sub-axis).
 ///
 /// **What's NOT compared.** SsKey identity, Module structure,
 /// Origin / Modality marks, static populations. Non-PK index
@@ -150,6 +151,19 @@ type PhysicalIndex =
 /// table coordinates and different column pairs. Comparing as a
 /// set of column-level entries handles composite cases by
 /// construction.
+///
+/// **`IsTrusted` — the Decision-axis trust sub-axis (THE VECTOR Wave 1 /
+/// M1).** `true` for a normally-enforced FK; `false` for a `WITH NOCHECK`
+/// (untrusted) FK. The decision arrives two ways, both reflected here so the
+/// general `diff` comparator observes a trust divergence:
+///   - the source `Reference.IsConstraintTrusted` (a deployed source FK that
+///     was already `WITH NOCHECK`, recovered at `ReadSide.fs:1171` from
+///     `sys.foreign_keys.is_not_trusted`), AND
+///   - a registered `EnforceConstraint (ScriptWithNoCheck _)` intervention,
+///     carried in `DecisionOverlay.NoCheckFk` and applied by `ofCatalogWith`.
+/// Before M1 this field did not exist, so `PhysicalSchema.diff` was
+/// structurally blind to FK trust — the over-claim the retired
+/// `ToleratedDivergence.FkTrustUnreflected` named.
 type PhysicalForeignKey =
     {
         SourceSchema : string
@@ -158,6 +172,9 @@ type PhysicalForeignKey =
         TargetSchema : string
         TargetTable : string
         TargetColumn : string
+        /// `true` ⇒ enforced/trusted; `false` ⇒ `WITH NOCHECK` (untrusted).
+        /// See the type docstring — the Decision-axis trust sub-axis.
+        IsTrusted : bool
     }
 
 /// A row's content fingerprint in physical-schema coordinates.
@@ -471,7 +488,17 @@ module PhysicalSchema =
     /// axis. Resolves each `IndexColumn`'s attribute SsKey to its physical
     /// column name (the same coordinate `toPhysicalColumns` keys on) and
     /// encodes the ordered key list so a reorder surfaces as a divergence.
-    let private toPhysicalIndexes (k: Kind) : PhysicalIndex list =
+    ///
+    /// THE VECTOR Wave 1 / M1 — `IsUnique` is additive over the overlay: an
+    /// index is UNIQUE iff the catalog already declared it unique OR a
+    /// registered `UniqueIndex` intervention decided `EnforceUnique`
+    /// (`DecisionOverlay.EnforceUnique`). This mirrors the emitter's own rule
+    /// at `SsdtDdlEmitter.indexStatements` (`isUnique || overlay.EnforceUnique`)
+    /// so the source projection and the read-back agree on the promotion (the
+    /// read leg recovers `sys.indexes.is_unique`), routing the unique-promotion
+    /// decision through the general comparator (retires
+    /// `ToleratedDivergence.UniquePromotionUnreflected`).
+    let private toPhysicalIndexes (overlay: DecisionOverlay) (k: Kind) : PhysicalIndex list =
         let schemaStr = SchemaName.value k.Physical.Schema
         let tableStr = TableName.value k.Physical.Table
         let colNameByKey =
@@ -491,7 +518,7 @@ module PhysicalSchema =
                 Schema = schemaStr
                 Table = tableStr
                 Name = Name.value idx.Name
-                IsUnique = IndexUniqueness.isUnique idx.Uniqueness
+                IsUnique = IndexUniqueness.isUnique idx.Uniqueness || Set.contains idx.SsKey overlay.EnforceUnique
                 KeyColumns = keyColumns
             })
 
@@ -603,6 +630,7 @@ module PhysicalSchema =
     /// `Attributes` (≈10 entries on avg, not worth the per-kind
     /// allocation of a separate map).
     let private toPhysicalForeignKeys
+        (overlay: DecisionOverlay)
         (kindByKey: Map<SsKey, Kind>)
         (targetPkColumnsByKey: Map<SsKey, string list>)
         (k: Kind)
@@ -634,6 +662,15 @@ module PhysicalSchema =
                         TargetSchema = SchemaName.value tk.Physical.Schema
                         TargetTable = TableName.value tk.Physical.Table
                         TargetColumn = tgtPkFirst
+                        // THE VECTOR Wave 1 / M1 — the Decision-axis trust
+                        // sub-axis. Untrusted iff the source FK is itself
+                        // `WITH NOCHECK` (`r.IsConstraintTrusted = false`,
+                        // recovered at `ReadSide.fs:1171`) OR a registered
+                        // intervention decided NOCHECK (`overlay.NoCheckFk`).
+                        // Mirrors the emitter's NOCHECK predicate
+                        // (`SsdtDdlEmitter.untrustedFkAlters`) so the source
+                        // projection and the read-back agree.
+                        IsTrusted = r.IsConstraintTrusted && not (Set.contains r.SsKey overlay.NoCheckFk)
                     }
             | _ ->
                 // Dropped: the source attribute is unresolvable, the target
@@ -647,12 +684,24 @@ module PhysicalSchema =
                 // not landed here.
                 None)
 
-    /// Project a Catalog to its `PhysicalSchema` view — the set of
-    /// `(schema, table, column, type, nullable, isPrimaryKey)`
-    /// tuples PLUS the set of `(src, tgt)` FK tuples reachable
-    /// through every Module's Kinds. Modules, Origin, Modality,
-    /// non-PK Indexes are projected out by construction.
-    let ofCatalog (c: Catalog) : PhysicalSchema =
+    /// Project a Catalog to its `PhysicalSchema` view under a
+    /// `DecisionOverlay` — the set of `(schema, table, column, type, nullable,
+    /// isPrimaryKey)` tuples PLUS the set of `(src, tgt, isTrusted)` FK tuples
+    /// reachable through every Module's Kinds. Modules, Origin, Modality are
+    /// projected out by construction.
+    ///
+    /// **THE VECTOR Wave 1 / M1 — the overlay-aware core.** The overlay
+    /// reflects the two Decision sub-axes the catalog does not itself bake in:
+    /// FK trust (`NoCheckFk` → `PhysicalForeignKey.IsTrusted`) and unique
+    /// promotion (`EnforceUnique` → `PhysicalIndex.IsUnique`). (Nullability
+    /// tightening is already baked into the catalog before projection, so it
+    /// round-trips without overlay threading.) At `DecisionOverlay.empty` this
+    /// is **byte-identical** to the pre-M1 projection — the T1 goldens
+    /// (`GoldenEmissionTests`) and `AdjunctionLawTests` are the guard. Mirrors
+    /// the `SsdtDdlEmitter.statements` / `statementsWith` precedent: the
+    /// emitter consults the same overlay at emission, so source projection and
+    /// read-back agree on the recovered decision.
+    let ofCatalogWith (overlay: DecisionOverlay) (c: Catalog) : PhysicalSchema =
         use _ = Bench.scope "physicalSchema.ofCatalog"
         let kinds = c.Modules |> List.collect (fun m -> m.Kinds)
         // Per session-35 — index lookups lifted once for FK projection
@@ -684,7 +733,7 @@ module PhysicalSchema =
             |> Set.ofList
         let foreignKeys =
             kinds
-            |> List.collect (toPhysicalForeignKeys kindByKey targetPkColumnsByKey)
+            |> List.collect (toPhysicalForeignKeys overlay kindByKey targetPkColumnsByKey)
             |> Set.ofList
         let rows =
             kinds
@@ -701,7 +750,7 @@ module PhysicalSchema =
             |> Set.ofList
         let indexes =
             kinds
-            |> List.collect toPhysicalIndexes
+            |> List.collect (toPhysicalIndexes overlay)
             |> Set.ofList
         {
             Columns = columns
@@ -711,6 +760,18 @@ module PhysicalSchema =
             Annotations = annotations
             Indexes = indexes
         }
+
+    /// Project a Catalog to its `PhysicalSchema` view with **no** decision
+    /// overlay — the `DecisionOverlay.empty` default of `ofCatalogWith`,
+    /// byte-identical to the pre-M1 projection and the function ~30 call sites
+    /// already use. The read-back leg (`ofCatalog` over a `ReadSide`-recovered
+    /// catalog) uses this form: the recovered `Reference.IsConstraintTrusted` /
+    /// `sys.indexes.is_unique` already carry the deployed decision, so no
+    /// overlay is needed to observe it. The source leg uses `ofCatalogWith` to
+    /// reflect a registered (not-yet-deployed) decision. Do NOT widen this
+    /// signature — `ofCatalogWith` is the overlay-aware entry point.
+    let ofCatalog (c: Catalog) : PhysicalSchema =
+        ofCatalogWith DecisionOverlay.empty c
 
     /// Diff two `PhysicalSchema` values across its axes (columns +
     /// FKs + per-row hashes + bindings + annotations + indexes). Per session-35 —
@@ -804,13 +865,14 @@ module PhysicalSchema =
                 c.IsIdentity
         let renderFk (f: PhysicalForeignKey) : string =
             sprintf
-                "  [%s].[%s].[%s] -> [%s].[%s].[%s]"
+                "  [%s].[%s].[%s] -> [%s].[%s].[%s] trusted=%b"
                 f.SourceSchema
                 f.SourceTable
                 f.SourceColumn
                 f.TargetSchema
                 f.TargetTable
                 f.TargetColumn
+                f.IsTrusted
         let renderRow (r: PhysicalRow) : string =
             sprintf
                 "  [%s].[%s] row hash=%s"

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -55,7 +55,6 @@
     <Compile Include="ArtifactByKind.fs" />
     <Compile Include="CatalogDiff.fs" />
     <Compile Include="Lifecycle.fs" />
-    <Compile Include="PhysicalSchema.fs" />
     <Compile Include="Tolerance.fs" />
     <Compile Include="CanaryResidual.fs" />
     <Compile Include="UserIdentity.fs" />
@@ -92,6 +91,18 @@
     <Compile Include="QueryHints.fs" />
     <Compile Include="ComposeState.fs" />
     <Compile Include="DecisionOverlay.fs" />
+    <!--
+      THE VECTOR Wave 1 / M1 — PhysicalSchema.fs moved here (was compile-order
+      ~58, before Tolerance.fs) so `PhysicalSchema.ofCatalogWith` can consume the
+      `DecisionOverlay` defined just above: it reflects the FK-trust (`NoCheckFk`)
+      and unique-promotion (`EnforceUnique`) decision sub-axes in the round-trip
+      comparator, routing the recovered decision through the general comparator
+      (retiring the M1′ `FkTrustUnreflected` / `UniquePromotionUnreflected`
+      tolerances). The move is dependency-safe: no Core file references
+      PhysicalSchema *in code* before this point — Coordinates / CatalogDiff /
+      Catalog / Tolerance / CanaryResidual cite it in docstrings only.
+    -->
+    <Compile Include="PhysicalSchema.fs" />
     <Compile Include="PolicyExpr.fs" />
     <Compile Include="VersionedPolicy.fs" />
     <Compile Include="ApprovalWorkflow.fs" />

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -165,46 +165,27 @@ type ToleratedDivergence =
     /// @ladder DecimalScaleTolerated Data AcceptedFaithful
     | DecimalScaleTolerated
 
-    /// M1′ (THE VECTOR, Wave 0 honesty) — the **Decision-axis** round-trip
-    /// cannot observe whether an FK's *trust* decision survived. The engine's
-    /// `DecisionOverlay.NoCheckFk` records the references decided
-    /// `EnforceConstraint (ScriptWithNoCheck _)` (emit the FK but `WITH NOCHECK`,
-    /// i.e. untrusted), `SsdtDdlEmitter` emits the `WITH NOCHECK` clause, and the
-    /// read leg recovers `sys.foreign_keys.is_not_trusted` into
-    /// `Reference.IsConstraintTrusted` (`ReadSide.fs:1171`). But the canary's
-    /// comparison primitive `PhysicalForeignKey` carries **no trust field**, so
-    /// `PhysicalSchema.diff` is structurally blind to it: a NOCHECK decision that
-    /// failed to round-trip (emitted trusted, or read back trusted) yields an
-    /// EMPTY diff. The only live Decision witness today
-    /// (`CanaryRoundTripTests.fs` — "decision adjunction: emitted-then-read-back
-    /// schema reproduces the DecisionOverlay") covers only the *nullability*
-    /// sub-axis; its own docstring admits FK readback is unwitnessed. Without
-    /// this variant the matrix marks Decision ✅-faithful **by construction** (no
-    /// Decision tolerance exists to cap it) — an over-claim the named-erasure law
-    /// forbids: an erasure that is real but absent from the closed set means the
-    /// set is not closed over that axis. Named here so the Decision axis drops to
-    /// an honest ◑ L2-partial. **Retiring it:** M1 (Wave 1) — add `IsTrusted` to
-    /// `PhysicalForeignKey`, make `PhysicalSchema.ofCatalog` overlay-aware, and
-    /// route the recovered trust through the general comparator; deleting this
-    /// tag then auto-flips Decision back to faithful.
-    /// @ladder FkTrustUnreflected Decision OpenGap
-    | FkTrustUnreflected
-
-    /// M1′ (THE VECTOR, Wave 0 honesty) — the **Decision-axis** round-trip
-    /// cannot observe whether a *unique-index promotion* decision survived.
-    /// `DecisionOverlay.EnforceUnique` records the index keys the
-    /// `UniqueIndexPass` decided to promote to UNIQUE and the emitter writes a
-    /// UNIQUE index; but `PhysicalSchema.toPhysicalIndexes` derives `IsUnique`
-    /// from the catalog's static `idx.Uniqueness` **alone** — it never consults
-    /// the overlay — so an `EnforceUnique` decision the emitter applied is
-    /// invisible to `PhysicalSchema.diff` (unique-index readback is also outside
-    /// today's ReadSide scope boundary; see the nullability-only Decision
-    /// witness). The same over-claim as `FkTrustUnreflected`: a real Decision
-    /// erasure with no named surface. **Retiring it:** M1 (Wave 1) —
-    /// `toPhysicalIndexes` sets `IsUnique = isUnique || overlay.EnforceUnique`
-    /// and the readback closes; deleting this tag auto-flips Decision back.
-    /// @ladder UniquePromotionUnreflected Decision OpenGap
-    | UniquePromotionUnreflected
+    // FkTrustUnreflected + UniquePromotionUnreflected (M1′, THE VECTOR Wave 0
+    // honesty) were RETIRED by M1 (THE VECTOR Wave 1, 2026-06-15) — the
+    // Decision-axis keystone. `PhysicalForeignKey.IsTrusted` + the overlay-aware
+    // `PhysicalSchema.ofCatalogWith` now route the FK-trust (`NoCheckFk`) and
+    // unique-promotion (`EnforceUnique`) decisions through the GENERAL
+    // `PhysicalSchema.diff` comparator: the source projection reflects the
+    // decision and the read leg recovers it (`sys.foreign_keys.is_not_trusted`
+    // at `ReadSide.fs:1171` / `sys.indexes.is_unique` via `readIndexes`), so a
+    // decision that failed to round-trip now surfaces as a real diff instead of
+    // an empty one. Witnessed on a real SQL Server (Docker, ~3 s — not a
+    // soft-skip) by `CanaryRoundTripTests."M1 (decision-readback adjunction):
+    // NoCheckFk + EnforceUnique survive emit / deploy / read-back through
+    // PhysicalSchema.diff"` — an AGREEMENT arm (source projection ≡ read-back on
+    // the FK/index axes) AND a FALSIFIABILITY arm (the un-routed comparator now
+    // SEES the divergence, proving the field is load-bearing). Both were
+    // `Decision OpenGap`; deleting their `@ladder` tags auto-flips the matrix's
+    // Decision axis from `◑ L2-partial` back to `✅ faithful` (the honesty
+    // mechanism — no axis can be hand-marked faithful while an open tolerance
+    // tags it). A retired OpenGap that closed leaves no DU variant behind (the
+    // dead-algebra-retirement precedent), uniform with the NM-16 kind-facet
+    // retirement above.
 
     /// M2 (THE VECTOR, Wave 0 honesty) — a `Statement.CreateTrigger` whose
     /// definition body fails to parse (`ScriptDomBuild.tryParseTriggerBody`
@@ -258,8 +239,6 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected       -> ToleratedDivergence.CompositePkFkUnreflected
         | ToleratedDivergence.CharAnsiPaddingTolerated       -> ToleratedDivergence.CharAnsiPaddingTolerated
         | ToleratedDivergence.DecimalScaleTolerated          -> ToleratedDivergence.DecimalScaleTolerated
-        | ToleratedDivergence.FkTrustUnreflected             -> ToleratedDivergence.FkTrustUnreflected
-        | ToleratedDivergence.UniquePromotionUnreflected     -> ToleratedDivergence.UniquePromotionUnreflected
         | ToleratedDivergence.TriggerBodyUnparsedDropped     -> ToleratedDivergence.TriggerBodyUnparsedDropped
 
     /// Every empirically-grounded `ToleratedDivergence` variant.
@@ -284,8 +263,6 @@ module ToleratedDivergence =
                 coverage ToleratedDivergence.CompositePkFkUnreflected
                 coverage ToleratedDivergence.CharAnsiPaddingTolerated
                 coverage ToleratedDivergence.DecimalScaleTolerated
-                coverage ToleratedDivergence.FkTrustUnreflected
-                coverage ToleratedDivergence.UniquePromotionUnreflected
                 coverage ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
 
@@ -304,8 +281,6 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected     -> "CompositePkFkUnreflected"
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> "CharAnsiPaddingTolerated"
         | ToleratedDivergence.DecimalScaleTolerated        -> "DecimalScaleTolerated"
-        | ToleratedDivergence.FkTrustUnreflected           -> "FkTrustUnreflected"
-        | ToleratedDivergence.UniquePromotionUnreflected   -> "UniquePromotionUnreflected"
         | ToleratedDivergence.TriggerBodyUnparsedDropped   -> "TriggerBodyUnparsedDropped"
 
     /// Parse a config token to its divergence, or `None` for an unrecognized

--- a/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/PhysicalSchemaReader.fs
@@ -77,6 +77,16 @@ module PhysicalSchemaReader =
                 TargetSchema = tgtSchemaStr
                 TargetTable = tgtTableStr
                 TargetColumn = fk.TargetColumn
+                // THE VECTOR Wave 1 / M1 — the Decision-axis trust sub-axis. The
+                // emitter writes `ForeignKeyDef.IsConstraintTrusted = r
+                // .IsConstraintTrusted` (the source FK's own trust); the
+                // overlay's `NoCheckFk` decision is emitted as a separate
+                // post-CREATE-TABLE NOCHECK alter, not on the inline FK, so this
+                // AST-side reader (empty-overlay adjunction) reflects the source
+                // trust only — keeping `ofCatalog c = ofStatementStream (emit c)`
+                // exact on the FK axis (`AdjunctionLawTests`). The overlay-aware
+                // trust round-trip is witnessed through the live ReadSide canary.
+                IsTrusted = fk.IsConstraintTrusted
             })
 
     /// Project a typed `seq<Statement>` to a `PhysicalSchema`.

--- a/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
@@ -915,3 +915,105 @@ let ``decision adjunction: emitted-then-read-back schema reproduces the Decision
         // undecided column did not — the engine's opinion survived the round-trip.
         Assert.Equal(Some false, colNullable "NOTE")
         Assert.Equal(Some true,  colNullable "MEMO")
+
+// ---------------------------------------------------------------------
+// M1 (THE VECTOR Wave 1 — the keystone) — the Decision-readback adjunction
+// THROUGH THE GENERAL COMPARATOR. The E3 / 6.A.8 / nullability witnesses
+// above prove the round-trip via BESPOKE per-axis assertions (read the
+// specific reconstructed index / FK / column and check its flag). M1 closes
+// the keystone: it routes the recovered FK-trust (`NoCheckFk`) and
+// unique-promotion (`EnforceUnique`) decisions through `PhysicalSchema.diff`
+// — the SAME general comparator the canary's R6 gate reads — by giving
+// `PhysicalForeignKey` an `IsTrusted` field and making
+// `PhysicalSchema.ofCatalogWith` overlay-aware. Two arms:
+//   (1) AGREEMENT — `ofCatalogWith overlay source` equals `ofCatalog
+//       readback` on the FK-trust and index-uniqueness axes (empty diff).
+//   (2) FALSIFIABILITY — WITHOUT the overlay reflection (`ofCatalog source`),
+//       the SAME read-back DIVERGES on exactly those axes. This is the proof
+//       the comparator is no longer blind — the precise over-claim the retired
+//       `FkTrustUnreflected` / `UniquePromotionUnreflected` tolerances named.
+//       Before M1 both diffs were empty; arm (2) is the regression guard that
+//       keeps the field load-bearing. Docker-gated (real ReadSide) —
+//       survival-rule #12: confirm a real duration, never the green count.
+// ---------------------------------------------------------------------
+
+[<Fact>]
+let ``M1 (decision-readback adjunction): NoCheckFk + EnforceUnique survive emit / deploy / read-back through PhysicalSchema.diff`` () =
+    if skipIfNoDocker "m1-decision-readback-general-comparator" then
+        // Source: Parent (PK Id, Code) + a NON-unique index on Code; Child
+        // (PK Id, FK ParentId -> Parent) with a TRUSTED reference. Both
+        // Decision intents ride the OVERLAY (not the catalog): NoCheckFk(ref)
+        // makes the emitter write the FK WITH NOCHECK; EnforceUnique(idx)
+        // promotes the index to UNIQUE.
+        let parentKey = ssKeySafe "OS_KIND_M1_Parent"
+        let childKey = ssKeySafe "OS_KIND_M1_Child"
+        let parentIdKey = ssKeySafe "OS_ATTR_M1_Parent_Id"
+        let codeKey = ssKeySafe "OS_ATTR_M1_Parent_Code"
+        let childIdKey = ssKeySafe "OS_ATTR_M1_Child_Id"
+        let parentFkAttr = ssKeySafe "OS_ATTR_M1_Child_ParentId"
+        let refKeyV = ssKeySafe "OS_REF_M1_Child_Parent"
+        let idxKey = ssKeySafe "OS_IDX_M1_Parent_Code"
+        let mkAttr (k: SsKey) (col: string) (isPk: bool) : Attribute =
+            { Attribute.create k (nameSafe col) Integer with
+                Column = ColumnRealization.create (col.ToUpperInvariant()) (not isPk) |> Result.value
+                IsPrimaryKey = isPk; IsMandatory = isPk }
+        let parent =
+            { Kind.create parentKey (nameSafe "Parent")
+                (mkTableId "dbo" "OSUSR_M1_PARENT")
+                [ mkAttr parentIdKey "Id" true
+                  mkAttr codeKey "Code" false ]
+              with Indexes = [ Index.ofKeyColumns idxKey (nameSafe "IX_M1Parent_Code") [ codeKey ] ] }
+        let child =
+            { Kind.create childKey (nameSafe "Child")
+                (mkTableId "dbo" "OSUSR_M1_CHILD")
+                [ mkAttr childIdKey "Id" true; mkAttr parentFkAttr "ParentId" false ]
+              with References = [ Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey ] }
+        let catalog =
+            match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_M1"; Name = nameSafe "M1Mod"; Kinds = [ parent; child ]; IsActive = true; ExtendedProperties = [] } ] [] with
+            | Ok c -> c | Error e -> failwithf "catalog %A" e
+
+        // The overlay IS the engine's opinion on the two Decision sub-axes M1
+        // closes: emit the FK WITH NOCHECK + promote the index to UNIQUE.
+        let overlay =
+            { DecisionOverlay.empty with
+                NoCheckFk = Set.singleton refKeyV
+                EnforceUnique = Set.singleton idxKey }
+        let sql = SsdtDdlEmitter.statementsWith overlay catalog |> Render.toText
+        let rt = (Deploy.runWithReadback sql).GetAwaiter().GetResult()
+        Assert.True(rt.Report.Ok, sprintf "deploy: %A" rt.Report.Errors)
+        let readback =
+            match rt.Reconstructed with
+            | Some c -> c
+            | None -> failwith "deploy produced no reconstructed catalog"
+        let readbackPhys = PhysicalSchema.ofCatalog readback
+
+        // Positive anchor — the read-back actually carries the tightened state,
+        // so the AGREEMENT arm below is not vacuously empty (FK/index present).
+        (match readbackPhys.ForeignKeys |> Set.toList with
+         | [ f ] -> Assert.False(f.IsTrusted, "the single read-back FK must be untrusted (NOCHECK survived)")
+         | fks -> Assert.Fail(sprintf "expected exactly one read-back FK, got %d" (List.length fks)))
+        Assert.True(readbackPhys.Indexes |> Set.exists (fun i -> i.IsUnique),
+                    "read-back must carry a UNIQUE index (EnforceUnique survived)")
+
+        // (1) AGREEMENT — the decision-aware source projection equals the
+        //     read-back on the FK-trust and index-uniqueness axes THROUGH THE
+        //     GENERAL COMPARATOR. Scoped to the Decision axes: the full diff may
+        //     carry incidental divergences on unrelated axes (logical-name
+        //     bindings, etc.), which the existing E3 / 6.A.8 witnesses likewise
+        //     isolate via bespoke per-axis reads.
+        let agree = PhysicalSchema.diff (PhysicalSchema.ofCatalogWith overlay catalog) readbackPhys
+        Assert.Empty agree.MissingForeignKeys
+        Assert.Empty agree.ExtraForeignKeys
+        Assert.Empty agree.MissingIndexes
+        Assert.Empty agree.ExtraIndexes
+
+        // (2) FALSIFIABILITY — without routing the overlay into the source
+        //     projection, the comparator SEES the divergence on exactly the
+        //     FK-trust and uniqueness axes (source claims trusted + non-unique;
+        //     read-back recovered untrusted + unique). Before M1 these axes were
+        //     structurally blind and this diff was empty — the over-claim the
+        //     retired M1' tolerances named. This arm keeps `IsTrusted` /
+        //     `IsUnique` load-bearing in the comparator.
+        let blind = PhysicalSchema.diff (PhysicalSchema.ofCatalog catalog) readbackPhys
+        Assert.NotEmpty (blind.MissingForeignKeys @ blind.ExtraForeignKeys)
+        Assert.NotEmpty (blind.MissingIndexes @ blind.ExtraIndexes)

--- a/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
@@ -52,6 +52,9 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
     // M1′ + M2 (THE VECTOR, Wave 0, 2026-06-15) added the two Decision-axis
     // tolerances (FkTrustUnreflected / UniquePromotionUnreflected) +
     // TriggerBodyUnparsedDropped (the named CreateTrigger text-render drop).
+    // M1 (THE VECTOR, Wave 1, 2026-06-15) RETIRED the two Decision-axis
+    // tolerances (FK-trust / unique-promotion now round-trip through the general
+    // comparator), so they no longer appear in the unsupported set.
     let result = Unsupported.compute () |> Set.ofList
     let expected =
         Set.ofList
@@ -59,13 +62,11 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
               "CompositePkFkUnreflected"
               "DecimalScaleTolerated"
               "EmptyTextNormalizedToNull"
-              "FkTrustUnreflected"
               "HeaderCommentsOmitted"
               "IndexOptionsUnreflected"
               "PostDeployForeignKeysSplit"
               "StaticPopulationsUnreflected"
-              "TriggerBodyUnparsedDropped"
-              "UniquePromotionUnreflected" ]
+              "TriggerBodyUnparsedDropped" ]
     Assert.Equal<Set<string>> (expected, result)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MatrixLadderTests.fs
@@ -77,7 +77,7 @@ let ``D1: an axis with only accepted tolerances reaches L3 (the generator discri
     Assert.DoesNotContain("L2-partial", data)
 
 [<Fact>]
-let ``D1: exactly two tolerances are open fidelity gaps today`` () =
+let ``D1: exactly three tolerances are open fidelity gaps today`` () =
     // The matrix's open-gap count is the codebase's named schema-fidelity debt.
     // Pinning it makes a silently-added OpenGap — or a silently-retired one
     // without regenerating — fail here. NM-16 (2026-06-13) added four kind-facet
@@ -87,4 +87,10 @@ let ``D1: exactly two tolerances are open fidelity gaps today`` () =
     // added CompositePkFkUnreflected (Schema OpenGap) → 6. NM-17 (2026-06-14)
     // RETIRED the four kind-facet OpenGaps by building the real `KindFacet`
     // diff channel → back to 2 (IndexOptionsUnreflected + CompositePkFkUnreflected).
-    Assert.Contains("2 open", generatedMatrix)
+    // M1′ (THE VECTOR Wave 0, 2026-06-15) added TriggerBodyUnparsedDropped (Schema
+    // OpenGap) + FkTrustUnreflected + UniquePromotionUnreflected (Decision OpenGap)
+    // → 5. M1 (THE VECTOR Wave 1, 2026-06-15) RETIRED the two Decision OpenGaps by
+    // routing FK-trust / unique-promotion through the general comparator → back to
+    // 3 (IndexOptionsUnreflected + CompositePkFkUnreflected + TriggerBodyUnparsedDropped,
+    // all Schema OpenGap; the Decision axis is now faithful).
+    Assert.Contains("3 open", generatedMatrix)

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -199,8 +199,6 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
         | ToleratedDivergence.CompositePkFkUnreflected     -> ()
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> ()
         | ToleratedDivergence.DecimalScaleTolerated        -> ()
-        | ToleratedDivergence.FkTrustUnreflected           -> ()
-        | ToleratedDivergence.UniquePromotionUnreflected   -> ()
         | ToleratedDivergence.TriggerBodyUnparsedDropped   -> ()
     // AC-D6 (NEITHER→HELD) added the two representation-only tolerances;
     // NM-28 (2026-06-14) added CompositePkFkUnreflected; NM-17 (2026-06-14)
@@ -208,8 +206,10 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
     // `KindFacet` diff channel), dropping the count from 12 to 8. M1′ + M2
     // (THE VECTOR, Wave 0, 2026-06-15) added the two Decision-axis tolerances
     // (FkTrustUnreflected / UniquePromotionUnreflected) + TriggerBodyUnparsedDropped,
-    // raising the count to 11.
-    Assert.Equal(11, Set.count ToleratedDivergence.allKnown)
+    // raising the count to 11. **M1 (THE VECTOR, Wave 1, 2026-06-15) RETIRED the
+    // two Decision-axis tolerances** — the round-trip now observes FK-trust /
+    // unique-promotion through the general comparator — dropping the count to 9.
+    Assert.Equal(9, Set.count ToleratedDivergence.allKnown)
 
 // ---------------------------------------------------------------------------
 // NM-70 (WP5) — the identity-annotation emit | omit gate.

--- a/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
@@ -39,8 +39,6 @@ type ToleratedDivergenceGen =
                 ToleratedDivergence.CompositePkFkUnreflected
                 ToleratedDivergence.CharAnsiPaddingTolerated
                 ToleratedDivergence.DecimalScaleTolerated
-                ToleratedDivergence.FkTrustUnreflected
-                ToleratedDivergence.UniquePromotionUnreflected
                 ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
         |> Arb.fromGen
@@ -60,7 +58,7 @@ let ``Tolerance.permissive is not strict`` () =
     Assert.False (Tolerance.isStrict Tolerance.permissive)
 
 [<Fact>]
-let ``Closed-DU coverage: ToleratedDivergence.allKnown contains eleven variants (M1prime Decision + M2 trigger added)`` () =
+let ``Closed-DU coverage: ToleratedDivergence.allKnown contains nine variants (M1 retired the two Decision tolerances)`` () =
     // Per the closed-DU expansion empirical-test discipline (`DECISIONS
     // 2026-05-13`): when a new ToleratedDivergence variant lands, this
     // count assertion fires until allKnown is extended. The companion
@@ -95,7 +93,13 @@ let ``Closed-DU coverage: ToleratedDivergence.allKnown contains eleven variants 
     // observe (over-claim correction — Decision drops to ◑ L2-partial; both
     // auto-retire when M1 lands), and `TriggerBodyUnparsedDropped` names the
     // formerly-silent CreateTrigger text-render drop (Schema OpenGap).
-    Assert.Equal (11, Set.count ToleratedDivergence.allKnown)
+    // **M1 (THE VECTOR, Wave 1, 2026-06-15):** back to 9 — `FkTrustUnreflected`
+    // and `UniquePromotionUnreflected` are RETIRED. `PhysicalForeignKey
+    // .IsTrusted` + the overlay-aware `PhysicalSchema.ofCatalogWith` route the
+    // FK-trust / unique-promotion decisions through the general comparator
+    // (witnessed Docker-real by the M1 decision-readback test), so the Decision
+    // axis flips back from ◑ L2-partial to ✅ faithful.
+    Assert.Equal (9, Set.count ToleratedDivergence.allKnown)
 
 [<Fact>]
 let ``Tolerance.ofSet round-trips through divergences`` () =
@@ -282,30 +286,25 @@ let ``AC-D6: a representation-tolerant environment passes Char/Decimal divergenc
     Assert.False(Tolerance.tolerates ToleratedDivergence.DecimalScaleTolerated strict)
 
 // ---------------------------------------------------------------------------
-// M1′ + M2 (THE VECTOR, Wave 0 honesty) — the three new tolerances are named,
-// parseable, and present in the closed set. The two Decision-axis tolerances
-// (FkTrustUnreflected / UniquePromotionUnreflected) name the FK-trust and
-// unique-promotion sub-axes the round-trip comparator cannot yet observe — so
-// matrix-status.sh drops Decision from an over-claimed ✅-faithful to ◑
-// L2-partial (their `@ladder … Decision OpenGap` tags are cross-checked by the
-// generator). TriggerBodyUnparsedDropped names the formerly-silent CreateTrigger
-// text-render drop. All three auto-flip / retire when their fix lands (M1 / a
-// faithful trigger round-trip).
+// M2 (THE VECTOR, Wave 0 honesty) — `TriggerBodyUnparsedDropped` is named,
+// parseable, and present in the closed set. It names the formerly-silent
+// CreateTrigger text-render drop (Schema OpenGap), retired when a faithful
+// trigger body round-trips. (M1′'s two Decision-axis tolerances that this test
+// formerly also covered — `FkTrustUnreflected` / `UniquePromotionUnreflected` —
+// were RETIRED by M1, THE VECTOR Wave 1, 2026-06-15: their round-trip is now
+// witnessed through the general comparator — see the M1 decision-readback
+// canary in `CanaryRoundTripTests` — so the Decision axis is honestly faithful.)
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``M1prime + M2: the three new tolerances are named, parseable, and in allKnown`` () =
-    // DISCRIMINATING: each must be in the closed set AND round-trip through the
+let ``M2: the trigger-body tolerance is named, parseable, and in allKnown`` () =
+    // DISCRIMINATING: must be in the closed set AND round-trip through the
     // operator-facing token surface (name ⇒ tryParse). A mislabeled-but-wrong
-    // implementation that dropped one from `allKnown`/`name` would fail here.
-    for d in [ ToleratedDivergence.FkTrustUnreflected
-               ToleratedDivergence.UniquePromotionUnreflected
-               ToleratedDivergence.TriggerBodyUnparsedDropped ] do
-        Assert.True(Set.contains d ToleratedDivergence.allKnown, sprintf "%A must be in allKnown" d)
-        Assert.Equal<ToleratedDivergence option>(Some d, ToleratedDivergence.tryParse (ToleratedDivergence.name d))
-    Assert.Equal("FkTrustUnreflected", ToleratedDivergence.name ToleratedDivergence.FkTrustUnreflected)
-    Assert.Equal("UniquePromotionUnreflected", ToleratedDivergence.name ToleratedDivergence.UniquePromotionUnreflected)
-    Assert.Equal("TriggerBodyUnparsedDropped", ToleratedDivergence.name ToleratedDivergence.TriggerBodyUnparsedDropped)
+    // implementation that dropped it from `allKnown`/`name` would fail here.
+    let d = ToleratedDivergence.TriggerBodyUnparsedDropped
+    Assert.True(Set.contains d ToleratedDivergence.allKnown, sprintf "%A must be in allKnown" d)
+    Assert.Equal<ToleratedDivergence option>(Some d, ToleratedDivergence.tryParse (ToleratedDivergence.name d))
+    Assert.Equal("TriggerBodyUnparsedDropped", ToleratedDivergence.name d)
 
 // ---------------------------------------------------------------------------
 // matchedResidual — the per-run residual the canary collector resolves

--- a/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
@@ -20,6 +20,35 @@ module private TransferCanaryFixtures =
         if Deploy.Docker.ensureRunning () then true
         else printfn "SKIP %s: Docker daemon not reachable." label; false
 
+    /// THE VECTOR Wave 1 / M1 follow-on — normalize the FK *trust* bit before a
+    /// transfer-canary comparison. M1 gave `PhysicalForeignKey` an `IsTrusted`
+    /// field so the SCHEMA round-trip canary (emit → deploy → read-back) observes
+    /// FK trust through the general comparator. The DATA transfer is a different
+    /// surface: `Transfer.Execute` loads rows via the high-throughput bulk path
+    /// (SqlBulkCopy WITHOUT `CHECK_CONSTRAINTS`), which SQL Server records by
+    /// marking the sink's FKs `is_not_trusted = 1`. So a trusted source FK reads
+    /// back as an UNTRUSTED sink FK — a divergence on the trust bit ALONE (the FK
+    /// structure — source/target schema·table·column — columns, rows, and indexes
+    /// all round-trip; verified because this helper normalizes ONLY `IsTrusted`,
+    /// so a genuine *structural* FK divergence still fails the canary).
+    ///
+    /// The transfer canary witnesses DATA + SCHEMA-STRUCTURE fidelity; FK-trust
+    /// ROUND-TRIP is witnessed separately on the schema surface
+    /// (`CanaryRoundTripTests` — the M1 decision-readback adjunction). Normalizing
+    /// the trust bit on BOTH sides scopes the transfer canary to its true claim —
+    /// a NAMED, explained exclusion (the `isSchemaEqual`-ignores-rows precedent),
+    /// not a silent one.
+    ///
+    /// OPEN QUESTION (operator / transfer-path owner — see DECISIONS 2026-06-15
+    /// "THE VECTOR Wave 1"): should `Transfer.Execute` re-validate FKs
+    /// (`WITH CHECK CHECK CONSTRAINT`) after the bulk load to re-TRUST them on the
+    /// sink — trading load throughput for trust fidelity — given the reverse leg's
+    /// hundreds-of-millions-of-rows scale target? If so, this normalization
+    /// retires and the transfer canary asserts full `isEqual` including trust.
+    let trustNormalizedFks (ps: PhysicalSchema) : PhysicalSchema =
+        { ps with
+            ForeignKeys = ps.ForeignKeys |> Set.map (fun fk -> { fk with IsTrusted = true }) }
+
     /// Acyclic two-table schema: Order has a NOT-NULL FK to Customer, so
     /// FK-safe ordering (Customer before Order) is required.
     let twoTableDdl =
@@ -347,12 +376,17 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
                                 Assert.True(report.Kinds |> List.forall (fun k -> k.RowsWritten = k.RowsIngested))
 
                                 // Sink reproduces Source on PhysicalSchema (incl. per-row hashes).
+                                // FK-trust is normalized on both sides: the bulk data load leaves
+                                // sink FKs untrusted (documented SqlBulkCopy behavior), a trust-bit-
+                                // only divergence the transfer canary scopes out by name — FK-trust
+                                // ROUND-TRIP is witnessed on the schema surface (the M1 canary). See
+                                // `TransferCanaryFixtures.trustNormalizedFks`.
                                 let! aR = ReadSide.read src
                                 let! bR = ReadSide.read sink
                                 let diff =
                                     PhysicalSchema.diff
-                                        (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR))
-                                        (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR))
+                                        (TransferCanaryFixtures.trustNormalizedFks (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR)))
+                                        (TransferCanaryFixtures.trustNormalizedFks (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR)))
                                 Assert.True(PhysicalSchema.isEqual diff, PhysicalSchema.renderDiff diff)
                             })
                 }))


### PR DESCRIPTION
First two chapters of **THE VECTOR** (`sidecar/projection/THE_VECTOR.md`). Wave 0 made the engine *honest* about its Decision axis; Wave 1 (M1, the keystone) makes it *true*. Carries both commits (Wave 0 was committed but never merged).

## Wave 0 — honesty & fitness (`a71bdc34`)
- **M1′** — named the two Decision-axis tolerances (`FkTrustUnreflected`, `UniquePromotionUnreflected`); the matrix honestly dropped Decision to `◑ L2-partial` (it was `✅`-by-construction, an over-claim).
- **M2** — named the formerly-silent `CreateTrigger` text-render drop (`TriggerBodyUnparsedDropped`).
- **M16** — `citationOf` became a gated existence check; the matrix binds witnesses by exact name, not substring.
- **M15** — architectural fitness functions in-assembly; the analyzer gate promoted to CI.

## Wave 1 — M1, the keystone (`663d4760`)
The Decision-readback adjunction: route the recovered FK-trust (`NoCheckFk`) and unique-promotion (`EnforceUnique`) decisions through the **general `PhysicalSchema.diff` comparator**.
- `PhysicalForeignKey.IsTrusted` + overlay-aware `PhysicalSchema.ofCatalogWith` (with `ofCatalog = ofCatalogWith empty` — **byte-identical** at empty, guarded by `GoldenEmissionTests` + `AdjunctionLawTests`). `toPhysicalForeignKeys`/`toPhysicalIndexes` mirror the emitter's own NoCheckFk/EnforceUnique predicates.
- **Docker decision-readback canary** — agreement (`ofCatalogWith overlay source` ≡ `ofCatalog readback`) **and** falsifiability (the un-routed comparator now *sees* the divergence). ~3 s real run, not a soft-skip.
- **M1′ retired** — both Decision tolerances, per-axis, only after the witness proved both round-trip. 11 → 9 variants; the matrix **auto-flips Decision to an earned `✅ L3`** (L2 4/5; tolerances 9, 3 open).
- Fixed a latent Wave 0 red (`MatrixLadderTests` pinned "2 open" while Wave 0 had raised it to 5 → now an honest "3 open").

## A real divergence M1 surfaced (named, not silenced)
With FK trust now in the comparator, the transfer canaries revealed that `Transfer.Execute` bulk-loads via `SqlBulkCopy` without `CHECK_CONSTRAINTS`, leaving the sink's FKs **untrusted** while the source is trusted (structure/rows/indexes all round-trip). Scoped out by name in the transfer canary (`trustNormalizedFks` — a precise exclusion); **operator decision flagged** in DECISIONS (re-validate for trust fidelity vs. throughput at scale).

## Witness
Debug + **Release** 0/0 · pure pool **3357/0** · **Docker 244/244** · `matrix-status.sh` gate=PASS (Decision `✅`, L2 4/5, `@ladder` cross-check passes) · `verifiability-gate.sh` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)