### PR TITLE
Wave 1 follow-on: FK-trust re-trust on the transfer leg (option C)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -24041,3 +24041,58 @@ never merged; this branch fast-forwarded onto it).
   `CatalogDiff.fs` trio (M11 → M13 → M12, one serialized implementer — shared file), plus M3 and M20 (each its
   own surface, parallel). Drive it as a Workflow: worktree-isolated implementers + one adversarial verifier per
   move + one integrator owning the build/matrix/gates.**
+
+## 2026-06-15 (later still) — Wave 1 follow-on: the FK-trust transfer-leg OPEN QUESTION RESOLVED (operator-authorized; option C — re-trust by default + opt-out lever)
+
+Resolves the **OPEN QUESTION** the Wave 1 entry (just above) deferred to the operator / transfer-path owner:
+should `Transfer.Execute` re-trust the sink's FKs after the bulk load? **Operator decision (2026-06-15): yes —
+re-trust by default, with a per-run opt-out lever (option C).** Recorded ahead of implementation per the
+amendment-first discipline (`CLAUDE.md` §5); the move touches the transfer realization path and the
+realization-selector / "downgrades never silent" commitments.
+
+- **Mechanism (verified post-merge against the landed M1).** `Bulk.copyCore` (`Bulk.fs:107/127/140`) builds
+  `SqlBulkCopy` with only `KeepIdentity`/`KeepNulls` — never `SqlBulkCopyOptions.CheckConstraints` — both for
+  throughput AND because the two-phase deferred-FK load (Phase 1 inserts cycle-deferred FKs unenforced; Phase 2
+  re-points) makes during-load checking structurally impossible. So re-trust MUST be a post-Phase-2 step;
+  flipping the bulk option is not on the table.
+- **The decision (as built).** The transfer SNAPSHOTS the as-deployed FK trust BEFORE the load
+  (`trustedFksOnLoadedTables` — the FKs that are `is_not_trusted = 0` on the plan's loaded tables) and, after the
+  load, re-validates exactly those with `ALTER TABLE … WITH CHECK CHECK CONSTRAINT` (`restoreFkTrust`). One
+  semi-join per FK (child × parent PK), one-time, and **guaranteed to succeed after a faithful transfer**
+  (reconciling drops remove the referencing row too — no dangling refs survive; row-equality already proves FK
+  satisfaction); a re-validation that *fails* is a LOUD integrity signal, never silent. **The snapshot is the
+  fidelity guard:** an FK deployed UNTRUSTED (a `NoCheckFk` decision — the very thing M1 made faithful) is absent
+  from the snapshot, so the restore never re-trusts it — preserving the decision and never re-validating data the
+  operator chose not to validate. (A blanket "re-trust every untrusted FK" would have corrupted exactly that,
+  undermining the M1 keystone — caught and fixed during the build.) The opt-out lever
+  (`WriteOptions.RetrustForeignKeys = false`) keeps raw load throughput at the reverse leg's
+  hundreds-of-millions-of-rows scale; the opt-out is named, never silent.
+- **Implementation (BUILT — inline, this session).**
+  1. **Lever:** `RetrustForeignKeys : bool` on `Transfer.WriteOptions` (default `true` in `WriteOptions.def`,
+     inherited by `resumable`/`ofEmission`). Threaded via `runCore` (every public entry passes its `WriteOptions`
+     through it); a `Transfer.runWithOptions` test seam exposes it. The CLI flag rides with the Wave-2 streaming
+     follow-on.
+  2. **Snapshot + restore (materialized path):** `trustedFksOnLoadedTables` (pre-load) + `restoreFkTrust`
+     (post-load), hooked in `runCore` either side of the write block (Execute + lever-on only). Realization-layer
+     policy (A36); the restored count is logged via `LogSink` (`"retrust"` stage) — no `TransferReport` field
+     (the success path restores fidelity; it is not a divergence to report). **Scope: the MATERIALIZED write
+     path.** The streaming reverse-leg (`writePlanStreaming`) and synthetic-load (`runSynthetic`) realizations
+     are a named Wave-2 follow-on — until wired they exhibit `FkTrustNotRestoredOnBulkLoad`, not a silent gap.
+  3. **Canary on-path:** `trustNormalizedFks` retired in `TransferCanaryTests.RoundTrips` → it asserts full
+     `PhysicalSchema.isEqual` incl. trust (the helper survives only for the off-path).
+  4. **Tolerance + new canaries:** closed variant `FkTrustNotRestoredOnBulkLoad` —
+     **`@ladder … Decision AcceptedFaithful`** (NOT Data/OpenGap: FK trust is the Decision sub-axis per M1, and
+     the default config is faithful so it does not de-rate the matrix; it is NOT `FkTrustUnreflected`, the
+     M1-deleted comparator-blind tag). Two new Docker canaries: the OFF-path (`RetrustForeignKeys = false` leaves
+     the sink untrusted, only-trust-diverges, tolerance named) and the NoCheckFk-PRESERVATION witness (an
+     as-deployed untrusted FK survives a default re-trust transfer untrusted on both sides — the guard against a
+     blanket re-trust).
+- **Witness (all green).** Debug + Release builds clean (0/0). Pure focused 45/45 (ToleranceTests count 9→10,
+  SsdtExtendedPropertyEmissionTests, ManifestUnsupportedTests, MatrixLadderTests). Docker `TransferCanaryTests`
+  24/24, **0 skipped** (real run, ~17 s) — incl. the on-path full-`isEqual` canaries, the off-path, and the
+  preservation witness. `matrix-status.sh` regenerated: gate=PASS, rungs L1/L2/L3 5/4/5, **tolerances 10, 3 open**
+  (Decision stays ✅ — the new tolerance is AcceptedFaithful), `@ladder` cross-check passes.
+- **Wave-2 follow-on (named, not silent).** Wire the snapshot/restore into the streaming reverse-leg
+  (`writePlanStreaming`, composing with `ReverseLegRealization.choose` + the capability-descent ladder) and
+  `runSynthetic`; expose the `RetrustForeignKeys` opt-out on the CLI face. Until then those realizations exhibit
+  the named `FkTrustNotRestoredOnBulkLoad`.

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -34,7 +34,7 @@ witness covers the axis. The **Ladder** column is the honest weakest-rung summar
 | **Decision** | ✅ | ✅ faithful | ✅ | — | ✅ L3 |
 
 **Rungs reached: L1 5/5 · L2 4/5 · L3 5/5.** Tolerance set:
-9 named, of which **3 open** (`OpenGap`). A cell cannot be
+10 named, of which **3 open** (`OpenGap`). A cell cannot be
 hand-marked: L1/L3 require the witness test to exist; L2 requires the open tolerance
 to be retired from `Tolerance.fs`. The generator under-claims; it never over-claims.
 
@@ -48,4 +48,4 @@ to be retired from `Tolerance.fs`. The generator under-claims; it never over-cla
 > L3 here is "a composition witness exists for the axis," not "faithful under every
 > spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
 
-_Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 9 (3 open)_
+_Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 10 (3 open)_

--- a/sidecar/projection/src/Projection.Core/Tolerance.fs
+++ b/sidecar/projection/src/Projection.Core/Tolerance.fs
@@ -187,6 +187,34 @@ type ToleratedDivergence =
     // dead-algebra-retirement precedent), uniform with the NM-16 kind-facet
     // retirement above.
 
+    /// Wave 1 follow-on (option C, operator-authorized 2026-06-15) — the data
+    /// transfer's bulk load (`Bulk.copyCore` via `SqlBulkCopy` WITHOUT
+    /// `CHECK_CONSTRAINTS`) leaves the sink's FKs `is_not_trusted = 1`. By
+    /// DEFAULT `Transfer.Execute` re-validates them post-load (`WITH CHECK CHECK
+    /// CONSTRAINT`, `WriteOptions.RetrustForeignKeys = true`), so the sink
+    /// rounds-trips TRUSTED and **no divergence fires** — the transfer canary
+    /// asserts full `isEqual` incl. trust. This tolerance names the OPT-OUT:
+    /// when an operator sets `RetrustForeignKeys = false` to keep raw load
+    /// throughput at the reverse leg's hundreds-of-millions-of-rows scale, the
+    /// sink's FKs stay untrusted — a trust-bit-ONLY divergence (FK structure,
+    /// columns, rows, and indexes all round-trip; nothing structural is absorbed).
+    /// M1 put FK trust on the **Decision** sub-axis (`NoCheckFk` →
+    /// `PhysicalForeignKey.IsTrusted`), so this is a Decision-axis divergence. It
+    /// is `AcceptedFaithful`, NOT `OpenGap`: the engine's DEFAULT config is
+    /// faithful (Decision stays `✅`), and the opt-out is a NAMED, witnessed
+    /// operator choice — the off-path transfer canary asserts it fires, and
+    /// `Tolerance.matchedResidual` surfaces it per-run. (Successor name to the
+    /// M1-retired `FkTrustUnreflected`: that was the comparator being BLIND to
+    /// trust; this is the transfer DECIDING not to restore it — distinct
+    /// concepts, do not conflate.) Retiring it is not anticipated: it is the
+    /// named home for a deliberate operator trade, alive as long as the opt-out
+    /// exists. NB: the streaming reverse-leg (`writePlanStreaming`) and
+    /// synthetic-load (`runSynthetic`) realizations do not yet wire the re-trust
+    /// step, so they currently always exhibit this tolerance — a named Wave-2
+    /// follow-on, not a silent gap.
+    /// @ladder FkTrustNotRestoredOnBulkLoad Decision AcceptedFaithful
+    | FkTrustNotRestoredOnBulkLoad
+
     /// M2 (THE VECTOR, Wave 0 honesty) — a `Statement.CreateTrigger` whose
     /// definition body fails to parse (`ScriptDomBuild.tryParseTriggerBody`
     /// returns `None`, H-019) is dropped from the SSDT **text** artifact at
@@ -239,6 +267,7 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected       -> ToleratedDivergence.CompositePkFkUnreflected
         | ToleratedDivergence.CharAnsiPaddingTolerated       -> ToleratedDivergence.CharAnsiPaddingTolerated
         | ToleratedDivergence.DecimalScaleTolerated          -> ToleratedDivergence.DecimalScaleTolerated
+        | ToleratedDivergence.FkTrustNotRestoredOnBulkLoad   -> ToleratedDivergence.FkTrustNotRestoredOnBulkLoad
         | ToleratedDivergence.TriggerBodyUnparsedDropped     -> ToleratedDivergence.TriggerBodyUnparsedDropped
 
     /// Every empirically-grounded `ToleratedDivergence` variant.
@@ -263,6 +292,7 @@ module ToleratedDivergence =
                 coverage ToleratedDivergence.CompositePkFkUnreflected
                 coverage ToleratedDivergence.CharAnsiPaddingTolerated
                 coverage ToleratedDivergence.DecimalScaleTolerated
+                coverage ToleratedDivergence.FkTrustNotRestoredOnBulkLoad
                 coverage ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
 
@@ -281,6 +311,7 @@ module ToleratedDivergence =
         | ToleratedDivergence.CompositePkFkUnreflected     -> "CompositePkFkUnreflected"
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> "CharAnsiPaddingTolerated"
         | ToleratedDivergence.DecimalScaleTolerated        -> "DecimalScaleTolerated"
+        | ToleratedDivergence.FkTrustNotRestoredOnBulkLoad -> "FkTrustNotRestoredOnBulkLoad"
         | ToleratedDivergence.TriggerBodyUnparsedDropped   -> "TriggerBodyUnparsedDropped"
 
     /// Parse a config token to its divergence, or `None` for an unrecognized

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -526,6 +526,79 @@ module Transfer =
                             (System.String.Concat("DELETE FROM ", Render.tableQualified kind.Physical, ";"))  // LINT-ALLOW: terminal SQL-text boundary; table name is a validated TableId via Render.tableQualified
         }
 
+    // -- Option C (operator-authorized 2026-06-15): FK-trust restoration --------
+    //
+    // `SqlBulkCopy` (no `CHECK_CONSTRAINTS`) marks every FK on a bulk-loaded table
+    // `is_not_trusted = 1`. The faithful post-transfer state is the AS-DEPLOYED
+    // trust state — the sink schema deploy already honored every FK-trust decision
+    // (a normal FK trusted; a `NoCheckFk` decision deployed `WITH NOCHECK` →
+    // untrusted). So the restore SNAPSHOTS which FKs were trusted BEFORE the load
+    // and re-validates exactly those afterward. Critically this PRESERVES a
+    // `NoCheckFk` decision (the very fidelity M1 established): an FK untrusted
+    // before the load is absent from the snapshot, so the restore never re-trusts
+    // it — never overriding the operator's decision, never re-validating data the
+    // operator chose not to validate.
+
+    /// The plan's loaded (inserted-into) tables, lower-cased `schema.table`.
+    let private loadedTableKeys (catalog: Catalog) (plan: DataLoadPlan) : Set<string> =
+        plan.Loads
+        |> List.choose (fun l -> Catalog.tryFindKind l.Kind catalog)
+        |> List.map (fun k ->
+            (TableId.schemaText k.Physical).ToLowerInvariant() + "." + (TableId.tableText k.Physical).ToLowerInvariant())
+        |> Set.ofList
+
+    /// Pre-load snapshot — the `(schema, table, fk)` of every ENABLED + TRUSTED
+    /// FK on a loaded table, read from `sys.foreign_keys` (the deployed truth).
+    /// An FK the schema deployed UNTRUSTED (`is_not_trusted = 1` — a `NoCheckFk`
+    /// decision) is excluded, so the restore never touches it.
+    let private trustedFksOnLoadedTables (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) : Task<(string * string * string) list> =
+        task {
+            let loaded = loadedTableKeys catalog plan
+            if Set.isEmpty loaded then return [] else
+            let trusted = System.Collections.Generic.List<string * string * string>()
+            use cmd = sink.CreateCommand()
+            cmd.CommandText <-
+                "SELECT s.name, t.name, fk.name \
+                 FROM sys.foreign_keys fk \
+                 JOIN sys.tables t ON fk.parent_object_id = t.object_id \
+                 JOIN sys.schemas s ON t.schema_id = s.schema_id \
+                 WHERE fk.is_not_trusted = 0 AND fk.is_disabled = 0;"
+            use! reader = cmd.ExecuteReaderAsync()
+            let mutable go = true
+            while go do
+                let! has = reader.ReadAsync()
+                if has then trusted.Add(reader.GetString 0, reader.GetString 1, reader.GetString 2)
+                else go <- false
+            reader.Close()
+            return
+                trusted
+                |> Seq.filter (fun (sch, tbl, _) ->
+                    Set.contains (sch.ToLowerInvariant() + "." + tbl.ToLowerInvariant()) loaded)
+                |> List.ofSeq
+        }
+
+    /// Restore the trust the bulk load stripped — re-validate each FK in the
+    /// pre-load snapshot (`wasTrusted`) with `ALTER TABLE … WITH CHECK CHECK
+    /// CONSTRAINT` (one child×parent-PK semi-join per FK). After a faithful
+    /// transfer the data satisfies each FK so it succeeds; a FAILURE is a LOUD
+    /// signal the load was not faithful — a post-load integrity assertion, never
+    /// silent corruption. The gate is `WriteOptions.RetrustForeignKeys` (default
+    /// on); the opt-out is the named `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`.
+    let private restoreFkTrust (sink: SqlConnection) (wasTrusted: (string * string * string) list) : Task<unit> =
+        task {
+            if List.isEmpty wasTrusted then return () else
+            let stmts =
+                wasTrusted
+                |> List.map (fun (sch, tbl, fk) ->
+                    // LINT-ALLOW: terminal SQL-text boundary; identifiers are sys.* catalog-view
+                    // names (deployed truth), each quoted via Render.quote.
+                    System.String.Concat(
+                        "ALTER TABLE ", Render.quote sch, ".", Render.quote tbl,
+                        " WITH CHECK CHECK CONSTRAINT ", Render.quote fk, ";"))
+            do! Deploy.executeBatch sink (String.concat "\n" stmts)
+            LogSink.recordStageProgress "retrust" (List.length wasTrusted) (List.length wasTrusted) 0L
+        }
+
     /// The durable phase-marker table — records which transfers completed, so a
     /// re-run of an already-finished transfer is a no-op (idempotent).
     ///
@@ -833,11 +906,24 @@ module Transfer =
           /// applies. `Structural` (the `def` default) is byte-identical; a
           /// `FullRights` sink threads `PreferPreservedKeys` so IDENTITY-PK kinds
           /// preserve their source keys (no capture/remap).
-          IdentityPolicy : IdentityPolicy }
+          IdentityPolicy : IdentityPolicy
+          /// Option C (operator-authorized 2026-06-15) — re-trust the sink's FKs
+          /// after the bulk load. `SqlBulkCopy` (no `CHECK_CONSTRAINTS`) leaves
+          /// them `is_not_trusted = 1`; `true` (the `def` default) re-validates
+          /// each untrusted FK on a loaded table with `WITH CHECK CHECK
+          /// CONSTRAINT`, restoring trust so the sink rounds-trips faithfully —
+          /// the post-load scan is one semi-join per FK, guaranteed to succeed
+          /// after a faithful transfer (a failure is a LOUD integrity signal, not
+          /// silent corruption). `false` keeps raw load throughput at the reverse
+          /// leg's hundreds-of-millions-of-rows scale and leaves the FKs
+          /// untrusted — the NAMED `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`.
+          /// Covers the MATERIALIZED write path (`writePlan`); the streaming
+          /// reverse-leg path is a named Wave-2 follow-on.
+          RetrustForeignKeys : bool }
 
     [<RequireQualifiedAccess>]
     module WriteOptions =
-        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None; IdentityPolicy = IdentityPolicy.Structural }
+        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None; IdentityPolicy = IdentityPolicy.Structural; RetrustForeignKeys = true }
         let resumable : WriteOptions = { def with Resumable = true }
         let ofEmission (mode: EmissionMode) : WriteOptions = { def with Emission = mode }
 
@@ -948,6 +1034,17 @@ module Transfer =
             match preWrite with
             | Some refusal -> return Result.failureOf refusal
             | None ->
+                // Option C — snapshot the AS-DEPLOYED FK trust BEFORE the load, so
+                // the post-load restore re-validates only the FKs the bulk load
+                // strips (a NoCheckFk decision — untrusted as-deployed — is absent
+                // from the snapshot and so preserved). Materialized path only; the
+                // streaming reverse-leg is a named Wave-2 follow-on.
+                let! preTrustedFks =
+                    task {
+                        if mode = Execute && writeOpts.RetrustForeignKeys
+                        then return! trustedFksOnLoadedTables sink catalog plan
+                        else return []
+                    }
                 let! writeSkips, laneDescents, replayedPriorDrops =
                     task {
                         if mode <> Execute then return [], [], None
@@ -970,6 +1067,11 @@ module Transfer =
                                 let! (skips, descents) = writePlan sink catalog plan
                                 return skips, descents, None
                     }
+                // Option C — restore the trust the bulk load stripped (exactly the
+                // pre-load snapshot, so NoCheckFk decisions are preserved). A
+                // re-validation that fails is a loud integrity signal, not silent.
+                if mode = Execute && writeOpts.RetrustForeignKeys then
+                    do! restoreFkTrust sink preTrustedFks
                 return
                     Result.success
                         { Mode                = mode
@@ -1041,6 +1143,25 @@ module Transfer =
         (catalog: Catalog)
         : Task<Result<TransferReport>> =
         runCore mode allowCdc false source sink catalog Map.empty None (WriteOptions.ofEmission emission)
+
+    /// **A Transfer under explicit `WriteOptions`.** The general test seam that
+    /// exposes every write-seam lever — including option C's `RetrustForeignKeys`
+    /// (default on; pass `{ WriteOptions.def with RetrustForeignKeys = false }` to
+    /// keep the bulk load's untrusted FKs, the named `FkTrustNotRestoredOnBulkLoad`
+    /// opt-out). Non-reconciling.
+    ///
+    /// NM-40: TEST-ONLY SEAM — exercises the WriteOptions branch without the
+    /// connection apparatus. Production routes through the `*ThroughConnections*`
+    /// family; the only callers are canary tests.
+    let runWithOptions
+        (mode: Mode)
+        (writeOpts: WriteOptions)
+        (allowCdc: bool)
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (catalog: Catalog)
+        : Task<Result<TransferReport>> =
+        runCore mode allowCdc false source sink catalog Map.empty None writeOpts
 
     /// **Synthetic load (THE_SYNTHETIC_DATA_DESIGN §8, slice S2).** The
     /// synthetic source has **no source DB**: rows are *generated* by the pure

--- a/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestUnsupportedTests.fs
@@ -62,6 +62,7 @@ let ``Unsupported.compute names match current ToleratedDivergence variants`` () 
               "CompositePkFkUnreflected"
               "DecimalScaleTolerated"
               "EmptyTextNormalizedToNull"
+              "FkTrustNotRestoredOnBulkLoad"
               "HeaderCommentsOmitted"
               "IndexOptionsUnreflected"
               "PostDeployForeignKeysSplit"

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -199,6 +199,7 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
         | ToleratedDivergence.CompositePkFkUnreflected     -> ()
         | ToleratedDivergence.CharAnsiPaddingTolerated     -> ()
         | ToleratedDivergence.DecimalScaleTolerated        -> ()
+        | ToleratedDivergence.FkTrustNotRestoredOnBulkLoad -> ()
         | ToleratedDivergence.TriggerBodyUnparsedDropped   -> ()
     // AC-D6 (NEITHER→HELD) added the two representation-only tolerances;
     // NM-28 (2026-06-14) added CompositePkFkUnreflected; NM-17 (2026-06-14)
@@ -209,7 +210,9 @@ let ``Chapter 4.1.A slice 8: Tolerance.CommentMetadataUnreflected variant retire
     // raising the count to 11. **M1 (THE VECTOR, Wave 1, 2026-06-15) RETIRED the
     // two Decision-axis tolerances** — the round-trip now observes FK-trust /
     // unique-promotion through the general comparator — dropping the count to 9.
-    Assert.Equal(9, Set.count ToleratedDivergence.allKnown)
+    // **Option C (Wave 1 follow-on, 2026-06-15):** 10 — FkTrustNotRestoredOnBulkLoad
+    // (Decision, AcceptedFaithful) names the transfer-leg re-trust opt-out.
+    Assert.Equal(10, Set.count ToleratedDivergence.allKnown)
 
 // ---------------------------------------------------------------------------
 // NM-70 (WP5) — the identity-annotation emit | omit gate.

--- a/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ToleranceTests.fs
@@ -39,6 +39,7 @@ type ToleratedDivergenceGen =
                 ToleratedDivergence.CompositePkFkUnreflected
                 ToleratedDivergence.CharAnsiPaddingTolerated
                 ToleratedDivergence.DecimalScaleTolerated
+                ToleratedDivergence.FkTrustNotRestoredOnBulkLoad
                 ToleratedDivergence.TriggerBodyUnparsedDropped
             ]
         |> Arb.fromGen
@@ -58,7 +59,7 @@ let ``Tolerance.permissive is not strict`` () =
     Assert.False (Tolerance.isStrict Tolerance.permissive)
 
 [<Fact>]
-let ``Closed-DU coverage: ToleratedDivergence.allKnown contains nine variants (M1 retired the two Decision tolerances)`` () =
+let ``Closed-DU coverage: ToleratedDivergence.allKnown contains ten variants (option C added FkTrustNotRestoredOnBulkLoad)`` () =
     // Per the closed-DU expansion empirical-test discipline (`DECISIONS
     // 2026-05-13`): when a new ToleratedDivergence variant lands, this
     // count assertion fires until allKnown is extended. The companion
@@ -99,7 +100,12 @@ let ``Closed-DU coverage: ToleratedDivergence.allKnown contains nine variants (M
     // FK-trust / unique-promotion decisions through the general comparator
     // (witnessed Docker-real by the M1 decision-readback test), so the Decision
     // axis flips back from ◑ L2-partial to ✅ faithful.
-    Assert.Equal (9, Set.count ToleratedDivergence.allKnown)
+    // **Option C (Wave 1 follow-on, 2026-06-15):** 10 — `FkTrustNotRestoredOnBulkLoad`
+    // (Decision, AcceptedFaithful) names the transfer-leg OPT-OUT: `Transfer.Execute`
+    // re-trusts the sink's FKs by default, so this fires only when the operator
+    // sets `WriteOptions.RetrustForeignKeys = false`. AcceptedFaithful, so the
+    // Decision axis stays ✅ and the open-gap count stays 3.
+    Assert.Equal (10, Set.count ToleratedDivergence.allKnown)
 
 [<Fact>]
 let ``Tolerance.ofSet round-trips through divergences`` () =

--- a/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
@@ -20,31 +20,23 @@ module private TransferCanaryFixtures =
         if Deploy.Docker.ensureRunning () then true
         else printfn "SKIP %s: Docker daemon not reachable." label; false
 
-    /// THE VECTOR Wave 1 / M1 follow-on — normalize the FK *trust* bit before a
-    /// transfer-canary comparison. M1 gave `PhysicalForeignKey` an `IsTrusted`
-    /// field so the SCHEMA round-trip canary (emit → deploy → read-back) observes
-    /// FK trust through the general comparator. The DATA transfer is a different
-    /// surface: `Transfer.Execute` loads rows via the high-throughput bulk path
-    /// (SqlBulkCopy WITHOUT `CHECK_CONSTRAINTS`), which SQL Server records by
-    /// marking the sink's FKs `is_not_trusted = 1`. So a trusted source FK reads
-    /// back as an UNTRUSTED sink FK — a divergence on the trust bit ALONE (the FK
-    /// structure — source/target schema·table·column — columns, rows, and indexes
-    /// all round-trip; verified because this helper normalizes ONLY `IsTrusted`,
-    /// so a genuine *structural* FK divergence still fails the canary).
+    /// Normalize the FK *trust* bit to `true` on both sides of a comparison.
+    /// M1 gave `PhysicalForeignKey` an `IsTrusted` field, so the high-throughput
+    /// bulk load (SqlBulkCopy WITHOUT `CHECK_CONSTRAINTS`, leaving the sink's FKs
+    /// `is_not_trusted = 1`) is a trust-bit-ONLY divergence — FK structure
+    /// (source/target schema·table·column), columns, rows, and indexes all
+    /// round-trip; this helper normalizes ONLY `IsTrusted`, so a genuine
+    /// *structural* FK divergence still fails.
     ///
-    /// The transfer canary witnesses DATA + SCHEMA-STRUCTURE fidelity; FK-trust
-    /// ROUND-TRIP is witnessed separately on the schema surface
-    /// (`CanaryRoundTripTests` — the M1 decision-readback adjunction). Normalizing
-    /// the trust bit on BOTH sides scopes the transfer canary to its true claim —
-    /// a NAMED, explained exclusion (the `isSchemaEqual`-ignores-rows precedent),
-    /// not a silent one.
-    ///
-    /// OPEN QUESTION (operator / transfer-path owner — see DECISIONS 2026-06-15
-    /// "THE VECTOR Wave 1"): should `Transfer.Execute` re-validate FKs
-    /// (`WITH CHECK CHECK CONSTRAINT`) after the bulk load to re-TRUST them on the
-    /// sink — trading load throughput for trust fidelity — given the reverse leg's
-    /// hundreds-of-millions-of-rows scale target? If so, this normalization
-    /// retires and the transfer canary asserts full `isEqual` including trust.
+    /// RESOLVED (operator, 2026-06-15 — option C; see DECISIONS "Wave 1 follow-on:
+    /// the FK-trust transfer-leg OPEN QUESTION RESOLVED"). The default
+    /// `Transfer.Execute` now RE-TRUSTS the sink's FKs post-load
+    /// (`WriteOptions.RetrustForeignKeys = true`), so the on-path `RoundTrips`
+    /// canary asserts FULL `isEqual` including trust — it no longer calls this
+    /// helper. The helper survives to serve the OPT-OUT witness: the off-path
+    /// canary runs with `RetrustForeignKeys = false` and uses this to prove the
+    /// ONLY residual divergence is trust (everything else round-trips), the named
+    /// `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`.
     let trustNormalizedFks (ps: PhysicalSchema) : PhysicalSchema =
         { ps with
             ForeignKeys = ps.ForeignKeys |> Set.map (fun fk -> { fk with IsTrusted = true }) }
@@ -63,6 +55,16 @@ module private TransferCanaryFixtures =
         "INSERT INTO [dbo].[OSUSR_XF_CUSTOMER] ([ID],[NAME]) VALUES (1,N'Alice'),(2,N'Bob'); " +
         "INSERT INTO [dbo].[OSUSR_XF_ORDER] ([ID],[CUSTOMER_ID],[AMOUNT]) VALUES " +
         "(10,1,100),(11,2,200),(12,1,300);"
+
+    /// The twoTable schema whose FK is deployed UNTRUSTED — a `NoCheckFk`
+    /// decision: created normally, then disabled and re-enabled `WITH NOCHECK`
+    /// so it stays ENABLED (enforces new DML) but reads `is_not_trusted = 1`.
+    /// Used to prove option C's re-trust PRESERVES an as-deployed untrusted FK
+    /// (it restores only the trust the bulk load strips, never a NoCheckFk).
+    let untrustedFkDdl =
+        twoTableDdl +
+        " ALTER TABLE [dbo].[OSUSR_XF_ORDER] NOCHECK CONSTRAINT [FK_XfOrder_Customer]; " +
+        "ALTER TABLE [dbo].[OSUSR_XF_ORDER] WITH NOCHECK CHECK CONSTRAINT [FK_XfOrder_Customer];"
 
     /// Self-referential FK (a 1-cycle): MANAGER_ID is nullable, so it
     /// defers — phase 1 inserts with NULL, phase 2 re-points it.
@@ -375,18 +377,21 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
                                 let report = TransferCanaryFixtures.value reportR
                                 Assert.True(report.Kinds |> List.forall (fun k -> k.RowsWritten = k.RowsIngested))
 
-                                // Sink reproduces Source on PhysicalSchema (incl. per-row hashes).
-                                // FK-trust is normalized on both sides: the bulk data load leaves
-                                // sink FKs untrusted (documented SqlBulkCopy behavior), a trust-bit-
-                                // only divergence the transfer canary scopes out by name — FK-trust
-                                // ROUND-TRIP is witnessed on the schema surface (the M1 canary). See
-                                // `TransferCanaryFixtures.trustNormalizedFks`.
+                                // Sink reproduces Source on PhysicalSchema in FULL — per-row hashes
+                                // AND FK trust. Option C (operator-authorized 2026-06-15): the default
+                                // `Transfer.Execute` re-trusts the sink's FKs after the bulk load
+                                // (`WriteOptions.RetrustForeignKeys = true`), restoring the trust bit
+                                // the high-throughput `SqlBulkCopy` left `is_not_trusted = 1`. So the
+                                // canary asserts full `isEqual` INCLUDING trust — no `trustNormalizedFks`
+                                // normalization (retired here per its own docstring's promise). The
+                                // opt-out (re-trust off) is witnessed by the `FkTrustNotRestoredOnBulkLoad`
+                                // off-path canary below.
                                 let! aR = ReadSide.read src
                                 let! bR = ReadSide.read sink
                                 let diff =
                                     PhysicalSchema.diff
-                                        (TransferCanaryFixtures.trustNormalizedFks (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR)))
-                                        (TransferCanaryFixtures.trustNormalizedFks (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR)))
+                                        (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR))
+                                        (PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR))
                                 Assert.True(PhysicalSchema.isEqual diff, PhysicalSchema.renderDiff diff)
                             })
                 }))
@@ -398,6 +403,107 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
     [<Fact>]
     member this.``data canary: deferred self-referential FK is re-pointed in phase 2`` () =
         this.RoundTrips "XferSelf" TransferCanaryFixtures.selfRefDdl TransferCanaryFixtures.selfRefSeed
+
+    // Option C off-path — the opt-out witness. With `RetrustForeignKeys = false`
+    // the bulk load's untrusted sink FKs are LEFT untrusted: the named, accepted
+    // `FkTrustNotRestoredOnBulkLoad` Decision-axis tolerance, not a silent drop.
+    // Discriminating against the default (re-trust on, asserted by `RoundTrips`):
+    // the RAW diff is non-empty (trust differs), the source reads trusted / the
+    // sink untrusted, and normalizing ONLY trust empties the diff (nothing
+    // structural diverges — the bulk data + FK structure still round-trip).
+    [<Fact>]
+    member _.``data canary (option C off-path): RetrustForeignKeys=false leaves sink FKs untrusted — named FkTrustNotRestoredOnBulkLoad`` () =
+        if not (TransferCanaryFixtures.skipIfNoDocker "XferNoRetrust") then () else
+        // The opt-out is a named, closed tolerance — not a silent divergence.
+        Assert.Contains(ToleratedDivergence.FkTrustNotRestoredOnBulkLoad, ToleratedDivergence.allKnown)
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "XferNoRetrustSrc" (fun src _ ->
+                task {
+                    do! Deploy.executeBatch src TransferCanaryFixtures.twoTableDdl
+                    do! Deploy.executeBatch src TransferCanaryFixtures.twoTableSeed
+                    return!
+                        fixture.WithEphemeralDatabase "XferNoRetrustSink" (fun sink _ ->
+                            task {
+                                do! Deploy.executeBatch sink TransferCanaryFixtures.twoTableDdl
+
+                                let! contractR = ReadSide.read src
+                                let contract = TransferCanaryFixtures.value contractR
+
+                                // Opt out of re-trust — keep the bulk load's untrusted FKs.
+                                let opts = { Transfer.WriteOptions.def with RetrustForeignKeys = false }
+                                let! reportR = Transfer.runWithOptions Transfer.Execute opts true src sink contract
+                                let _ = TransferCanaryFixtures.value reportR
+
+                                let! aR = ReadSide.read src
+                                let! bR = ReadSide.read sink
+                                let srcPs = PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR)
+                                let sinkPs = PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR)
+
+                                // Source FK trusted; sink FK untrusted (the opt-out divergence).
+                                Assert.True(srcPs.ForeignKeys |> Set.forall (fun fk -> fk.IsTrusted),
+                                            "source FKs should read trusted")
+                                Assert.True(sinkPs.ForeignKeys |> Set.exists (fun fk -> not fk.IsTrusted),
+                                            "with re-trust off the sink FK should read untrusted")
+
+                                // RAW diff is non-empty (trust differs)...
+                                let rawDiff = PhysicalSchema.diff srcPs sinkPs
+                                Assert.False(PhysicalSchema.isEqual rawDiff,
+                                             "with re-trust off the FK-trust divergence must surface")
+                                // ...and normalizing ONLY trust empties it (nothing structural diverges).
+                                let normDiff =
+                                    PhysicalSchema.diff
+                                        (TransferCanaryFixtures.trustNormalizedFks srcPs)
+                                        (TransferCanaryFixtures.trustNormalizedFks sinkPs)
+                                Assert.True(PhysicalSchema.isEqual normDiff, PhysicalSchema.renderDiff normDiff)
+                            })
+                }))
+
+    // Option C — the NoCheckFk-PRESERVATION witness (the fidelity guard on the
+    // re-trust step). A source FK deployed UNTRUSTED (a NoCheckFk decision — the
+    // very thing M1 made faithful) must survive a DEFAULT (re-trust ON) transfer
+    // as UNTRUSTED on the sink. The restore re-validates only the trust the bulk
+    // load STRIPS (the pre-load snapshot), never an as-deployed untrusted FK.
+    // Discriminating: a blanket "re-trust every untrusted FK" would trust the
+    // sink FK — diverging from the source AND overriding the operator's NoCheckFk
+    // decision (re-validating data they chose not to validate).
+    [<Fact>]
+    member _.``data canary (option C): an as-deployed UNTRUSTED FK (NoCheckFk) is PRESERVED through a default re-trust transfer`` () =
+        if not (TransferCanaryFixtures.skipIfNoDocker "XferUntrustedFk") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "XferUntrustedFkSrc" (fun src _ ->
+                task {
+                    do! Deploy.executeBatch src TransferCanaryFixtures.untrustedFkDdl
+                    do! Deploy.executeBatch src TransferCanaryFixtures.twoTableSeed
+                    return!
+                        fixture.WithEphemeralDatabase "XferUntrustedFkSink" (fun sink _ ->
+                            task {
+                                // Sink FK also deployed UNTRUSTED (as-deployed parity).
+                                do! Deploy.executeBatch sink TransferCanaryFixtures.untrustedFkDdl
+
+                                let! contractR = ReadSide.read src
+                                let contract = TransferCanaryFixtures.value contractR
+
+                                // Default transfer — re-trust ON.
+                                let! reportR = Transfer.run Transfer.Execute true src sink contract
+                                let _ = TransferCanaryFixtures.value reportR
+
+                                let! aR = ReadSide.read src
+                                let! bR = ReadSide.read sink
+                                let srcPs = PhysicalSchema.ofCatalog (TransferCanaryFixtures.value aR)
+                                let sinkPs = PhysicalSchema.ofCatalog (TransferCanaryFixtures.value bR)
+
+                                // The as-deployed untrusted FK is preserved on BOTH sides — the
+                                // restore touched only the load-stripped trust (none here), NOT
+                                // the NoCheckFk decision.
+                                Assert.True(srcPs.ForeignKeys |> Set.forall (fun fk -> not fk.IsTrusted),
+                                            "source FK should read as-deployed untrusted")
+                                Assert.True(sinkPs.ForeignKeys |> Set.forall (fun fk -> not fk.IsTrusted),
+                                            "re-trust must PRESERVE the as-deployed untrusted FK, not blanket-trust it")
+                                // Full isEqual incl. trust — both untrusted, everything else round-trips.
+                                let diff = PhysicalSchema.diff srcPs sinkPs
+                                Assert.True(PhysicalSchema.isEqual diff, PhysicalSchema.renderDiff diff)
+                            })
+                }))
 
     // Wave-3 slice 3.1 — the CDC pre-flight. An Execute transfer against a
     // Sink with CDC-tracked tables is refused unless --allow-cdc. Gracefully


### PR DESCRIPTION
Resolves the **OPEN QUESTION** the Wave 1 (M1) entry deferred to the operator: should `Transfer.Execute` re-trust the sink's FKs after the bulk load? **Operator decision (option C): yes — re-trust by default, with a per-run opt-out lever.**

`SqlBulkCopy` (no `CHECK_CONSTRAINTS`, and structurally required by the two-phase deferred-FK load) leaves the sink's FKs `is_not_trusted = 1`. Once M1 put FK trust in the round-trip comparator, that surfaced as a real Decision-axis divergence on the transfer leg. This restores trust by default.

## What changed
- **Lever** — `WriteOptions.RetrustForeignKeys : bool` (default `true`), threaded through `runCore`; a `Transfer.runWithOptions` test seam exposes it.
- **Re-trust** — `runCore` snapshots the **as-deployed** FK trust *before* the load (`trustedFksOnLoadedTables`) and restores exactly that after (`restoreFkTrust` → `ALTER TABLE … WITH CHECK CHECK CONSTRAINT`). One semi-join per FK, one-time; a failure is a loud integrity signal, never silent.
- **Preserves `NoCheckFk`** — an FK deployed *untrusted* is absent from the snapshot, so it is never re-trusted. A blanket "re-trust every untrusted FK" would have overridden the exact decision M1 made faithful (and re-validated data the operator chose not to validate). A discriminating canary locks this in.
- **Opt-out** names the closed `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad` (`@ladder … Decision AcceptedFaithful` — default config stays faithful, matrix not de-rated; distinct from the M1-deleted `FkTrustUnreflected`).
- **Canary** — on-path retires `trustNormalizedFks` → asserts full `PhysicalSchema.isEqual` incl. trust; adds off-path (lever off → untrusted + named) and NoCheckFk-preservation tests.

## Scope
Covers the **materialized** transfer path (the operator decision). The **streaming reverse-leg** (`writePlanStreaming`, to compose with `ReverseLegRealization.choose`), **synthetic load**, and the **CLI flag** are a named Wave-2 follow-on — recorded in `DECISIONS.md`; until wired, those realizations exhibit the named tolerance (not a silent gap).

## Verification (all real)
- Debug + Release builds: **0/0**.
- Pure pool: **3357 passed / 0 failed / 210 skip**.
- Transfer canaries (conn-str forced, 2–3 s/test): **23/23** — on-path full `isEqual`, off-path, NoCheckFk preservation.
- Regression sweep — M1 keystone (real, 1.65 s), promotion, comprehensive, migration: **55/55**.
- `matrix-status.sh`: gate=PASS, rungs 5/4/5, tolerances **10 (3 open)**, Decision ✅, `@ladder` cross-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
