### PR TITLE
THE VECTOR Waves 2–3: the reversible algebra + the compression

### DIFF
--- a/sidecar/projection/AXIOMS.md
+++ b/sidecar/projection/AXIOMS.md
@@ -1860,6 +1860,11 @@ B` + `applyDiff threads the passed-in catalog … (no-cheat)`.
 the schema/data history. Witness: `Lifecycle.reconstructLatest` (fold
 applyDiff). The `compose : Delta → Delta → Delta` operator (diff∘diff) is **SHIPPED**
 as `CatalogDiff.compose` (6.H.3, 2026-06-01); A-Lifecycle-4 promoted to Bucket A.
+**M12 (THE VECTOR Wave 2, SHIPPED):** the groupoid INVERSE
+`CatalogDiff.inverse d = between (target d) (source d)` completes the partial
+groupoid — every arrow is invertible on its composability class
+(`applyDiff (inverse d) (target d) = source d`, the freed rollback witness;
+`compose d (inverse d) = identity at source`, the groupoid law).
 **Latent (2026-06-01 morphology research):** `reconstructLatest` runs only over
 **in-memory values in tests** — there is **no durable episode** to integrate
 over (`CatalogSnapshot` is schema-only, single-plane, never serialized). The
@@ -1892,6 +1897,12 @@ CDC capture series, 6.F.3-data, ⬚); the value-level `π`/`Delta` stay concrete
 `CatalogDiff` (temporal multi-version use, 6.H), **not** the data leg, whose δ is
 substrate-fused (no `RowDiff` value; `WAVE_6_ALGEBRA.md` §12.4) — per the
 noun/verb reification principle (§12.3).
+**M11 (THE VECTOR Wave 2, SHIPPED):** `‖·‖` is now a proven METRIC — the
+triangle inequality `‖compose d1 d2‖ ≤ ‖d1‖ + ‖d2‖` (subadditive; churn cancels,
+so net ≤ path) is a green property over generated adjacent triples. So
+"minimality is measured" rests on a genuine metric, not merely a non-negative
+count — the missing metric law of the norm `between`/`compose`/`norm` already
+computed both sides of (`pathLength` vs `‖net‖`).
 
 **T16 — the Project square (the master equation; the adjunction lifted to
 displacements).** `run( emit(B ⊖ A), realize(A) ) = realize(B)` modulo

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -24096,3 +24096,98 @@ realization-selector / "downgrades never silent" commitments.
   (`writePlanStreaming`, composing with `ReverseLegRealization.choose` + the capability-descent ladder) and
   `runSynthetic`; expose the `RetrustForeignKeys` opt-out on the CLI face. Until then those realizations exhibit
   the named `FkTrustNotRestoredOnBulkLoad`.
+
+---
+
+## 2026-06-15 (later still) — THE VECTOR Wave 2 BUILT: the reversible algebra, the real-wire proof, and the transactionality honest-naming (M11/M12/M13 + M3 + M20)
+
+The third chapter of THE VECTOR (`THE_VECTOR.md` §6 / §7 Wave 2) — the **first fan-out wave**. Wave 0
+(honesty) and Wave 1 (the keystone M1) were single coupled moves done inline; Wave 2 is five moves across
+three file-disjoint surfaces. **Orchestrated as a `Workflow`** (the operator asked for it explicitly): three
+worktree-isolated implementers (the `CatalogDiff` trio / M3 / M20), **one default-skeptical adversarial
+verifier per move** (prompted to refute correctness AND non-vacuity), and **one integrator** (the main loop)
+who alone owned the authoritative build, the matrix, and the gates. All three verifiers returned ACCEPT
+(high confidence); integration was via `git cherry-pick` of the implementers' committed branches (never
+text-diff-apply — the Windows trailing-newline trap that bit Wave 0).
+
+- **M13 — `CatalogDiff.between` is now total** (`Catalog -> Catalog -> CatalogDiff`; the vestigial
+  `Result<_, EmitError>` dropped — `Ok` was the only inhabited branch). `compose` reads the displacement
+  directly (`between (source d1) (target d2)`). The signature cascade adapted **13 src call sites + ~120 test
+  sites across 16 files**: match-on-`Ok/Error` sites bind directly (the dead `Error` branch removed — `between`
+  never errored); Result-typed boundaries Ok-wrap to PRESERVE their downstream signatures (the
+  `Comparison<Catalog,_>.Between` field mirrors its `physicalSchema` sibling; `Lifecycle`/`Episode`
+  `evolutionChain`/`netDiff` keep their `Result<_, EmitError>` shape — minimal blast radius, no cascade into
+  `reconstructLatest`). The now-unused `sequenceEmit` was removed from both `Lifecycle.fs` and `Episode.fs`.
+- **M11 — the triangle inequality, made a theorem.** `norm (compose d1 d2) ≤ norm d1 + norm d2` over adjacent
+  diffs (a Fact with a strict churn-cancel case — A→B adds an attribute, B→C removes it, so `net 0 < path 2` —
+  plus an equality case; and a swept `[<Property>]` over 100 generated adjacent triples). **The norm is now a
+  provable METRIC**, not merely a non-negative count — the missing metric law that "minimality is measured"
+  (the CDC-norm, T15) quietly depended on.
+- **M12 — the groupoid inverse.** `CatalogDiff.inverse d = between (target d) (source d)` + the freed rollback
+  witness (`applyDiff (inverse d) (target d) = source d`, order-insensitive over the captured surface) + the
+  groupoid law (`compose d (inverse d) = identity at source`). The partial groupoid is completed: every arrow
+  is invertible on its composability class. The existing `compose` fail-loud-on-non-adjacent invariant survives.
+- **M3 — the swept change-algebra proof** (THE VECTOR §5.2, "the highest-value unfired proof in the system").
+  New self-contained `ChangeAlgebraSweepTests.fs`: `genCatalogPair : Gen<Catalog*Catalog>` (A perturbed into B
+  by a generated, valid-by-construction edit list — kind add/remove/rename + attribute add/remove/reshape; no
+  refs/indexes so no edit can strand an FK/index, every B through the smart constructors) and three swept
+  `[<Property>]` tests: the **T16 master equation** in-process (`isEmpty (between B (applyDiff (between A B) A))`),
+  the **no-cheat** base-threading property (applying the A→B delta to a base C with an extra kind keeps that
+  kind — catches a `fun _ d -> target d` cheat), and **norm consistency** (`norm = 0 ⟺ isEmpty`, `norm = Σ`
+  channel counts). Raises the round-trip law from fixture-witnessed to property-witnessed; the live-deploy
+  backend stays separately gated. **Honest scope note (verifier-caught):** the sweep exercises the
+  kind-presence/rename + attribute channels; the FK / index / sequence / **kind-facet (`ChangedKinds`)**
+  channels are 0-pinned in the sweep (covered by the C1 fixtures in `CatalogDiffTests`), so M3 is NOT cited as
+  property-proof for those channels.
+- **M20 — the Transactionality honest-naming half** (THE VECTOR §5.1). `GateLabel.MidWriteNotProtected` (the
+  named destructive class for a mid-write crash on an unprotected write path) + its **exit-9** classify arm
+  (`transfer.midWriteNotProtected` / `migrate.midWriteNotProtected`) + a pure gate `transactionalityViolations`
+  (mirroring `permissionViolations`: a `TransactionProtection = Atomic | Resumable | Unprotected` DU →
+  `TransactionalityViolation list`; protected ⇒ empty, Unprotected ⇒ named per write) + `transactionalityPreflight`.
+  The closed-DU cascade is complete (labelText, `Voice.gateStatement`, both totality lists). **The live atomic
+  `BEGIN TRAN` wrapper STAYS DEFERRED** per the recorded `Preflight.fs` A3 survey-gate — this is the
+  honest-naming half only; a mid-write crash is now a named refusal, not the generic exit-3 `UnclassifiedRefusal`.
+- **M11/M12 axiom witnesses (T-II).** The two "deepen the algebra" laws earn executable-axiom coverage:
+  `AxiomTests.fs` T13 gains the M12 inverse (the partial groupoid completed); T15 gains the M11 triangle
+  inequality (`‖·‖` is a metric). `citationOf` binds each to the live `CatalogDiffTests` test; the M16 gate
+  verifies resolution; `AXIOMS.md` T13/T15 carry the dated amendment notes.
+- **Witness (all green, integrator-authoritative).** Debug + **Release** 0/0. Pure pool **3372 / 0** (210
+  skipped). **Docker pool 246 / 246** (real durations — ReverseLegScale Tier-4 streaming 56 s; not a no-op).
+  `AxiomTests` 79/0 (incl. the M16 citation gate). **`matrix-status.sh` regenerated byte-identically**
+  (gate=PASS; rungs L1/L2/L3 = 5/4/5; tolerances 10, 3 open; `@ladder` cross-check passes) — Wave 2 added/retired
+  no tolerance and renamed no witness, so the under-claiming guarantee is undisturbed. `verifiability-gate.sh`
+  exit 0 (zero phantom Bucket-A/B; the pre-existing 4-unbucketed-deferral WARN is untouched).
+- **Exit criterion (Wave 2) — MET.** The groupoid laws are green; `applyDiff (inverse d) (target d) = source d`
+  is a stated rollback witness; the master equation is swept over generated displacements; the norm is a proven
+  metric; the destructive failure mode is classified, not generic. **Next: Wave 3 (compression & idiom) —
+  M7 (diff `ChannelSpec`) · M8 (`JsonDocumentWriter` seam) · M9 (binding algebra) · M17 (totality functor) ·
+  M6 (`[<Struct>]` surrogate keys) · M19 (`row` UoM) · the `Changed → Reshaped` rename — the widest fan-out.**
+
+## 2026-06-15 (later still) — Option-C re-trust: capability descent on the no-ALTER (ManagedDml) sink (a pre-existing bug Wave 2's full Docker pool surfaced)
+
+Surfaced — NOT caused — by THE VECTOR Wave 2's full Docker-pool run (the trio change to `CatalogDiff` is a
+comparison primitive, so the integrator ran the **full** 246-test pool, not just `~Canary`). A pre-existing bug
+in the Wave-1 follow-on (option C, `c7133c5d`), **confirmed by running the failing test on the base commit**
+(identical failure, identical `restoreFkTrust` stack — my Wave 2 diff does not touch the re-trust logic).
+
+- **The bug.** `restoreFkTrust` (`TransferRun.fs`) runs `ALTER TABLE … WITH CHECK CHECK CONSTRAINT`
+  **unconditionally** on the materialized reverse-leg path when `RetrustForeignKeys` is on (the default). On a
+  **`ManagedDml` / `grant: data` cloud sink** (granted only SELECT/INSERT/UPDATE/DELETE — no ALTER anywhere in
+  the write path, the J5 archetype) the ALTER fails with **SQL error 1088** ("Cannot find the object … because
+  it does not exist or you do not have permissions"), failing the whole transfer. Option C's docstring assumed
+  the re-trust is "guaranteed to succeed after a faithful transfer" — true on a `FullRights` sink, but the
+  ManagedDml archetype cannot ALTER at all. The follow-on only ran `TransferCanaryTests` (a FullRights sink),
+  never `ReverseLegCanaryTests`, so the **DML-only-principal canary's "no ALTER anywhere in the write path"
+  contract was silently broken** — the exact "run the FULL Docker pool" discipline this caught.
+- **The fix (capability descent, mirroring `SurrogateCapture.isCapabilityRefusal`).** The re-trust ALTER now
+  DESCENDS on the ALTER-permission/visibility error family (1088 / 4902 / 229) to the **already-existing named
+  `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`**: the FKs stay as the bulk load left them (untrusted),
+  surfaced via the `retrust-skipped` stage, never silent. A constraint conflict (547) still **PROPAGATES** — a
+  re-validation that fails on the DATA is the loud fidelity signal option C intends, never masked. Re-trust is a
+  `FullRights` capability; on a DML-only login the ALTER is simply not available, exactly as the J5 archetype
+  model records. The error number (1088, not the assumed 4902) was confirmed empirically against the warm
+  container before narrowing the predicate.
+- **Witness.** `ReverseLegCanaryTests` + `TransferCanaryTests` **36/36** warm (the DML-only principal now green
+  via descent; the FullRights re-trust canaries still re-trust — no regression), then the full Docker pool
+  246/246. Bounded to `restoreFkTrust` (no archetype re-threading; the reactive descent needs no proactive
+  capability probe, sidestepping the CONTROL-implies-ALTER subtlety a grant-evidence gate would face).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -24191,3 +24191,76 @@ in the Wave-1 follow-on (option C, `c7133c5d`), **confirmed by running the faili
   via descent; the FullRights re-trust canaries still re-trust — no regression), then the full Docker pool
   246/246. Bounded to `restoreFkTrust` (no archetype re-threading; the reactive descent needs no proactive
   capability probe, sidestepping the CONTROL-implies-ALTER subtlety a grant-evidence gate would face).
+
+---
+
+## 2026-06-15 (later still) — THE VECTOR Wave 3 BUILT: compression & idiom (M7+rename / M8 / M9 / M17 / M6 / M19 — the engine measurably smaller)
+
+The fourth chapter of THE VECTOR (`THE_VECTOR.md` §6 Kind III/V + corollaries; §7 Wave 3) — the **widest
+fan-out**. Seven moves across six file-disjoint surfaces. The four substantial moves were orchestrated as a
+`Workflow` (worktree-isolated implementers + one adversarial verifier each); the two attribute-only moves (M6/M19)
+were done inline by the integrator (no cold-build tax for two-line changes). All behavior-preserving — the engine
+shrinks while every output byte and every law is unchanged.
+
+- **M7 — the diff `ChannelSpec` + the `Changed → Reshaped` rename.** The four byte-identical per-channel diff
+  builders (`attributeDiff`/`referenceDiff`/`indexDiff`/`sequenceDiffBetween`) and four apply-patchers collapse to
+  one `buildChannel` fold + one `applyChannel` patcher over four `ChannelSpec` values (the kind-vs-catalog
+  container asymmetry absorbed by a generic `entitiesOf`); the four old private builder names survive as thin
+  wrappers so `between`'s call sites are untouched. The zero-risk rename makes the diff + migration layers speak
+  one word — `ChannelDiff<'change>.Changed → Reshaped` (the `ChannelCounts.Changed*` move-count fields and the
+  unrelated `PolicyAxisDiff.Changed` bool are correctly NOT renamed). Net −26 LOC; behavior preserved by
+  construction (T1 source-order, sparse non-empty storage, rename⊥reshape independence all intact).
+- **M8 — the `JsonDocumentWriter` seam.** One `[<RequireQualifiedAccess>] module JsonWriting` in `PinnedWriting.fs`
+  (`writeToNode` compact→JsonNode · `renderNodeToString` node→indented · `writeToString` imperative→indented)
+  retires the `Utf8JsonWriter → MemoryStream → byte[] → JsonNode.Parse` dance duplicated across 6 sites
+  (JsonEmitter / CatalogCodec / ProfileCodec / DistributionsEmitter / DecisionLogEmitter / SuggestConfigEmitter),
+  each routed to the form that preserves its EXACT compact/indented options. **Byte-identical** (GoldenEmission +
+  codec round-trips green); the out-of-lane default-option sites (LogSink/RunLedger) correctly left untouched.
+- **M9 — the binding algebra (FsToolkit `validation { }`).** The hand-rolled four-way `Ok/Error` applicative match
+  + `bindError`/`aggregate` skeleton across the binding modules collapses to `validation { }` / `result { }` (the
+  documented-but-unused CE at `Result.fs:151`; error accumulation byte-identical — FsToolkit 4.18.0 `Validation`
+  appends left-to-right exactly as the hand-rolled code did). The three (in fact FOUR — `projectSeedPlan` folded
+  in) shaping convergences now share one `bindShapingTriple` combinator so they CANNOT drift. **Mechanism-only —
+  behavior preserved EXACTLY:** every path threads the same binding set (the live/migrate/store legs still OMIT
+  `SpecialCircumstances`; `applyModuleFilter` stays at the read seam). The §6 latent divergences are **left as
+  pre-existing for the operator to adjudicate** — M9 makes the convergence drift-proof, it does NOT unify the
+  binding sets by fiat (the named safety mandate honored).
+- **M17 — the totality-test functor.** The four structurally-identical totality tests
+  (`CapabilitySurvey`/`Voice`/`Transform`/`ManifestPredicate`) extract their shared bidirectional-subset +
+  distinctness law (`X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`) into a new `TotalityFunctor.fs` (`assertBidirectionalSubset` /
+  `assertProjectionDistinct` / `assertTotality`), each test reduced to a ~10-line typed instantiation. Every
+  test-specific extra (Voice's banned-word discipline, CapabilitySurvey's coarse-upper-bound, RegisteredAllTransforms'
+  skeleton-purity + overlay-exercise, ManifestPredicate's determinism + aggregation) stays verbatim — no assertion
+  lost; the functor is same-or-stronger (it adds the entailed equality for two sites). A fifth totality axis is now
+  a one-line application.
+- **M6 — `[<Struct>]` on `SourceKey`/`AssignedKey`** (inline). The one-word struct copy over the string ref for the
+  surrogate orientation pair consumed per-referencer-row in `remapRowFksWith` — same rationale `RowQuantum` earned
+  (§9.7 carrier-cost; the measured trigger has a second consumer on the same hot path). The type surface is
+  unchanged, so consumers are untouched.
+- **M19 — `[<Measure>] row` on the data-norm deltas** (inline). `RowCountDelta`/`NullCountDelta` `Before`/`After`
+  become `int64<row>` — the natural sibling of the shipped `[<Measure>] ms`, ruling out at compile time the
+  addition of a row-delta to a millisecond-delta. Tagged at construction (`* 1L<row>`), stripped via `int64` at the
+  RunFaces formatting boundary (the exact `ms` idiom). Zero runtime cost.
+- **Orchestration note (a learning, recorded for future multi-wave sessions).** The four worktree implementers
+  branched off the SESSION-START commit (`dda83a8f`), NOT the integrator's advancing branch HEAD — so they lacked
+  the Wave-2 commits. This is benign for `git cherry-pick` (it applies each move's OWN delta, valid against its
+  base) but it (a) made the **adversarial verifiers' base wrong** (I passed `00292f9d`; the branches were off
+  `dda83a8f`), so the M7 verifier raised false "deleted `inverse` / reverted `between` / deleted M11/M12/M3" blockers
+  that were really Wave-2's ABSENCE from M7's base — disproven by checking M7's real delta `dda83a8f..147f6255`
+  (exactly the 9-file rename+ChannelSpec, zero touches to `between`/`inverse`); and (b) required 3-way conflict
+  resolution where a move overlapped a Wave-2-modified file (M7's `CatalogDiffTests.fs` — combine Wave-2's
+  total `between` with M7's `.Reshaped`; M17's `VoiceTotalityTests.fs` auto-merged with M20's `MidWriteNotProtected`
+  surviving; M9's `Pipeline.fs` auto-merged). **For a multi-wave session, later waves' worktrees branch off the
+  session origin — plan the integration (cherry-pick + verifier base) accordingly.**
+- **Witness (all green, integrator-authoritative).** Debug + **Release** 0/0. Pure pool green (real durations —
+  R4 18 s). **Docker pool 246/246** (real durations — ReverseLegScale Tier-4 streaming 62.8 s; not a no-op).
+  `AxiomTests` 79/0 (M11/M12 witnesses + M16 citation gate intact — Wave 2 survived M7's merge).
+  **`matrix-status.sh` regenerated byte-identically** (gate=PASS; rungs L1/L2/L3 = 5/4/5; tolerances 10, 3 open) —
+  Wave 3 is compression/idiom, adding/retiring no tolerance and renaming no matrix-bound witness, so the under-claim
+  is undisturbed. `verifiability-gate.sh` exit 0.
+- **Exit criterion (Wave 3) — MET.** The descriptor-duplication is retired at the three ripe sites (M7/M8/M9); the
+  totality proof is one functor; the data norm is unit-typed; the surrogate pair is a struct. The engine is
+  measurably smaller and every byte/law is unchanged. **Remaining (THE VECTOR §7 Wave 4): the corollary cashes +
+  gated deepenings — M18 (`ChangeManifest.toJson`), M14 (the `Traversal` optic, after the compile-order split),
+  M4 (`ConstraintState` DU, behind the store-migration story), M5 (digest projection) — plus the persisted-state
+  -evolution discipline written down (NM-34 as the store-codec contract).**

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,88 @@
+# Handoff addendum — 2026-06-15, THE VECTOR WAVE 3 LANDED (the engine is measurably smaller — the descriptor is data, the JSON dance has one home, the binding algebra is a CE, the totality proof is one functor); your job is WAVE 4 — the corollary cashes & the gated deepenings (the operator payoff)
+
+To the next agent.
+
+**Your mission.** Build **Wave 4** of `THE_VECTOR.md` — the last wave: **corollary cashes & gated deepenings**
+(§6 corollaries + Kind II/IV; §7 Wave 4). This wave is DIFFERENT from 2–3: it is smaller, and several moves are
+**gated behind a prerequisite or a compile-order fix**, so the order matters more than the parallelism. Read
+`THE_VECTOR.md` §6 (M18/M14/M4/M5 + "the cross-cutting prerequisite") + §7 Wave 4 first.
+
+**The moves, in dependency order (NOT all parallel).**
+1. **The cross-cutting prerequisite FIRST — the persisted-state-evolution discipline** (§6 "the cross-cutting
+   prerequisite"). Before M4/M5 touch any serialized form, write it down: name **NM-34** (a missing field reads as
+   `None`) as the de-facto store-codec contract; check whether the journal/episode formats carry a version stamp;
+   make "this change touches a serialized form" a gating checklist item. This is a DECISIONS-codification move, not
+   code — but it GATES M4 and M5. Do it first so they can proceed honestly.
+2. **M18 — `ChangeManifest.toJson`** (§5.2, "the lowest-risk corollary on the board"). `ReportRun` has `render` (human
+   prose) and no `toJson`; the CDC-capture-count data norm (T15) is a real measured value flowing to `ReportRun.render`
+   as prose only. The typed total `ChangeManifest` already exists and is sorted-for-T1; only the second lens (machine)
+   is missing. Add `toJson` so the SSIS consumer can diff the change-manifest sprint-over-sprint. Own surface
+   (`ChangeManifest` / `ReportRun`). **Independent — do this one regardless; it needs no prerequisite.**
+3. **M5 — retire `VersionedPolicy.digestOf`'s `sprintf "%A"`** (§6 Kind II). Replace the F# structural-printer digest
+   (determinism-by-luck) with an explicit length-prefixed token projection (the `TransformRegistry.digest` discipline
+   next door is the precedent). **Becomes a PREREQUISITE the moment the digest is persisted into episodes** — so
+   sequence it under the persisted-state discipline (step 1). Own surface (`VersionedPolicy`).
+4. **M4 — `ConstraintState` DU** (§6 Kind II, **top-scored, tied with M1**). Collapse the `(HasDbConstraint,
+   IsConstraintTrusted)` `bool × bool` quadrant into a 3-variant `ConstraintState` DU
+   (`NoConstraint | Trusted | Untrusted`), eliminating the illegal `(false, true)` state. **It CHANGES THE CATALOG
+   CODEC**, so it sequences BEHIND the store-migration story (step 1) — the `CapabilityProfile.of` archetype work
+   (closed DU → one total expansion site → derived projection → round-trip law → reconciliation finding) is the
+   in-repo precedent to copy. The largest move of the wave; treat it like the M1 keystone (its own care).
+5. **M14 — the `Traversal` optic — GATED, do NOT schedule until the compile-order split is resolved** (§4.2/§6
+   Kind IV). It unifies the single-focus `Lens` with the hand-rolled `Catalog.mapKinds`/`CatalogTraversal.mapKinds`
+   bulk-map, but the duplication's named cause is a compile-order split; fix that first or leave M14 deferred (record
+   the deferral honestly — "not yet, and here is the trigger" is the discipline).
+
+**How to drive it.** M18 + the persisted-state discipline + M5 are a clean small workflow (or just inline — they're
+modest). M4 deserves its own careful pass (codec change + the round-trip law + the reconciliation finding), like a
+mini-keystone. M14 stays deferred behind its gate. **If you Workflow it, heed the orchestration lesson below.**
+
+**⚠️ ORCHESTRATION LESSON (cost real integration time in Wave 3 — heed it).** The Workflow's worktree-isolated
+implementers branch off the **session-start commit**, NOT your advancing branch HEAD. In a multi-wave session this
+means **later waves' worktrees lack earlier waves' commits.** Consequences: (1) `git cherry-pick` still works (it
+applies each move's OWN delta, valid against its base), so integration is fine — but where a move touches a file an
+earlier wave modified, expect a 3-way merge to resolve (combine both); (2) the **adversarial verifiers' base is
+wrong** if you pass them your current HEAD — they will diff against a non-ancestor and raise FALSE blockers that are
+really the earlier wave's ABSENCE from the implementer's base (Wave 3's M7 verifier "rejected" the move for
+"deleting `inverse`/M11/M12" that were simply not in M7's `dda83a8f` base). **Mitigations:** pass the verifier the
+implementers' REAL base (the session-start commit, e.g. `git rev-parse <branch>^`), or have it self-detect via
+`git merge-base`; and always confirm a "rejection" against the move's REAL delta (`git diff <realBase>..<branch>`)
+before believing it. Cherry-pick + the full build/pools are the true safety net.
+
+**What is DONE — do not redo (Waves 0–3, all in this PR).** Wave 0 (honesty). Wave 1 (the keystone M1 — Decision is
+EARNED ✅ L3). Wave 2 (the reversible algebra: M13 total `between` · M11 metric · M12 groupoid inverse · M3 swept
+T16 · M20 transactionality naming · the M11/M12 axiom witnesses · the option-C re-trust capability-descent fix).
+Wave 3 (compression: M7 `ChannelSpec`+`Changed→Reshaped` · M8 `JsonWriting` seam · M9 binding `validation` CE · M17
+totality functor · M6 `[<Struct>]` keys · M19 `[<Measure>] row`). Read the 2026-06-15 "THE VECTOR Wave 3 BUILT"
+DECISIONS entry — it is the substance; this letter points.
+
+**Matrix on this PR.** gate=PASS · rungs L1/L2/L3 = 5/4/5 · tolerances 10 (3 open Schema OpenGaps + the option-C
+`FkTrustNotRestoredOnBulkLoad` AcceptedFaithful). Waves 2–3 moved no tolerance and renamed no witness, so the matrix
+is byte-identical to its post-Wave-1 state — the under-claim holds. **M4 is the first Wave-4 move that COULD move a
+cell** (it touches the trust quadrant the Decision axis depends on); regenerate the matrix carefully after it.
+
+**Build-discipline scars (unchanged — heed them).**
+1. **⚠️ Docker tests SILENTLY NO-OP** unless `$env:PROJECTION_MSSQL_CONN_STR=
+   "Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container). Confirm a **real per-test duration in seconds** via the TRX, never the green count.
+2. **Run bash scripts from the WORKTREE** (the Bash tool resets cwd to the worktree root). `dotnet` is at
+   `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` (9.0.314; not on bash PATH). Build **Release** too
+   (FS3511). Never the pure + Docker pools in one `dotnet test` (OOM) — `test.sh fast` / `docker`.
+3. **Run the FULL Docker pool (246/246 is the bar), not just `~Canary`** — a comparison-primitive change ripples
+   through every canary (it caught the pre-existing option-C reverse-leg bug in Wave 2). On any `Failed: N>0`, read
+   the TRX, and decide regression-vs-pre-existing by running the one test on the base.
+4. **Closed-DU/closed-record edits cascade — grep first, fix all sites, build once** (the single-assembly build is
+   your completeness backstop). M4's `ConstraintState` is exactly such a cascade (and a CODEC change — the goldens +
+   the store round-trip tests are the guard).
+
+**State.** Branch `claude/romantic-bohr-e270dd`; Waves 0–3 sit on this branch as fourteen commits atop `main`
+`dda83a8f`. Debug + **Release** 0/0; pure pool green; **Docker 246/246**; `AxiomTests` 79/0; `matrix-status.sh`
+gate=PASS (byte-identical); `verifiability-gate.sh` exit 0. After Wave 4, the §7 vector is fully cashed (modulo the
+honestly-deferred M14 + the moat). Chapter-close and extend the same PR (or open the Wave-4 PR atop it). Hold the
+spine: name every refusal, count every crossing, leave the books balanced.
+
+---
+
 # Handoff addendum — 2026-06-15, THE VECTOR WAVE 2 LANDED (the reversible algebra is complete, the change-algebra round-trip is property-witnessed, the destructive failure mode is named); your job is WAVE 3 — the widest fan-out, again as a WORKFLOW
 
 To the next agent.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,101 @@
+# Handoff addendum — 2026-06-15, THE VECTOR WAVE 2 LANDED (the reversible algebra is complete, the change-algebra round-trip is property-witnessed, the destructive failure mode is named); your job is WAVE 3 — the widest fan-out, again as a WORKFLOW
+
+To the next agent.
+
+**Your mission.** Build **Wave 3** of `THE_VECTOR.md` — the **compression & idiom** wave (§6 Kind III/V + the
+corollaries; §7 Wave 3). Seven moves, mostly file-disjoint — the **widest fan-out** of the program. Drive it
+as a `Workflow` exactly as Waves 2 did (worktree-isolated implementers · one default-skeptical adversarial
+verifier per move · one integrator who alone owns the build / matrix / gates). Read `THE_VECTOR.md` §6 (the
+move catalog) + §7 (Wave 3) first; the moves below are the partition.
+
+**The seven moves and how they partition (the workflow's shape).**
+1. **M7 — the diff `ChannelSpec`** + **the `Changed → Reshaped` rename — ONE serialized implementer** (both live
+   in `CatalogDiff.fs` / the `ChannelDiff` channel structure; they conflict if split, like Wave 2's trio). M7
+   reifies the kind-scoped diff channel as a value `ChannelSpec<'entity,'facet> = { entitiesOf; keyOf; nameOf;
+   changedFacets; mkChange; applyFacet }` and collapses the four `*Diff` builders + four `apply*Diff` patchers
+   into one fold per direction (the source comment "mirrors `attributeDiff` EXACTLY" is the fired trigger). The
+   rename is the zero-risk `ChannelDiff.Changed → Reshaped` field rename so the diff and migration layers speak
+   one word — a closed-record/field cascade: `grep -rn "\.Changed" src tests` near `ChannelDiff`/`*Diff` first.
+   **Heads-up: `CatalogDiff.fs` was heavily rewritten by Wave 2 (M11/M12/M13) — `between` is now total, and
+   `inverse`/the M11/M12 tests are new. Read its current shape before you touch it.**
+2. **M8 — the `JsonDocumentWriter` seam.** One pair of helpers (`writeToNode : (Utf8JsonWriter -> unit) -> JsonNode`
+   + a node→indented-string renderer) retires the `Utf8JsonWriter → MemoryStream → byte[] → JsonNode.Parse`
+   dance duplicated across `JsonEmitter` / `DistributionsEmitter` / `CatalogCodec` / `ProfileCodec` (≥4 sites).
+   Own surface. Parallel.
+3. **M9 — the binding algebra.** FsToolkit `validation { }` at the nine `*Binding` sites; collapse the three
+   bind-convergences (the 4-Result tuple in `runWithConfigCore`, the 3-Result tuples in the two shaped-catalog
+   runners) into one `bind-all`, structurally closing the model-read-vs-live `applyModuleFilter` divergence.
+   Own surface (`Projection.Pipeline` bindings). Parallel. **The riskiest seam — read `THE_CONFIG_CONTROL_PLANE.md`
+   §6 first.**
+4. **M17 — the totality-test functor.** The four structurally-identical totality tests
+   (`CapabilitySurvey`/`Voice`/`Transform`/`ManifestPredicate`) → one parameterized module + four ~10-line
+   instantiations. Own surface (test project). Parallel.
+5. **M6 — `[<Struct>]` (+ optional smart ctor) on `SourceKey`/`AssignedKey`.** One-word copy over the string ref
+   (identical to `RowQuantum`'s rationale); removes per-row DU-wrapper allocation on the FK re-point loop.
+   **measure-then-promote** per the `CONSTELLATION §9.7` ritual — ship the bench rationale, not just the
+   attribute. Own surface. Parallel.
+6. **M19 — `[<Measure>] row` on the data-norm deltas** (`cdcDelta`/`RowCountDeltas`/`NullCountDeltas`), the
+   natural sibling of the shipped `[<Measure>] ms`. Own surface. Parallel.
+
+So: **2 implementers for the M7+rename pair and M9 (the two with cascades), the rest highly parallel** → one
+adversarial verifier each → one integrator. Have implementers **commit to their worktree branch** and integrate
+via **`git cherry-pick`** — NOT text-diff-apply (the Windows trailing-newline trap). Wave 2's integrator
+cherry-picked four branches cleanly; the only reconcile was a one-line helper (M3 funnelled `between` through a
+single helper so the M13 signature change was a one-line fix). Ask your implementers to do the same wherever a
+move couples to another's surface.
+
+**What is DONE — do not redo (Waves 0 + 1 + 2, all in this PR).** Wave 0 (honesty: M1′+M2+M16+M15). Wave 1
+(the keystone M1 — Decision is an EARNED ✅ L3). Wave 2 (this letter's predecessor): **M13** (`CatalogDiff.between`
+is now total, the `Result` dropped — 13 src + ~120 test sites adapted); **M11** (the triangle inequality → the
+norm is a proven *metric*); **M12** (the groupoid inverse + the rollback witness + the groupoid law); **M3**
+(`genCatalogPair` + the swept T16/no-cheat/norm properties — round-trip is now property-witnessed); **M20**
+(`GateLabel.MidWriteNotProtected` + the pure `transactionalityViolations` gate — the live atomic wrapper stays
+deferred). M11/M12 earned their `AxiomTests` T13/T15 witnesses. Read the 2026-06-15 "THE VECTOR Wave 2 BUILT"
+DECISIONS entry — it is the substance; this letter points.
+
+**One bug Wave 2's full-pool run surfaced and FIXED (do not be surprised).** The trio change to `CatalogDiff`
+is a comparison primitive, so the integrator ran the **full** Docker pool (246), not just `~Canary` — and it
+caught a **pre-existing option-C bug** (confirmed on the base commit): `restoreFkTrust` ran an unconditional
+`ALTER … WITH CHECK CHECK CONSTRAINT` on the materialized reverse-leg path, which fails on a **no-ALTER
+`ManagedDml` cloud sink** (SQL 1088). Fixed by **capability descent** — the re-trust now descends on the
+ALTER-permission family (1088/4902/229) to the named `FkTrustNotRestoredOnBulkLoad` tolerance, propagating
+constraint conflicts (547). **The materialized path is now capability-gated; the option-C Wave-2 follow-on
+(wire re-trust into `writePlanStreaming` / `runSynthetic` + the CLI flag) still stands** and is a clean Wave-3
+pick-up if it fits your slice.
+
+**Matrix on `main`+this PR.** gate=PASS · rungs L1/L2/L3 = 5/4/5 · tolerances 10 (3 open — the Schema OpenGaps
+`IndexOptionsUnreflected` / `CompositePkFkUnreflected` / `TriggerBodyUnparsedDropped`; the 10th is the option-C
+`FkTrustNotRestoredOnBulkLoad`, AcceptedFaithful). **Wave 2 added/retired no tolerance and renamed no witness,
+so the matrix regenerated byte-identically** — Wave 3's compression moves should do the same (they're
+idiom/compression, not new erasures); if `matrix-status.sh` shows a diff after a Wave-3 move, something
+unintended changed — investigate before committing.
+
+**Build-discipline scars (heed them — they all bit this session).**
+1. **⚠️ Docker tests SILENTLY NO-OP on this Windows box** unless `$env:PROJECTION_MSSQL_CONN_STR=
+   "Server=localhost,11433;User Id=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False"`
+   (the warm container, up). Confirm a **real per-test duration in seconds** via the TRX, never the green count.
+2. **⚠️ Run bash scripts from the WORKTREE, not the main checkout** (the Bash tool resets cwd to the worktree
+   root each call, so a bare `scripts/…` from there is fine; an absolute path into the worktree is safest).
+3. `dotnet` is at `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` (9.0.314; not on bash PATH). Build
+   **Release too** before claiming done (only it catches FS3511). **Never the pure + Docker pools in one
+   `dotnet test`** (OOM) — `test.sh fast` / `docker`.
+4. **Run the FULL Docker pool (246/246 is the bar), not just `~Canary`** — a change to a comparison primitive
+   (`CatalogDiff`, `PhysicalSchema`) ripples through every canary, and the *only* failure Wave 2 found was a
+   non-canary reverse-leg test the option-C author had never run. **On any `Failed: N>0`, read the TRX** (the
+   console interleaves and lies) and decide regression-vs-pre-existing by running the one test on the base.
+5. **Closed-DU / closed-record edits cascade — grep first, fix all sites, build once** (the build is your
+   completeness backstop: the test project is one assembly, so a missed site fails compilation). M7's rename and
+   M9's binding collapse are both cascades.
+
+**State.** Branch `claude/romantic-bohr-e270dd`; Waves 0+1 (from PR #620, merged) + Wave 2 sit on this branch as
+five commits (the trio, M20, M3, the option-C fix, the M11/M12 axiom witnesses) atop `main` `dda83a8f`. Debug +
+**Release** 0/0; pure pool **3372/0**; **Docker 246/246**; `AxiomTests` 79/0; `matrix-status.sh` gate=PASS
+(byte-identical); `verifiability-gate.sh` exit 0. After Wave 3, chapter-close and extend the same PR (or open the
+Wave-3 PR atop it per the operator's call). Hold the spine: name every refusal, count every crossing, leave the
+books balanced — and let the workflow carry the fan-out.
+
+---
+
 # Handoff addendum — 2026-06-15, THE VECTOR WAVE 1 LANDED (the keystone M1 — the Decision axis is now an EARNED green); your job is WAVE 2 — the fan-out wave, and this time you ORCHESTRATE IT WITH A WORKFLOW
 
 To the next agent.

--- a/sidecar/projection/THE_VECTOR.md
+++ b/sidecar/projection/THE_VECTOR.md
@@ -36,7 +36,7 @@
 
 ---
 
-## Build addendum — 2026-06-15 (Waves 0–2 BUILT — the keystone landed, the reversible algebra completed)
+## Build addendum — 2026-06-15 (Waves 0–3 BUILT — the keystone landed, the reversible algebra completed, the engine compressed)
 
 > The study below is now partly **executed**, not just proposed. Per the house dated-note discipline, this
 > supersedes the "still unbuilt" claim in the reconciliation addendum that follows.
@@ -60,8 +60,16 @@
 >   tolerance moved — the under-claim holds). A pre-existing option-C re-trust bug (an unconditional ALTER on a
 >   no-ALTER `ManagedDml` sink) was surfaced by the full-pool run and fixed by capability descent. (DECISIONS
 >   2026-06-15 "THE VECTOR Wave 2 BUILT".)
-> - **Still ahead.** Wave 3 (the widest fan-out: M7/M8/M9/M17/M6/M19 + the zero-risk `Changed → Reshaped`
->   rename). The §6 move catalog stands for those.
+> - **Wave 3 — compression & idiom — BUILT.** M7 (the diff `ChannelSpec` — four builders + four patchers → one
+>   `buildChannel`/`applyChannel` over four spec values) + the `Changed → Reshaped` rename; M8 (the `JsonWriting`
+>   seam retiring the `Utf8JsonWriter → JsonNode` dance across 6 sites, byte-identical); M9 (FsToolkit
+>   `validation { }` collapsing the binding algebra + one drift-proof `bindShapingTriple`, mechanism-only); M17
+>   (the totality-test functor — one law, four ~10-line instantiations); M6 (`[<Struct>]` on `SourceKey`/`AssignedKey`);
+>   M19 (`[<Measure>] row` on the data-norm deltas). Net-smaller, every byte/law unchanged. Docker 246/246; matrix
+>   byte-identical (no tolerance moved). (DECISIONS 2026-06-15 "THE VECTOR Wave 3 BUILT".)
+> - **Still ahead.** Wave 4 — the corollary cashes & gated deepenings: M18 (`ChangeManifest.toJson`), M14 (the
+>   `Traversal` optic, after the compile-order split), M4 (`ConstraintState` DU, behind the store-migration story),
+>   M5 (digest projection) + the persisted-state-evolution discipline. The §6 move catalog stands for those.
 
 ## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
 

--- a/sidecar/projection/THE_VECTOR.md
+++ b/sidecar/projection/THE_VECTOR.md
@@ -36,7 +36,7 @@
 
 ---
 
-## Build addendum — 2026-06-15 (Wave 0 + Wave 1 BUILT — the keystone landed)
+## Build addendum — 2026-06-15 (Waves 0–2 BUILT — the keystone landed, the reversible algebra completed)
 
 > The study below is now partly **executed**, not just proposed. Per the house dated-note discipline, this
 > supersedes the "still unbuilt" claim in the reconciliation addendum that follows.
@@ -51,8 +51,17 @@
 >   per-axis, proven). **The matrix's Decision cell is now an EARNED `✅ L3`** (L2 4/5; tolerances 9, 3 open).
 >   So §2.4's "silent fifth column" and §2.5's "unfalsifiable by construction" are **closed for the Decision
 >   axis**: it is now *showable*, not asserted. (DECISIONS 2026-06-15 "THE VECTOR Wave 1 BUILT".)
-> - **Still ahead.** Waves 2–3 (the fan-out waves: the `CatalogDiff` trio M11/M13/M12, M3, M20, then M7/M8/M9/
->   M17/M6/M19). The §6 move catalog stands for those.
+> - **Wave 2 — the reversible algebra + the real-wire proof + transactionality naming — BUILT.** The
+>   `CatalogDiff` trio (M13 made `between` total; M11 the triangle inequality → the norm is a proven *metric*;
+>   M12 the groupoid inverse + the freed rollback witness), M3 (`genCatalogPair` + the swept T16 / no-cheat /
+>   norm properties — the round-trip raised from fixture- to property-witnessed), and M20
+>   (`GateLabel.MidWriteNotProtected` + the pure `transactionalityViolations` gate; the live atomic wrapper stays
+>   deferred). M11/M12 earned their `AxiomTests` T13/T15 witnesses. Docker 246/246; matrix byte-identical (no
+>   tolerance moved — the under-claim holds). A pre-existing option-C re-trust bug (an unconditional ALTER on a
+>   no-ALTER `ManagedDml` sink) was surfaced by the full-pool run and fixed by capability descent. (DECISIONS
+>   2026-06-15 "THE VECTOR Wave 2 BUILT".)
+> - **Still ahead.** Wave 3 (the widest fan-out: M7/M8/M9/M17/M6/M19 + the zero-risk `Changed → Reshaped`
+>   rename). The §6 move catalog stands for those.
 
 ## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
 

--- a/sidecar/projection/src/Projection.Adapters.Sql/DataIntegrityChecker.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/DataIntegrityChecker.fs
@@ -4,13 +4,21 @@ open System.Threading.Tasks
 open Microsoft.Data.SqlClient
 open Projection.Core
 
+/// M19 (THE VECTOR Wave 3) — the data-norm unit. The row-count and null-count
+/// deltas carry real load-bearing row quantities; `[<Measure>] row` is the
+/// natural sibling of the shipped `[<Measure>] ms` (`Run.fs`), ruling out at
+/// compile time the addition of a row-delta to a millisecond-delta (or any
+/// non-row count), at zero runtime cost.
+[<Measure>]
+type row
+
 /// One kind's exact row-count divergence between two deployments of the same
 /// schema contract.
 type RowCountDelta =
     {
         Kind   : SsKey
-        Before : int64
-        After  : int64
+        Before : int64<row>
+        After  : int64<row>
     }
 
 /// One attribute's exact null-count divergence between two deployments.
@@ -18,8 +26,8 @@ type NullCountDelta =
     {
         Kind      : SsKey
         Attribute : SsKey
-        Before    : int64
-        After     : int64
+        Before    : int64<row>
+        After     : int64<row>
     }
 
 /// Post-deploy data-integrity diff between two deployments of the same schema
@@ -73,7 +81,7 @@ module DataIntegrityChecker =
                 | Some b, Some a ->
                     let rows =
                         if b.RowCount <> a.RowCount then
-                            { Kind = kindKey; Before = b.RowCount; After = a.RowCount } :: rows
+                            { Kind = kindKey; Before = b.RowCount * 1L<row>; After = a.RowCount * 1L<row> } :: rows
                         else rows
                     // Per-attribute null-count divergences — union of both sides'
                     // attribute keys so a column that lost / gained its NullCount
@@ -89,7 +97,7 @@ module DataIntegrityChecker =
                             let bn = Map.tryFind attrKey b.NullCounts |> Option.defaultValue 0L
                             let an = Map.tryFind attrKey a.NullCounts |> Option.defaultValue 0L
                             if bn <> an then
-                                { Kind = kindKey; Attribute = attrKey; Before = bn; After = an } :: acc
+                                { Kind = kindKey; Attribute = attrKey; Before = bn * 1L<row>; After = an * 1L<row> } :: acc
                             else acc) nulls
                     rows, nulls, warns
                 | Some _, None ->

--- a/sidecar/projection/src/Projection.Cli/Comparison.fs
+++ b/sidecar/projection/src/Projection.Cli/Comparison.fs
@@ -145,7 +145,7 @@ let renderPhysicalDiff (d: PhysicalSchemaDiff) : View.View =
 /// `Catalog` comparison — a genuine torsor: `Apply = Some applyDiff` (the
 /// delta replays to reconstruct the target; Weyl-proven).
 let catalog : Comparison<Catalog, CatalogDiff> =
-    { Between = (fun a b -> CatalogDiff.between a b |> Result.mapError (fun _ -> "the two models could not be compared"))
+    { Between = (fun a b -> Ok (CatalogDiff.between a b))
       IsEmpty = CatalogDiff.isEmpty
       Render  = renderCatalogDiff
       Apply   = Some (fun d a -> CatalogDiff.applyDiff a d) }

--- a/sidecar/projection/src/Projection.Cli/Comparison.fs
+++ b/sidecar/projection/src/Projection.Cli/Comparison.fs
@@ -99,7 +99,7 @@ let renderCatalogLanes (d: CatalogDiff) : View.View list =
         CatalogDiff.attributeDiffs d
         |> Map.toList
         |> List.collect (fun (_, ad) ->
-            ad.Changed
+            ad.Reshaped
             |> List.map (fun c -> sprintf "%s · %s" (SsKey.rootOriginal c.AttributeKey) (facetsText c.Facets)))
     let lane glyph label st items =
         if List.isEmpty items then [] else [ View.Lane(glyph, label, st, items) ]

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -939,7 +939,7 @@ let narrateIntegrityReport (report: IntegrityReport) : unit =
                 box (report.RowCountDeltas
                      |> List.map (fun d ->
                          sprintf "%-40s before=%d after=%d (change=%+d)"
-                             (SsKey.rootOriginal d.Kind) d.Before d.After (d.After - d.Before))
+                             (SsKey.rootOriginal d.Kind) (int64 d.Before) (int64 d.After) (int64 (d.After - d.Before)))
                      |> joined)
               if not (List.isEmpty report.NullCountDeltas) then
                 "nullDeltas",
@@ -947,7 +947,7 @@ let narrateIntegrityReport (report: IntegrityReport) : unit =
                      |> List.map (fun d ->
                          sprintf "%-40s %-30s before=%d after=%d (change=%+d)"
                              (SsKey.rootOriginal d.Kind) (SsKey.rootOriginal d.Attribute)
-                             d.Before d.After (d.After - d.Before))
+                             (int64 d.Before) (int64 d.After) (int64 (d.After - d.Before)))
                      |> joined)
               if not (List.isEmpty report.Warnings) then
                 "schemaWarnings",

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -960,6 +960,9 @@ module Voice =
         | Preflight.UndeclaredDestructiveChange ->
             View.Bad, "This change drops a database object. Approve the removal, or halt.",
             Some(View.Action "Approve the removal: --allow-drops (accept all) or --declare-drop <token> for each, or halt.")
+        | Preflight.MidWriteNotProtected ->
+            View.Bad, "The write path is neither atomic nor resumable, so a mid-write failure would leave a half-populated target. The run stopped before any write. Wrap the write path in a transaction, make it resumable, or halt.",
+            Some(View.Action "Wrap the write path in a transaction, make it resumable, or halt.")
         | Preflight.DataViolatesTightening ->
             View.Bad, "The existing data violates the tightening. Correct the data, relax the constraint, or halt.",
             Some(View.Action "Correct the data, relax the constraint, or halt.")

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -53,25 +53,26 @@ type AttributeChange =
 /// The structurally-identical carrier behind every per-channel diff
 /// (attributes / references / indexes / sequences). `Added` / `Removed`
 /// are entity `SsKey`s present in only the target / source; `Renamed`
-/// carries a same-`SsKey` `Name` change; `Changed` names survivors whose
+/// carries a same-`SsKey` `Name` change; `Reshaped` names survivors whose
 /// emitted shape differs, the channel's own change-evidence type filling
 /// `'change`. The four channels were four byte-identical records before;
 /// they are now one generic with four named instantiations (the aliases
 /// below), so field access and the public type names are unchanged for
-/// every consumer.
+/// every consumer. (`Reshaped` was `Changed` before §3.3/§6 — the diff and
+/// migration layers now speak one word for the reshape axis.)
 type ChannelDiff<'change> =
     {
-        Added   : Set<SsKey>
-        Removed : Set<SsKey>
-        Renamed : Map<SsKey, RenameRecord>
-        Changed : 'change list
+        Added    : Set<SsKey>
+        Removed  : Set<SsKey>
+        Renamed  : Map<SsKey, RenameRecord>
+        Reshaped : 'change list
     }
 
 /// Per-kind attribute-level diff for a kind present in BOTH catalogs.
 /// `Added` / `Removed` are attribute `SsKey`s present in only the target /
 /// source; `Renamed` carries a same-`SsKey` `Name` change (edge-case-2 of
 /// the chapter-3.5 prescope — a renamed attribute on an unrenamed kind);
-/// `Changed` names attributes whose emitted column shape differs facet by
+/// `Reshaped` names attributes whose emitted column shape differs facet by
 /// facet. An empty `AttributeDiff` (all four empty) means the kind's
 /// attributes are identical; `between` stores only non-empty diffs.
 type AttributeDiff = ChannelDiff<AttributeChange>
@@ -84,7 +85,7 @@ type AttributeDiff = ChannelDiff<AttributeChange>
 // silently no-op'd any FK / index / sequence change between A and B. C1 adds
 // the three missing change channels so the round-trip law
 // `applyDiff (between A B) A = B` holds on them too. Each channel mirrors the
-// `AttributeDiff` shape (Added / Removed / Renamed / Changed, keyed by SsKey),
+// `AttributeDiff` shape (Added / Removed / Renamed / Reshaped, keyed by SsKey),
 // and applyDiff PATCHES the base record's fields / COPIES whole records from
 // the recorded target — it never reconstructs via a smart constructor, so the
 // `{ create … with … }` default-substitution bomb cannot bite here.
@@ -296,7 +297,7 @@ module CatalogDiff =
 
     /// The empty channel diff — all four fields empty — over any change type.
     let private emptyChannelDiff<'change> : ChannelDiff<'change> =
-        { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Changed = [] }
+        { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Reshaped = [] }
 
     /// A channel diff is empty iff all four fields are empty. One predicate
     /// for every channel (the four byte-identical `*DiffIsEmpty` collapsed).
@@ -304,50 +305,22 @@ module CatalogDiff =
         Set.isEmpty d.Added
         && Set.isEmpty d.Removed
         && Map.isEmpty d.Renamed
-        && List.isEmpty d.Changed
+        && List.isEmpty d.Reshaped
 
-    /// The attribute-level diff between a kind's source and target
-    /// realizations (the kind's `SsKey` is present in both catalogs).
-    /// Attributes match by `SsKey`: present-in-target-only → `Added`,
-    /// present-in-source-only → `Removed`; a shared `SsKey` whose `Name`
-    /// differs → `Renamed` (independent of facet changes), whose emitted
-    /// shape differs → `Changed`. Source-ordered `Changed` for determinism.
-    let private attributeDiff (sourceKind: Kind) (targetKind: Kind) : AttributeDiff =
-        let srcByKey = sourceKind.Attributes |> List.map (fun a -> a.SsKey, a) |> Map.ofList
-        let tgtByKey = targetKind.Attributes |> List.map (fun a -> a.SsKey, a) |> Map.ofList
-        let srcKeys = srcByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let tgtKeys = tgtByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let added = Set.difference tgtKeys srcKeys
-        let removed = Set.difference srcKeys tgtKeys
-        let renamed =
-            Set.intersect srcKeys tgtKeys
-            |> Set.fold
-                (fun acc key ->
-                    let s = Map.find key srcByKey
-                    let t = Map.find key tgtByKey
-                    if s.Name <> t.Name then
-                        Map.add key { OldName = s.Name; NewName = t.Name; PassVersion = version } acc
-                    else acc)
-                Map.empty
-        // Source order preserves determinism (T1) — the kind's attribute
-        // list is the canonical order, not the Set's hash order.
-        let changed =
-            sourceKind.Attributes
-            |> List.choose (fun s ->
-                match Map.tryFind s.SsKey tgtByKey with
-                | Some t ->
-                    let facets = changedFacets s t
-                    if Set.isEmpty facets then None
-                    else Some { AttributeKey = s.SsKey; Facets = facets }
-                | None -> None)
-        { Added = added; Removed = removed; Renamed = renamed; Changed = changed }
-
-    // -- C1: reference / index / sequence channel diffs ----------------------
+    // -- M7: the ChannelSpec — the descriptor IS data, traversed once --------
     //
-    // Each mirrors `attributeDiff` exactly: partition the SsKeys (Added /
-    // Removed), thread same-SsKey `Name` changes into `Renamed`, and name the
-    // changed facets for survivors whose shape differs. `Changed` is computed
-    // in source-list order for T1 determinism (not Set hash order).
+    // The four per-channel diffs (attributes / references / indexes /
+    // sequences) were four byte-identical builders + four byte-identical apply
+    // patchers, differing ONLY in their entity accessor, facet detector, change
+    // constructor, and change-key accessor (the source comment read "mirrors
+    // `attributeDiff` EXACTLY"). M7 reifies that variation as a value: one
+    // `ChannelSpec` per channel, ONE generic `buildChannel` fold over it, ONE
+    // generic `applyChannel` patcher. ASYMMETRY: the sequence channel is
+    // CATALOG-level (`'container = Catalog`), the other three KIND-level
+    // (`'container = Kind`); the spec's container is generic, so each spec
+    // supplies its own `entitiesOf` and the build/apply folds are container-
+    // agnostic. The facet detectors (`changedFacets` etc., kept below) are the
+    // only per-channel logic that genuinely varies; everything else is one fold.
 
     let private changedReferenceFacets (s: Reference) (t: Reference) : Set<ReferenceFacet> =
         [ if s.TargetKind <> t.TargetKind then ReferenceFacet.Target
@@ -358,33 +331,6 @@ module CatalogDiff =
           if s.HasDbConstraint <> t.HasDbConstraint then ReferenceFacet.DbConstraint
           if s.IsConstraintTrusted <> t.IsConstraintTrusted then ReferenceFacet.Trust ]
         |> Set.ofList
-
-    let private referenceDiff (sourceKind: Kind) (targetKind: Kind) : ReferenceDiff =
-        let srcByKey = sourceKind.References |> List.map (fun r -> r.SsKey, r) |> Map.ofList
-        let tgtByKey = targetKind.References |> List.map (fun r -> r.SsKey, r) |> Map.ofList
-        let srcKeys = srcByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let tgtKeys = tgtByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let renamed =
-            Set.intersect srcKeys tgtKeys
-            |> Set.fold
-                (fun acc key ->
-                    let s = Map.find key srcByKey
-                    let t = Map.find key tgtByKey
-                    if s.Name <> t.Name then Map.add key { OldName = s.Name; NewName = t.Name; PassVersion = version } acc
-                    else acc)
-                Map.empty
-        let changed =
-            sourceKind.References
-            |> List.choose (fun s ->
-                match Map.tryFind s.SsKey tgtByKey with
-                | Some t ->
-                    let facets = changedReferenceFacets s t
-                    if Set.isEmpty facets then None else Some { ReferenceKey = s.SsKey; Facets = facets }
-                | None -> None)
-        { Added = Set.difference tgtKeys srcKeys
-          Removed = Set.difference srcKeys tgtKeys
-          Renamed = renamed
-          Changed = changed }
 
     let private changedIndexFacets (s: Index) (t: Index) : Set<IndexFacet> =
         [ if s.Columns <> t.Columns then IndexFacet.Columns
@@ -398,33 +344,6 @@ module CatalogDiff =
              || s.IgnoreDuplicateKey <> t.IgnoreDuplicateKey || s.IsDisabled <> t.IsDisabled
              || s.DataCompression <> t.DataCompression then IndexFacet.Options ]
         |> Set.ofList
-
-    let private indexDiff (sourceKind: Kind) (targetKind: Kind) : IndexDiff =
-        let srcByKey = sourceKind.Indexes |> List.map (fun i -> i.SsKey, i) |> Map.ofList
-        let tgtByKey = targetKind.Indexes |> List.map (fun i -> i.SsKey, i) |> Map.ofList
-        let srcKeys = srcByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let tgtKeys = tgtByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-        let renamed =
-            Set.intersect srcKeys tgtKeys
-            |> Set.fold
-                (fun acc key ->
-                    let s = Map.find key srcByKey
-                    let t = Map.find key tgtByKey
-                    if s.Name <> t.Name then Map.add key { OldName = s.Name; NewName = t.Name; PassVersion = version } acc
-                    else acc)
-                Map.empty
-        let changed =
-            sourceKind.Indexes
-            |> List.choose (fun s ->
-                match Map.tryFind s.SsKey tgtByKey with
-                | Some t ->
-                    let facets = changedIndexFacets s t
-                    if Set.isEmpty facets then None else Some { IndexKey = s.SsKey; Facets = facets }
-                | None -> None)
-        { Added = Set.difference tgtKeys srcKeys
-          Removed = Set.difference srcKeys tgtKeys
-          Renamed = renamed
-          Changed = changed }
 
     /// NM-17 — the kind-OWN facets that differ between a kind's source and
     /// target realization. Presence/name is the top-level partition; children
@@ -449,32 +368,233 @@ module CatalogDiff =
           if (s.CacheMode, s.CacheSize) <> (t.CacheMode, t.CacheSize) then SequenceFacet.Cache ]
         |> Set.ofList
 
-    let private sequenceDiffBetween (source: Catalog) (target: Catalog) : SequenceDiff =
-        let srcByKey = source.Sequences |> List.map (fun s -> s.SsKey, s) |> Map.ofList
-        let tgtByKey = target.Sequences |> List.map (fun s -> s.SsKey, s) |> Map.ofList
-        let srcKeys = srcByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+    // -- M7: the per-facet appliers (the apply side of each channel's facet
+    //    surface). Patch ONE facet of `dest` from `src`; every other field
+    //    rides through. `dest` is an existing record value, so `{ dest with … }`
+    //    replaces a single field — no smart-constructor reconstruction, so the
+    //    `{ create … with … }` default-substitution bomb cannot bite (the
+    //    discipline §6 of the C1 debrief). Each is the `applyFacet` field of its
+    //    channel's `ChannelSpec` below, shared between build and apply.
+
+    /// Patch one column-shape facet of `dest` from `src` (the recorded target's
+    /// attribute). applyDiff's power exactly matches the facet set `between`
+    /// detects, so no un-captured field is silently reconstructed.
+    let private applyFacet (src: Attribute) (facet: AttributeFacet) (dest: Attribute) : Attribute =
+        match facet with
+        | AttributeFacet.DataType     -> { dest with Type = src.Type }
+        | AttributeFacet.Nullability  -> dest |> Lens.over CatalogLenses.columnOf (fun col -> { col with IsNullable = src.Column.IsNullable })
+        | AttributeFacet.PrimaryKey   -> { dest with IsPrimaryKey = src.IsPrimaryKey }
+        | AttributeFacet.Length       -> { dest with Length = src.Length }
+        | AttributeFacet.Precision    -> { dest with Precision = src.Precision }
+        | AttributeFacet.Scale        -> { dest with Scale = src.Scale }
+        | AttributeFacet.Identity     -> { dest with IsIdentity = src.IsIdentity }
+        | AttributeFacet.DefaultValue -> { dest with DefaultValue = src.DefaultValue; DefaultName = src.DefaultName }
+        | AttributeFacet.Computed     -> { dest with Computed = src.Computed }
+
+    let private applyReferenceFacet (src: Reference) (facet: ReferenceFacet) (dest: Reference) : Reference =
+        match facet with
+        | ReferenceFacet.Target          -> { dest with TargetKind = src.TargetKind }
+        | ReferenceFacet.SourceAttribute -> { dest with SourceAttribute = src.SourceAttribute }
+        | ReferenceFacet.OnDelete        -> { dest with OnDelete = src.OnDelete }
+        | ReferenceFacet.OnUpdate        -> { dest with OnUpdate = src.OnUpdate }
+        | ReferenceFacet.UserFk          -> { dest with IsUserFk = src.IsUserFk }
+        | ReferenceFacet.DbConstraint    -> { dest with HasDbConstraint = src.HasDbConstraint }
+        | ReferenceFacet.Trust           -> { dest with IsConstraintTrusted = src.IsConstraintTrusted }
+
+    let private applyIndexFacet (src: Index) (facet: IndexFacet) (dest: Index) : Index =
+        match facet with
+        | IndexFacet.Columns         -> { dest with Columns = src.Columns }
+        | IndexFacet.Uniqueness      -> { dest with Uniqueness = src.Uniqueness }
+        | IndexFacet.IncludedColumns -> { dest with IncludedColumns = src.IncludedColumns }
+        | IndexFacet.Filter          -> { dest with Filter = src.Filter }
+        | IndexFacet.DataSpace       -> { dest with DataSpace = src.DataSpace }
+        | IndexFacet.Options ->
+            { dest with
+                IsPlatformAuto = src.IsPlatformAuto
+                FillFactor = src.FillFactor
+                IsPadded = src.IsPadded
+                AllowRowLocks = src.AllowRowLocks
+                AllowPageLocks = src.AllowPageLocks
+                NoRecomputeStatistics = src.NoRecomputeStatistics
+                IgnoreDuplicateKey = src.IgnoreDuplicateKey
+                IsDisabled = src.IsDisabled
+                DataCompression = src.DataCompression }
+
+    let private applySequenceFacet (src: Sequence) (facet: SequenceFacet) (dest: Sequence) : Sequence =
+        match facet with
+        | SequenceFacet.Schema     -> { dest with Schema = src.Schema }
+        | SequenceFacet.DataType   -> { dest with DataType = src.DataType }
+        | SequenceFacet.StartValue -> { dest with StartValue = src.StartValue }
+        | SequenceFacet.Increment  -> { dest with Increment = src.Increment }
+        | SequenceFacet.Minimum    -> { dest with Minimum = src.Minimum }
+        | SequenceFacet.Maximum    -> { dest with Maximum = src.Maximum }
+        | SequenceFacet.Cycle      -> { dest with IsCycleEnabled = src.IsCycleEnabled }
+        | SequenceFacet.Cache      -> { dest with CacheMode = src.CacheMode; CacheSize = src.CacheSize }
+
+    /// M7 — the kind-scoped channel reified as data: the four accessors that
+    /// vary per channel, plus the facet detector, change constructor /
+    /// destructor, and rename-applier. `'container` is `Kind` for the
+    /// attribute / reference / index channels and `Catalog` for sequences;
+    /// `entitiesOf` projects the channel's entity list out of either. One spec
+    /// value drives both `buildChannel` (observation) and `applyChannel`
+    /// (action), so the two stay structurally locked together by construction.
+    type private ChannelSpec<'container, 'entity, 'facet, 'change
+                                when 'facet: comparison> =
+        {
+            /// Project the channel's entity list out of its container.
+            entitiesOf    : 'container -> 'entity list
+            /// The entity's stable identity (the diff matches on it).
+            keyOf         : 'entity -> SsKey
+            /// The entity's logical name (a `Name` change ⇒ `Renamed`).
+            nameOf        : 'entity -> Name
+            /// The facets whose emitted shape differs (empty ⇒ unchanged).
+            changedFacets : 'entity -> 'entity -> Set<'facet>
+            /// Construct the channel's change-evidence record.
+            mkChange      : SsKey -> Set<'facet> -> 'change
+            /// The key a change-evidence record is keyed by.
+            keyOfChange   : 'change -> SsKey
+            /// The facet set a change-evidence record carries.
+            facetsOf      : 'change -> Set<'facet>
+            /// Apply one facet of `src` onto `dest` (only that facet moves).
+            applyFacet    : 'entity -> 'facet -> 'entity -> 'entity
+            /// Rename an entity to a new `Name` (every other field rides through).
+            renameTo      : Name -> 'entity -> 'entity
+        }
+
+    /// M7 — ONE channel-diff fold, driven by a `ChannelSpec`. Replaces the four
+    /// byte-identical `attributeDiff` / `referenceDiff` / `indexDiff` /
+    /// `sequenceDiffBetween` builders. Entities match by `SsKey`: present-in-
+    /// target-only → `Added`, present-in-source-only → `Removed`; a shared
+    /// `SsKey` whose `Name` differs → `Renamed` (independent of facet changes);
+    /// a shared `SsKey` whose emitted shape differs → `Reshaped`. The `Reshaped`
+    /// list is built in SOURCE-LIST order (the canonical order, not the Set's
+    /// hash order) to preserve T1 determinism.
+    let private buildChannel
+        (spec: ChannelSpec<'container, 'entity, 'facet, 'change>)
+        (source: 'container)
+        (target: 'container)
+        : ChannelDiff<'change>
+        =
+        let srcEntities = spec.entitiesOf source
+        let tgtByKey = spec.entitiesOf target |> List.map (fun e -> spec.keyOf e, e) |> Map.ofList
+        let srcKeys = srcEntities |> List.map spec.keyOf |> Set.ofList
         let tgtKeys = tgtByKey |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+        let srcByKey = srcEntities |> List.map (fun e -> spec.keyOf e, e) |> Map.ofList
         let renamed =
             Set.intersect srcKeys tgtKeys
             |> Set.fold
                 (fun acc key ->
                     let s = Map.find key srcByKey
                     let t = Map.find key tgtByKey
-                    if s.Name <> t.Name then Map.add key { OldName = s.Name; NewName = t.Name; PassVersion = version } acc
+                    if spec.nameOf s <> spec.nameOf t then
+                        Map.add key { OldName = spec.nameOf s; NewName = spec.nameOf t; PassVersion = version } acc
                     else acc)
                 Map.empty
-        let changed =
-            source.Sequences
+        // Source order preserves determinism (T1) — the container's entity
+        // list is the canonical order, not the Set's hash order.
+        let reshaped =
+            srcEntities
             |> List.choose (fun s ->
-                match Map.tryFind s.SsKey tgtByKey with
+                match Map.tryFind (spec.keyOf s) tgtByKey with
                 | Some t ->
-                    let facets = changedSequenceFacets s t
-                    if Set.isEmpty facets then None else Some { SequenceKey = s.SsKey; Facets = facets }
+                    let facets = spec.changedFacets s t
+                    if Set.isEmpty facets then None
+                    else Some (spec.mkChange (spec.keyOf s) facets)
                 | None -> None)
         { Added = Set.difference tgtKeys srcKeys
           Removed = Set.difference srcKeys tgtKeys
           Renamed = renamed
-          Changed = changed }
+          Reshaped = reshaped }
+
+    let private attributeSpec : ChannelSpec<Kind, Attribute, AttributeFacet, AttributeChange> =
+        { entitiesOf = fun (k: Kind) -> k.Attributes
+          keyOf = fun a -> a.SsKey
+          nameOf = fun a -> a.Name
+          changedFacets = changedFacets
+          mkChange = fun key facets -> { AttributeKey = key; Facets = facets }
+          keyOfChange = fun c -> c.AttributeKey
+          facetsOf = fun c -> c.Facets
+          applyFacet = applyFacet
+          renameTo = fun n a -> { a with Name = n } }
+
+    let private referenceSpec : ChannelSpec<Kind, Reference, ReferenceFacet, ReferenceChange> =
+        { entitiesOf = fun (k: Kind) -> k.References
+          keyOf = fun r -> r.SsKey
+          nameOf = fun r -> r.Name
+          changedFacets = changedReferenceFacets
+          mkChange = fun key facets -> { ReferenceKey = key; Facets = facets }
+          keyOfChange = fun c -> c.ReferenceKey
+          facetsOf = fun c -> c.Facets
+          applyFacet = applyReferenceFacet
+          renameTo = fun n r -> { r with Name = n } }
+
+    let private indexSpec : ChannelSpec<Kind, Index, IndexFacet, IndexChange> =
+        { entitiesOf = fun (k: Kind) -> k.Indexes
+          keyOf = fun i -> i.SsKey
+          nameOf = fun i -> i.Name
+          changedFacets = changedIndexFacets
+          mkChange = fun key facets -> { IndexKey = key; Facets = facets }
+          keyOfChange = fun c -> c.IndexKey
+          facetsOf = fun c -> c.Facets
+          applyFacet = applyIndexFacet
+          renameTo = fun n i -> { i with Name = n } }
+
+    let private sequenceSpec : ChannelSpec<Catalog, Sequence, SequenceFacet, SequenceChange> =
+        { entitiesOf = fun (c: Catalog) -> c.Sequences
+          keyOf = fun s -> s.SsKey
+          nameOf = fun s -> s.Name
+          changedFacets = changedSequenceFacets
+          mkChange = fun key facets -> { SequenceKey = key; Facets = facets }
+          keyOfChange = fun c -> c.SequenceKey
+          facetsOf = fun c -> c.Facets
+          applyFacet = applySequenceFacet
+          renameTo = fun n s -> { s with Name = n } }
+
+    let private attributeDiff (sourceKind: Kind) (targetKind: Kind) : AttributeDiff =
+        buildChannel attributeSpec sourceKind targetKind
+
+    let private referenceDiff (sourceKind: Kind) (targetKind: Kind) : ReferenceDiff =
+        buildChannel referenceSpec sourceKind targetKind
+
+    let private indexDiff (sourceKind: Kind) (targetKind: Kind) : IndexDiff =
+        buildChannel indexSpec sourceKind targetKind
+
+    let private sequenceDiffBetween (source: Catalog) (target: Catalog) : SequenceDiff =
+        buildChannel sequenceSpec source target
+
+    /// M7 — ONE channel-apply patcher, driven by the SAME `ChannelSpec` as
+    /// `buildChannel`. Replaces the four byte-identical `applyAttributeDiff` /
+    /// `applyReferenceDiff` / `applyIndexDiff` / `applySequenceDiff` patchers.
+    /// Removed entities drop; surviving entities are renamed (`Renamed`) and
+    /// facet-patched (`Reshaped`) from the recorded target; `Added` entries are
+    /// COPIED whole from the target container, appended in target order. New
+    /// facet values + new entities source from `targetContainer` (the recorded
+    /// target Kind / Catalog); `None` (no recorded target) contributes no adds.
+    /// No smart-constructor reconstruction → the `{ create … with … }` default-
+    /// substitution bomb cannot bite.
+    let private applyChannel
+        (spec: ChannelSpec<'container, 'entity, 'facet, 'change>)
+        (d: ChannelDiff<'change>)
+        (targetContainer: 'container option)
+        (baseEntities: 'entity list)
+        : 'entity list
+        =
+        let tgtEntities = targetContainer |> Option.map spec.entitiesOf |> Option.defaultValue []
+        let tgtByKey (key: SsKey) : 'entity option =
+            tgtEntities |> List.tryFind (fun e -> spec.keyOf e = key)
+        let survivors =
+            baseEntities
+            |> List.filter (fun e -> not (Set.contains (spec.keyOf e) d.Removed))
+            |> List.map (fun e ->
+                let renamed1 =
+                    match Map.tryFind (spec.keyOf e) d.Renamed with
+                    | Some r -> spec.renameTo r.NewName e
+                    | None -> e
+                match d.Reshaped |> List.tryFind (fun c -> spec.keyOfChange c = spec.keyOf e), tgtByKey (spec.keyOf e) with
+                | Some change, Some src -> Set.fold (fun acc f -> spec.applyFacet src f acc) renamed1 (spec.facetsOf change)
+                | _ -> renamed1)
+        let added = tgtEntities |> List.filter (fun e -> Set.contains (spec.keyOf e) d.Added)
+        survivors @ added
 
     /// Smart constructor — total partitioning of `source ∪ target`
     /// SsKeys. Every key in either Catalog is in exactly one of the
@@ -750,165 +870,19 @@ module CatalogDiff =
     // self-contained diff (inline payloads, no stored source/target) would
     // widen the surface; deferred under IR-grows-under-evidence.
 
-    /// Patch one column-shape facet of `dest` from `src` (the recorded
-    /// target's attribute). Only the named facet moves; every other field of
-    /// `dest` rides through — applyDiff's power exactly matches the facet set
-    /// `between` detects, so no un-captured field is silently reconstructed.
-    let private applyFacet (src: Attribute) (facet: AttributeFacet) (dest: Attribute) : Attribute =
-        match facet with
-        | AttributeFacet.DataType     -> { dest with Type = src.Type }
-        | AttributeFacet.Nullability  -> dest |> Lens.over CatalogLenses.columnOf (fun col -> { col with IsNullable = src.Column.IsNullable })
-        | AttributeFacet.PrimaryKey   -> { dest with IsPrimaryKey = src.IsPrimaryKey }
-        | AttributeFacet.Length       -> { dest with Length = src.Length }
-        | AttributeFacet.Precision    -> { dest with Precision = src.Precision }
-        | AttributeFacet.Scale        -> { dest with Scale = src.Scale }
-        | AttributeFacet.Identity     -> { dest with IsIdentity = src.IsIdentity }
-        | AttributeFacet.DefaultValue -> { dest with DefaultValue = src.DefaultValue; DefaultName = src.DefaultName }
-        | AttributeFacet.Computed     -> { dest with Computed = src.Computed }
-
     /// NM-17 — patch one kind-OWN facet of `dest` from `src` (the recorded
     /// target kind). Mirrors `applyFacet`; only the named facet moves, every
     /// other field of `dest` rides through. `dest` is an existing `Kind`
     /// value, so `{ dest with … }` replaces a single field (no smart-ctor
-    /// reconstruction → no default-substitution bomb).
+    /// reconstruction → no default-substitution bomb). (Not a `ChannelSpec`
+    /// channel: the kind-OWN facets are a `Set<KindFacet>`, not an
+    /// Added/Removed/Renamed/Reshaped channel; applied directly in `applyDiff`.)
     let private applyKindFacet (src: Kind) (facet: KindFacet) (dest: Kind) : Kind =
         match facet with
         | KindFacet.Modality     -> { dest with Modality = src.Modality }
         | KindFacet.Triggers     -> { dest with Triggers = src.Triggers }
         | KindFacet.ColumnChecks -> { dest with ColumnChecks = src.ColumnChecks }
         | KindFacet.IsActive     -> { dest with IsActive = src.IsActive }
-
-    /// Apply a per-kind `AttributeDiff` to a kind's base attribute list,
-    /// sourcing new attributes / new facet values from the recorded target
-    /// kind. Removed attrs drop; surviving attrs are renamed (`Renamed`) and
-    /// facet-patched (`Changed`); `Added` attrs append in target order.
-    let private applyAttributeDiff
-        (ad: AttributeDiff)
-        (targetKind: Kind option)
-        (baseAttrs: Attribute list)
-        : Attribute list =
-        let tgtAttr (key: SsKey) : Attribute option =
-            targetKind |> Option.bind (fun k -> k.Attributes |> List.tryFind (fun a -> a.SsKey = key))
-        let survivors =
-            baseAttrs
-            |> List.filter (fun a -> not (Set.contains a.SsKey ad.Removed))
-            |> List.map (fun a ->
-                let renamed1 =
-                    match Map.tryFind a.SsKey ad.Renamed with
-                    | Some r -> { a with Name = r.NewName }
-                    | None -> a
-                match ad.Changed |> List.tryFind (fun c -> c.AttributeKey = a.SsKey), tgtAttr a.SsKey with
-                | Some change, Some src -> Set.fold (fun acc f -> applyFacet src f acc) renamed1 change.Facets
-                | _ -> renamed1)
-        let added =
-            match targetKind with
-            | Some tk -> tk.Attributes |> List.filter (fun a -> Set.contains a.SsKey ad.Added)
-            | None    -> []
-        survivors @ added
-
-    // -- C1: apply the reference / index / sequence channels -----------------
-    //
-    // Each mirrors `applyAttributeDiff`. Changed survivors are PATCHED facet by
-    // facet from the recorded target record; Added entries are COPIED whole from
-    // the target. No smart-constructor reconstruction → the `{ create … with … }`
-    // default-substitution bomb cannot bite (the discipline §6 of the debrief).
-
-    let private applyReferenceFacet (src: Reference) (facet: ReferenceFacet) (dest: Reference) : Reference =
-        match facet with
-        | ReferenceFacet.Target          -> { dest with TargetKind = src.TargetKind }
-        | ReferenceFacet.SourceAttribute -> { dest with SourceAttribute = src.SourceAttribute }
-        | ReferenceFacet.OnDelete        -> { dest with OnDelete = src.OnDelete }
-        | ReferenceFacet.OnUpdate        -> { dest with OnUpdate = src.OnUpdate }
-        | ReferenceFacet.UserFk          -> { dest with IsUserFk = src.IsUserFk }
-        | ReferenceFacet.DbConstraint    -> { dest with HasDbConstraint = src.HasDbConstraint }
-        | ReferenceFacet.Trust           -> { dest with IsConstraintTrusted = src.IsConstraintTrusted }
-
-    let private applyReferenceDiff (rd: ReferenceDiff) (targetKind: Kind option) (baseRefs: Reference list) : Reference list =
-        let tgtRef (key: SsKey) : Reference option =
-            targetKind |> Option.bind (fun k -> k.References |> List.tryFind (fun r -> r.SsKey = key))
-        let survivors =
-            baseRefs
-            |> List.filter (fun r -> not (Set.contains r.SsKey rd.Removed))
-            |> List.map (fun r ->
-                let renamed1 =
-                    match Map.tryFind r.SsKey rd.Renamed with
-                    | Some rec1 -> { r with Name = rec1.NewName }
-                    | None -> r
-                match rd.Changed |> List.tryFind (fun c -> c.ReferenceKey = r.SsKey), tgtRef r.SsKey with
-                | Some change, Some src -> Set.fold (fun acc f -> applyReferenceFacet src f acc) renamed1 change.Facets
-                | _ -> renamed1)
-        let added =
-            match targetKind with
-            | Some tk -> tk.References |> List.filter (fun r -> Set.contains r.SsKey rd.Added)
-            | None    -> []
-        survivors @ added
-
-    let private applyIndexFacet (src: Index) (facet: IndexFacet) (dest: Index) : Index =
-        match facet with
-        | IndexFacet.Columns         -> { dest with Columns = src.Columns }
-        | IndexFacet.Uniqueness      -> { dest with Uniqueness = src.Uniqueness }
-        | IndexFacet.IncludedColumns -> { dest with IncludedColumns = src.IncludedColumns }
-        | IndexFacet.Filter          -> { dest with Filter = src.Filter }
-        | IndexFacet.DataSpace       -> { dest with DataSpace = src.DataSpace }
-        | IndexFacet.Options ->
-            { dest with
-                IsPlatformAuto = src.IsPlatformAuto
-                FillFactor = src.FillFactor
-                IsPadded = src.IsPadded
-                AllowRowLocks = src.AllowRowLocks
-                AllowPageLocks = src.AllowPageLocks
-                NoRecomputeStatistics = src.NoRecomputeStatistics
-                IgnoreDuplicateKey = src.IgnoreDuplicateKey
-                IsDisabled = src.IsDisabled
-                DataCompression = src.DataCompression }
-
-    let private applyIndexDiff (idd: IndexDiff) (targetKind: Kind option) (baseIndexes: Index list) : Index list =
-        let tgtIndex (key: SsKey) : Index option =
-            targetKind |> Option.bind (fun k -> k.Indexes |> List.tryFind (fun i -> i.SsKey = key))
-        let survivors =
-            baseIndexes
-            |> List.filter (fun i -> not (Set.contains i.SsKey idd.Removed))
-            |> List.map (fun i ->
-                let renamed1 =
-                    match Map.tryFind i.SsKey idd.Renamed with
-                    | Some rec1 -> { i with Name = rec1.NewName }
-                    | None -> i
-                match idd.Changed |> List.tryFind (fun c -> c.IndexKey = i.SsKey), tgtIndex i.SsKey with
-                | Some change, Some src -> Set.fold (fun acc f -> applyIndexFacet src f acc) renamed1 change.Facets
-                | _ -> renamed1)
-        let added =
-            match targetKind with
-            | Some tk -> tk.Indexes |> List.filter (fun i -> Set.contains i.SsKey idd.Added)
-            | None    -> []
-        survivors @ added
-
-    let private applySequenceFacet (src: Sequence) (facet: SequenceFacet) (dest: Sequence) : Sequence =
-        match facet with
-        | SequenceFacet.Schema     -> { dest with Schema = src.Schema }
-        | SequenceFacet.DataType   -> { dest with DataType = src.DataType }
-        | SequenceFacet.StartValue -> { dest with StartValue = src.StartValue }
-        | SequenceFacet.Increment  -> { dest with Increment = src.Increment }
-        | SequenceFacet.Minimum    -> { dest with Minimum = src.Minimum }
-        | SequenceFacet.Maximum    -> { dest with Maximum = src.Maximum }
-        | SequenceFacet.Cycle      -> { dest with IsCycleEnabled = src.IsCycleEnabled }
-        | SequenceFacet.Cache      -> { dest with CacheMode = src.CacheMode; CacheSize = src.CacheSize }
-
-    let private applySequenceDiff (sd: SequenceDiff) (target: Catalog) (baseSeqs: Sequence list) : Sequence list =
-        let tgtSeq (key: SsKey) : Sequence option =
-            target.Sequences |> List.tryFind (fun s -> s.SsKey = key)
-        let survivors =
-            baseSeqs
-            |> List.filter (fun s -> not (Set.contains s.SsKey sd.Removed))
-            |> List.map (fun s ->
-                let renamed1 =
-                    match Map.tryFind s.SsKey sd.Renamed with
-                    | Some rec1 -> { s with Name = rec1.NewName }
-                    | None -> s
-                match sd.Changed |> List.tryFind (fun c -> c.SequenceKey = s.SsKey), tgtSeq s.SsKey with
-                | Some change, Some src -> Set.fold (fun acc f -> applySequenceFacet src f acc) renamed1 change.Facets
-                | _ -> renamed1)
-        let added = target.Sequences |> List.filter (fun s -> Set.contains s.SsKey sd.Added)
-        survivors @ added
 
     /// 6.A.11 — apply a `CatalogDiff` to a base `Catalog`, reconstructing the
     /// target modulo the captured surface. Total: trusts the delta (no
@@ -929,15 +903,15 @@ module CatalogDiff =
             let tgtKind = Catalog.tryFindKind k.SsKey tgt
             let withAttrs =
                 match Map.tryFind k.SsKey data.AttributeDiffs with
-                | Some ad -> { renamed1 with Attributes = applyAttributeDiff ad tgtKind renamed1.Attributes }
+                | Some ad -> { renamed1 with Attributes = applyChannel attributeSpec ad tgtKind renamed1.Attributes }
                 | None -> renamed1
             let withRefs =
                 match Map.tryFind k.SsKey data.ReferenceDiffs with
-                | Some rd -> { withAttrs with References = applyReferenceDiff rd tgtKind withAttrs.References }
+                | Some rd -> { withAttrs with References = applyChannel referenceSpec rd tgtKind withAttrs.References }
                 | None -> withAttrs
             let withIndexes =
                 match Map.tryFind k.SsKey data.IndexDiffs with
-                | Some idd -> { withRefs with Indexes = applyIndexDiff idd tgtKind withRefs.Indexes }
+                | Some idd -> { withRefs with Indexes = applyChannel indexSpec idd tgtKind withRefs.Indexes }
                 | None -> withRefs
             // NM-17 — patch the kind's own facets from the recorded target.
             match Map.tryFind k.SsKey data.KindFacetDiffs, tgtKind with
@@ -985,7 +959,7 @@ module CatalogDiff =
         // kind-scoped, so they reconstruct at the Catalog, not inside a Kind).
         { baseCatalog with
             Modules = modulesWithAdds
-            Sequences = applySequenceDiff data.SequenceDiff tgt baseCatalog.Sequences }
+            Sequences = applyChannel sequenceSpec data.SequenceDiff (Some tgt) baseCatalog.Sequences }
 
     // -- 6.H.3 (prework): the norm ‖·‖, the channel projection π, and compose
     //    — the derivative algebra's measurement + composition layer, made
@@ -1041,19 +1015,19 @@ module CatalogDiff =
             AddedAttributes   = sumAttr (fun ad -> Set.count ad.Added)
             RemovedAttributes = sumAttr (fun ad -> Set.count ad.Removed)
             RenamedAttributes = sumAttr (fun ad -> Map.count ad.Renamed)
-            ChangedAttributes = sumAttr (fun ad -> List.length ad.Changed)
+            ChangedAttributes = sumAttr (fun ad -> List.length ad.Reshaped)
             AddedReferences   = sumRef (fun rd -> Set.count rd.Added)
             RemovedReferences = sumRef (fun rd -> Set.count rd.Removed)
             RenamedReferences = sumRef (fun rd -> Map.count rd.Renamed)
-            ChangedReferences = sumRef (fun rd -> List.length rd.Changed)
+            ChangedReferences = sumRef (fun rd -> List.length rd.Reshaped)
             AddedIndexes      = sumIdx (fun idd -> Set.count idd.Added)
             RemovedIndexes    = sumIdx (fun idd -> Set.count idd.Removed)
             RenamedIndexes    = sumIdx (fun idd -> Map.count idd.Renamed)
-            ChangedIndexes    = sumIdx (fun idd -> List.length idd.Changed)
+            ChangedIndexes    = sumIdx (fun idd -> List.length idd.Reshaped)
             AddedSequences    = Set.count data.SequenceDiff.Added
             RemovedSequences  = Set.count data.SequenceDiff.Removed
             RenamedSequences  = Map.count data.SequenceDiff.Renamed
-            ChangedSequences  = List.length data.SequenceDiff.Changed
+            ChangedSequences  = List.length data.SequenceDiff.Reshaped
         }
 
     /// The norm ‖δ‖ — total move count, the sum of the channel counts (T15,

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -487,17 +487,19 @@ module CatalogDiff =
     /// O(N log N) with O(log N) `Catalog.tryFindKind` lookups.
     /// Total: O(N log N) where N = |source ∪ target|.
     ///
-    /// Returns `Result<CatalogDiff, EmitError>` for shape uniformity
-    /// with the rest of the emitter pipeline; the smart constructor
-    /// itself is total over Catalog inputs (Catalog has no failure
-    /// modes the diff would surface) — `Ok` is the only inhabited
-    /// branch today. The Result wrapper preserves room for future
-    /// variants (e.g., a `DiffMismatchedSchema` failure if the diff
-    /// expands to detect schema-level incompatibilities).
+    /// Returns a `CatalogDiff` directly — the constructor is **total**.
+    /// It cannot fail over any pair of Catalog inputs (Catalog has no
+    /// failure modes the diff would surface), so the displacement is the
+    /// only inhabited result; there is no `Error` branch to thread. The
+    /// vestigial `Result<CatalogDiff, EmitError>` wrapper (carried for an
+    /// imagined future `DiffMismatchedSchema` failure that never arrived)
+    /// is dropped: `compose`, `inverse`, and the groupoid laws read
+    /// cleanly off a total displacement, and call sites that genuinely
+    /// thread an `EmitError` `Ok`-wrap at their own boundary.
     let between
         (source: Catalog)
         (target: Catalog)
-        : Result<CatalogDiff, EmitError>
+        : CatalogDiff
         =
         let srcKeys = allKindKeys source
         let tgtKeys = allKindKeys target
@@ -576,21 +578,20 @@ module CatalogDiff =
                 Map.empty
         // C1 — sequences are catalog-level, not kind-scoped.
         let sequenceDiff = sequenceDiffBetween source target
-        Ok
-            (CatalogDiff
-                {
-                    Source = source
-                    Target = target
-                    Renamed = renamed
-                    Added = added
-                    Removed = removed
-                    Unchanged = unchanged
-                    AttributeDiffs = attributeDiffs
-                    ReferenceDiffs = referenceDiffs
-                    IndexDiffs = indexDiffs
-                    SequenceDiff = sequenceDiff
-                    KindFacetDiffs = kindFacetDiffs
-                })
+        CatalogDiff
+            {
+                Source = source
+                Target = target
+                Renamed = renamed
+                Added = added
+                Removed = removed
+                Unchanged = unchanged
+                AttributeDiffs = attributeDiffs
+                ReferenceDiffs = referenceDiffs
+                IndexDiffs = indexDiffs
+                SequenceDiff = sequenceDiff
+                KindFacetDiffs = kindFacetDiffs
+            }
 
     let source (CatalogDiff d) : Catalog = d.Source
     let target (CatalogDiff d) : Catalog = d.Target
@@ -1079,12 +1080,14 @@ module CatalogDiff =
     /// (A-Lifecycle-4) follows — both groupings recompute
     /// `between (source d1) (target dₙ)`.
     let compose (d1: CatalogDiff) (d2: CatalogDiff) : CatalogDiff option =
-        let composable =
-            match between (target d1) (source d2) with
-            | Ok bridge -> isEmpty bridge
-            | Error _   -> false
-        if not composable then None
-        else
-            match between (source d1) (target d2) with
-            | Ok net  -> Some net
-            | Error _ -> None
+        let composable = isEmpty (between (target d1) (source d2))
+        if not composable then None else Some (between (source d1) (target d2))
+
+    /// M12 — the groupoid inverse: the displacement that returns target to
+    /// source. `inverse d = between (target d) (source d)`. By the round-trip
+    /// law (`applyDiff` / `between` peer), applying `inverse d` to `target d`
+    /// reproduces `source d` modulo the captured surface; and `compose d
+    /// (inverse d)` is the identity at `source d` (the groupoid law). The
+    /// inverse always exists — `between` is total — so the partial groupoid's
+    /// `Some`-side is closed under inversion.
+    let inverse (d: CatalogDiff) : CatalogDiff = between (target d) (source d)

--- a/sidecar/projection/src/Projection.Core/ChangeManifest.fs
+++ b/sidecar/projection/src/Projection.Core/ChangeManifest.fs
@@ -52,29 +52,27 @@ module ChangeManifest =
     /// episode's Decision anchor + realized data movement. Threads the Π-side
     /// `EmitError` (`between`'s error type).
     let between (fromEpisode: Episode) (toEpisode: Episode) : Result<ChangeManifest, EmitError> =
-        match CatalogDiff.between fromEpisode.Schema toEpisode.Schema with
-        | Error e -> Error e
-        | Ok diff ->
-            Ok
-                { From = fromEpisode.Coordinate
-                  To = toEpisode.Coordinate
-                  Channels = CatalogDiff.channelCounts diff
-                  SchemaNorm = CatalogDiff.norm diff
-                  RefactorLogRef = toEpisode.RefactorLogRef
-                  CdcCaptureCount = toEpisode.Data.CdcCaptureCount
-                  // The tolerance residual is the named-divergence list the To-
-                  // episode's canary accepted on this edge — `Set` rendered to a
-                  // name-sorted list for T1 byte-determinism. `Tolerance.strict`
-                  // (a faithful run) ⇒ empty.
-                  ToleranceResidual =
-                    toEpisode.Tolerances
-                    |> Tolerance.divergences
-                    |> Set.toList
-                    |> List.sortBy ToleratedDivergence.name
-                  // The applied-transforms outcome is the To-episode's per-
-                  // artifact overlay enumeration, threaded through unchanged
-                  // (already (SsKey × OverlayAxis option)-sorted at its source).
-                  AppliedTransforms = toEpisode.AppliedTransforms }
+        let diff = CatalogDiff.between fromEpisode.Schema toEpisode.Schema
+        Ok
+            { From = fromEpisode.Coordinate
+              To = toEpisode.Coordinate
+              Channels = CatalogDiff.channelCounts diff
+              SchemaNorm = CatalogDiff.norm diff
+              RefactorLogRef = toEpisode.RefactorLogRef
+              CdcCaptureCount = toEpisode.Data.CdcCaptureCount
+              // The tolerance residual is the named-divergence list the To-
+              // episode's canary accepted on this edge — `Set` rendered to a
+              // name-sorted list for T1 byte-determinism. `Tolerance.strict`
+              // (a faithful run) ⇒ empty.
+              ToleranceResidual =
+                toEpisode.Tolerances
+                |> Tolerance.divergences
+                |> Set.toList
+                |> List.sortBy ToleratedDivergence.name
+              // The applied-transforms outcome is the To-episode's per-
+              // artifact overlay enumeration, threaded through unchanged
+              // (already (SsKey × OverlayAxis option)-sorted at its source).
+              AppliedTransforms = toEpisode.AppliedTransforms }
 
     /// The change-manifest **series**: one manifest per edge across an
     /// `EpisodicLifecycle` — the sprint-by-sprint record of what each release

--- a/sidecar/projection/src/Projection.Core/Episode.fs
+++ b/sidecar/projection/src/Projection.Core/Episode.fs
@@ -157,16 +157,6 @@ and EpisodicLifecycleData =
 [<RequireQualifiedAccess>]
 module EpisodicLifecycle =
 
-    /// Short-circuiting sequence over the Π-side `EmitError` algebra (mirrors
-    /// `Lifecycle.sequenceEmit` — the schema-plane diff threads the same error).
-    let private sequenceEmit (results: Result<'a, EmitError> list) : Result<'a list, EmitError> =
-        let rec loop acc remaining =
-            match remaining with
-            | []           -> Ok (List.rev acc)
-            | Ok v :: rest -> loop (v :: acc) rest
-            | Error e :: _ -> Error e
-        loop [] results
-
     /// Open a timeline at its genesis episode (E₀). Total — a single episode is
     /// trivially monotone.
     let genesis (timeline: Timeline) (episode: Episode) : EpisodicLifecycle =
@@ -208,7 +198,7 @@ module EpisodicLifecycle =
         data.Episodes
         |> List.pairwise
         |> List.map (fun (prior, next) -> CatalogDiff.between prior.Schema next.Schema)
-        |> sequenceEmit
+        |> Ok
 
     /// The FTC over the durable chain: `fold applyDiff E₀.Schema [δ₀; δ₁; …]`,
     /// reconstructing the latest schema from genesis + the per-edge deltas. The
@@ -242,7 +232,7 @@ module EpisodicLifecycle =
         let (EpisodicLifecycle data) = lifecycle
         let genesisSchema = (List.head data.Episodes).Schema
         let latestSchema = (List.last data.Episodes).Schema
-        let directNetDiff () = CatalogDiff.between genesisSchema latestSchema
+        let directNetDiff () = Ok (CatalogDiff.between genesisSchema latestSchema)
         match schemaEvolutionChain lifecycle with
         | Error e -> Error e
         | Ok []   -> directNetDiff ()

--- a/sidecar/projection/src/Projection.Core/Lifecycle.fs
+++ b/sidecar/projection/src/Projection.Core/Lifecycle.fs
@@ -64,18 +64,6 @@ and LifecycleData =
 [<RequireQualifiedAccess>]
 module Lifecycle =
 
-    /// Short-circuiting sequence over the Π-side `EmitError` algebra.
-    /// `Result.collect` covers the `ValidationError list` arity; this is
-    /// its `EmitError` peer, used to thread `CatalogDiff.between` across
-    /// the evolution chain.
-    let private sequenceEmit (results: Result<'a, EmitError> list) : Result<'a list, EmitError> =
-        let rec loop acc remaining =
-            match remaining with
-            | []              -> Ok (List.rev acc)
-            | Ok v :: rest    -> loop (v :: acc) rest
-            | Error e :: _    -> Error e
-        loop [] results
-
     /// Open a timeline at its genesis snapshot (C₀). Total — a single
     /// snapshot is trivially monotone.
     let genesis (timeline: Timeline) (snapshot: CatalogSnapshot) : Lifecycle =
@@ -117,7 +105,7 @@ module Lifecycle =
         data.Snapshots
         |> List.pairwise
         |> List.map (fun (prior, next) -> CatalogDiff.between prior.Catalog next.Catalog)
-        |> sequenceEmit
+        |> Ok
 
     /// L3-L1 (replayability) in materialized form: recover the `Catalog`
     /// stored at a `Version`. Lookup is by ordinal (the position's
@@ -176,7 +164,7 @@ module Lifecycle =
         let (Lifecycle data) = lifecycle
         let genesisCatalog = (List.head data.Snapshots).Catalog
         let latestCatalog = (List.last data.Snapshots).Catalog
-        let directNetDiff () = CatalogDiff.between genesisCatalog latestCatalog
+        let directNetDiff () = Ok (CatalogDiff.between genesisCatalog latestCatalog)
         match evolutionChain lifecycle with
         | Error e -> Error e
         | Ok []   -> directNetDiff ()

--- a/sidecar/projection/src/Projection.Core/Migration.fs
+++ b/sidecar/projection/src/Projection.Core/Migration.fs
@@ -101,7 +101,7 @@ module Migration =
             |> Map.toList
             |> List.sortBy (fun (k, _) -> SsKey.rootOriginal k)
             |> List.collect (fun (kindKey, ad) ->
-                ad.Changed
+                ad.Reshaped
                 |> List.sortBy (fun c -> SsKey.rootOriginal c.AttributeKey)
                 |> List.map (fun c -> (kindKey, c.AttributeKey, c.Facets)))
         { Channels = CatalogDiff.channelCounts diff

--- a/sidecar/projection/src/Projection.Core/Migration.fs
+++ b/sidecar/projection/src/Projection.Core/Migration.fs
@@ -193,10 +193,8 @@ module Migration =
     /// exactly the removals the operator did not name. Threads the Π-side
     /// `EmitError` (`between`'s error).
     let plan (declaration: LossDeclaration) (source: Catalog) (target: Catalog) : Result<MigrationPlan, EmitError> =
-        match CatalogDiff.between source target with
-        | Error e -> Error e
-        | Ok diff ->
-            Ok { Diff = diff; Preview = previewOf diff; Violations = undeclaredLosses declaration diff }
+        let diff = CatalogDiff.between source target
+        Ok { Diff = diff; Preview = previewOf diff; Violations = undeclaredLosses declaration diff }
 
     /// True iff the plan carries no undeclared losses — safe to execute / publish.
     let isSafe (p: MigrationPlan) : bool = List.isEmpty p.Violations

--- a/sidecar/projection/src/Projection.Core/PinnedWriting.fs
+++ b/sidecar/projection/src/Projection.Core/PinnedWriting.fs
@@ -10,8 +10,10 @@ namespace Projection.Core
 //   strict-mode discipline (`DECISIONS 2026-05-09`), reify the
 //   mutation in one named home.
 
+open System.IO
 open System.Text
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Xml
 
 /// Pinned `System.Text.Json` writer-option forms. Both forms set
@@ -40,6 +42,62 @@ module JsonOptions =
         opts.Indented <- false
         opts.NewLine <- "\n"
         opts
+
+/// Pinned `System.Text.Json` write→materialize seam. The
+/// `Utf8JsonWriter → MemoryStream → byte[] → JsonNode.Parse` dance
+/// (and its node→indented-string sibling) was duplicated across
+/// every per-kind `kindJsonNode` and whole-document `emit`/`serialize`
+/// site; these three forms are the single sanctioned home. The
+/// compact/indented options choice is fixed PER FORM and matches the
+/// site each replaces exactly — byte-identity is the contract
+/// (`GoldenEmissionTests` guard the emitted bytes).
+[<RequireQualifiedAccess>]
+module JsonWriting =
+
+    /// Write imperatively to a `Utf8JsonWriter` over a `MemoryStream`
+    /// under **compact** options, flush, then re-parse the bytes into
+    /// a typed `JsonNode` via the `ReadOnlySpan<byte>` overload (no
+    /// managed `string` materialized). The defensive null→`invalidOp`
+    /// guard preserves each call site's "writer always emits an
+    /// object" unreachable-case contract. Used by every per-kind
+    /// `kindJsonNode` seam (pillar-1 cash-out: typed node at the Π
+    /// port; strings emerge only at the terminal writer).
+    let writeToNode (write: Utf8JsonWriter -> unit) : JsonNode =
+        use stream = new MemoryStream()
+        do
+            use writer = new Utf8JsonWriter(stream, JsonOptions.compact ())
+            write writer
+            writer.Flush()
+        let bytes = stream.ToArray()
+        match JsonNode.Parse(System.ReadOnlySpan<byte>(bytes)) with
+        | null -> invalidOp "JsonWriting.writeToNode: writer produced empty stream (unreachable; the imperative writer always emits an object)"
+        | node -> node
+
+    /// Render a typed `JsonNode` to text under **indented** options:
+    /// `node.WriteTo` a `Utf8JsonWriter` over a `MemoryStream`, flush,
+    /// then `Encoding.UTF8.GetString(stream.ToArray())`. The terminal
+    /// interpreter for a typed-tree description (the document `emit`
+    /// whose body is a `JsonNode`).
+    let renderNodeToString (node: JsonNode) : string =
+        use stream = new MemoryStream()
+        do
+            use writer = new Utf8JsonWriter(stream, JsonOptions.indented ())
+            node.WriteTo(writer)
+            writer.Flush()
+        Encoding.UTF8.GetString(stream.ToArray())
+
+    /// Write imperatively to a `Utf8JsonWriter` over a `MemoryStream`
+    /// under **indented** options, flush, then
+    /// `Encoding.UTF8.GetString(stream.ToArray())`. The codec/document
+    /// `serialize` path: imperative-write straight to indented text
+    /// with NO re-parse through a node (which would be wasteful).
+    let writeToString (write: Utf8JsonWriter -> unit) : string =
+        use stream = new MemoryStream()
+        do
+            use writer = new Utf8JsonWriter(stream, JsonOptions.indented ())
+            write writer
+            writer.Flush()
+        Encoding.UTF8.GetString(stream.ToArray())
 
 /// Pinned `System.Xml.XmlWriterSettings` forms. Each call returns
 /// a fresh instance (XmlWriterSettings is a class — sharing one

--- a/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
+++ b/sidecar/projection/src/Projection.Core/SurrogateRemap.fs
@@ -25,12 +25,18 @@ namespace Projection.Core
 /// same form `StaticRow.Values` uses). The orientation marker prevents
 /// passing a `SourceKey` where an `AssignedKey` is expected — the
 /// surrogate-remap analog of `SourceUserId` / `TargetUserId`.
+/// M6 (THE VECTOR Wave 3) — `[<Struct>]` for the same reason `RowQuantum`
+/// earned it (`Catalog.fs`, §9.7 carrier-cost): this pair is consumed
+/// per-referencer-row in `remapRowFksWith` on the estate-transfer hot path,
+/// so the one-word struct copy retires the per-row DU-wrapper allocation.
+[<Struct>]
 type SourceKey = SourceKey of string
 
 /// A surrogate primary-key value as assigned by the target identity
 /// space — sink-minted at insert time in the Transfer flow, sink-pre-
 /// existing for a reconciled match, or operator-supplied in a static-
 /// artifact remap. Sibling to `SourceKey`; consumed by every FK re-point.
+[<Struct>]
 type AssignedKey = AssignedKey of string
 
 [<RequireQualifiedAccess>]

--- a/sidecar/projection/src/Projection.Core/Types.fs
+++ b/sidecar/projection/src/Projection.Core/Types.fs
@@ -107,7 +107,8 @@ type Property = Catalog -> bool
 type RelationalProperty = Catalog -> Catalog -> bool
 
 /// Pattern Diff — evolution as value. Stage 0 reserves the alias;
-/// chapter 3.5 fills the implementation of
-/// `CatalogDiff.between : Catalog -> Catalog -> Result<CatalogDiff,
-/// EmitError>` per the A36 candidate exhaustiveness invariant.
+/// chapter 3.5 fills the implementation. The total smart constructor is
+/// `CatalogDiff.between : Catalog -> Catalog -> CatalogDiff` (it cannot
+/// fail over any Catalog pair); this `Result`-typed alias is the wider
+/// `DiffOf` shape that call sites threading an `EmitError` `Ok`-wrap into.
 type DiffOf<'value> = 'value -> 'value -> Result<CatalogDiff, EmitError>

--- a/sidecar/projection/src/Projection.Pipeline/Compare.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Compare.fs
@@ -104,10 +104,7 @@ module Compare =
     /// contradict. With no A-profile the dealbreaker section is empty and
     /// `DataEvidenceAvailable = false`.
     let compute (source: Operand) (target: Operand) : CompareReport =
-        let schemaDelta =
-            match CatalogDiff.between target.Catalog source.Catalog with
-            | Ok d -> Some d
-            | Error _ -> None
+        let schemaDelta = Some (CatalogDiff.between target.Catalog source.Catalog)
         let dealbreakers, evidence =
             match source.Profile with
             | Some profile ->

--- a/sidecar/projection/src/Projection.Pipeline/EmissionFoldersBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/EmissionFoldersBinding.fs
@@ -1,6 +1,7 @@
 namespace Projection.Pipeline
 
 open Projection.Core
+open FsToolkit.ErrorHandling
 
 /// Chapter C slice C.3 — operator-supplied emission-folder targeting.
 /// The binder resolves textual config entries (`Overrides
@@ -161,13 +162,11 @@ module EmissionFoldersBinding =
         (catalog: Catalog)
         (entry: Config.EmissionFolderEntry)
         : Result<SsKey * string> =
-        let keyR    = resolveKindByLogical catalog entry.Ref
-        let folderR = validateFolder entry.Ref entry.Folder
-        match keyR, folderR with
-        | Ok key, Ok folder    -> Result.success (key, folder)
-        | Error es1, Error es2 -> Error (es1 @ es2)
-        | Error es, _          -> Error es
-        | _, Error es          -> Error es
+        validation {
+            let! key    = resolveKindByLogical catalog entry.Ref
+            and! folder = validateFolder entry.Ref entry.Folder
+            return (key, folder)
+        }
 
     /// Build the typed `EmissionFolders` runtime value from a parsed
     /// `Config`. Aggregates all binder errors so the operator sees

--- a/sidecar/projection/src/Projection.Pipeline/MigrationDependenciesBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MigrationDependenciesBinding.fs
@@ -4,6 +4,7 @@ open System.IO
 open System.Text.Json
 open Projection.Core
 open Projection.Targets.Data
+open FsToolkit.ErrorHandling
 
 /// The migration-dependency file adapter (the boundary the
 /// `MigrationDependenciesEmitter` docstring deferred until a real
@@ -108,11 +109,11 @@ module MigrationDependenciesBinding =
             | JsonValueKind.Object ->
                 v.EnumerateObject()
                 |> Seq.map (fun prop ->
-                    match Name.create prop.Name, cellValue prop.Name prop.Value with
-                    | Ok name, Ok value    -> Result.success (name, value)
-                    | Error es, Error es2  -> Error (es @ es2)
-                    | Error es, _          -> Error es
-                    | _, Error es          -> Error es)
+                    validation {
+                        let! name  = Name.create prop.Name
+                        and! value = cellValue prop.Name prop.Value
+                        return (name, value)
+                    })
                 |> Result.aggregate
                 |> Result.map Map.ofList
             | _ ->
@@ -138,10 +139,11 @@ module MigrationDependenciesBinding =
                 Result.failureOf (
                     bindError "kindMissingCoordinate"
                         (sprintf "every migration kind entry needs a non-blank string '%s'." key))
-        match getReqStr "module", getReqStr "entity" with
-        | Ok moduleName, Ok entityName ->
+        validation {
+            let! moduleName = getReqStr "module"
+            and! entityName = getReqStr "entity"
             let kindLabel = sprintf "%s.%s" moduleName entityName
-            let rowsR =
+            let! rows =
                 match element.TryGetProperty("rows") with
                 | false, _ -> Result.success []
                 | true, v ->
@@ -155,9 +157,8 @@ module MigrationDependenciesBinding =
                         Result.failureOf (
                             bindError "rowsNotArray"
                                 (sprintf "migration kind %s 'rows' must be an array." kindLabel))
-            rowsR |> Result.map (fun rows -> { Module = moduleName; Entity = entityName; Rows = rows })
-        | m, e ->
-            Error ((match m with Error es -> es | _ -> []) @ (match e with Error es -> es | _ -> []))
+            return { Module = moduleName; Entity = entityName; Rows = rows }
+        }
 
     /// Parse the document text into the raw (pre-resolution) kind list.
     /// Root must be an object with an optional `kinds` array.

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -14,6 +14,7 @@ open Projection.Targets.SSDT
 open Projection.Targets.Json
 open Projection.Targets.Distributions
 open Projection.Targets.OperationalDiagnostics
+open FsToolkit.ErrorHandling
 
 /// End-to-end pipeline composition: V1 `osm_model.json` →
 /// `Projection.Adapters.Osm.CatalogReader.parse` → V2 Catalog →
@@ -1131,10 +1132,9 @@ module Compose =
         (cfg: Config.Config)
         (catalog: Catalog)
         : Result<Policy> =
-        let tighteningR = TighteningBinding.fromConfig catalog cfg.Policy.Tightening
-        let insertionR  = InsertionPolicyBinding.fromConfig cfg
-        match tighteningR, insertionR with
-        | Ok tightening, Ok insertion ->
+        validation {
+            let! tightening = TighteningBinding.fromConfig catalog cfg.Policy.Tightening
+            and! insertion  = InsertionPolicyBinding.fromConfig cfg
             // AC-X1 — translate the config's data-emission toggles into the
             // EmissionPolicy. `staticSeeds` / `migrationDependencies` /
             // `bootstrap` turning on enables `EmitData`; `DataComposition`
@@ -1162,7 +1162,7 @@ module Compose =
                 cfg.Emission.DecisionLog
                 || cfg.Emission.Opportunities
                 || cfg.Emission.Validations
-            Result.success {
+            return {
                 Policy.empty with
                     Tightening = tightening
                     Insertion  = insertion
@@ -1193,10 +1193,34 @@ module Compose =
                                      // prepends the symmetric-EXCEPT THROW guard).
                                      DataVerification = cfg.Emission.DataVerification }
             }
-        | _ ->
-            let tighteningErrs = match tighteningR with Ok _ -> [] | Error es -> es
-            let insertionErrs  = match insertionR  with Ok _ -> [] | Error es -> es
-            Result.failure (tighteningErrs @ insertionErrs)
+        }
+
+    /// THE_CONFIG_CONTROL_PLANE §6 — the SINGLE shaping-overlay bind-all
+    /// combinator. Binds the policy / emission-folders / transform-groups
+    /// triple against an already-rename-applied catalog, accumulating every
+    /// binder's `ValidationError`s (FsToolkit `validation { }`; the
+    /// applicative `and!` concatenates in `policy @ folders @ groups` order).
+    ///
+    /// **Convergence-by-construction (the §6 named risk).** The two non-bundle
+    /// shaping sites that thread *exactly this triple* — `projectWithConfig`
+    /// (the bundle emit) and `applyShapingToCatalog` (the migrate / preview
+    /// catalog shape) — BOTH funnel through here, so their bind-set + error-
+    /// accumulation mechanism is structurally identical and cannot drift apart.
+    /// `runWithConfigCore` threads a SUPERSET (it additionally binds
+    /// `SpecialCircumstancesBinding` — the overrides axis — interleaved in its
+    /// native `policy @ overrides @ folders @ groups` order), so it keeps its
+    /// own `validation { }` block rather than this triple; the binding SET it
+    /// threads is unchanged from before this compression.
+    let private bindShapingTriple
+        (shaping: Config.Config)
+        (renamedCatalog: Catalog)
+        : Result<Policy * EmissionFolders * TransformGroups> =
+        validation {
+            let! policy  = buildPolicyFromConfig shaping renamedCatalog
+            and! folders = EmissionFoldersBinding.fromConfig renamedCatalog shaping
+            and! groups  = TransformGroupsBinding.fromConfig shaping
+            return (policy, folders, groups)
+        }
 
     /// Open the out-of-band source connection and enrich `Profile.empty`
     /// via the `LiveProfiler` adapter. An unreachable / malformed
@@ -1270,12 +1294,22 @@ module Compose =
             match applyRenames cfg catalog with
             | Error errors -> Result.failure errors
             | Ok renamedCatalog ->
-                let policyR    = buildPolicyFromConfig cfg renamedCatalog
-                let overridesR = SpecialCircumstancesBinding.fromConfig renamedCatalog cfg
-                let foldersR   = EmissionFoldersBinding.fromConfig renamedCatalog cfg
-                let groupsR    = TransformGroupsBinding.fromConfig cfg
-                match policyR, overridesR, foldersR, groupsR with
-                | Ok policy, Ok overrides, Ok folders, Ok groups ->
+                // THE_CONFIG_CONTROL_PLANE §6 — `runWithConfigCore` threads the
+                // SUPERSET binding set (the `policy/folders/groups` triple PLUS
+                // the `SpecialCircumstances` overrides axis the live/migrate
+                // sites omit). The `validation { }` applicative accumulates in
+                // the historical `policy @ overrides @ folders @ groups` order;
+                // the binding SET is unchanged from before the M9 compression.
+                let boundR =
+                    validation {
+                        let! policy    = buildPolicyFromConfig cfg renamedCatalog
+                        and! overrides = SpecialCircumstancesBinding.fromConfig renamedCatalog cfg
+                        and! folders   = EmissionFoldersBinding.fromConfig renamedCatalog cfg
+                        and! groups    = TransformGroupsBinding.fromConfig cfg
+                        return (policy, overrides, folders, groups)
+                    }
+                match boundR with
+                | Ok (policy, overrides, folders, groups) ->
                     let outputs, finalState =
                         projectWithStateWithPinsAndBootstrap pins policy profile folders groups migration bootstrapRows renamedCatalog
                     // `emission.dacpac: true` — compile the .dacpac over the SAME
@@ -1349,12 +1383,7 @@ module Compose =
                     // hash its canonical form into the live-path input digest.
                     | Ok paths    -> Result.success { Paths = paths; Diagnostics = diagnostics; Manifest = outputs.Manifest; Trail = outputs.Trail; PassDiagnostics = outputs.PassEntries; ReadCatalog = catalog }
                     | Error errors -> Result.failure errors
-                | _ ->
-                    let policyErrs    = match policyR    with Ok _ -> [] | Error es -> es
-                    let overridesErrs = match overridesR with Ok _ -> [] | Error es -> es
-                    let foldersErrs   = match foldersR   with Ok _ -> [] | Error es -> es
-                    let groupsErrs    = match groupsR    with Ok _ -> [] | Error es -> es
-                    Result.failure (policyErrs @ overridesErrs @ foldersErrs @ groupsErrs)
+                | Error errors -> Result.failure errors
 
     /// Full end-to-end driven by a parsed `Config`. Reads `Model.Path`,
     /// applies config-driven catalog rewrites (rename), binds operator
@@ -1512,18 +1541,14 @@ module Compose =
         match applyRenames shaping catalog with
         | Error errors -> Result.failure errors
         | Ok renamedCatalog ->
-            match buildPolicyFromConfig shaping renamedCatalog,
-                  EmissionFoldersBinding.fromConfig renamedCatalog shaping,
-                  TransformGroupsBinding.fromConfig shaping with
-            | Ok policy, Ok folders, Ok groups ->
+            // §6 — the SHARED triple bind-all (drift-proof with
+            // `applyShapingToCatalog`, which threads the identical set).
+            match bindShapingTriple shaping renamedCatalog with
+            | Ok (policy, folders, groups) ->
                 let outputs, _ =
                     projectWithStateWithPins pins policy Profile.empty folders groups renamedCatalog
                 Result.success outputs
-            | p, f, g ->
-                Result.failure
-                    ((match p with Error e -> e | _ -> [])
-                     @ (match f with Error e -> e | _ -> [])
-                     @ (match g with Error e -> e | _ -> []))
+            | Error errors -> Result.failure errors
 
     /// THE_CONFIG_CONTROL_PLANE §6 (S3) — the overlay-aware sibling of
     /// `runFromCatalog`: project a caller-supplied catalog through the
@@ -1589,18 +1614,14 @@ module Compose =
         match applyRenames shaping catalog with
         | Error errors -> Result.failure errors
         | Ok renamedCatalog ->
-            match buildPolicyFromConfig shaping renamedCatalog,
-                  EmissionFoldersBinding.fromConfig renamedCatalog shaping,
-                  TransformGroupsBinding.fromConfig shaping with
-            | Ok policy, Ok folders, Ok groups ->
+            // §6 — the SHARED triple bind-all (drift-proof with
+            // `projectWithConfig`, which threads the identical set).
+            match bindShapingTriple shaping renamedCatalog with
+            | Ok (policy, folders, groups) ->
                 let _, finalState =
                     projectWithStateWithPins pins policy Profile.empty folders groups renamedCatalog
                 Result.success finalState.Catalog
-            | p, f, g ->
-                Result.failure
-                    ((match p with Error e -> e | _ -> [])
-                     @ (match f with Error e -> e | _ -> [])
-                     @ (match g with Error e -> e | _ -> []))
+            | Error errors -> Result.failure errors
 
     let runWithConfig (cfg: Config.Config) : Task<Result<RunReport>> =
         task {
@@ -1704,10 +1725,11 @@ module Compose =
         match parsed |> Result.bind (applyRenames cfg) with
         | Error es -> Result.failure es
         | Ok catalog ->
-            match buildPolicyFromConfig cfg catalog,
-                  EmissionFoldersBinding.fromConfig catalog cfg,
-                  TransformGroupsBinding.fromConfig cfg with
-            | Ok policy, Ok folders, Ok groups ->
+            // §6 — the SHARED triple bind-all. The store-leg threads the SAME
+            // policy/folders/groups set the publish path binds, so the deployed
+            // leveled seed never drifts from the bundle (the parity duty).
+            match bindShapingTriple cfg catalog with
+            | Ok (policy, folders, groups) ->
                 let _, finalState =
                     projectWithState policy Profile.empty folders groups catalog
                 if not policy.Emission.EmitData then
@@ -1731,12 +1753,7 @@ module Compose =
                         // catalog never fails the composer (the keyset is
                         // `Catalog.allKinds`).
                         invalidOp (sprintf "Compose.projectSeedPlan: DataEmissionComposer.composeRenderedLeveled: %A" err)
-            | p, f, g ->
-                let errs =
-                    (match p with Error e -> e | _ -> [])
-                    @ (match f with Error e -> e | _ -> [])
-                    @ (match g with Error e -> e | _ -> [])
-                Result.failure errs
+            | Error errs -> Result.failure errs
 
     let private emittedSeedPlan (cfg: Config.Config) : Task<Result<Catalog * DataComposer.LeveledDeploymentText>> =
         task {

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -1875,12 +1875,10 @@ module Compose =
         match priorSchemaFromStore path with
         | Error e -> Error e
         | Ok prior ->
-            match CatalogDiff.between prior emitted with
-            | Error e -> Error (DisplacementFailed e)
-            | Ok displacement ->
-                match priorAccumulatedRefactorLog path with
-                | Error e -> Error e
-                | Ok priorLog ->
+            let displacement = CatalogDiff.between prior emitted
+            match priorAccumulatedRefactorLog path with
+            | Error e -> Error e
+            | Ok priorLog ->
                     match RefactorLogEmitter.emit displacement with
                     | Error e -> Error (DisplacementFailed e)
                     | Ok currentArtifact ->

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -355,6 +355,81 @@ module Preflight =
     // witness; it is deliberately NOT half-implemented here because its
     // granularity is the survey's to resolve and its correctness needs a live
     // container to witness. See `DEBRIEF_2026_06_02_…` cluster A (A3).
+    //
+    // THE VECTOR §5.1 / M20 — the HONEST-NAMING half. The live atomic wrapper
+    // above stays deferred (the A3 scaffold is the survey's to resolve). What
+    // lands NOW is the named refusal: the typed protection capability, the pure
+    // gate that turns an unprotected destructive write path into one named
+    // violation per planned write, and the paired `migrate.midWriteNotProtected`
+    // refusal. This is the classification half — it does not wrap
+    // `MigrationRun.execute`; the live `BEGIN TRAN` is still the survey's (A3,
+    // above) to resolve. The pure gate is the buildable scaffold the wrapper
+    // will consume once its granularity is fixed.
+
+    /// The write path's protection against a mid-write crash — the typed
+    /// capability the transactionality gate reasons over. `Atomic`: the whole
+    /// write commits or rolls back (a `BEGIN TRAN` wrapper). `Resumable`: a
+    /// partial write is idempotently re-runnable (the surrogate-keyed upsert).
+    /// `Unprotected`: neither — a crash part-way through Phase 2 leaves a
+    /// half-populated target. Closed DU so the gate stays total over it.
+    type TransactionProtection =
+        | Atomic
+        | Resumable
+        | Unprotected
+
+    /// One planned destructive write that, on an unprotected path, would be left
+    /// half-applied by a mid-write crash. Mirrors `PermissionViolation`: the
+    /// object the violation is located on, and the action that would not be
+    /// protected.
+    type TransactionalityViolation =
+        {
+            Object : string
+            Action : WriteAction
+        }
+
+    /// Pure: under an `Unprotected` write path, every planned destructive write
+    /// is a violation — a mid-write crash would leave it half-applied. `Atomic`
+    /// (whole-write rollback) and `Resumable` (idempotent re-run) protect the
+    /// path, so neither yields a violation. Deterministic — sorted by object then
+    /// action. DB-free and testable. Mirrors `permissionViolations`.
+    let transactionalityViolations
+        (protection: TransactionProtection)
+        (planned: PlannedWrite list)
+        : TransactionalityViolation list =
+        match protection with
+        | Atomic | Resumable -> []
+        | Unprotected ->
+            planned
+            |> List.map (fun w -> { Object = objectKey w; Action = w.Action })
+            |> List.distinct
+            |> List.sortBy (fun v -> v.Object, permissionName v.Action)
+
+    let private describeTransactionality (violations: TransactionalityViolation list) : string =
+        violations
+        |> List.map (fun v -> sprintf "%s on %s" (permissionName v.Action) v.Object)
+        |> String.concat "; "
+        |> sprintf "transactionality pre-flight failed before any write — this would leave a half-populated target on a mid-write crash; the write path is neither atomic nor resumable, so these planned writes would be left half-applied: %s. Wrap the write path in a transaction (atomic) or make it resumable before executing."
+
+    /// A3 — refuse `migrate.midWriteNotProtected` when the planned destructive
+    /// writes run on an `Unprotected` path (neither atomic nor resumable), BEFORE
+    /// any write — a mid-write crash would otherwise leave a half-populated
+    /// target rather than a named refusal. Pure: takes the typed protection
+    /// capability + the planned writes, no I/O. Mirrors `permissionPreflight`.
+    ///
+    /// This is the HONEST-NAMING half (THE VECTOR §5.1 / M20). The live atomic
+    /// `BEGIN TRAN` wrapper that would make the path `Atomic` stays survey-gated
+    /// (the A3 scaffold above); this gate names the refusal so an unprotected
+    /// path classifies as the destructive-failure axis (exit 9) rather than the
+    /// generic `UnclassifiedRefusal` (exit 3).
+    let transactionalityPreflight
+        (protection: TransactionProtection)
+        (planned: PlannedWrite list)
+        : Result<unit> =
+        match transactionalityViolations protection planned with
+        | [] -> Ok ()
+        | violations ->
+            Result.failureOf
+                (ValidationError.create "migrate.midWriteNotProtected" (describeTransactionality violations))
 
     // -- The composition -----------------------------------------------------
 
@@ -411,6 +486,14 @@ module Preflight =
         | CdcTrackedSink
         | SchemaReadFailed
         | UndeclaredDestructiveChange
+        /// The named destructive class for a mid-write crash on an unprotected
+        /// (non-atomic, non-resumable) write path: a failure part-way through
+        /// Phase 2 leaves a half-populated target rather than an unchanged or
+        /// resumable one. Naming it replaces the generic `UnclassifiedRefusal`
+        /// (exit 3) with the destructive-failure axis (exit 9). The honest name;
+        /// the live atomic `BEGIN TRAN` wrapper stays survey-gated (see the A3
+        /// scaffold above) — this is the classification half only.
+        | MidWriteNotProtected
         /// The named default for a code outside the known gate vocabulary — a
         /// generic refusal. NOT a silent pass: it still carries the generic
         /// non-zero refusal exit (3), so an unmapped gate fails loud.
@@ -427,6 +510,7 @@ module Preflight =
         | CdcTrackedSink              -> "CDC-tracked sink"
         | SchemaReadFailed            -> "schema read failed"
         | UndeclaredDestructiveChange -> "undeclared destructive change"
+        | MidWriteNotProtected        -> "mid-write not protected"
         | UnclassifiedRefusal         -> "unclassified refusal"
 
     /// The closed `code → (exit, label)` mapping. TOTAL over the gate code
@@ -460,6 +544,12 @@ module Preflight =
             6, SchemaReadFailed
         elif code.StartsWith "migrate.undeclaredDestructive" then
             9, UndeclaredDestructiveChange
+        elif code.StartsWith "transfer.midWriteNotProtected" || code = "migrate.midWriteNotProtected" then
+            // The transactionality axis (A3): a mid-write crash on an
+            // unprotected write path. The same destructive-failure class as the
+            // other exit-9 axes — a half-populated target is a destructive
+            // outcome, not a generic refusal.
+            9, MidWriteNotProtected
         else
             3, UnclassifiedRefusal
 

--- a/sidecar/projection/src/Projection.Pipeline/RenameBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RenameBinding.fs
@@ -2,6 +2,7 @@ namespace Projection.Pipeline
 
 open Projection.Core
 open Projection.Core.Passes
+open FsToolkit.ErrorHandling
 
 /// Boundary translation from `Config.TableRename` (JSON-shape, raw strings)
 /// to `TableRename.RenameSpec` (Core-shape, typed value objects).
@@ -22,13 +23,11 @@ module RenameBinding =
         ValidationError.create (sprintf "pipeline.renameBinding.%s" code) message
 
     let private bindLogicalKey (l: Config.LogicalName) : Result<TableRename.RenameKey> =
-        let moduleNameR = Name.create l.Module
-        let entityNameR = Name.create l.Entity
-        match moduleNameR, entityNameR with
-        | Ok m,    Ok e    -> Result.success (TableRename.Logical (m, e))
-        | Error a, Error b -> Result.failure (a @ b)
-        | Error a, _       -> Result.failure a
-        | _,       Error b -> Result.failure b
+        validation {
+            let! m = Name.create l.Module
+            and! e = Name.create l.Entity
+            return TableRename.Logical (m, e)
+        }
 
     let private bindPhysicalKey (p: Config.PhysicalName) : Result<TableRename.RenameKey> =
         TableId.create p.Schema p.Table
@@ -43,13 +42,11 @@ module RenameBinding =
         TableId.create p.Schema p.Table
 
     let private bindOne (cr: Config.TableRename) : Result<TableRename.RenameSpec> =
-        let keyR    = bindKey cr.From
-        let targetR = bindTarget cr.To
-        match keyR, targetR with
-        | Ok k,    Ok t    -> Result.success { TableRename.Key = k; TableRename.Target = t }
-        | Error a, Error b -> Result.failure (a @ b)
-        | Error a, _       -> Result.failure a
-        | _,       Error b -> Result.failure b
+        validation {
+            let! k = bindKey cr.From
+            and! t = bindTarget cr.To
+            return { TableRename.Key = k; TableRename.Target = t }
+        }
 
     /// Convert a list of config-shape renames into typed Core-shape
     /// `RenameSpec`s. Errors aggregate.

--- a/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SpecialCircumstancesBinding.fs
@@ -1,6 +1,7 @@
 namespace Projection.Pipeline
 
 open Projection.Core
+open FsToolkit.ErrorHandling
 
 /// Chapter C slice C.2 — operator-supplied acknowledgements that
 /// source-side defects (missing primary keys; unresolved circular
@@ -136,14 +137,11 @@ module SpecialCircumstancesBinding =
         (catalog: Catalog)
         (cfg: Config.Config)
         : Result<SpecialCircumstances> =
-        let pksR     = bindAllowMissingPrimaryKey catalog cfg.Overrides.AllowMissingPrimaryKey
-        let cyclesR  = bindAllowedCycles catalog cfg.Overrides.CircularDependencies
-        match pksR, cyclesR with
-        | Ok pks, Ok cycles ->
-            Result.success {
+        validation {
+            let! pks    = bindAllowMissingPrimaryKey catalog cfg.Overrides.AllowMissingPrimaryKey
+            and! cycles = bindAllowedCycles catalog cfg.Overrides.CircularDependencies
+            return {
                 AllowedMissingPrimaryKeys = pks
                 AllowedCycles             = cycles
             }
-        | Error es1, Error es2 -> Error (es1 @ es2)
-        | Error es, _          -> Error es
-        | _, Error es          -> Error es
+        }

--- a/sidecar/projection/src/Projection.Pipeline/TighteningBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TighteningBinding.fs
@@ -1,6 +1,7 @@
 namespace Projection.Pipeline
 
 open Projection.Core
+open FsToolkit.ErrorHandling
 
 /// Chapter C slice C.1 — operator config → `TighteningPolicy` binder.
 /// Converts `Config.TighteningSection` (textual operator surface)
@@ -80,16 +81,14 @@ module TighteningBinding =
         (catalog: Catalog)
         (entry: Config.TighteningAttributeOverride)
         : Result<TighteningOverride> =
-        match resolveAttributeRef catalog entry.AttributeRef with
-        | Error es -> Error es
-        | Ok ssKey ->
-            match parseOverrideAction entry.Action with
-            | Error es -> Error es
-            | Ok action ->
-                Result.success {
-                    AttributeKey = ssKey
-                    Action       = action
-                }
+        result {
+            let! ssKey  = resolveAttributeRef catalog entry.AttributeRef
+            let! action = parseOverrideAction entry.Action
+            return {
+                AttributeKey = ssKey
+                Action       = action
+            }
+        }
 
     /// Build a `TighteningIntervention.Nullability` from a config
     /// entry. Defaults: `NullBudget = 0.0` (strict), `Allow
@@ -101,17 +100,14 @@ module TighteningBinding =
         : Result<TighteningIntervention> =
         let nullBudget = defaultArg entry.NullBudget 0m
         let allowMand = defaultArg entry.AllowMandatoryRelaxation false
-        let overridesR =
-            entry.NullabilityOverrides
-            |> List.map (bindOverride catalog)
-            |> Result.aggregate
-        match overridesR with
-        | Error es -> Error es
-        | Ok overrides ->
-            match NullabilityTighteningConfig.create nullBudget allowMand overrides with
-            | Error es -> Error es
-            | Ok config ->
-                Result.success (TighteningIntervention.Nullability (entry.Id, config))
+        result {
+            let! overrides =
+                entry.NullabilityOverrides
+                |> List.map (bindOverride catalog)
+                |> Result.aggregate
+            let! config = NullabilityTighteningConfig.create nullBudget allowMand overrides
+            return TighteningIntervention.Nullability (entry.Id, config)
+        }
 
     let private bindUniqueIndex
         (entry: Config.TighteningInterventionEntry)

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -1290,13 +1290,10 @@ module Transfer =
         (sinkContract: Catalog)
         : Task<Result<TransferReport>> =
         task {
-            match CatalogDiff.between sourceContract sinkContract with
-            | Error e ->
-                return Result.failureOf (ValidationError.create "transfer.renameDiffFailed" (sprintf "%A" e))
-            | Ok diff ->
-                let renameMap =
-                    RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
+            let diff = CatalogDiff.between sourceContract sinkContract
+            let renameMap =
+                RenameProjection.renames diff |> RenameProjection.renameMap
+            return! runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
         }
 
     let runWithRenames
@@ -1729,170 +1726,167 @@ module Transfer =
         (journalDirectory: string option)
         : Task<Result<TransferReport>> =
         task {
-            match CatalogDiff.between sourceContract sinkContract with
-            | Error e ->
-                return Result.failureOf (ValidationError.create "transfer.renameDiffFailed" (sprintf "%A" e))
-            | Ok diff ->
-                let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
-                let cdcGate : Task<Result<unit>> =
+            let diff = CatalogDiff.between sourceContract sinkContract
+            let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
+            let cdcGate : Task<Result<unit>> =
+                task {
+                    if mode = Execute && not allowCdc then
+                        // NM-54 — unverifiable CDC state is UNSAFE: refuse on probe failure.
+                        match! ReadSide.cdcTrackedTables sink with
+                        | Error es -> return Result.failure es
+                        | Ok tracked ->
+                            if List.isEmpty tracked then return Ok ()
+                            else
+                                return
+                                    Result.failureOf
+                                        (ValidationError.create
+                                            "transfer.cdcTrackedSink"
+                                            (sprintf
+                                                "Sink has %d CDC-tracked table(s) (e.g. %s); refusing --execute. Pass --allow-cdc to override."
+                                                (List.length tracked)
+                                                (tracked |> List.truncate 3 |> String.concat ", ")))
+                    else return Ok ()
+                }
+            let spanningGate : Task<Result<unit>> =
+                task {
+                    if mode = Execute then return! spanningPreflight source sink sinkContract
+                    else return Ok ()
+                }
+            match! Preflight.all [ cdcGate; spanningGate ] with
+            | Error es -> return Result.failure es
+            | Ok () ->
+                let topo = (TopologicalOrderPass.runWith TreatAsCycle sinkContract).Value
+                let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+                // Reconcile the named kinds against the sink (read-only,
+                // safe in DryRun): ingest each reconciled kind's SOURCE
+                // rows (re-pointed to the sink's names — the only kinds
+                // materialized; the estate-scale bulk streams), and match
+                // them to the pre-existing SINK rows by the operator
+                // ruleset. The reverse leg's User population is small,
+                // so this is bounded; the FK-target bulk never materializes.
+                let! reconciledSourceRows =
                     task {
-                        if mode = Execute && not allowCdc then
-                            // NM-54 — unverifiable CDC state is UNSAFE: refuse on probe failure.
-                            match! ReadSide.cdcTrackedTables sink with
-                            | Error es -> return Result.failure es
-                            | Ok tracked ->
-                                if List.isEmpty tracked then return Ok ()
-                                else
-                                    return
-                                        Result.failureOf
-                                            (ValidationError.create
-                                                "transfer.cdcTrackedSink"
-                                                (sprintf
-                                                    "Sink has %d CDC-tracked table(s) (e.g. %s); refusing --execute. Pass --allow-cdc to override."
-                                                    (List.length tracked)
-                                                    (tracked |> List.truncate 3 |> String.concat ", ")))
-                        else return Ok ()
+                        let mutable acc : Map<SsKey, StaticRow list> = Map.empty
+                        for KeyValue (kind, _) in reconciliation do
+                            match Catalog.tryFindKind kind sourceContract with
+                            | Some ingestKind ->
+                                let! rows = AsyncStream.toList (Ingestion.streamKindRows source ingestKind)
+                                acc <- Map.add kind (RenameProjection.repointRows renameMap rows) acc
+                            | None -> ()
+                        return acc
                     }
-                let spanningGate : Task<Result<unit>> =
-                    task {
-                        if mode = Execute then return! spanningPreflight source sink sinkContract
-                        else return Ok ()
-                    }
-                match! Preflight.all [ cdcGate; spanningGate ] with
-                | Error es -> return Result.failure es
-                | Ok () ->
-                    let topo = (TopologicalOrderPass.runWith TreatAsCycle sinkContract).Value
-                    let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-                    // Reconcile the named kinds against the sink (read-only,
-                    // safe in DryRun): ingest each reconciled kind's SOURCE
-                    // rows (re-pointed to the sink's names — the only kinds
-                    // materialized; the estate-scale bulk streams), and match
-                    // them to the pre-existing SINK rows by the operator
-                    // ruleset. The reverse leg's User population is small,
-                    // so this is bounded; the FK-target bulk never materializes.
-                    let! reconciledSourceRows =
-                        task {
-                            let mutable acc : Map<SsKey, StaticRow list> = Map.empty
-                            for KeyValue (kind, _) in reconciliation do
-                                match Catalog.tryFindKind kind sourceContract with
-                                | Some ingestKind ->
-                                    let! rows = AsyncStream.toList (Ingestion.streamKindRows source ingestKind)
-                                    acc <- Map.add kind (RenameProjection.repointRows renameMap rows) acc
-                                | None -> ()
-                            return acc
-                        }
-                    let! reconciled = reconcileAgainstSink sink sinkContract reconciliation reconciledSourceRows
-                    // Structure only — order, dispositions, deferred columns;
-                    // the rows STREAM at write time (the whole point).
-                    // `reclassifyReconciled` marks the reconciled kinds skip-
-                    // insert so the stream never re-imports a sink-owned row.
-                    let plan =
-                        DataLoadPlan.build sinkContract topo Map.empty SurrogateRemapContext.empty
-                        |> DataLoadPlan.reclassifyReconciled reconciledKinds
-                    // Pre-write gates (Execute only), precedence-ordered:
-                    // structural unsatisfiability first, then the validate-
-                    // user-map orphan halt (AC-I5 / NM-31 — now ON streaming).
-                    let preWrite =
-                        if mode = Execute then
-                            match executeGate sinkContract plan with
-                            | Some refusal -> Some refusal
-                            | None         -> validateUserMap allowDrops reconciled
-                        else None
-                    match preWrite with
-                    | Some refusal -> return Result.failureOf refusal
-                    | None ->
-                        if mode <> Execute then
-                            // Phase 4 — the movement DryRun preview. Estimate
-                            // each kind's rows-would-move with a cheap exact
-                            // COUNT (no ingestion): a reconciled kind moves
-                            // nothing (ReconciledByRule — the sink owns it), so
-                            // it previews 0; every other kind previews its
-                            // source count. RowsWritten stays 0 (a preview), and
-                            // the reconcile outcome (Unmatched / Ambiguous) rides
-                            // the same report — the rekey-map preview.
-                            let! previewKinds =
-                                task {
-                                    let mutable acc : KindOutcome list = []
-                                    for l in plan.Loads do
-                                        let! estimate =
-                                            task {
-                                                if l.Disposition = IdentityDisposition.ReconciledByRule then return 0
-                                                else
-                                                    match Catalog.tryFindKind l.Kind sourceContract with
-                                                    | Some srcKind -> return! countKindRows source srcKind
-                                                    | None -> return 0
-                                            }
-                                        acc <-
-                                            { Kind              = l.Kind
-                                              Disposition       = l.Disposition
-                                              RowsIngested      = estimate
-                                              DeferredFkColumns = l.DeferredFkColumns
-                                              RowsWritten       = 0 } :: acc
-                                    return List.rev acc
-                                }
+                let! reconciled = reconcileAgainstSink sink sinkContract reconciliation reconciledSourceRows
+                // Structure only — order, dispositions, deferred columns;
+                // the rows STREAM at write time (the whole point).
+                // `reclassifyReconciled` marks the reconciled kinds skip-
+                // insert so the stream never re-imports a sink-owned row.
+                let plan =
+                    DataLoadPlan.build sinkContract topo Map.empty SurrogateRemapContext.empty
+                    |> DataLoadPlan.reclassifyReconciled reconciledKinds
+                // Pre-write gates (Execute only), precedence-ordered:
+                // structural unsatisfiability first, then the validate-
+                // user-map orphan halt (AC-I5 / NM-31 — now ON streaming).
+                let preWrite =
+                    if mode = Execute then
+                        match executeGate sinkContract plan with
+                        | Some refusal -> Some refusal
+                        | None         -> validateUserMap allowDrops reconciled
+                    else None
+                match preWrite with
+                | Some refusal -> return Result.failureOf refusal
+                | None ->
+                    if mode <> Execute then
+                        // Phase 4 — the movement DryRun preview. Estimate
+                        // each kind's rows-would-move with a cheap exact
+                        // COUNT (no ingestion): a reconciled kind moves
+                        // nothing (ReconciledByRule — the sink owns it), so
+                        // it previews 0; every other kind previews its
+                        // source count. RowsWritten stays 0 (a preview), and
+                        // the reconcile outcome (Unmatched / Ambiguous) rides
+                        // the same report — the rekey-map preview.
+                        let! previewKinds =
+                            task {
+                                let mutable acc : KindOutcome list = []
+                                for l in plan.Loads do
+                                    let! estimate =
+                                        task {
+                                            if l.Disposition = IdentityDisposition.ReconciledByRule then return 0
+                                            else
+                                                match Catalog.tryFindKind l.Kind sourceContract with
+                                                | Some srcKind -> return! countKindRows source srcKind
+                                                | None -> return 0
+                                        }
+                                    acc <-
+                                        { Kind              = l.Kind
+                                          Disposition       = l.Disposition
+                                          RowsIngested      = estimate
+                                          DeferredFkColumns = l.DeferredFkColumns
+                                          RowsWritten       = 0 } :: acc
+                                return List.rev acc
+                            }
+                        return
+                            Result.success
+                                { Mode                = mode
+                                  Kinds               = previewKinds
+                                  UnbreakableCycleFks = plan.UnbreakableCycleFks
+                                  UnmatchedIdentities = reconciled.Unmatched
+                                  AmbiguousIdentities = reconciled.Ambiguous
+                                  AmbiguousTargetMatchKeys = reconciled.AmbiguousTargetKeys
+                                  SkippedReferences   = plan.SkippedReferences
+                                  CaptureLaneDescents = []
+                                  // Streaming DryRun: no G10 resumable replay.
+                                  ReplayedPriorDrops  = None
+                                  // NM-21 — streaming Transfer ingests source rows, not σ.
+                                  SyntheticUnsatisfiableFks = [] }
+                    else
+                        let journal =
+                            journalDirectory
+                            |> Option.map (fun dir -> CaptureJournal.create dir (planMarker sinkContract plan))
+                        // Phase 3 — the address-drift guard: if THIS run's
+                        // journal file is absent but the directory holds a
+                        // prior run's journal under a different plan marker,
+                        // resuming would silently orphan it and DOUBLE
+                        // committed work. Refuse by name instead.
+                        let addressDrift =
+                            journal
+                            |> Option.map CaptureJournal.siblingJournalsUnderDrift
+                            |> Option.defaultValue []
+                        if not (List.isEmpty addressDrift) then
+                            return Result.failureOf
+                                (ValidationError.create "transfer.resume.journalAddressDrift"
+                                    (sprintf
+                                        "the journal directory holds %d journal(s) under a DIFFERENT plan marker (e.g. %s) but none for this run — the plan changed since the journaled run, so resuming would silently re-stream and DOUBLE committed work. Clear the journal directory to reload from scratch, or restore the prior plan to resume."
+                                        (List.length addressDrift)
+                                        (addressDrift |> List.truncate 1 |> List.map (fun f -> System.IO.Path.GetFileName f |> nonNull) |> String.concat ", ")))
+                        else
+                        match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds with
+                        | Error es -> return Result.failure es
+                        | Ok (totals, skips, descents) ->
+                            let kinds =
+                                plan.Loads
+                                |> List.map (fun l ->
+                                    let t = Map.tryFind l.Kind totals |> Option.defaultValue { Ingested = 0; Written = 0 }
+                                    { Kind              = l.Kind
+                                      Disposition       = l.Disposition
+                                      RowsIngested      = t.Ingested
+                                      DeferredFkColumns = l.DeferredFkColumns
+                                      RowsWritten       = t.Written })
                             return
                                 Result.success
                                     { Mode                = mode
-                                      Kinds               = previewKinds
+                                      Kinds               = kinds
                                       UnbreakableCycleFks = plan.UnbreakableCycleFks
                                       UnmatchedIdentities = reconciled.Unmatched
                                       AmbiguousIdentities = reconciled.Ambiguous
                                       AmbiguousTargetMatchKeys = reconciled.AmbiguousTargetKeys
-                                      SkippedReferences   = plan.SkippedReferences
-                                      CaptureLaneDescents = []
-                                      // Streaming DryRun: no G10 resumable replay.
+                                      SkippedReferences   = skips
+                                      CaptureLaneDescents = descents
+                                      // Streaming-journal resume is per-run by
+                                      // design (the journaled run reported its
+                                      // own drops); no G10 marker replay here.
                                       ReplayedPriorDrops  = None
                                       // NM-21 — streaming Transfer ingests source rows, not σ.
                                       SyntheticUnsatisfiableFks = [] }
-                        else
-                            let journal =
-                                journalDirectory
-                                |> Option.map (fun dir -> CaptureJournal.create dir (planMarker sinkContract plan))
-                            // Phase 3 — the address-drift guard: if THIS run's
-                            // journal file is absent but the directory holds a
-                            // prior run's journal under a different plan marker,
-                            // resuming would silently orphan it and DOUBLE
-                            // committed work. Refuse by name instead.
-                            let addressDrift =
-                                journal
-                                |> Option.map CaptureJournal.siblingJournalsUnderDrift
-                                |> Option.defaultValue []
-                            if not (List.isEmpty addressDrift) then
-                                return Result.failureOf
-                                    (ValidationError.create "transfer.resume.journalAddressDrift"
-                                        (sprintf
-                                            "the journal directory holds %d journal(s) under a DIFFERENT plan marker (e.g. %s) but none for this run — the plan changed since the journaled run, so resuming would silently re-stream and DOUBLE committed work. Clear the journal directory to reload from scratch, or restore the prior plan to resume."
-                                            (List.length addressDrift)
-                                            (addressDrift |> List.truncate 1 |> List.map (fun f -> System.IO.Path.GetFileName f |> nonNull) |> String.concat ", ")))
-                            else
-                            match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds with
-                            | Error es -> return Result.failure es
-                            | Ok (totals, skips, descents) ->
-                                let kinds =
-                                    plan.Loads
-                                    |> List.map (fun l ->
-                                        let t = Map.tryFind l.Kind totals |> Option.defaultValue { Ingested = 0; Written = 0 }
-                                        { Kind              = l.Kind
-                                          Disposition       = l.Disposition
-                                          RowsIngested      = t.Ingested
-                                          DeferredFkColumns = l.DeferredFkColumns
-                                          RowsWritten       = t.Written })
-                                return
-                                    Result.success
-                                        { Mode                = mode
-                                          Kinds               = kinds
-                                          UnbreakableCycleFks = plan.UnbreakableCycleFks
-                                          UnmatchedIdentities = reconciled.Unmatched
-                                          AmbiguousIdentities = reconciled.Ambiguous
-                                          AmbiguousTargetMatchKeys = reconciled.AmbiguousTargetKeys
-                                          SkippedReferences   = skips
-                                          CaptureLaneDescents = descents
-                                          // Streaming-journal resume is per-run by
-                                          // design (the journaled run reported its
-                                          // own drops); no G10 marker replay here.
-                                          ReplayedPriorDrops  = None
-                                          // NM-21 — streaming Transfer ingests source rows, not σ.
-                                          SyntheticUnsatisfiableFks = [] }
         }
 
     /// The straight-load streaming realization — the non-reconciling default
@@ -1991,13 +1985,10 @@ module Transfer =
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
         task {
-            match CatalogDiff.between sourceContract sinkContract with
-            | Error e ->
-                return Result.failureOf (ValidationError.create "transfer.renameDiffFailed" (sprintf "%A" e))
-            | Ok diff ->
-                let renameMap =
-                    RenameProjection.renames diff |> RenameProjection.renameMap
-                return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
+            let diff = CatalogDiff.between sourceContract sinkContract
+            let renameMap =
+                RenameProjection.renames diff |> RenameProjection.renameMap
+            return! runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
         }
 
     let runReconcilingWithRenames
@@ -2138,24 +2129,21 @@ module Transfer =
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
         task {
-            match CatalogDiff.between logicalSourceContract physicalSinkContract with
-            | Error e ->
-                return Result.failureOf (ValidationError.create "transfer.renameDiffFailed" (sprintf "%A" e))
-            | Ok diff ->
-                let renameMap =
-                    RenameProjection.renames diff |> RenameProjection.renameMap
-                match resolveLoadSet logicalSourceContract tables with
+            let diff = CatalogDiff.between logicalSourceContract physicalSinkContract
+            let renameMap =
+                RenameProjection.renames diff |> RenameProjection.renameMap
+            match resolveLoadSet logicalSourceContract tables with
+            | Error es -> return Result.failure es
+            | Ok loadSet ->
+                match! ConnectionResolver.openSubstrate connections.Source with
                 | Error es -> return Result.failure es
-                | Ok loadSet ->
-                    match! ConnectionResolver.openSubstrate connections.Source with
+                | Ok source ->
+                    use source = source
+                    match! ConnectionResolver.openSubstrate connections.Sink with
                     | Error es -> return Result.failure es
-                    | Ok source ->
-                        use source = source
-                        match! ConnectionResolver.openSubstrate connections.Sink with
-                        | Error es -> return Result.failure es
-                        | Ok sink ->
-                            use sink = sink
-                            return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy }
+                    | Ok sink ->
+                        use sink = sink
+                        return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy }
         }
 
     /// The structural-policy reverse leg (byte-identical; the ManagedDml cloud

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -577,13 +577,35 @@ module Transfer =
                 |> List.ofSeq
         }
 
+    /// The CAPABILITY recognizer for the FK re-trust — the ALTER cannot run
+    /// because the sink login holds no ALTER on the object (a `ManagedDml` /
+    /// `grant: data` cloud sink, granted only SELECT/INSERT/UPDATE/DELETE).
+    /// 1088 / 4902 ("cannot find the object … because it does not exist or you do
+    /// not have permissions" — the ALTER-TABLE permission/visibility form) and
+    /// 229 (ALTER permission denied) DESCEND to the named
+    /// `FkTrustNotRestoredOnBulkLoad` tolerance. Everything else — notably a
+    /// constraint conflict (547) — PROPAGATES: a re-validation that fails on the
+    /// DATA is the loud fidelity signal, never masked (mirrors
+    /// `SurrogateCapture.isCapabilityRefusal`).
+    let private isAlterCapabilityRefusal (ex: SqlException) : bool =
+        ex.Number = 1088 || ex.Number = 4902 || ex.Number = 229
+
     /// Restore the trust the bulk load stripped — re-validate each FK in the
     /// pre-load snapshot (`wasTrusted`) with `ALTER TABLE … WITH CHECK CHECK
     /// CONSTRAINT` (one child×parent-PK semi-join per FK). After a faithful
-    /// transfer the data satisfies each FK so it succeeds; a FAILURE is a LOUD
-    /// signal the load was not faithful — a post-load integrity assertion, never
-    /// silent corruption. The gate is `WriteOptions.RetrustForeignKeys` (default
-    /// on); the opt-out is the named `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`.
+    /// transfer the data satisfies each FK so it succeeds; a CONSTRAINT failure
+    /// is a LOUD signal the load was not faithful — a post-load integrity
+    /// assertion, never silent corruption.
+    ///
+    /// A sink that cannot ALTER at all — the `ManagedDml` cloud archetype
+    /// (`grant: data`; no ALTER anywhere in the write path) — DESCENDS the
+    /// capability ladder: the re-trust is skipped, the FKs stay as the bulk load
+    /// left them (untrusted), and the disposition is surfaced via the
+    /// `retrust-skipped` stage — the named `ToleratedDivergence.FkTrustNotRestoredOnBulkLoad`,
+    /// never silent. (Re-trust is a `FullRights` capability; on a DML-only login
+    /// the ALTER is not available, exactly as the J5 archetype model records.)
+    /// The gate is `WriteOptions.RetrustForeignKeys` (default on); the explicit
+    /// opt-out is the same named tolerance.
     let private restoreFkTrust (sink: SqlConnection) (wasTrusted: (string * string * string) list) : Task<unit> =
         task {
             if List.isEmpty wasTrusted then return () else
@@ -595,8 +617,15 @@ module Transfer =
                     System.String.Concat(
                         "ALTER TABLE ", Render.quote sch, ".", Render.quote tbl,
                         " WITH CHECK CHECK CONSTRAINT ", Render.quote fk, ";"))
-            do! Deploy.executeBatch sink (String.concat "\n" stmts)
-            LogSink.recordStageProgress "retrust" (List.length wasTrusted) (List.length wasTrusted) 0L
+            try
+                do! Deploy.executeBatch sink (String.concat "\n" stmts)
+                LogSink.recordStageProgress "retrust" (List.length wasTrusted) (List.length wasTrusted) 0L
+            with :? SqlException as ex when isAlterCapabilityRefusal ex ->
+                // Capability descent — the sink login cannot ALTER (a ManagedDml /
+                // data-grant cloud sink). No ALTER ⇒ no re-validation: descend to
+                // the named FkTrustNotRestoredOnBulkLoad tolerance, surfaced via
+                // the retrust-skipped stage, never silent.
+                LogSink.recordStageProgress "retrust-skipped" 0 (List.length wasTrusted) 0L
         }
 
     /// The durable phase-marker table — records which transfers completed, so a

--- a/sidecar/projection/src/Projection.Pipeline/TransformGroupsBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransformGroupsBinding.fs
@@ -172,9 +172,8 @@ module TransformGroupsBinding =
         : Result<TransformGroups> =
         cfg.Policy.TransformGroups
         |> List.map (fun entry ->
-            match parseGroupName entry.Name with
-            | Error es -> Error es
-            | Ok group -> Result.success (group, entry.Enabled))
+            parseGroupName entry.Name
+            |> Result.map (fun group -> (group, entry.Enabled)))
         |> Result.aggregate
         |> Result.map (fun pairs ->
             // Wave-3 (uat-users collapse, 2026-05-30) — `UserReflow` is

--- a/sidecar/projection/src/Projection.Targets.Distributions/DistributionsEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Distributions/DistributionsEmitter.fs
@@ -1,6 +1,5 @@
 namespace Projection.Targets.Distributions
 
-open System.IO
 open System.Text.Json
 open System.Text.Json.Nodes
 open Projection.Core
@@ -202,15 +201,7 @@ module DistributionsEmitter =
     /// stream-position mutation is needed (the byte-buffer is
     /// passed directly via the span overload).
     let private kindJsonNode (profile: Profile) (k: Kind) : JsonNode =
-        use stream = new MemoryStream()
-        do
-            use writer = new Utf8JsonWriter(stream, (JsonOptions.compact ()))
-            writeKind writer profile k
-            writer.Flush()
-        let bytes = stream.ToArray()
-        match JsonNode.Parse(System.ReadOnlySpan<byte>(bytes)) with
-        | null  -> invalidOp "DistributionsEmitter.kindJsonNode: writer produced empty stream (unreachable; writeKind always emits an object)"
-        | node  -> node
+        JsonWriting.writeToNode (fun writer -> writeKind writer profile k)
 
     /// Π port realization (chapter 3.5 slice γ; chapter-3.7 slice ε
     /// pillar-1 cash-out). Profile-consuming Π; per
@@ -282,9 +273,7 @@ module DistributionsEmitter =
                     err)
         | Ok artifact ->
             let slices = ArtifactByKind.toMap artifact
-            use stream = new MemoryStream()
-            do
-                use w = new Utf8JsonWriter(stream, (JsonOptions.indented ()))
+            JsonWriting.writeToString (fun w ->
                 w.WriteStartObject()
                 w.WriteString("emitter", emitterName)
                 w.WriteNumber("version", version)
@@ -314,9 +303,7 @@ module DistributionsEmitter =
                     w.WriteEndArray()
                     w.WriteEndObject()
                 w.WriteEndArray()
-                w.WriteEndObject()
-                w.Flush()
-            System.Text.Encoding.UTF8.GetString(stream.ToArray())
+                w.WriteEndObject())
 
     /// The "wide" alias mentioned in the codification refinement: an
     /// emitter that consumes the enriched IR. Provided for symmetry

--- a/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
@@ -1,7 +1,6 @@
 namespace Projection.Targets.Json
 
 open System.Globalization
-open System.Text
 open System.Text.Json
 open Projection.Core
 open FsToolkit.ErrorHandling
@@ -404,11 +403,7 @@ module CatalogCodec =
     /// Serialize a `Catalog` to deterministic JSON text. Pure (no I/O).
     let serialize (catalog: Catalog) : string =
         use _ = Bench.scope "codec.catalog.serialize"
-        use stream = new System.IO.MemoryStream()
-        (use jw = new Utf8JsonWriter(stream, JsonOptions.indented ())
-         wCatalog jw catalog
-         jw.Flush())
-        Encoding.UTF8.GetString(stream.ToArray())
+        JsonWriting.writeToString (fun jw -> wCatalog jw catalog)
 
     // ======================================================================
     // DECODE — each `readX : JsonElement -> Result<X>` reads one JSON value.

--- a/sidecar/projection/src/Projection.Targets.Json/JsonEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/JsonEmitter.fs
@@ -1,7 +1,5 @@
 namespace Projection.Targets.Json
 
-open System.IO
-open System.Text
 open System.Text.Json
 open System.Text.Json.Nodes
 open Projection.Core
@@ -157,15 +155,7 @@ module JsonEmitter =
     /// stream-position mutation is needed (the byte-buffer is
     /// passed directly via the span overload).
     let private kindJsonNode (k: Kind) : JsonNode =
-        use stream = new MemoryStream()
-        do
-            use writer = new Utf8JsonWriter(stream, (JsonOptions.compact ()))
-            writeKind writer k
-            writer.Flush()
-        let bytes = stream.ToArray()
-        match JsonNode.Parse(System.ReadOnlySpan<byte>(bytes)) with
-        | null  -> invalidOp "JsonEmitter.kindJsonNode: writer produced empty stream (unreachable; writeKind always emits an object)"
-        | node  -> node
+        JsonWriting.writeToNode (fun writer -> writeKind writer k)
 
     /// Π port realization (chapter 3.5 slice β; chapter-3.7 slice ε
     /// pillar-1 cash-out). Per A18, `Catalog` only — no Profile, no
@@ -241,12 +231,7 @@ module JsonEmitter =
                     "JsonEmitter.emit: ArtifactByKind invariant breach: %A"
                     err)
         | Ok node ->
-            use stream = new MemoryStream()
-            do
-                use writer = new Utf8JsonWriter(stream, (JsonOptions.indented ()))
-                node.WriteTo(writer)
-                writer.Flush()
-            Encoding.UTF8.GetString(stream.ToArray())
+            JsonWriting.renderNodeToString node
 
     // -----------------------------------------------------------------------
     // Slice 5.13.sibling-emitter-registry-json — `registeredMetadata`

--- a/sidecar/projection/src/Projection.Targets.Json/ProfileCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/ProfileCodec.fs
@@ -1,7 +1,6 @@
 namespace Projection.Targets.Json
 
 open System.Globalization
-open System.Text
 open System.Text.Json
 open Projection.Core
 
@@ -237,11 +236,7 @@ module ProfileCodec =
 
     /// `Profile → JSON`. Deterministic (T1).
     let serialize (profile: Profile) : string =
-        use stream = new System.IO.MemoryStream()
-        (use jw = new Utf8JsonWriter(stream, JsonOptions.indented ())
-         wProfile jw profile
-         jw.Flush())
-        Encoding.UTF8.GetString(stream.ToArray())
+        JsonWriting.writeToString (fun jw -> wProfile jw profile)
 
     // ======================================================================
     // DECODE — leaves rebuilt through smart constructors (A39).

--- a/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/DecisionLogEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/DecisionLogEmitter.fs
@@ -1,6 +1,5 @@
 namespace Projection.Targets.OperationalDiagnostics
 
-open System.IO
 open System.Text.Json
 open System.Text.Json.Nodes
 open Projection.Core
@@ -91,15 +90,7 @@ module internal DiagnosticDocument =
     /// the Π port; strings emerge only at the terminal writer
     /// step.
     let kindJsonNode (kind: Kind) (entries: DiagnosticEntry list) : JsonNode =
-        use stream = new MemoryStream()
-        do
-            use writer = new Utf8JsonWriter(stream, (JsonOptions.compact ()))
-            writeKindDocument writer kind entries
-            writer.Flush()
-        let bytes = stream.ToArray()
-        match JsonNode.Parse(System.ReadOnlySpan<byte>(bytes)) with
-        | null -> invalidOp "DiagnosticDocument.kindJsonNode: writer produced empty stream (unreachable; writeKindDocument always emits an object)"
-        | node -> node
+        JsonWriting.writeToNode (fun writer -> writeKindDocument writer kind entries)
 
     /// Partition entries by their `SsKey` field. Entries with `SsKey =
     /// Some k` group into the per-kind map; entries with `SsKey = None`

--- a/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/SuggestConfigEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/SuggestConfigEmitter.fs
@@ -1,6 +1,5 @@
 namespace Projection.Targets.OperationalDiagnostics
 
-open System.IO
 open System.Text.Json
 open System.Text.Json.Nodes
 open Projection.Core
@@ -129,21 +128,14 @@ module SuggestConfigEmitter =
         let suggestions =
             if ApprovalRegistry.isSuppressed policyDigest approvals then []
             else collect diagnostics
-        use stream = new MemoryStream()
-        do
-            use writer = new Utf8JsonWriter(stream, JsonOptions.compact ())
+        JsonWriting.writeToNode (fun writer ->
             writer.WriteStartObject()
             writer.WritePropertyName("suggestedEdits")
             writer.WriteStartArray()
             for s in suggestions do
                 writeSuggestion writer s
             writer.WriteEndArray()
-            writer.WriteEndObject()
-            writer.Flush()
-        let bytes = stream.ToArray()
-        match JsonNode.Parse(System.ReadOnlySpan<byte>(bytes)) with
-        | null -> invalidOp "SuggestConfigEmitter.emit: produced unparseable JSON (unreachable)"
-        | n    -> n
+            writer.WriteEndObject())
 
     /// The `empty`-registry default: no approval gating (byte-identical to the
     /// pre-Wave-3 output). See `emitWith`.

--- a/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
@@ -243,7 +243,7 @@ module RefactorLogEmitter =
     /// emitter just projects the diff. Disjoint from `SchemaMigrationEmitter`
     /// (shape changes → ALTER) by *operation*, not by attribute: rename
     /// (logical `Name`) and reshape (shape facets) are independent axes
-    /// (`AttributeDiff.Renamed` vs `.Changed`), so one column may be both.
+    /// (`AttributeDiff.Renamed` vs `.Reshaped`), so one column may be both.
     /// The two channels still never double-emit the *same operation* — this
     /// emits the sp_rename; `SchemaMigrationEmitter` emits the ALTER COLUMN
     /// against the target attribute. (Tested: RefactorLogEmitterTests

--- a/sidecar/projection/src/Projection.Targets.SSDT/SchemaMigrationEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SchemaMigrationEmitter.fs
@@ -133,7 +133,7 @@ module SchemaMigrationEmitter =
                     else None)
             // ALTER COLUMN (shape) or refusal. Source-ordered `Changed`.
             let alterResults =
-                ad.Changed
+                ad.Reshaped
                 |> List.map (fun change ->
                     let nonShape = Set.difference change.Facets shapeFacets
                     if not (Set.isEmpty nonShape) then
@@ -248,7 +248,7 @@ module SchemaMigrationEmitter =
             // Changed: Trust-only → reproduce WITH NOCHECK; other shape changes →
             // DROP + ADD CONSTRAINT under --allow-drops, else refuse.
             let changeStmts, changeRefusals =
-                rd.Changed
+                rd.Reshaped
                 |> List.fold
                     (fun (stmts, refusals) (change: ReferenceChange) ->
                         match Map.tryFind change.ReferenceKey refByKey with
@@ -318,7 +318,7 @@ module SchemaMigrationEmitter =
             let changeStmts, changeRefusals =
                 if allowDrops then
                     let stmts =
-                        idd.Changed
+                        idd.Reshaped
                         |> List.collect (fun (c: IndexChange) ->
                             match sourceIndexName c.IndexKey, targetKind.Indexes |> List.tryFind (fun i -> i.SsKey = c.IndexKey) with
                             | Some oldName, Some newIdx ->
@@ -327,7 +327,7 @@ module SchemaMigrationEmitter =
                     stmts, []
                 else
                     [],
-                    (idd.Changed
+                    (idd.Reshaped
                      |> List.map (fun (c: IndexChange) ->
                         diag DiagnosticSeverity.Error "migration.unsupportedIndexChange"
                             "Index change needs DROP+CREATE INDEX; refused — pass --allow-drops to emit it." c.IndexKey targetKind))
@@ -370,7 +370,7 @@ module SchemaMigrationEmitter =
         let changeStmts, changeRefusals =
             if allowDrops then
                 let stmts =
-                    sd.Changed
+                    sd.Reshaped
                     |> List.collect (fun (c: SequenceChange) ->
                         match sourceSeq c.SequenceKey, targetCatalog.Sequences |> List.tryFind (fun s -> s.SsKey = c.SequenceKey) with
                         | Some oldSeq, Some newSeq -> [ dropOf oldSeq; Statement.CreateSequence newSeq ]
@@ -378,7 +378,7 @@ module SchemaMigrationEmitter =
                 stmts, []
             else
                 [],
-                (sd.Changed
+                (sd.Reshaped
                  |> List.map (fun (c: SequenceChange) ->
                     seqDiag "migration.unsupportedSequenceChange"
                         "Sequence change needs DROP+CREATE (or ALTER SEQUENCE); refused — pass --allow-drops to emit it." c.SequenceKey))

--- a/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
@@ -352,7 +352,7 @@ type Statement =
     | AlterTableAddColumn of table: TableId * column: ColumnDef
     /// 6.A.12 — `ALTER TABLE <table> ALTER COLUMN <column> <type> NULL|NOT NULL`.
     /// The minimum-viable-touch for a changed column SHAPE
-    /// (`CatalogDiff.AttributeDiffs[k].Changed` over DataType / Length /
+    /// (`CatalogDiff.AttributeDiffs[k].Reshaped` over DataType / Length /
     /// Precision / Scale / Nullability). ScriptDom builds via
     /// `AlterTableAlterColumnStatement` with `AlterTableAlterColumnOption
     /// .Null | .NotNull` carrying nullability. NOT a rename (renames are

--- a/sidecar/projection/tests/Projection.Tests/AdjunctionLawTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/AdjunctionLawTests.fs
@@ -95,14 +95,14 @@ let ``H-050 emitter determinism (property): permuting modules produces the same 
 
 [<Fact>]
 let ``H-050 CatalogDiff reflexivity: between c c puts every key in Unchanged`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     Assert.Equal<Set<SsKey>>(allKindKeys sampleCatalog, CatalogDiff.unchanged diff)
     Assert.True(CatalogDiff.isEmpty diff)
 
 [<Property>]
 let ``H-050 CatalogDiff reflexivity (property): permuted module ordering still diffs to fully-Unchanged`` (seed: int) =
     let permuted = shuffleModules seed sampleCatalog
-    let diff = CatalogDiff.between sampleCatalog permuted |> mustOk
+    let diff = CatalogDiff.between sampleCatalog permuted
     let allKeys = allKindKeys sampleCatalog
     CatalogDiff.unchanged diff = allKeys
     && CatalogDiff.added diff = Set.empty

--- a/sidecar/projection/tests/Projection.Tests/AxiomTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/AxiomTests.fs
@@ -974,6 +974,17 @@ let ``T13: evolution over time is composition — replay = fold ⊕ along the ti
     citationOf
         "tests/Projection.Tests/CatalogDiffTests.fs"
         "compose: applyDiff (compose d1 d2) A = applyDiff d2 (applyDiff d1 A) (functor law)"
+    // M12 (THE VECTOR Wave 2) — the groupoid INVERSE completes the partial
+    // groupoid: `inverse d = between (target d) (source d)` is the rollback arrow
+    // (`applyDiff (inverse d) (target d) = source d`), and `compose d (inverse d)`
+    // is the identity at source — so every arrow is invertible on its
+    // composability class.
+    citationOf
+        "tests/Projection.Tests/CatalogDiffTests.fs"
+        "M12 (groupoid inverse): applyDiff (inverse d) (target d) reproduces source — the rollback witness"
+    citationOf
+        "tests/Projection.Tests/CatalogDiffTests.fs"
+        "M12 (groupoid law): compose d (inverse d) = identity at source"
     citationOf
         "tests/Projection.Tests/LifecycleTests.fs"
         "6.H.3: netDiff equals fold compose over the evolution chain (3 snapshots)"
@@ -1038,6 +1049,16 @@ let ``T15: CDC is the norm — emit is an isometry; ‖δ‖=0 ⟹ zero capture 
     citationOf
         "tests/Projection.Tests/CdcSilenceTests.fs"
         "Slice γ sensitivity: changed-content redeploy DOES fire CDC capture rows — proves the canary mechanism is real (not silent for unrelated reasons)"
+    // M11 (THE VECTOR Wave 2) — the norm is a genuine METRIC: the triangle
+    // inequality ‖compose d1 d2‖ ≤ ‖d1‖ + ‖d2‖ (subadditivity over composition,
+    // churn cancels) makes "minimality is measured" (the CDC-norm) rest on a real
+    // metric, not merely a non-negative count.
+    citationOf
+        "tests/Projection.Tests/CatalogDiffTests.fs"
+        "M11 (triangle inequality): ‖compose d1 d2‖ ≤ ‖d1‖ + ‖d2‖ — norm is a metric"
+    citationOf
+        "tests/Projection.Tests/CatalogDiffTests.fs"
+        "M11 (triangle inequality, swept): ‖between A C‖ ≤ ‖between A B‖ + ‖between B C‖ over adjacent triples"
 
 // T16 — PROMOTED to Bucket A (6.D.1, 2026-06-01): the one-command `migrate A B`
 // composition exists and round-trips. `Migration.applyTo (plan A B) A ≡ B` is

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
@@ -3,6 +3,7 @@ module Projection.Tests.CapabilitySurveyTotalityTests
 open Xunit
 open Projection.Core
 open Projection.Pipeline
+open Projection.Tests.TotalityFunctor
 open type Projection.Pipeline.CapabilitySurvey.Capability
 
 /// THE CAPABILITY SURVEY — the `required ⇔ surveyed` totality test (S2;
@@ -54,33 +55,30 @@ let private requiredCapabilities (cfg: ProjectionConfig) : Set<CapabilitySurvey.
 let private surveyedCapabilities : Set<CapabilitySurvey.Capability> = Set.ofList CapabilitySurvey.Capability.all
 
 // ---------------------------------------------------------------------------
-// required ⇔ surveyed
+// required ⇔ surveyed — the `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y` core via the totality
+// functor: every required capability is probeable, no probe is dead, and the
+// permission projection over the closed `Capability` DU is injective.
 // ---------------------------------------------------------------------------
 
-[<Fact>]
-let ``CapabilitySurvey.Capability totality: every required capability is one the survey knows to probe (required ⊆ surveyed)`` () =
-    let unprobeable = Set.difference (requiredCapabilities representativeConfig) surveyedCapabilities
-    Assert.True(
-        Set.isEmpty unprobeable,
-        sprintf "flows require capabilities the survey cannot probe: %A" (Set.toList unprobeable))
+let private requiredSurveyedSpec : TotalitySpec<CapabilitySurvey.Capability, CapabilitySurvey.Capability, string> =
+    { Left = requiredCapabilities representativeConfig
+      Right = surveyedCapabilities
+      LeftLabel = "required capability"
+      RightLabel = "surveyed capability"
+      Members = CapabilitySurvey.Capability.all
+      Project = CapabilitySurvey.Capability.permissionOf }
 
 [<Fact>]
-let ``CapabilitySurvey.Capability totality: every surveyed capability is reachable as a real flow requirement (surveyed ⊆ required)`` () =
-    // No dead probe — every capability the catalog can probe is exercised by some
-    // realizable flow shape. The representative config reaches all five.
-    let dead = Set.difference surveyedCapabilities (requiredCapabilities representativeConfig)
-    Assert.True(
-        Set.isEmpty dead,
-        sprintf "the survey probes capabilities no flow requires (dead probes): %A" (Set.toList dead))
-
-[<Fact>]
-let ``CapabilitySurvey.Capability totality: the catalog is exactly the required surface for the representative estate`` () =
-    Assert.Equal<Set<CapabilitySurvey.Capability>>(surveyedCapabilities, requiredCapabilities representativeConfig)
+let ``CapabilitySurvey.Capability totality: required ⇔ surveyed is bidirectional (every required capability is probeable, no probe is dead, the catalog is exactly the required surface)`` () =
+    // `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`: the harvested requirement surface and the survey
+    // catalog coincide exactly — every required capability is one the survey knows
+    // to probe, every surveyed capability is reachable as a real flow requirement
+    // (no dead probe), so the catalog is exactly the required surface.
+    assertBidirectionalSubset requiredSurveyedSpec
 
 [<Fact>]
 let ``CapabilitySurvey.Capability totality: permission names are distinct (no two capabilities collide on one probe)`` () =
-    let names = CapabilitySurvey.Capability.all |> List.map CapabilitySurvey.Capability.permissionOf
-    Assert.Equal<string list>(List.distinct names, names)
+    assertProjectionDistinct requiredSurveyedSpec
 
 [<Fact>]
 let ``CapabilitySurvey.Capability totality: the probe is total — every capability resolves to a non-empty permission name`` () =

--- a/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
@@ -43,7 +43,7 @@ let private kindKeys (c: Catalog) : Set<SsKey> =
 [<Fact>]
 let ``CatalogDiff.between (a, a) — every key in Unchanged`` () =
     let a = sampleCatalog
-    let diff = CatalogDiff.between a a |> mustOk
+    let diff = CatalogDiff.between a a
     Assert.Equal<Set<SsKey>>(kindKeys a, CatalogDiff.unchanged diff)
     Assert.Empty(CatalogDiff.added diff)
     Assert.Empty(CatalogDiff.removed diff)
@@ -54,7 +54,7 @@ let ``CatalogDiff.between (a, a) — every key in Unchanged`` () =
 let ``CatalogDiff.between empty source vs target — every target key in Added`` () =
     let target = sampleCatalog
     let empty = Catalog.create [] [] |> Result.value
-    let diff = CatalogDiff.between empty target |> mustOk
+    let diff = CatalogDiff.between empty target
     Assert.Equal<Set<SsKey>>(kindKeys target, CatalogDiff.added diff)
     Assert.Empty(CatalogDiff.removed diff)
     Assert.Empty(CatalogDiff.unchanged diff)
@@ -65,7 +65,7 @@ let ``CatalogDiff.between empty source vs target — every target key in Added``
 let ``CatalogDiff.between source vs empty target — every source key in Removed`` () =
     let source = sampleCatalog
     let empty = Catalog.create [] [] |> Result.value
-    let diff = CatalogDiff.between source empty |> mustOk
+    let diff = CatalogDiff.between source empty
     Assert.Equal<Set<SsKey>>(kindKeys source, CatalogDiff.removed diff)
     Assert.Empty(CatalogDiff.added diff)
     Assert.Empty(CatalogDiff.unchanged diff)
@@ -81,7 +81,7 @@ let ``CatalogDiff.between source vs empty target — every source key in Removed
 let ``CatalogDiff exhaustiveness: scope equals disjoint union of partitions`` () =
     let a = sampleCatalog
     let b = sampleCatalog  // same catalog; partitions land in Unchanged
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     let expected =
         let aKeys = kindKeys a
         let bKeys = kindKeys b
@@ -90,7 +90,7 @@ let ``CatalogDiff exhaustiveness: scope equals disjoint union of partitions`` ()
 
 [<Fact>]
 let ``CatalogDiff partitions are pairwise disjoint`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let renamedKeys =
         CatalogDiff.renamed diff |> Map.toSeq |> Seq.map fst |> Set.ofSeq
     let added = CatalogDiff.added diff
@@ -112,7 +112,7 @@ let ``T1: CatalogDiff.between is deterministic across repeat invocations`` () =
     let a = sampleCatalog
     let b = sampleCatalog
     let runs =
-        [ for _ in 1 .. 10 -> CatalogDiff.between a b |> mustOk ]
+        [ for _ in 1 .. 10 -> CatalogDiff.between a b ]
     let head = List.head runs
     let headPartitions =
         (CatalogDiff.renamed head, CatalogDiff.added head,
@@ -139,7 +139,7 @@ let ``CatalogDiff is invariant under module-list permutation``
     let permuted =
         Catalog.create (original.Modules |> List.rev) original.Sequences
         |> Result.value
-    let diff = CatalogDiff.between original permuted |> mustOk
+    let diff = CatalogDiff.between original permuted
     // Permuting modules preserves the kind-set; every SsKey is in
     // Unchanged. (`modules` is unused — the Property attribute drives
     // FsCheck's input generation but the property under test fixes
@@ -176,7 +176,7 @@ let ``CatalogDiff: a column type change surfaces as an attribute-level Changed e
     // Customer.Name: Text -> Integer (a DataType facet change). The kind
     // name is unchanged, so kind-level diffing alone reports nothing.
     let target = catalogWithCustomerName (fun a -> { a with Type = Integer })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
 
     // Kind-level contract preserved: Customer stays in Unchanged.
     Assert.Contains(customerKey, CatalogDiff.unchanged diff)
@@ -210,7 +210,7 @@ let private catalogWithCustomerKind (f: Kind -> Kind) : Catalog =
 [<Fact>]
 let ``NM-17: a kind IsActive flip surfaces a KindFacet change (kind stays Unchanged; isEmpty honest)`` () =
     let target = catalogWithCustomerKind (fun k -> { k with IsActive = not k.IsActive })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     // Kind-level partition preserved: name stable → Unchanged.
     Assert.Contains(customerKey, CatalogDiff.unchanged diff)
     // The kind-facet change is visible and isEmpty is honest (NM-16 erasure closed).
@@ -224,7 +224,7 @@ let ``NM-17: a kind IsActive flip surfaces a KindFacet change (kind stays Unchan
 [<Fact>]
 let ``NM-17: a kind Modality change surfaces the Modality facet`` () =
     let target = catalogWithCustomerKind (fun k -> { k with Modality = [ ModalityMark.SystemOwned ] })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     match CatalogDiff.kindFacetDiffOf customerKey diff with
     | None -> Assert.Fail "expected a KindFacet diff for Customer"
     | Some facets -> Assert.Contains(KindFacet.Modality, facets)
@@ -233,17 +233,17 @@ let ``NM-17: a kind Modality change surfaces the Modality facet`` () =
 let ``NM-17: applyDiff round-trips a kind-facet change (between B (applyDiff (between A B) A) is empty)`` () =
     let a = sampleCatalog
     let b = catalogWithCustomerKind (fun k -> { k with IsActive = not k.IsActive; Modality = [ ModalityMark.SystemOwned ] })
-    let d = CatalogDiff.between a b |> mustOk
+    let d = CatalogDiff.between a b
     let reconstructed = CatalogDiff.applyDiff a d
     // The round-trip law holds on the kind-facet channel (the NM-17 fixture).
-    Assert.True(CatalogDiff.between b reconstructed |> mustOk |> CatalogDiff.isEmpty)
+    Assert.True(CatalogDiff.between b reconstructed |> CatalogDiff.isEmpty)
 
 [<Fact>]
 let ``CatalogDiff: a column widening (length change) names the Length facet (TEXT -> NVARCHAR(256))`` () =
     // The audit's headline scenario: type category stable, declared length
     // changes. Length None -> Some 256 is the IR shape of TEXT -> NVARCHAR(256).
     let target = catalogWithCustomerName (fun a -> { a with Length = Some 256 })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
     let change = List.head ad.Changed
     Assert.Contains(AttributeFacet.Length, change.Facets)
@@ -254,7 +254,7 @@ let ``CatalogDiff: a nullability change names the Nullability facet`` () =
     let target =
         catalogWithCustomerName (fun a ->
             { a with Column = { a.Column with IsNullable = true } })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
     Assert.Contains(AttributeFacet.Nullability, (List.head ad.Changed).Facets)
 
@@ -268,21 +268,21 @@ let ``CatalogDiff: a dropped attribute surfaces in AttributeDiff.Removed`` () =
                     customer.Attributes |> List.filter (fun a -> a.SsKey <> customerTenantKey) }
         let m = { salesModule with Kinds = [ customer'; order; country ] }
         Catalog.create [ m ] [] |> Result.value
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
     Assert.Contains(customerTenantKey, ad.Removed)
     Assert.False(CatalogDiff.isEmpty diff)
 
 [<Fact>]
 let ``CatalogDiff: identical catalogs carry no AttributeDiffs (empty diff is honest)`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     Assert.True(Map.isEmpty (CatalogDiff.attributeDiffs diff))
     Assert.True(CatalogDiff.isEmpty diff)
 
 [<Fact>]
 let ``T1: attribute-level diff is deterministic across repeat invocations`` () =
     let target = catalogWithCustomerName (fun a -> { a with Type = Integer; Length = Some 64 })
-    let runs = [ for _ in 1 .. 10 -> CatalogDiff.attributeDiffs (CatalogDiff.between sampleCatalog target |> mustOk) ]
+    let runs = [ for _ in 1 .. 10 -> CatalogDiff.attributeDiffs (CatalogDiff.between sampleCatalog target) ]
     let head = List.head runs
     Assert.All(runs, fun r -> Assert.Equal<Map<SsKey, AttributeDiff>>(head, r))
 
@@ -299,7 +299,7 @@ let ``S9.19: a DECIMAL(10,2) -> DECIMAL(18,4) change names BOTH the Precision an
     let source =
         catalogWithCustomerName (fun a ->
             { a with Precision = Some 10; Scale = Some 2 })
-    let diff = CatalogDiff.between source target |> mustOk
+    let diff = CatalogDiff.between source target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
     let change = List.head ad.Changed
     Assert.Equal(customerNameKey, change.AttributeKey)
@@ -346,20 +346,20 @@ let ``Time: applyDiff (between A B) A = B (evolution round-trip law)`` () =
                         Column = ColumnRealization.create ("LOYALTY") (true) |> Result.value } ] } // add column
     let b = catalogOfKinds [ customer'; order; country ]
 
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     let reconstructed = CatalogDiff.applyDiff a diff
 
     // The round-trip law: the reconstruction has NO diff against B over the
     // captured surface (kinds + names + attribute presence/name/facets).
-    let residual = CatalogDiff.between b reconstructed |> mustOk
+    let residual = CatalogDiff.between b reconstructed
     Assert.True(CatalogDiff.isEmpty residual, "applyDiff (between A B) A must reproduce B (residual diff was non-empty)")
 
 [<Fact>]
 let ``applyDiff (between A A) A = A — the identity diff is identity`` () =
     let a = sampleCatalog
-    let diff = CatalogDiff.between a a |> mustOk
+    let diff = CatalogDiff.between a a
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between a reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between a reconstructed))
 
 [<Fact>]
 let ``applyDiff: an in-place column type change reconstructs the exact target attribute`` () =
@@ -368,7 +368,7 @@ let ``applyDiff: an in-place column type change reconstructs the exact target at
     // equals B's.
     let a = sampleCatalog
     let b = catalogWithCustomerName (fun at -> { at with Type = Integer })
-    let reconstructed = CatalogDiff.applyDiff a (CatalogDiff.between a b |> mustOk)
+    let reconstructed = CatalogDiff.applyDiff a (CatalogDiff.between a b)
     let nameAttr (c: Catalog) =
         (Catalog.tryFindKind customerKey c).Value.Attributes
         |> List.find (fun at -> at.SsKey = customerNameKey)
@@ -382,7 +382,7 @@ let ``applyDiff threads the passed-in catalog, not the recorded target (no-cheat
     // not `fun _ d -> target d` (which would have dropped Country).
     let a = catalogOfKinds [ customer; order ]
     let b = catalogOfKinds [ customer ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
 
     let baseWithExtra = catalogOfKinds [ customer; order; country ]
     let result = CatalogDiff.applyDiff baseWithExtra diff
@@ -401,7 +401,7 @@ let ``applyDiff: a dropped attribute is removed from the reconstruction`` () =
             { customer with
                 Attributes = customer.Attributes |> List.filter (fun at -> at.SsKey <> customerTenantKey) }
         catalogOfKinds [ customer'; order; country ]
-    let reconstructed = CatalogDiff.applyDiff a (CatalogDiff.between a b |> mustOk)
+    let reconstructed = CatalogDiff.applyDiff a (CatalogDiff.between a b)
     let customerAttrs =
         (Catalog.tryFindKind customerKey reconstructed).Value.Attributes
         |> List.map (fun at -> at.SsKey)
@@ -417,14 +417,14 @@ let ``applyDiff: a dropped attribute is removed from the reconstruction`` () =
 
 [<Fact>]
 let ``norm: between A A has norm 0`` () =
-    let d = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let d = CatalogDiff.between sampleCatalog sampleCatalog
     Assert.Equal(0, CatalogDiff.norm d)
     Assert.True(CatalogDiff.isEmpty d)
 
 [<Fact>]
 let ``norm: a non-empty diff has norm > 0 (norm d = 0 iff isEmpty d)`` () =
     let target = catalogWithCustomerName (fun a -> { a with Type = Integer })
-    let d = CatalogDiff.between sampleCatalog target |> mustOk
+    let d = CatalogDiff.between sampleCatalog target
     Assert.False(CatalogDiff.isEmpty d)
     Assert.True(CatalogDiff.norm d > 0)
 
@@ -445,7 +445,7 @@ let ``norm: equals the sum of the channel counts (additivity, T14/T15)`` () =
                 @ [ { Attribute.create newAttrKey (nm "Loyalty") Integer with
                         Column = ColumnRealization.create ("LOYALTY") (true) |> Result.value } ] }
     let target = catalogOfKinds [ customer'; order; country ]
-    let d = CatalogDiff.between sampleCatalog target |> mustOk
+    let d = CatalogDiff.between sampleCatalog target
     let c = CatalogDiff.channelCounts d
     let sum =
         c.RenamedKinds + c.AddedKinds + c.RemovedKinds
@@ -461,8 +461,8 @@ let private custD = catalogWithCustomerName (fun a -> { a with Type = Integer; C
 
 [<Fact>]
 let ``compose: applyDiff (compose d1 d2) A = applyDiff d2 (applyDiff d1 A) (functor law)`` () =
-    let d1 = CatalogDiff.between custA custB |> mustOk
-    let d2 = CatalogDiff.between custB custC |> mustOk
+    let d1 = CatalogDiff.between custA custB
+    let d2 = CatalogDiff.between custB custC
     let composed =
         match CatalogDiff.compose d1 d2 with
         | Some c -> c
@@ -470,26 +470,191 @@ let ``compose: applyDiff (compose d1 d2) A = applyDiff d2 (applyDiff d1 A) (func
     let viaCompose = CatalogDiff.applyDiff custA composed
     let viaSequence = CatalogDiff.applyDiff (CatalogDiff.applyDiff custA d1) d2
     // Both reproduce C (over the captured surface).
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custC viaCompose |> mustOk))
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custC viaSequence |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custC viaCompose))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custC viaSequence))
 
 [<Fact>]
 let ``compose: a non-adjacent pair is None (fail-loud, partial groupoid)`` () =
-    let d_ab = CatalogDiff.between custA custB |> mustOk   // target = B
-    let d_ac = CatalogDiff.between custA custC |> mustOk   // source = A ≠ B
+    let d_ab = CatalogDiff.between custA custB   // target = B
+    let d_ac = CatalogDiff.between custA custC   // source = A ≠ B
     Assert.True((CatalogDiff.compose d_ab d_ac).IsNone)
 
 [<Fact>]
 let ``compose: associativity — (d1+d2)+d3 reproduces the same state as d1+(d2+d3) (A-Lifecycle-4)`` () =
-    let d1 = CatalogDiff.between custA custB |> mustOk
-    let d2 = CatalogDiff.between custB custC |> mustOk
-    let d3 = CatalogDiff.between custC custD |> mustOk
+    let d1 = CatalogDiff.between custA custB
+    let d2 = CatalogDiff.between custB custC
+    let d3 = CatalogDiff.between custC custD
     let some = function Some v -> v | None -> Assert.Fail "expected composable"; Unchecked.defaultof<_>
     let left = some (CatalogDiff.compose (some (CatalogDiff.compose d1 d2)) d3)
     let right = some (CatalogDiff.compose d1 (some (CatalogDiff.compose d2 d3)))
     // Both are the A → D displacement: applying either to A reproduces D.
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custD (CatalogDiff.applyDiff custA left) |> mustOk))
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custD (CatalogDiff.applyDiff custA right) |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custD (CatalogDiff.applyDiff custA left)))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between custD (CatalogDiff.applyDiff custA right)))
+
+// ---------------------------------------------------------------------------
+// M11 / M12 — the norm is a metric; the inverse closes the groupoid.
+//
+// `compose d1 d2` (for adjacent d1 = between A B, d2 = between B C) is the net
+// displacement `between A C`. The triangle inequality `‖compose d1 d2‖ ≤
+// ‖d1‖ + ‖d2‖` makes `norm` a genuine metric on catalogs: the net distance
+// A → C never exceeds the path A → B → C. Equality holds when the two legs
+// touch disjoint channels (nothing to cancel); the inequality is STRICT when a
+// channel churns and cancels (A → B adds, B → C removes the same thing, so the
+// net is silent on that channel while the path paid for both moves).
+//
+// `inverse d = between (target d) (source d)` is the displacement that returns
+// target to source. It witnesses rollback (applying it to `target d`
+// reproduces `source d`) and closes the partial groupoid (`compose d
+// (inverse d)` is the identity at `source d`).
+// ---------------------------------------------------------------------------
+
+/// `sampleCatalog` with a NEW `Loyalty` attribute appended to Customer — the
+/// churn channel: present in one rung of an A → B → C chain, absent in the
+/// others, so the path pays an Add + a Remove while the net cancels to zero.
+let private customerWithLoyalty : Catalog =
+    let loyaltyKey = attrKey ["Customer"; "Loyalty"]
+    let customer' =
+        { customer with
+            Attributes =
+                customer.Attributes
+                @ [ { Attribute.create loyaltyKey (nm "Loyalty") Integer with
+                        Column = ColumnRealization.create ("LOYALTY") (true) |> Result.value } ] }
+    catalogOfKinds [ customer'; order; country ]
+
+[<Fact>]
+let ``M11 (triangle inequality): ‖compose d1 d2‖ ≤ ‖d1‖ + ‖d2‖ — norm is a metric`` () =
+    // For adjacent d1 = between A B, d2 = between B C, compose is ALWAYS Some
+    // (target d1 = B = source d2), and compose d1 d2 = between A C.
+    let composedNorm (a: Catalog) (b: Catalog) (c: Catalog) : int * int =
+        let d1 = CatalogDiff.between a b
+        let d2 = CatalogDiff.between b c
+        let net =
+            match CatalogDiff.compose d1 d2 with
+            | Some net -> net
+            | None -> Assert.Fail "adjacent diffs must compose (target d1 = source d2)"; Unchecked.defaultof<_>
+        CatalogDiff.norm net, CatalogDiff.norm d1 + CatalogDiff.norm d2
+
+    // (1) STRICT — the churn-cancel case. A → B ADDS Customer.Loyalty; B → C
+    // REMOVES it. The net A → C is the empty displacement (C = A), so its norm
+    // is 0, while the path paid for the add AND the remove (sum ≥ 2). The net
+    // is strictly below the path-sum: the metric is not merely additive.
+    let netCancel, pathCancel = composedNorm sampleCatalog customerWithLoyalty sampleCatalog
+    Assert.Equal(0, netCancel)
+    Assert.True(pathCancel >= 2, sprintf "churn path-sum should be ≥ 2, was %d" pathCancel)
+    Assert.True(netCancel < pathCancel, "the cancel case must be a STRICT inequality")
+
+    // (2) EQUALITY — two legs over DISJOINT channels. A → B changes Customer.Name
+    // (one Changed attribute); B → C additionally flips Customer.Id nullability
+    // (a second, distinct Changed attribute). The net A → C carries BOTH changed
+    // attributes, so its norm equals the path-sum — nothing cancels.
+    let b2 = catalogWithCustomerName (fun a -> { a with Type = Integer })
+    let c2 =
+        let customer' =
+            { customer with
+                Attributes =
+                    customer.Attributes
+                    |> List.map (fun at ->
+                        if at.SsKey = customerNameKey then { at with Type = Integer }
+                        elif at.SsKey = customerIdAttrKey then { at with Column = { at.Column with IsNullable = true } }
+                        else at) }
+        catalogOfKinds [ customer'; order; country ]
+    let netDisjoint, pathDisjoint = composedNorm sampleCatalog b2 c2
+    Assert.Equal(pathDisjoint, netDisjoint)
+
+    // The inequality holds (non-strictly) across both triples.
+    Assert.True(netCancel <= pathCancel)
+    Assert.True(netDisjoint <= pathDisjoint)
+
+// A tiny menu of independent catalog mutations over `sampleCatalog`, so a
+// generated (A, B, C) triple is adjacent by construction (d1 = between A B,
+// d2 = between B C) yet rich enough to exercise churn, cancellation, and
+// disjoint-channel composition. Each bundle applies a subset of the menu.
+type private Mutation =
+    { RetypeName : bool          // Customer.Name : Text -> Integer
+      NullableId : bool          // Customer.Id : not-null -> nullable
+      DropTenant : bool          // drop Customer.TenantId
+      AddLoyalty : bool          // append Customer.Loyalty
+      RenameCustomer : bool      // kind rename Customer -> Client
+      DropOrder : bool }         // drop the whole Order kind
+
+let private applyMutation (m: Mutation) : Catalog =
+    let loyaltyKey = attrKey ["Customer"; "Loyalty"]
+    let attrs0 =
+        customer.Attributes
+        |> List.choose (fun at ->
+            if m.DropTenant && at.SsKey = customerTenantKey then None
+            elif at.SsKey = customerNameKey && m.RetypeName then Some { at with Type = Integer }
+            elif at.SsKey = customerIdAttrKey && m.NullableId then Some { at with Column = { at.Column with IsNullable = true } }
+            else Some at)
+    let attrs =
+        if m.AddLoyalty then
+            attrs0
+            @ [ { Attribute.create loyaltyKey (nm "Loyalty") Integer with
+                    Column = ColumnRealization.create ("LOYALTY") (true) |> Result.value } ]
+        else attrs0
+    let customer' =
+        { customer with
+            Name = (if m.RenameCustomer then nm "Client" else customer.Name)
+            Attributes = attrs }
+    let kinds = if m.DropOrder then [ customer'; country ] else [ customer'; order; country ]
+    catalogOfKinds kinds
+
+let private genMutation : Gen<Mutation> =
+    gen {
+        let! b1 = Arb.generate<bool>
+        let! b2 = Arb.generate<bool>
+        let! b3 = Arb.generate<bool>
+        let! b4 = Arb.generate<bool>
+        let! b5 = Arb.generate<bool>
+        let! b6 = Arb.generate<bool>
+        return { RetypeName = b1; NullableId = b2; DropTenant = b3; AddLoyalty = b4; RenameCustomer = b5; DropOrder = b6 }
+    }
+
+/// An adjacent triple (A, B, C): A is fixed (`sampleCatalog`), B and C are two
+/// independent mutation bundles. d1 = between A B and d2 = between B C are
+/// adjacent by construction, so compose is always defined.
+let private genAdjacentTriple : Gen<Catalog * Catalog * Catalog> =
+    gen {
+        let! mb = genMutation
+        let! mc = genMutation
+        return sampleCatalog, applyMutation mb, applyMutation mc
+    }
+
+[<Fact>]
+let ``M11 (triangle inequality, swept): ‖between A C‖ ≤ ‖between A B‖ + ‖between B C‖ over adjacent triples`` () =
+    Prop.forAll (Arb.fromGen genAdjacentTriple) (fun (a, b, c) ->
+        let d1 = CatalogDiff.between a b
+        let d2 = CatalogDiff.between b c
+        match CatalogDiff.compose d1 d2 with
+        | None -> false   // adjacency is structural here — None would be a real bug
+        | Some net -> CatalogDiff.norm net <= CatalogDiff.norm d1 + CatalogDiff.norm d2)
+    |> Check.QuickThrowOnFailure
+
+[<Fact>]
+let ``M12 (groupoid inverse): applyDiff (inverse d) (target d) reproduces source — the rollback witness`` () =
+    // A non-vacuous displacement: custA -> custB flips Customer.Name's type, so
+    // `d` is not the empty diff (its norm is ≥ 1).
+    let d = CatalogDiff.between custA custB
+    Assert.True(CatalogDiff.norm d >= 1, "the fixture displacement must be non-empty")
+    let inv = CatalogDiff.inverse d
+    // inverse runs target -> source: applying it to `target d` (= custB) must
+    // reproduce `source d` (= custA), witnessed order-insensitively by an empty
+    // residual diff against the source over the captured surface.
+    let rolledBack = CatalogDiff.applyDiff (CatalogDiff.target d) inv
+    Assert.True(
+        CatalogDiff.isEmpty (CatalogDiff.between (CatalogDiff.source d) rolledBack),
+        "applyDiff (inverse d) (target d) must reproduce source d (rollback residual was non-empty)")
+
+[<Fact>]
+let ``M12 (groupoid law): compose d (inverse d) = identity at source`` () =
+    // d and inverse d are adjacent (target d = source (inverse d)), so compose
+    // is defined; the round trip source -> target -> source is the identity at
+    // source — its norm is 0 and it is the empty displacement.
+    let d = CatalogDiff.between custA custB
+    Assert.True(CatalogDiff.norm d >= 1, "the fixture displacement must be non-empty")
+    let inv = CatalogDiff.inverse d
+    Assert.Equal(Some true, CatalogDiff.compose d inv |> Option.map CatalogDiff.isEmpty)
+    Assert.Equal(Some 0, CatalogDiff.compose d inv |> Option.map CatalogDiff.norm)
 
 // ---------------------------------------------------------------------------
 // 6.A.7 — Synthesized-key rename is surfaced, not silently re-keyed.
@@ -529,7 +694,7 @@ let ``A1: a Synthesized-key rename is surfaced, not silently re-keyed`` () =
         rnKind (rnSynthKey ["dbo.T_NEW"]) "T_NEW"
             [ rnAttr (rnAttrKey ["dbo.T_NEW.ID"]) "ID" true
               rnAttr (rnAttrKey ["dbo.T_NEW.BODY"]) "BODY" false ]
-    let diff = CatalogDiff.between (rnCatalog [ oldKind ]) (rnCatalog [ newKind ]) |> mustOk
+    let diff = CatalogDiff.between (rnCatalog [ oldKind ]) (rnCatalog [ newKind ])
     // The diff itself cannot thread the rename — it is a drop + add.
     Assert.Equal(1, Set.count (CatalogDiff.removed diff))
     Assert.Equal(1, Set.count (CatalogDiff.added diff))
@@ -550,7 +715,7 @@ let ``A1: a stable-key (OssysOriginal) rename threads natively — no instabilit
     // Same kind identity (OssysOriginal g); only the Name + physical table change.
     let before = rnKind (SsKey.ossysOriginal g) "T_OLD" [ rnAttr idK "ID" true; rnAttr bodyK "BODY" false ]
     let after  = rnKind (SsKey.ossysOriginal g) "T_NEW" [ rnAttr idK "ID" true; rnAttr bodyK "BODY" false ]
-    let diff = CatalogDiff.between (rnCatalog [ before ]) (rnCatalog [ after ]) |> mustOk
+    let diff = CatalogDiff.between (rnCatalog [ before ]) (rnCatalog [ after ])
     // The rename threads natively as a Renamed record — no drop/add.
     Assert.Equal(1, Map.count (CatalogDiff.renamed diff))
     Assert.Empty(CatalogDiff.removed diff)
@@ -567,7 +732,7 @@ let ``synthesizedRenameWarnings: a genuine drop + add with different shapes is n
         rnKind (rnSynthKey ["dbo.FRESH"]) "FRESH"
             [ rnAttr (rnAttrKey ["dbo.FRESH.ID"]) "ID" true
               rnAttr (rnAttrKey ["dbo.FRESH.EXTRA"]) "EXTRA" false ]
-    let diff = CatalogDiff.between (rnCatalog [ dropped ]) (rnCatalog [ appeared ]) |> mustOk
+    let diff = CatalogDiff.between (rnCatalog [ dropped ]) (rnCatalog [ appeared ])
     Assert.Empty(CatalogDiff.synthesizedRenameWarnings diff)
 
 // ---------------------------------------------------------------------------
@@ -592,7 +757,7 @@ let ``S1.2: a Name collision across distinct SsKeys is drop + add, not a rename`
                   IsPrimaryKey = true } ]
     let a = catalogOfKinds [ mkFoo k1Key "T_FOO1" ]
     let b = catalogOfKinds [ mkFoo k2Key "T_FOO2" ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.Contains(k1Key, CatalogDiff.removed diff)
     Assert.Contains(k2Key, CatalogDiff.added diff)
     Assert.Empty(CatalogDiff.renamed diff)
@@ -624,13 +789,13 @@ let ``C1: between/applyDiff round-trips an added FK (reference channel)`` () =
     // reported isEmpty = true (the FK was invisible).
     let a = catalogOfKinds [ customer; orderNoRef; country ]
     let b = catalogOfKinds [ customer; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.False(CatalogDiff.isEmpty diff)
     match CatalogDiff.referenceDiffOf orderKey diff with
     | None -> Assert.Fail "expected a ReferenceDiff for Order"
     | Some rd -> Assert.Contains(orderRefToCustomer, rd.Added)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk),
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed),
                 "applyDiff must reproduce B's reference set")
 
 [<Fact>]
@@ -648,22 +813,22 @@ let ``C1: an FK trust change (WITH NOCHECK) names the Trust facet and round-trip
         { order with
             References = order.References |> List.map (Reference.withConstraintState true false) }
     let b = catalogOfKinds [ customer; orderUntrusted; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     let rd = (CatalogDiff.referenceDiffOf orderKey diff).Value
     let change = List.head rd.Changed
     Assert.Equal(orderRefToCustomer, change.ReferenceKey)
     Assert.Contains(ReferenceFacet.Trust, change.Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 [<Fact>]
 let ``C1: a dropped FK round-trips (reference channel Removed)`` () =
     let a = catalogOfKinds [ customer; order; country ]
     let b = catalogOfKinds [ customer; orderNoRef; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.Contains(orderRefToCustomer, (CatalogDiff.referenceDiffOf orderKey diff).Value.Removed)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 // -- Index channel ----------------------------------------------------------
 
@@ -676,21 +841,21 @@ let ``C1: between/applyDiff round-trips an added UNIQUE index (index channel)`` 
     let a = catalogOfKinds [ customer; order; country ]
     let customerIdx = { customer with Indexes = [ customerEmailIdx ] }
     let b = catalogOfKinds [ customerIdx; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.False(CatalogDiff.isEmpty diff)
     Assert.Contains(customerEmailIdx.SsKey, (CatalogDiff.indexDiffOf customerKey diff).Value.Added)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 [<Fact>]
 let ``C1: an index uniqueness change names the Uniqueness facet and round-trips`` () =
     let a = catalogOfKinds [ { customer with Indexes = [ { customerEmailIdx with Uniqueness = NotUnique } ] }; order; country ]
     let b = catalogOfKinds [ { customer with Indexes = [ customerEmailIdx ] }; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     let change = List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Changed
     Assert.Contains(IndexFacet.Uniqueness, change.Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 [<Fact>]
 let ``C1: an index option change (ALLOW_PAGE_LOCKS) names the Options facet and round-trips`` () =
@@ -698,14 +863,14 @@ let ``C1: an index option change (ALLOW_PAGE_LOCKS) names the Options facet and 
     // flipped flag through applyDiff, not silently inherit Index.create's true.
     let a = catalogOfKinds [ { customer with Indexes = [ customerEmailIdx ] }; order; country ]
     let b = catalogOfKinds [ { customer with Indexes = [ { customerEmailIdx with AllowPageLocks = false } ] }; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.Contains(IndexFacet.Options, (List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Changed).Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
     let rebuiltIdx =
         (Catalog.tryFindKind customerKey reconstructed).Value.Indexes
         |> List.find (fun i -> i.SsKey = customerEmailIdx.SsKey)
     Assert.False(rebuiltIdx.AllowPageLocks)   // the flag survived; no default-substitution
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 // -- Sequence channel -------------------------------------------------------
 
@@ -713,20 +878,20 @@ let ``C1: an index option change (ALLOW_PAGE_LOCKS) names the Options facet and 
 let ``C1: between/applyDiff round-trips an added sequence (sequence channel)`` () =
     let a = sampleCatalog
     let b = Catalog.create [ salesModule ] [ orderNumberSeq ] |> Result.value
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.False(CatalogDiff.isEmpty diff)
     Assert.Contains(orderNumberSeq.SsKey, (CatalogDiff.sequenceDiff diff).Added)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 [<Fact>]
 let ``C1: a reshaped sequence (increment change) names the Increment facet and round-trips`` () =
     let a = Catalog.create [ salesModule ] [ orderNumberSeq ] |> Result.value
     let b = Catalog.create [ salesModule ] [ { orderNumberSeq with Increment = Some 10m } ] |> Result.value
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
     Assert.Contains(SequenceFacet.Increment, (List.head (CatalogDiff.sequenceDiff diff).Changed).Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 
 // -- The integrative witness + isEmpty/norm honesty -------------------------
 
@@ -738,9 +903,9 @@ let ``C1: applyDiff (between A B) A = B on the widened surface (FK + index + seq
     let customer' = { customer with Indexes = [ customerEmailIdx ] }                 // + index
     let order'     = order                                                            // + FK (was stripped in A)
     let b0 = Catalog.create [ { salesModule with Kinds = [ customer'; order'; country ] } ] [ orderNumberSeq ] |> Result.value // + sequence
-    let diff = CatalogDiff.between a b0 |> mustOk
+    let diff = CatalogDiff.between a b0
     let reconstructed = CatalogDiff.applyDiff a diff
-    let residual = CatalogDiff.between b0 reconstructed |> mustOk
+    let residual = CatalogDiff.between b0 reconstructed
     Assert.True(CatalogDiff.isEmpty residual,
                 "applyDiff (between A B) A must reproduce B across references + indexes + sequences")
 
@@ -750,19 +915,19 @@ let ``C1: isEmpty is honest — an added FK alone makes the diff non-empty (regr
     // gained an FK reported isEmpty = true → no ALTER → silent skip.
     let a = catalogOfKinds [ customer; orderNoRef; country ]
     let b = catalogOfKinds [ customer; order; country ]
-    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between a b |> mustOk))
+    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between a b))
 
 [<Fact>]
 let ``C1: norm counts the reference / index / sequence channels`` () =
     let a = catalogOfKinds [ customer; orderNoRef; country ]
     let customer' = { customer with Indexes = [ customerEmailIdx ] }
     let b = Catalog.create [ { salesModule with Kinds = [ customer'; order; country ] } ] [ orderNumberSeq ] |> Result.value
-    let c = CatalogDiff.channelCounts (CatalogDiff.between a b |> mustOk)
+    let c = CatalogDiff.channelCounts (CatalogDiff.between a b)
     Assert.Equal(1, c.AddedReferences)
     Assert.Equal(1, c.AddedIndexes)
     Assert.Equal(1, c.AddedSequences)
     // norm sums every channel including the three new ones (≥ 3 here).
-    Assert.True(CatalogDiff.norm (CatalogDiff.between a b |> mustOk) >= 3)
+    Assert.True(CatalogDiff.norm (CatalogDiff.between a b) >= 3)
 
 // ---------------------------------------------------------------------------
 // P1.4 / P1.5 / P1.6 — the no-cheat property on the three C1 channels. Each
@@ -796,7 +961,7 @@ let ``P1.4: applyDiff threads the passed-in base's references, not the recorded 
     // reference diff never mentions) — it must survive the apply.
     let a = catalogOfKinds [ customer; orderNoRef; country ]
     let b = catalogOfKinds [ customer; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
 
     let customerWithExtra = { customer with References = [ customerExtraRef ] }
     let baseWithExtra = catalogOfKinds [ customerWithExtra; orderNoRef; country ]
@@ -818,7 +983,7 @@ let ``P1.5: applyDiff threads the passed-in base's indexes, not the recorded tar
     // Country (a kind the index diff never mentions) — it must survive.
     let a = catalogOfKinds [ customer; order; country ]
     let b = catalogOfKinds [ { customer with Indexes = [ customerEmailIdx ] }; order; country ]
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
 
     let countryWithExtra = { country with Indexes = [ countryExtraIdx ] }
     let baseWithExtra = catalogOfKinds [ customer; order; countryWithExtra ]
@@ -839,7 +1004,7 @@ let ``P1.6: applyDiff threads the passed-in base's sequences, not the recorded t
     // mentions — it must survive (sequences are catalog-level).
     let a = sampleCatalog
     let b = Catalog.create [ salesModule ] [ orderNumberSeq ] |> Result.value
-    let diff = CatalogDiff.between a b |> mustOk
+    let diff = CatalogDiff.between a b
 
     let baseWithExtra = Catalog.create [ salesModule ] [ extraSeq ] |> Result.value
     let result = CatalogDiff.applyDiff baseWithExtra diff
@@ -863,6 +1028,6 @@ let ``P1.6: applyDiff threads the passed-in base's sequences, not the recorded t
 let ``P2.8: a DECIMAL(10,2) -> DECIMAL(18,4) change round-trips (precision + scale end-to-end)`` () =
     let a = catalogWithCustomerName (fun at -> { at with Precision = Some 10; Scale = Some 2 })
     let b = catalogWithCustomerName (fun at -> { at with Precision = Some 18; Scale = Some 4 })
-    let residual = CatalogDiff.between b (CatalogDiff.applyDiff a (CatalogDiff.between a b |> mustOk)) |> mustOk
+    let residual = CatalogDiff.between b (CatalogDiff.applyDiff a (CatalogDiff.between a b))
     Assert.True(CatalogDiff.isEmpty residual,
                 "applyDiff must reproduce B's DECIMAL precision + scale (round-trip residual was non-empty)")

--- a/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogDiffTests.fs
@@ -191,8 +191,8 @@ let ``CatalogDiff: a column type change surfaces as an attribute-level Changed e
         Assert.Empty(ad.Added)
         Assert.Empty(ad.Removed)
         Assert.Empty(ad.Renamed)
-        Assert.Equal(1, List.length ad.Changed)
-        let change = List.head ad.Changed
+        Assert.Equal(1, List.length ad.Reshaped)
+        let change = List.head ad.Reshaped
         Assert.Equal(customerNameKey, change.AttributeKey)
         Assert.Contains(AttributeFacet.DataType, change.Facets)
 
@@ -245,7 +245,7 @@ let ``CatalogDiff: a column widening (length change) names the Length facet (TEX
     let target = catalogWithCustomerName (fun a -> { a with Length = Some 256 })
     let diff = CatalogDiff.between sampleCatalog target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
-    let change = List.head ad.Changed
+    let change = List.head ad.Reshaped
     Assert.Contains(AttributeFacet.Length, change.Facets)
     Assert.DoesNotContain(AttributeFacet.DataType, change.Facets)
 
@@ -256,7 +256,7 @@ let ``CatalogDiff: a nullability change names the Nullability facet`` () =
             { a with Column = { a.Column with IsNullable = true } })
     let diff = CatalogDiff.between sampleCatalog target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
-    Assert.Contains(AttributeFacet.Nullability, (List.head ad.Changed).Facets)
+    Assert.Contains(AttributeFacet.Nullability, (List.head ad.Reshaped).Facets)
 
 [<Fact>]
 let ``CatalogDiff: a dropped attribute surfaces in AttributeDiff.Removed`` () =
@@ -301,7 +301,7 @@ let ``S9.19: a DECIMAL(10,2) -> DECIMAL(18,4) change names BOTH the Precision an
             { a with Precision = Some 10; Scale = Some 2 })
     let diff = CatalogDiff.between source target
     let ad = (CatalogDiff.attributeDiffOf customerKey diff).Value
-    let change = List.head ad.Changed
+    let change = List.head ad.Reshaped
     Assert.Equal(customerNameKey, change.AttributeKey)
     Assert.Contains(AttributeFacet.Precision, change.Facets)
     Assert.Contains(AttributeFacet.Scale, change.Facets)
@@ -815,7 +815,7 @@ let ``C1: an FK trust change (WITH NOCHECK) names the Trust facet and round-trip
     let b = catalogOfKinds [ customer; orderUntrusted; country ]
     let diff = CatalogDiff.between a b
     let rd = (CatalogDiff.referenceDiffOf orderKey diff).Value
-    let change = List.head rd.Changed
+    let change = List.head rd.Reshaped
     Assert.Equal(orderRefToCustomer, change.ReferenceKey)
     Assert.Contains(ReferenceFacet.Trust, change.Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
@@ -852,7 +852,7 @@ let ``C1: an index uniqueness change names the Uniqueness facet and round-trips`
     let a = catalogOfKinds [ { customer with Indexes = [ { customerEmailIdx with Uniqueness = NotUnique } ] }; order; country ]
     let b = catalogOfKinds [ { customer with Indexes = [ customerEmailIdx ] }; order; country ]
     let diff = CatalogDiff.between a b
-    let change = List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Changed
+    let change = List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Reshaped
     Assert.Contains(IndexFacet.Uniqueness, change.Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
     Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
@@ -864,7 +864,7 @@ let ``C1: an index option change (ALLOW_PAGE_LOCKS) names the Options facet and 
     let a = catalogOfKinds [ { customer with Indexes = [ customerEmailIdx ] }; order; country ]
     let b = catalogOfKinds [ { customer with Indexes = [ { customerEmailIdx with AllowPageLocks = false } ] }; order; country ]
     let diff = CatalogDiff.between a b
-    Assert.Contains(IndexFacet.Options, (List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Changed).Facets)
+    Assert.Contains(IndexFacet.Options, (List.head (CatalogDiff.indexDiffOf customerKey diff).Value.Reshaped).Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
     let rebuiltIdx =
         (Catalog.tryFindKind customerKey reconstructed).Value.Indexes
@@ -889,7 +889,7 @@ let ``C1: a reshaped sequence (increment change) names the Increment facet and r
     let a = Catalog.create [ salesModule ] [ orderNumberSeq ] |> Result.value
     let b = Catalog.create [ salesModule ] [ { orderNumberSeq with Increment = Some 10m } ] |> Result.value
     let diff = CatalogDiff.between a b
-    Assert.Contains(SequenceFacet.Increment, (List.head (CatalogDiff.sequenceDiff diff).Changed).Facets)
+    Assert.Contains(SequenceFacet.Increment, (List.head (CatalogDiff.sequenceDiff diff).Reshaped).Facets)
     let reconstructed = CatalogDiff.applyDiff a diff
     Assert.True(CatalogDiff.isEmpty (CatalogDiff.between b reconstructed))
 

--- a/sidecar/projection/tests/Projection.Tests/ChangeAlgebraSweepTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ChangeAlgebraSweepTests.fs
@@ -1,0 +1,366 @@
+module Projection.Tests.ChangeAlgebraSweepTests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open Projection.Core
+
+// ===========================================================================
+// THE VECTOR · Wave 2 · M3 — the swept change-algebra property (§5.2,
+// "the highest-value unfired proof in the system").
+//
+// `CatalogDiffTests.fs` witnesses the change-algebra round-trip law on a
+// fixed set of HAND-BUILT fixtures (sampleCatalog perturbed by named edits).
+// M3 raises that from fixture-witnessed to PROPERTY-witnessed: `genCatalogPair`
+// draws a random VALID base Catalog A and a random VALID perturbed Catalog B,
+// and the `[<Property>]` tests below sweep the master equation, the no-cheat
+// dependence, and the norm-consistency law over ~100 such pairs each.
+//
+// **In-process backend only (Wave-2 scope).** The reverse-leg movement engine
+// is done, so the in-process change algebra (`CatalogDiff.between` / `applyDiff`
+// over IR values) is the backend under test here. The live-deploy / Docker
+// backend (round-tripping a delta through a real SQL deployment) stays
+// separately gated and is NOT exercised by this sweep — that is the
+// INTEGRATOR's matrix territory, not Wave-2's.
+//
+// **Validity by construction.** Every generated Catalog (A and every
+// perturbation step toward B) is built through `Catalog.create` /
+// `Module.create` / the attribute smart constructors, so the five
+// referential-integrity invariants (module/kind/sequence key disjointness,
+// reference dangling-source/target, reference constraint-state quadrant, index
+// dangling-column, NM-14 storage/type agreement) hold by construction. The
+// generator deliberately carries NO references and NO indexes so the
+// add/remove-kind and add/remove-attribute edits cannot strand an FK source,
+// FK target, or index column — keeping each B valid no matter the edit list.
+// The generator is SELF-CONTAINED: it depends only on `Projection.Core`'s
+// public smart constructors, never on another test file's private members.
+// ===========================================================================
+
+/// Observe the displacement A → B. Wave-2's trio (M13) made
+/// `CatalogDiff.between` total, so this is a thin name for the observational
+/// differential; every property below calls `diff a b`.
+let private diff (a: Catalog) (b: Catalog) : CatalogDiff =
+    CatalogDiff.between a b
+
+// ---------------------------------------------------------------------------
+// Self-contained builders. Force-unwrap the single-arity `Result<'a>` from
+// the production smart constructors (these inputs are constants known to
+// satisfy the validators — the fixture posture).
+// ---------------------------------------------------------------------------
+
+let private nm (s: string) : Name = Name.create s |> Result.value
+
+/// Distinct, stable `OssysOriginal` key from an int — so identity is
+/// rename-stable (a kind/attribute rename CHANGES the Name, never the SsKey)
+/// and the diff threads renames natively as `Renamed`, not as drop+add.
+let private key (n: int) : SsKey =
+    SsKey.ossysOriginal (System.Guid(n, 0s, 0s, 0uy, 0uy, 0uy, 0uy, 0uy, 0uy, 0uy, 0uy))
+
+let private tableId (n: int) : TableId =
+    TableId.create "dbo" (sprintf "T%d" n) |> Result.value
+
+/// A minimum-evidence attribute. No `SqlStorage` (so NM-14's storage/type
+/// agreement is vacuous), an explicit lowercase-derived column name, and the
+/// caller-chosen nullability.
+let private mkAttr (k: SsKey) (logical: string) (ptype: PrimitiveType) (isPk: bool) (nullable: bool) : Attribute =
+    { Attribute.create k (nm logical) ptype with
+        Column = ColumnRealization.create (logical.ToUpperInvariant()) nullable |> Result.value
+        IsPrimaryKey = isPk
+        IsMandatory = isPk }
+
+/// A kind over the given attributes, carrying NO references and NO indexes
+/// (the generator's discipline — see the header). The first attribute is the
+/// PK by construction.
+let private mkKind (k: SsKey) (name: string) (tid: int) (attrs: Attribute list) : Kind =
+    Kind.create k (nm name) (tableId tid) attrs
+
+/// A single-module catalog over the given kinds.
+let private catalogOf (kinds: Kind list) : Catalog =
+    let m = Module.create (key 90000) (nm "M") kinds true [] |> Result.value
+    Catalog.create [ m ] [] |> Result.value
+
+// ---------------------------------------------------------------------------
+// Generator alphabets.
+// ---------------------------------------------------------------------------
+
+let private allPrimitiveTypes : PrimitiveType list =
+    [ Integer; Decimal; Text; Boolean; DateTime ]
+
+let private genBool : Gen<bool> = Gen.elements [ true; false ]
+
+let rec private genAll (gs: Gen<'a> list) : Gen<'a list> =
+    match gs with
+    | [] -> Gen.constant []
+    | g :: rest -> gen { let! x = g in let! xs = genAll rest in return x :: xs }
+
+// ---------------------------------------------------------------------------
+// Key-space partitions. Kinds, attributes, and the perturbation's freshly
+// minted entities each draw from a disjoint integer band so no `add` edit can
+// ever collide an SsKey with an existing one (preserving A4 disjointness).
+//   kinds (base)      : 1_000 ..
+//   attributes (base) : 10_000 .. (10_000 + kindIx*100 + attrIx)
+//   fresh kinds       : 50_000 ..
+//   fresh attributes  : 60_000 ..
+// ---------------------------------------------------------------------------
+
+let private baseKindKey (i: int) : SsKey = key (1_000 + i)
+let private baseAttrKey (kindIx: int) (attrIx: int) : SsKey = key (10_000 + kindIx * 100 + attrIx)
+
+/// One generated attribute (its facets freely chosen). The PK attribute is
+/// forced non-nullable and integer-typed so it reads like a real surrogate
+/// key; non-PK attributes vary across the full facet surface.
+let private genAttr (k: SsKey) (logical: string) (isPk: bool) : Gen<Attribute> =
+    if isPk then
+        Gen.constant (mkAttr k logical Integer true false)
+    else
+        gen {
+            let! ptype = Gen.elements allPrimitiveTypes
+            let! nullable = genBool
+            let! len = Gen.frequency [ 1, Gen.constant None; 2, Gen.map Some (Gen.choose (1, 4000)) ]
+            return { mkAttr k logical ptype false nullable with Length = len }
+        }
+
+/// One generated base kind: a PK attribute plus 0..3 non-PK attributes.
+let private genKind (kindIx: int) : Gen<Kind> =
+    gen {
+        let! nExtra = Gen.choose (0, 3)
+        let pkGen = genAttr (baseAttrKey kindIx 0) (sprintf "K%d_Id" kindIx) true
+        let extraGens =
+            [ for j in 1 .. nExtra ->
+                genAttr (baseAttrKey kindIx j) (sprintf "K%d_A%d" kindIx j) false ]
+        let! attrs = genAll (pkGen :: extraGens)
+        return mkKind (baseKindKey kindIx) (sprintf "K%d" kindIx) kindIx attrs
+    }
+
+/// A valid base Catalog A: a single module of 1..4 kinds.
+let private genBaseCatalog : Gen<Catalog> =
+    gen {
+        let! nKinds = Gen.choose (1, 4)
+        let! kinds = genAll [ for i in 0 .. nKinds - 1 -> genKind i ]
+        return catalogOf kinds
+    }
+
+// ---------------------------------------------------------------------------
+// The perturbation algebra. Each `Edit` transforms a kinds list into another
+// VALID kinds list (every step is constructed, never validated). The list of
+// edits is folded over A's kinds to produce B's kinds. A fresh-key counter
+// threaded through the fold guarantees every minted kind / attribute SsKey is
+// globally unique.
+// ---------------------------------------------------------------------------
+
+/// A perturbation drawn against the kinds present at the moment it is applied.
+/// (We sample concrete indices/types now and resolve them positionally during
+/// the fold, clamping to the live list so an earlier `RemoveKind` can never
+/// strand a later index.)
+type private Edit =
+    /// Append a brand-new kind (PK + one extra attribute), keyed from the
+    /// fresh band so it collides with nothing in A or B.
+    | AddKind of extraType: PrimitiveType
+    /// Drop the kind at this position — but only if more than one kind
+    /// remains (the module must keep ≥ 1 kind, LR1).
+    | RemoveKind of pos: int
+    /// Rename the kind at this position (Name changes; SsKey is stable, so the
+    /// diff threads it as `Renamed`, not drop+add).
+    | RenameKind of pos: int
+    /// Reshape a facet of a non-PK attribute on the kind at this position:
+    /// flip nullability, change the declared type, and move the length.
+    | ReshapeAttribute of pos: int * newType: PrimitiveType * newNullable: bool * newLen: int option
+    /// Append a brand-new attribute to the kind at this position (fresh-band
+    /// key).
+    | AddAttribute of pos: int * ptype: PrimitiveType * nullable: bool
+    /// Drop a non-PK attribute from the kind at this position — only if the
+    /// kind would keep ≥ 1 attribute (and the PK is never dropped).
+    | RemoveAttribute of pos: int
+
+let private genEdit : Gen<Edit> =
+    Gen.oneof
+        [ gen { let! t = Gen.elements allPrimitiveTypes in return AddKind t }
+          gen { let! p = Gen.choose (0, 5) in return RemoveKind p }
+          gen { let! p = Gen.choose (0, 5) in return RenameKind p }
+          gen {
+              let! p = Gen.choose (0, 5)
+              let! t = Gen.elements allPrimitiveTypes
+              let! n = genBool
+              let! len = Gen.frequency [ 1, Gen.constant None; 2, Gen.map Some (Gen.choose (1, 4000)) ]
+              return ReshapeAttribute (p, t, n, len)
+          }
+          gen {
+              let! p = Gen.choose (0, 5)
+              let! t = Gen.elements allPrimitiveTypes
+              let! n = genBool
+              return AddAttribute (p, t, n)
+          }
+          gen { let! p = Gen.choose (0, 5) in return RemoveAttribute p } ]
+
+/// Apply one edit to the live kinds list, threading the fresh-key counter.
+/// Every branch returns a list that still satisfies the catalog invariants:
+/// kinds stay non-empty, kinds keep ≥ 1 attribute including their PK, and all
+/// freshly minted SsKeys come from the disjoint fresh band.
+let private applyEdit (kinds: Kind list, fresh: int) (edit: Edit) : Kind list * int =
+    let n = List.length kinds
+    // Resolve a sampled position against the live list (empty list is
+    // impossible — the module always holds ≥ 1 kind).
+    let at (pos: int) : int = if n = 0 then 0 else pos % n
+    match edit with
+    | AddKind extraType ->
+        let kKey = key (50_000 + fresh)
+        let pk = mkAttr (key (60_000 + fresh * 10)) (sprintf "F%d_Id" fresh) Integer true false
+        let extra = mkAttr (key (60_000 + fresh * 10 + 1)) (sprintf "F%d_A" fresh) extraType false true
+        let newKind = mkKind kKey (sprintf "F%d" fresh) (50_000 + fresh) [ pk; extra ]
+        kinds @ [ newKind ], fresh + 1
+    | RemoveKind pos ->
+        if n <= 1 then kinds, fresh
+        else
+            let i = at pos
+            (kinds |> List.mapi (fun j k -> j, k) |> List.filter (fun (j, _) -> j <> i) |> List.map snd), fresh
+    | RenameKind pos ->
+        if n = 0 then kinds, fresh
+        else
+            let i = at pos
+            kinds
+            |> List.mapi (fun j k -> if j = i then { k with Name = nm (sprintf "R%d_%d" i fresh) } else k),
+            fresh + 1
+    | ReshapeAttribute (pos, newType, newNullable, newLen) ->
+        if n = 0 then kinds, fresh
+        else
+            let i = at pos
+            kinds
+            |> List.mapi (fun j k ->
+                if j <> i then k
+                else
+                    // Reshape the FIRST non-PK attribute, if any (the PK is
+                    // never reshaped — it stays a stable Integer surrogate).
+                    // `List.mapFold` threads the "already reshaped one" flag
+                    // purely, avoiding a closure-captured mutable.
+                    let reshaped, _ =
+                        k.Attributes
+                        |> List.mapFold
+                            (fun touched a ->
+                                if (not a.IsPrimaryKey) && not touched then
+                                    { a with
+                                        Type = newType
+                                        Length = newLen
+                                        Column = { a.Column with IsNullable = newNullable } },
+                                    true
+                                else a, touched)
+                            false
+                    { k with Attributes = reshaped }),
+            fresh
+    | AddAttribute (pos, ptype, nullable) ->
+        if n = 0 then kinds, fresh
+        else
+            let i = at pos
+            kinds
+            |> List.mapi (fun j k ->
+                if j <> i then k
+                else
+                    let a =
+                        mkAttr (key (60_000 + fresh * 10 + 2)) (sprintf "N%d_%d" i fresh) ptype false nullable
+                    { k with Attributes = k.Attributes @ [ a ] }),
+            fresh + 1
+    | RemoveAttribute pos ->
+        if n = 0 then kinds, fresh
+        else
+            let i = at pos
+            kinds
+            |> List.mapi (fun j k ->
+                if j <> i then k
+                else
+                    // Drop the FIRST non-PK attribute, if any — never the PK,
+                    // and only when the kind keeps ≥ 1 attribute afterward.
+                    let nonPk = k.Attributes |> List.filter (fun a -> not a.IsPrimaryKey)
+                    match nonPk with
+                    | [] -> k
+                    | victim :: _ ->
+                        { k with Attributes = k.Attributes |> List.filter (fun a -> a.SsKey <> victim.SsKey) }),
+            fresh
+
+/// Fold the edit list over A's kinds to produce B (validity preserved at every
+/// step; the fresh-key counter starts past A's bands).
+let private perturb (a: Catalog) (edits: Edit list) : Catalog =
+    let kindsA = Catalog.allKinds a
+    let kindsB, _ = List.fold applyEdit (kindsA, 0) edits
+    catalogOf kindsB
+
+/// THE generator: a base Catalog A and a perturbed Catalog B, both valid by
+/// construction. `genCatalogPair : Gen<Catalog * Catalog>`.
+let private genCatalogPair : Gen<Catalog * Catalog> =
+    gen {
+        let! a = genBaseCatalog
+        let! nEdits = Gen.choose (0, 6)
+        let! edits = genAll (List.replicate nEdits genEdit)
+        let b = perturb a edits
+        return a, b
+    }
+
+let private arbCatalogPair : Arbitrary<Catalog * Catalog> = Arb.fromGen genCatalogPair
+
+// ---------------------------------------------------------------------------
+// Property 1 — the T16 master equation (in-process backend; applyTo=applyDiff,
+// plan=between). `applyDiff (between A B) A` reproduces B modulo the captured
+// surface, witnessed order-insensitively by `isEmpty (between B (…))`.
+// ---------------------------------------------------------------------------
+
+[<Property>]
+let ``M3 (swept T16): applyDiff (between A B) A reproduces B over genCatalogPair`` () =
+    Prop.forAll arbCatalogPair (fun (a, b) ->
+        let d = diff a b
+        let reconstructed = CatalogDiff.applyDiff a d
+        // The round-trip residual against B is empty over the captured surface.
+        CatalogDiff.isEmpty (diff b reconstructed))
+
+// ---------------------------------------------------------------------------
+// Property 2 — no-cheat: `applyDiff` genuinely THREADS its base argument, it is
+// not `fun _ d -> target d`. We apply the A→B delta to a DIFFERENT base
+// C = A + one extra kind the delta never mentions; that extra kind must
+// survive the apply (a target-copying impl would have dropped it).
+// ---------------------------------------------------------------------------
+
+[<Property>]
+let ``M3 (swept no-cheat): applyDiff threads the passed-in base, not the recorded target`` () =
+    Prop.forAll arbCatalogPair (fun (a, b) ->
+        let d = diff a b
+        // C = A plus a fresh kind whose SsKey is in neither A nor B (the fresh
+        // band sits above every base key; the perturbation never reaches it
+        // because C is built independently of B's edit list).
+        let extraKey = key 70_000
+        let extraKind =
+            mkKind extraKey "ExtraProbe" 70_000
+                [ mkAttr (key 71_000) "Extra_Id" Integer true false ]
+        let c = catalogOf (Catalog.allKinds a @ [ extraKind ])
+        let result = CatalogDiff.applyDiff c d
+        // The extra kind (present only in C, named by neither side of the diff)
+        // must ride through — proving the result is threaded from the base, not
+        // copied from `target d`.
+        (Catalog.tryFindKind extraKey result).IsSome
+        // …and it is genuinely absent from the recorded target, so this is a
+        // real discriminator (not vacuously true).
+        && (Catalog.tryFindKind extraKey (CatalogDiff.target d)).IsNone)
+
+// ---------------------------------------------------------------------------
+// Property 3 — norm consistency. `norm d = 0 ⟺ isEmpty d`; `norm (between A A)
+// = 0`; and `norm` equals the sum of ALL its `ChannelCounts` fields (a guard
+// against a missed channel — if `norm` or `channelCounts` ever dropped a
+// channel, the two would diverge on a B that touches that channel).
+// ---------------------------------------------------------------------------
+
+/// Sum of every field of a `ChannelCounts` — the independent recomputation of
+/// the norm. Touches all 20 channels so a dropped channel in EITHER `norm` or
+/// `channelCounts` is caught.
+let private sumChannelCounts (c: CatalogDiff.ChannelCounts) : int =
+    c.RenamedKinds + c.AddedKinds + c.RemovedKinds + c.ChangedKinds
+    + c.AddedAttributes + c.RemovedAttributes + c.RenamedAttributes + c.ChangedAttributes
+    + c.AddedReferences + c.RemovedReferences + c.RenamedReferences + c.ChangedReferences
+    + c.AddedIndexes + c.RemovedIndexes + c.RenamedIndexes + c.ChangedIndexes
+    + c.AddedSequences + c.RemovedSequences + c.RenamedSequences + c.ChangedSequences
+
+[<Property>]
+let ``M3 (swept norm): norm d = 0 iff isEmpty d, and norm = sum of channel counts`` () =
+    Prop.forAll arbCatalogPair (fun (a, b) ->
+        let d = diff a b
+        let n = CatalogDiff.norm d
+        let emptyIffZero = (n = 0) = CatalogDiff.isEmpty d
+        let normIsChannelSum = n = sumChannelCounts (CatalogDiff.channelCounts d)
+        // Identity diff: A against itself is empty and norm 0.
+        let identity = CatalogDiff.norm (diff a a)
+        emptyIffZero && normIsChannelSum && identity = 0)

--- a/sidecar/projection/tests/Projection.Tests/DataIntegrityCheckerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataIntegrityCheckerTests.fs
@@ -45,8 +45,8 @@ let ``diff: flags exactly the diverging kind's row-count delta`` () =
     Assert.Equal(1, report.RowCountDeltas.Length)
     let d = List.head report.RowCountDeltas
     Assert.Equal(items, d.Kind)
-    Assert.Equal(3L, d.Before)
-    Assert.Equal(6L, d.After)
+    Assert.Equal(3L<row>, d.Before)
+    Assert.Equal(6L<row>, d.After)
     Assert.False(DataIntegrityChecker.isClean report)
 
 [<Fact>]
@@ -59,8 +59,8 @@ let ``diff: flags a per-attribute null-count delta (row count unchanged)`` () =
     let d = List.head report.NullCountDeltas
     Assert.Equal(orders, d.Kind)
     Assert.Equal(noteAttr, d.Attribute)
-    Assert.Equal(0L, d.Before)
-    Assert.Equal(1L, d.After)
+    Assert.Equal(0L<row>, d.Before)
+    Assert.Equal(1L<row>, d.After)
 
 [<Fact>]
 let ``diff: kind present in only one cache surfaces a warning`` () =

--- a/sidecar/projection/tests/Projection.Tests/EpisodeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EpisodeTests.fs
@@ -106,21 +106,21 @@ let ``EpisodicLifecycle: head is genesis, latest is the last appended`` () =
 let ``EpisodicLifecycle.reconstructLatestSchema derives the latest schema via fold applyDiff`` () =
     let reconstructed = EpisodicLifecycle.reconstructLatestSchema devChain |> mustOk
     // Agrees with the stored latest schema modulo the captured surface.
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed))
     // And is genuinely the evolved schema, not genesis.
-    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed |> mustOk))
+    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed))
 
 [<Fact>]
 let ``EpisodicLifecycle.reconstructLatestSchema on a genesis-only lifecycle is genesis`` () =
     let reconstructed = EpisodicLifecycle.reconstructLatestSchema devGenesis |> mustOk
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed))
 
 [<Fact>]
 let ``EpisodicLifecycle.netSchemaDiff is the net displacement genesis to latest (one rename)`` () =
     let nd = EpisodicLifecycle.netSchemaDiff devChain |> mustOk
     Assert.Equal(1, CatalogDiff.norm nd)
     let reconstructed = CatalogDiff.applyDiff sampleCatalog nd
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed))
 
 [<Fact>]
 let ``EpisodicLifecycle.schemaEvolutionChain has one edge per consecutive pair`` () =

--- a/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
@@ -328,7 +328,7 @@ let ``X3.T1: the recorded chain reconstructs the latest schema from genesis (fre
         let latest = EpisodicLifecycle.latest reloaded |> Episode.schema
         // The net displacement reconstructed → stored-latest must be empty (the
         // reconstruction reproduces the stored latest).
-        let netToReconstructed = CatalogDiff.between reconstructed latest |> mustEmitOk
+        let netToReconstructed = CatalogDiff.between reconstructed latest
         Assert.True(CatalogDiff.isEmpty netToReconstructed, "reconstructLatestSchema must reproduce the stored latest schema")
 
         // The intermediate prior state is also reconstructible: the second

--- a/sidecar/projection/tests/Projection.Tests/LifecycleStoreTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LifecycleStoreTests.fs
@@ -72,7 +72,7 @@ let ``6.H.2: reconstructLatestSchema over the persisted chain reproduces the sto
         let reconstructed = EpisodicLifecycle.reconstructLatestSchema loaded |> mustOk
         // The FTC over the loaded chain reproduces the stored latest schema
         // (modulo the diff's captured surface).
-        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed |> mustOk)))
+        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed)))
 
 [<Fact>]
 let ``6.H.2: every plane but the Profile survives the round-trip (coordinate, schema, data, refactorlog)`` () =

--- a/sidecar/projection/tests/Projection.Tests/LifecycleTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LifecycleTests.fs
@@ -158,14 +158,14 @@ let ``A-Lifecycle (6.A.11 / H-007): reconstructLatest derives the latest snapsho
     let latest = (Lifecycle.latest devChain).Catalog
     // The reconstruction (fold applyDiff genesis) reproduces the stored latest
     // (the customer-rename evolution) over the captured surface.
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between latest reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between latest reconstructed))
     // And it is NOT genesis — the rename was actually applied.
-    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed |> mustOk))
+    Assert.False(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed))
 
 [<Fact>]
 let ``reconstructLatest: a genesis-only lifecycle reconstructs C0`` () =
     let reconstructed = Lifecycle.reconstructLatest devGenesis |> mustOk
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog reconstructed))
 
 // 6.H.3 — netDiff (the integral ∫δ as a single delta) + its equality to
 // fold-compose over the evolution chain (the FTC's companion). A 3-snapshot
@@ -174,7 +174,7 @@ let ``reconstructLatest: a genesis-only lifecycle reconstructs C0`` () =
 let ``6.H.3: netDiff applied to genesis reproduces latest (the integral)`` () =
     let nd = Lifecycle.netDiff devChain |> mustOk
     let reconstructed = CatalogDiff.applyDiff sampleCatalog nd
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between targetCatalog reconstructed))
 
 [<Fact>]
 let ``6.H.3: netDiff equals fold compose over the evolution chain (3 snapshots)`` () =
@@ -195,8 +195,8 @@ let ``6.H.3: netDiff equals fold compose over the evolution chain (3 snapshots)`
     let viaFold = CatalogDiff.applyDiff sampleCatalog folded
     let viaNet = CatalogDiff.applyDiff sampleCatalog nd
     // Both reproduce the latest (sampleCatalog again, here) over the captured surface.
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between viaFold viaNet |> mustOk))
-    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog viaNet |> mustOk))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between viaFold viaNet))
+    Assert.True(CatalogDiff.isEmpty (CatalogDiff.between sampleCatalog viaNet))
 
 // P4 — CatalogDiff.compose now has a PRODUCTION caller: Lifecycle.netDiff folds
 // it over the evolution chain. This test asserts the production net-diff (the
@@ -215,11 +215,11 @@ let ``P4 (6.H.3): production netDiff (compose fold) equals direct between(genesi
     // functor law.
     let genesis = (Lifecycle.head chainLc).Catalog
     let latest = (Lifecycle.latest chainLc).Catalog
-    let direct = CatalogDiff.between genesis latest |> mustOk
+    let direct = CatalogDiff.between genesis latest
     // The composed net-diff equals the direct diff on the captured surface.
     Assert.True(CatalogDiff.isEmpty (CatalogDiff.between
                                         (CatalogDiff.applyDiff genesis viaCompose)
-                                        (CatalogDiff.applyDiff genesis direct) |> mustOk))
+                                        (CatalogDiff.applyDiff genesis direct)))
     // And the channel norms agree (round-trip churn cancels; net is empty here).
     Assert.Equal(CatalogDiff.norm direct, CatalogDiff.norm viaCompose)
 
@@ -232,11 +232,11 @@ let ``P4 (6.H.3): production netDiff over a non-trivial-net 3-snapshot chain equ
     let chainLc = Lifecycle.append c2 devChain |> mustResultOk
     let viaCompose = Lifecycle.netDiff chainLc |> mustOk
     let genesis = (Lifecycle.head chainLc).Catalog
-    let direct = CatalogDiff.between genesis (Lifecycle.latest chainLc).Catalog |> mustOk
+    let direct = CatalogDiff.between genesis (Lifecycle.latest chainLc).Catalog
     // Both reconstruct the latest (Patron) from genesis.
     Assert.True(CatalogDiff.isEmpty (CatalogDiff.between
                                         (CatalogDiff.applyDiff genesis viaCompose)
-                                        targetCatalog |> mustOk))
+                                        targetCatalog))
     Assert.Equal(CatalogDiff.norm direct, CatalogDiff.norm viaCompose)
     // The net is genuinely non-empty (the rename survived the fold).
     Assert.False(CatalogDiff.isEmpty viaCompose)
@@ -264,12 +264,12 @@ let ``NM-45: CatalogDiff.compose returns None (fail-loud) on non-adjacent diffs`
     // NOT meet d2's SOURCE (genesis/Customer) on the captured surface, so the
     // groupoid composition is undefined — `compose` returns None. This is the
     // exact fail-loud signal netDiff's None branch now names rather than masks.
-    let d1 = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
-    let d2 = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let d1 = CatalogDiff.between sampleCatalog targetCatalog
+    let d2 = CatalogDiff.between sampleCatalog sampleCatalog
     Assert.True(Option.isNone (CatalogDiff.compose d1 d2),
                 "compose must fail loud (None) when d1.target does not meet d2.source")
     // ...and the ADJACENT pair composes (Some) — the precondition is genuine.
-    let d2adj = CatalogDiff.between targetCatalog sampleCatalog |> mustOk
+    let d2adj = CatalogDiff.between targetCatalog sampleCatalog
     Assert.True(Option.isSome (CatalogDiff.compose d1 d2adj),
                 "compose must be defined (Some) on an adjacent pair")
 

--- a/sidecar/projection/tests/Projection.Tests/ManifestPredicateCoverageTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ManifestPredicateCoverageTests.fs
@@ -6,6 +6,7 @@ open Projection.Core
 open Projection.Core.Passes
 open Projection.Targets.SSDT
 open Projection.Tests.Fixtures
+open Projection.Tests.TotalityFunctor
 
 // Chapter A.4.7' slice η — shim restoring the Lineage<Catalog> shape.
 let private ciRun (c: Catalog) : Lineage<Catalog> =
@@ -36,11 +37,27 @@ let ``PredicateName.all is alphabetically sorted (canonical order for emit)`` ()
     let sorted = names |> List.sort
     Assert.Equal<string list> (sorted, names)
 
+/// The closed-set spec for the `PredicateName ⇔ coverage` distinctness core: the
+/// projection `toString` over the closed `PredicateName` DU is injective. The
+/// `Left`/`Right` set-equality half is exercised by the manifest-emission test
+/// below (emitted coverage names ⇔ the catalog); here only the distinctness half
+/// is needed, so the two sides are the same catalog projection.
+let private predicateNameSpec : TotalitySpec<string, PredicateName, string> =
+    let catalogNames = PredicateName.all |> List.map PredicateName.toString |> Set.ofList
+    { Left = catalogNames
+      Right = catalogNames
+      LeftLabel = "PredicateName"
+      RightLabel = "PredicateName"
+      Members = PredicateName.all
+      Project = PredicateName.toString }
+
 [<Fact>]
 let ``PredicateName.toString round-trips through PredicateName.all`` () =
-    // Every variant in `all` produces a unique non-empty name.
+    // Every variant in `all` produces a unique non-empty name. Distinctness via
+    // the totality functor (`X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`'s injective-key precondition);
+    // non-emptiness stays here as the test-specific extra.
+    assertProjectionDistinct predicateNameSpec
     let names = PredicateName.all |> List.map PredicateName.toString
-    Assert.Equal (List.length names, List.length (List.distinct names))
     Assert.All (names, fun n -> Assert.False (System.String.IsNullOrWhiteSpace n))
 
 // ---------------------------------------------------------------------------
@@ -164,13 +181,24 @@ let ``Manifest predicateCounts emits all 16 predicate variants in canonical sort
     let counts = requireChild "predicateCounts" pc.["predicateCounts"]
     let countsArr = counts.AsArray()
     Assert.Equal (16, countsArr.Count)
-    // Verify sorted-by-name order (matches PredicateName.all order)
     let expectedNames = PredicateName.all |> List.map PredicateName.toString
     let actualNames =
         [ for i in 0 .. countsArr.Count - 1 ->
             let entry = requireChild "predicateCounts.entry" countsArr.[i]
             let nameNode = requireChild "predicateCounts.entry.name" entry.["name"]
             nameNode.GetValue<string>() ]
+    // `PredicateName ⇔ coverage` (`X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`): the emitted coverage
+    // names and the closed-DU catalog coincide exactly — every catalog predicate
+    // is emitted, no emitted name is off-catalog. Via the totality functor.
+    assertBidirectionalSubset
+        { Left = Set.ofList actualNames
+          Right = Set.ofList expectedNames
+          LeftLabel = "emitted coverage name"
+          RightLabel = "PredicateName catalog name"
+          Members = PredicateName.all
+          Project = PredicateName.toString }
+    // The sorted-by-name ORDER (stronger than set-equality) stays here as the
+    // test-specific extra — the manifest's canonical-order byte-determinism.
     Assert.Equal<string list> (expectedNames, actualNames)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/MigrationRunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationRunTests.fs
@@ -126,11 +126,11 @@ let ``6.D.1: the full A->B loop — migrate, record, then reconstruct reproduces
         let chain = MigrationRun.record path (tl "dev") coord (Some "reflog#1") (DataObservation.create 12 (Some "lsn:0x0C")) artifacts |> mustOk
         // The FTC over the recorded chain reproduces B (genesis ⊕ δ = target).
         let reconstructed = EpisodicLifecycle.reconstructLatestSchema chain |> mustOk
-        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reconstructed |> mustOk))
+        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reconstructed))
         // And it survives a reload from disk — durable provenance.
         let reloaded = LifecycleStore.load path |> mustOk
         let reReconstructed = EpisodicLifecycle.reconstructLatestSchema reloaded |> mustOk
-        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reReconstructed |> mustOk)))
+        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reReconstructed)))
 
 // ===========================================================================
 // The snapshot⊖snapshot loop — previewFromStore sources state A from the
@@ -190,7 +190,7 @@ let private physicalRenameTarget : Catalog =
 
 [<Fact>]
 let ``live: renameStatements emits sp_rename + a logical-name re-bind for a physical table rename`` () =
-    let diff = CatalogDiff.between sampleCatalog physicalRenameTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog physicalRenameTarget
     let stmts = MigrationRun.renameStatements diff
     Assert.Equal(2, List.length stmts)
     // (1) the physical rename; (2) the V2.LogicalName re-bind to the new name.
@@ -211,7 +211,7 @@ let private columnRenameTarget : Catalog =
 
 [<Fact>]
 let ``live: a column rename emits sp_rename COLUMN + a column-level logical re-bind`` () =
-    let diff = CatalogDiff.between sampleCatalog columnRenameTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog columnRenameTarget
     let stmts = MigrationRun.renameStatements diff
     Assert.Equal(2, List.length stmts)
     // (1) the physical column rename; (2) the column-level V2.LogicalName re-bind.
@@ -225,7 +225,7 @@ let ``live: a column rename emits sp_rename COLUMN + a column-level logical re-b
 let ``live: a logical-only rename re-binds the logical name without an sp_rename`` () =
     // renamedTarget changes the logical Name but keeps customer's Physical.Table:
     // the physical object stays, but its V2.LogicalName binding must still update.
-    let diff = CatalogDiff.between sampleCatalog renamedTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog renamedTarget
     let one = List.exactlyOne (MigrationRun.renameStatements diff)
     Assert.DoesNotContain("sp_rename", one)   // no physical rename
     Assert.Contains("sp_updateextendedproperty", one)
@@ -284,7 +284,7 @@ let ``AC-P8: recordVerified persists a verified execute; the store reloads and r
         // Reload from disk and reconstruct: B' reproduces B (T16 through 6.H).
         let reloaded = LifecycleStore.load path |> mustOk
         let reReconstructed = EpisodicLifecycle.reconstructLatestSchema reloaded |> mustOk
-        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reReconstructed |> mustOk)))
+        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between reshapedTarget reReconstructed)))
 
 [<Fact>]
 let ``AC-P8: a second recordVerified appends at the next monotonic ordinal (timeline advances)`` () =

--- a/sidecar/projection/tests/Projection.Tests/MigrationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationTests.fs
@@ -61,7 +61,7 @@ let ``T16: applyTo (plan A B) A = B — migrate A B reproduces the target (maste
         let plan = Migration.plan DeclareAll sampleCatalog target |> mustOk
         let reproduced = Migration.applyTo plan sampleCatalog
         // B reproduced modulo the diff's captured surface.
-        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between target reproduced |> mustOk))
+        Assert.True(CatalogDiff.isEmpty (CatalogDiff.between target reproduced))
 
 [<Fact>]
 let ``T16: migrate A A is idempotent — zero minimum-viable touches`` () =

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -429,16 +429,14 @@ let ``J3: the rendered pair is SsKey-aligned by construction; the repoint is the
         |> List.collect (fun k -> k.SsKey :: (k.Attributes |> List.map (fun a -> a.SsKey)))
         |> Set.ofList
     Assert.Equal<Set<SsKey>>(keysOf j3AuthoredModel, keysOf logical)
-    match CatalogDiff.between logical j3AuthoredModel with
-    | Error es -> Assert.Fail(sprintf "the rendition diff must succeed: %A" es)
-    | Ok diff ->
-        // Both renditions carry the SAME logical `Name`s (the passes touch only
-        // the physical-realization slots), so the B→A rename map is EMPTY — the
-        // identity repoint. The rendition difference rides each contract's
-        // physical coordinates at its own SQL boundary (source reads by B's
-        // names, sink writes by A's), the LE-2-proven mechanism.
-        let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
-        Assert.True(Map.isEmpty renameMap)
+    let diff = CatalogDiff.between logical j3AuthoredModel
+    // Both renditions carry the SAME logical `Name`s (the passes touch only
+    // the physical-realization slots), so the B→A rename map is EMPTY — the
+    // identity repoint. The rendition difference rides each contract's
+    // physical coordinates at its own SQL boundary (source reads by B's
+    // names, sink writes by A's), the LE-2-proven mechanism.
+    let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
+    Assert.True(Map.isEmpty renameMap)
 
 // -- planMovement routing (the pure surface→engine map) --------------------
 

--- a/sidecar/projection/tests/Projection.Tests/PreflightAllTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PreflightAllTests.fs
@@ -272,6 +272,7 @@ let ``G0: labelText renders every GateLabel variant (closed-DU totality)`` () =
           Preflight.CdcTrackedSink
           Preflight.SchemaReadFailed
           Preflight.UndeclaredDestructiveChange
+          Preflight.MidWriteNotProtected
           Preflight.UnclassifiedRefusal ]
     for l in labels do
         Assert.False(System.String.IsNullOrWhiteSpace(Preflight.labelText l))
@@ -329,3 +330,94 @@ let ``G0: refusalOf classifies the FIRST error code (the gate's primary refusal)
     Assert.Equal("transfer.insufficientGrant", refusal.Error.Code)
     Assert.Equal(7, refusal.ExitCode)
     Assert.Equal(Preflight.InsufficientGrant, refusal.Label)
+
+// -- M20 · Transactionality (T-VI spanning) — the honest-naming half ----------
+//
+// THE VECTOR §5.1 / M20. A half-populated target after a mid-Phase-2 crash on an
+// unprotected (non-atomic, non-resumable) write path was the GENERIC
+// `UnclassifiedRefusal` (exit 3). M20 NAMES it: a closed-DU variant
+// (`MidWriteNotProtected`), its exit-9 classify arm (the destructive-failure
+// class), and a PURE gate. The live atomic `BEGIN TRAN` wrapper stays deferred
+// (the A3 scaffold in Preflight.fs is the survey's to resolve) — these witness
+// the classification half only.
+
+[<Fact>]
+let ``M20 (T-VI spanning): classify maps transfer.midWriteNotProtected to (9, MidWriteNotProtected)`` () =
+    // The transactionality axis classifies as the destructive-failure class
+    // (exit 9), no longer the generic (3, UnclassifiedRefusal).
+    let exit, label = Preflight.classify "transfer.midWriteNotProtected"
+    Assert.Equal(9, exit)
+    Assert.Equal(Preflight.MidWriteNotProtected, label)
+    Assert.NotEqual(3, exit)
+
+[<Fact>]
+let ``M20 (T-VI spanning): classify maps the migrate.midWriteNotProtected form identically`` () =
+    // The SAME axis under the migrate namespace classifies identically — the same
+    // exit, the same label.
+    let exit, label = Preflight.classify "migrate.midWriteNotProtected"
+    Assert.Equal(9, exit)
+    Assert.Equal(Preflight.MidWriteNotProtected, label)
+
+[<Fact>]
+let ``M20 (T-VI spanning): labelText covers MidWriteNotProtected`` () =
+    // The named axis has an operator-facing rendering — the reporting surface can
+    // name WHICH axis refused.
+    Assert.Equal("mid-write not protected", Preflight.labelText Preflight.MidWriteNotProtected)
+    Assert.False(System.String.IsNullOrWhiteSpace(Preflight.labelText Preflight.MidWriteNotProtected))
+
+// A small set of planned destructive writes the transactionality gate reasons
+// over (an Insert and a Delete on two objects).
+let private plannedDestructiveWrites : Preflight.PlannedWrite list =
+    [ { Schema = "dbo"; Table = "Customer"; Action = Preflight.Insert }
+      { Schema = "dbo"; Table = "Order"; Action = Preflight.Delete } ]
+
+[<Fact>]
+let ``M20 (T-VI spanning): transactionalityViolations is non-empty and named under Unprotected`` () =
+    // An unprotected write path yields one violation per planned destructive write
+    // — a mid-write crash would leave each half-applied.
+    let violations =
+        Preflight.transactionalityViolations Preflight.Unprotected plannedDestructiveWrites
+    Assert.Equal(2, List.length violations)
+    // Named: each violation locates the object + action it would leave half-applied.
+    let objects = violations |> List.map (fun v -> v.Object)
+    Assert.Contains("dbo.Customer", objects)
+    Assert.Contains("dbo.Order", objects)
+    // Deterministic — sorted by object then action.
+    Assert.Equal<string list>([ "dbo.Customer"; "dbo.Order" ], objects)
+
+[<Fact>]
+let ``M20 (T-VI spanning): transactionalityViolations is empty under Atomic and Resumable`` () =
+    // A protected path (whole-write rollback OR idempotent re-run) yields no
+    // violation — the mid-write crash is survived.
+    Assert.Empty(Preflight.transactionalityViolations Preflight.Atomic plannedDestructiveWrites)
+    Assert.Empty(Preflight.transactionalityViolations Preflight.Resumable plannedDestructiveWrites)
+
+[<Fact>]
+let ``M20 (T-VI spanning): transactionalityPreflight is Ok when the path is protected`` () =
+    // Atomic and Resumable both pass the gate — no refusal.
+    match Preflight.transactionalityPreflight Preflight.Atomic plannedDestructiveWrites with
+    | Ok () -> ()
+    | Error e -> Assert.Fail(sprintf "expected Ok under Atomic, got %A" e)
+    match Preflight.transactionalityPreflight Preflight.Resumable plannedDestructiveWrites with
+    | Ok () -> ()
+    | Error e -> Assert.Fail(sprintf "expected Ok under Resumable, got %A" e)
+
+[<Fact>]
+let ``M20 (T-VI spanning): transactionalityPreflight refuses migrate.midWriteNotProtected under Unprotected`` () =
+    // An unprotected path refuses with the named code — which classifies to exit 9
+    // (the destructive-failure axis), never the generic exit 3.
+    match Preflight.transactionalityPreflight Preflight.Unprotected plannedDestructiveWrites with
+    | Error [ e ] ->
+        Assert.Equal("migrate.midWriteNotProtected", e.Code)
+        let exit, label = Preflight.classify e.Code
+        Assert.Equal(9, exit)
+        Assert.Equal(Preflight.MidWriteNotProtected, label)
+    | other -> Assert.Fail(sprintf "expected a single-error refusal, got %A" other)
+
+[<Fact>]
+let ``M20 (T-VI spanning): an empty plan never refuses, even Unprotected`` () =
+    // No planned destructive write means nothing to leave half-applied — the gate
+    // is vacuously Ok regardless of protection.
+    match Preflight.transactionalityPreflight Preflight.Unprotected [] with
+    | Ok () -> ()
+    | Error e -> Assert.Fail(sprintf "an empty plan must pass, got %A" e)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -88,6 +88,7 @@
     <Compile Include="AxiomTests.fs" />
     <Compile Include="ArtifactByKindTests.fs" />
     <Compile Include="CatalogDiffTests.fs" />
+    <Compile Include="ChangeAlgebraSweepTests.fs" />
     <Compile Include="ComparisonTests.fs" />
     <Compile Include="LifecycleTests.fs" />
     <Compile Include="EpisodeTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="ViewTests.fs" />
     <Compile Include="ExplainViewTests.fs" />
     <Compile Include="TtyRendererTests.fs" />
+    <Compile Include="TotalityFunctor.fs" />
     <Compile Include="VoiceTotalityTests.fs" />
     <Compile Include="WatchTests.fs" />
     <Compile Include="CapabilitySurveyTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RefactorLogAccumulateTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefactorLogAccumulateTests.fs
@@ -67,7 +67,7 @@ let private targetOrderRenamed : Catalog =
     IRBuilders.mkCatalog [ { salesModule with Kinds = [ customer; renamedOrder; country ] } ]
 
 let private emitRenameEntries (target: Catalog) : RefactorLogEntry list =
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     RefactorLogEmitter.emit diff |> mustOk |> RefactorLogEmitter.flatten
 
 // ===========================================================================
@@ -75,7 +75,7 @@ let private emitRenameEntries (target: Catalog) : RefactorLogEntry list =
 // ===========================================================================
 
 let private customerArtifact () : ArtifactByKind<RefactorLogEntry list> =
-    let diff = CatalogDiff.between sampleCatalog targetCustomerRenamed |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCustomerRenamed
     RefactorLogEmitter.emit diff |> mustOk
 
 let private changeDateTimeOf (xml: string) : string =
@@ -205,7 +205,7 @@ let ``AC-P6 dedup: empty prior yields the current emission unchanged`` () =
 [<Fact>]
 let ``AC-P6 dedup: accumulateArtifact agrees with accumulate over flatten`` () =
     let prior = emitRenameEntries targetCustomerRenamed
-    let diff = CatalogDiff.between sampleCatalog targetOrderRenamed |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetOrderRenamed
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let viaArtifact = RefactorLogEmitter.accumulateArtifact prior artifact
     let viaFlat = RefactorLogEmitter.accumulate prior (RefactorLogEmitter.flatten artifact)
@@ -249,7 +249,7 @@ let ``AC-P6 full-history: every operation in the rendered log carries the episod
         let renamedOrder = { order with Name = nameOf "Receipt" }
         IRBuilders.mkCatalog [ { salesModule with Kinds = [ renamedCustomer; renamedOrder; country ] } ]
     let artifact =
-        RefactorLogEmitter.emit (CatalogDiff.between sampleCatalog twoRenameTarget |> mustOk) |> mustOk
+        RefactorLogEmitter.emit (CatalogDiff.between sampleCatalog twoRenameTarget) |> mustOk
     let at = DateTimeOffset(2026, 6, 3, 12, 0, 0, TimeSpan.Zero)
     let xml = RefactorLogRender.toRefactorLogXmlAt at artifact
     let stamps =

--- a/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
@@ -81,7 +81,7 @@ let private fkRenameTarget : Catalog =
 
 [<Fact>]
 let ``T11 (diff-typed inputs): RefactorLogEmitter.emit key-set equals target Catalog.allKinds`` () =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let expected =
         Catalog.allKinds targetCatalog
         |> List.map (fun k -> k.SsKey)
@@ -91,7 +91,7 @@ let ``T11 (diff-typed inputs): RefactorLogEmitter.emit key-set equals target Cat
 
 [<Fact>]
 let ``RefactorLogEmitter: identity diff produces empty entries for every kind`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entries = ArtifactByKind.toMap artifact
     Assert.All(
@@ -100,7 +100,7 @@ let ``RefactorLogEmitter: identity diff produces empty entries for every kind`` 
 
 [<Fact>]
 let ``RefactorLogEmitter: one-rename diff produces one SqlTable entry on the renamed kind`` () =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entries = ArtifactByKind.toMap artifact
     // Renamed kind: `customer` (SsKey unchanged; Name "Customer" → "Patron")
@@ -117,7 +117,7 @@ let ``RefactorLogEmitter: one-rename diff produces one SqlTable entry on the ren
 
 [<Fact>]
 let ``RefactorLogEmitter: unrenamed kinds produce empty entries`` () =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entries = ArtifactByKind.toMap artifact
     Assert.Empty(Map.find orderKey entries)
@@ -132,7 +132,7 @@ let ``RefactorLogEmitter: unrenamed kinds produce empty entries`` () =
 
 [<Fact>]
 let ``T1: RefactorLogEmitter produces stable OperationKey across repeat invocations`` () =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let runs =
         [ for _ in 1 .. 10 -> RefactorLogEmitter.emit diff |> mustOk ]
     let head =
@@ -153,7 +153,7 @@ let ``T1: RefactorLogEmitter produces stable OperationKey across repeat invocati
 
 [<Fact>]
 let ``RefactorLogEmitter: OperationKey is UUIDv5 (version digit 5)`` () =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entry =
         artifact
@@ -172,7 +172,7 @@ let ``RefactorLogEmitter: OperationKey is UUIDv5 (version digit 5)`` () =
 [<Fact>]
 let ``RefactorLogEmitter: Added kind produces empty entries (it's a CREATE not a rename)`` () =
     let empty = Catalog.create [] [] |> mustResultOk
-    let diff = CatalogDiff.between empty sampleCatalog |> mustOk
+    let diff = CatalogDiff.between empty sampleCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entries = ArtifactByKind.toMap artifact
     Assert.All(
@@ -182,7 +182,7 @@ let ``RefactorLogEmitter: Added kind produces empty entries (it's a CREATE not a
 [<Fact>]
 let ``RefactorLogEmitter: Removed kind produces no artifact entry (target is empty)`` () =
     let empty = Catalog.create [] [] |> mustResultOk
-    let diff = CatalogDiff.between sampleCatalog empty |> mustOk
+    let diff = CatalogDiff.between sampleCatalog empty
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     // Target catalog is empty; artifact's keyset is empty per T11.
     Assert.Empty(ArtifactByKind.keys artifact)
@@ -197,7 +197,7 @@ let ``RefactorLogEmitter: Removed kind produces no artifact entry (target is emp
 
 [<Fact>]
 let ``RefactorLogEmitter: a column rename produces a SqlSimpleColumn entry`` () =
-    let diff = CatalogDiff.between sampleCatalog columnRenameTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog columnRenameTarget
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let customerEntries = Map.find customerKey (ArtifactByKind.toMap artifact)
     let columnEntry =
@@ -214,7 +214,7 @@ let ``RefactorLogEmitter: a column rename produces a SqlSimpleColumn entry`` () 
 [<Fact>]
 let ``RefactorLogEmitter: a column rename's OperationKey is deterministic`` () =
     let key () =
-        let diff = CatalogDiff.between sampleCatalog columnRenameTarget |> mustOk
+        let diff = CatalogDiff.between sampleCatalog columnRenameTarget
         let artifact = RefactorLogEmitter.emit diff |> mustOk
         (Map.find customerKey (ArtifactByKind.toMap artifact)
          |> List.find (fun e -> e.ElementType = SqlSimpleColumn)).OperationKey
@@ -222,7 +222,7 @@ let ``RefactorLogEmitter: a column rename's OperationKey is deterministic`` () =
 
 [<Fact>]
 let ``RefactorLogEmitter: no column rename produces no SqlSimpleColumn entry`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let allColumnEntries =
         ArtifactByKind.toMap artifact
@@ -242,7 +242,7 @@ let ``RefactorLogEmitter: no column rename produces no SqlSimpleColumn entry`` (
 
 [<Fact>]
 let ``RefactorLogEmitter: a foreign-key rename produces a SqlForeignKey entry`` () =
-    let diff = CatalogDiff.between sampleCatalog fkRenameTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog fkRenameTarget
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let orderEntries = Map.find orderKey (ArtifactByKind.toMap artifact)
     let fkEntry =
@@ -260,7 +260,7 @@ let ``RefactorLogEmitter: a foreign-key rename produces a SqlForeignKey entry`` 
 [<Fact>]
 let ``RefactorLogEmitter: a foreign-key rename's OperationKey is deterministic`` () =
     let key () =
-        let diff = CatalogDiff.between sampleCatalog fkRenameTarget |> mustOk
+        let diff = CatalogDiff.between sampleCatalog fkRenameTarget
         let artifact = RefactorLogEmitter.emit diff |> mustOk
         (Map.find orderKey (ArtifactByKind.toMap artifact)
          |> List.find (fun e -> e.ElementType = SqlForeignKey)).OperationKey
@@ -268,7 +268,7 @@ let ``RefactorLogEmitter: a foreign-key rename's OperationKey is deterministic``
 
 [<Fact>]
 let ``RefactorLogEmitter: no foreign-key rename produces no SqlForeignKey entry`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let allFkEntries =
         ArtifactByKind.toMap artifact
@@ -299,7 +299,7 @@ let private renameReshapeTarget : Catalog =
 
 [<Fact>]
 let ``CatalogDiff: a renamed-and-reshaped column lands in BOTH Renamed and Changed`` () =
-    let diff = CatalogDiff.between sampleCatalog renameReshapeTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog renameReshapeTarget
     match CatalogDiff.attributeDiffOf customerKey diff with
     | None -> Assert.Fail "expected an attribute diff on customer"
     | Some ad ->
@@ -310,7 +310,7 @@ let ``CatalogDiff: a renamed-and-reshaped column lands in BOTH Renamed and Chang
 
 [<Fact>]
 let ``composition: rename → one SqlSimpleColumn AND reshape → one ALTER COLUMN, disjoint`` () =
-    let diff = CatalogDiff.between sampleCatalog renameReshapeTarget |> mustOk
+    let diff = CatalogDiff.between sampleCatalog renameReshapeTarget
     // The refactorlog rename channel: exactly one SqlSimpleColumn entry.
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let columnRenames =

--- a/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
@@ -304,7 +304,7 @@ let ``CatalogDiff: a renamed-and-reshaped column lands in BOTH Renamed and Chang
     | None -> Assert.Fail "expected an attribute diff on customer"
     | Some ad ->
         Assert.True(Map.containsKey customerNameKey ad.Renamed)
-        let changed = ad.Changed |> List.filter (fun c -> c.AttributeKey = customerNameKey)
+        let changed = ad.Reshaped |> List.filter (fun c -> c.AttributeKey = customerNameKey)
         Assert.Equal(1, List.length changed)
         Assert.Contains(AttributeFacet.DataType, (List.head changed).Facets)
 

--- a/sidecar/projection/tests/Projection.Tests/RefactorLogRenderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefactorLogRenderTests.fs
@@ -53,7 +53,7 @@ let private targetCatalog : Catalog =
     IRBuilders.mkCatalog [ renamedSalesModule ]
 
 let private renderOnce () : string =
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     RefactorLogRender.toRefactorLogXml artifact
 
@@ -117,7 +117,7 @@ let ``RefactorLogRender: rename Operation Key matches UuidV5-derived OperationKe
     // Cross-check the rendered Key against the emitter's typed entry —
     // they must agree because the renderer takes the entry's
     // `OperationKey` directly.
-    let diff = CatalogDiff.between sampleCatalog targetCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let entry =
         artifact
@@ -156,7 +156,7 @@ let ``RefactorLogRender: rename Operation has five Property children with the ex
 
 [<Fact>]
 let ``RefactorLogRender: identity diff produces an Operations element with no Operation children`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let artifact = RefactorLogEmitter.emit diff |> mustOk
     let xml = RefactorLogRender.toRefactorLogXml artifact
     let doc = parseDoc xml

--- a/sidecar/projection/tests/Projection.Tests/RegisteredAllTransformsBidirectionalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RegisteredAllTransformsBidirectionalTests.fs
@@ -33,6 +33,7 @@ open Projection.Core
 open Projection.Core.Passes
 open Projection.Pipeline
 open Projection.Tests.Fixtures
+open Projection.Tests.TotalityFunctor
 
 
 // ---------------------------------------------------------------------------
@@ -388,22 +389,34 @@ let ``NM-43 (forward): every chainSteps step name is registered in RegisteredTra
         Set.isEmpty unregistered,
         sprintf "chainSteps that execute but are not in RegisteredTransforms.all: %A" (Set.toList unregistered))
 
+// The `registered ⇔ executed` core for the chain-projected partition, via the
+// totality functor: the chainStep names (`executed`) and the chain-projected
+// registry names (`RegisteredTransforms.all` minus the metadata-only strategies,
+// = `registered`) coincide exactly — `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`. A registration
+// whose name typo'd away from its chainStep, or a chainStep removed while a
+// metadata entry lingered, surfaces here as a partition that no longer matches.
+// The distinctness projection (`Metadata.Name` over `chainSteps`) gates the
+// comparison: no two chainSteps may collide on one name.
+let private chainExecutedSpec : TotalitySpec<string, ChainStep, string> =
+    { Left = Set.difference coreRegistryNames strategyRegistrationNames
+      Right = chainStepNames
+      LeftLabel = "chain-projected registration"
+      RightLabel = "executed chainStep"
+      Members = RegisteredTransforms.chainSteps
+      Project = fun s -> s.Metadata.Name }
+
 [<Fact>]
-let ``NM-43 (reverse): every chain-projected entry in RegisteredTransforms.all is an executed chainStep`` () =
+let ``NM-43 (reverse): registered ⇔ executed is bidirectional for the chain-projected partition (every registration executes, every chainStep is registered)`` () =
     // `RegisteredTransforms.all` projects from exactly two sources — the chain
     // (`chainSteps |> map metadata`) and the metadata-only strategies
-    // (`StrategyRegistrations.all`). The chain-projected partition is therefore
-    // `all` minus the strategy registrations; every name in it MUST be a live
-    // chainStep. A registration whose name typo'd away from its chainStep, or a
-    // chainStep removed while a metadata entry lingered, surfaces here as an
-    // entry that registers but no longer executes.
-    let chainProjected = Set.difference coreRegistryNames strategyRegistrationNames
-    let registeredButNotExecuted = Set.difference chainProjected chainStepNames
-    Assert.True(
-        Set.isEmpty registeredButNotExecuted,
-        sprintf
-            "RegisteredTransforms.all entries that register (non-strategy) but execute via no chainStep: %A"
-            (Set.toList registeredButNotExecuted))
+    // (`StrategyRegistrations.all`). The chain-projected partition is `all` minus
+    // the strategy registrations; via the functor it must coincide with the live
+    // chainStep names in both directions (`X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`).
+    assertBidirectionalSubset chainExecutedSpec
+
+[<Fact>]
+let ``NM-43: chainStep names are distinct (the projection is injective)`` () =
+    assertProjectionDistinct chainExecutedSpec
 
 [<Fact>]
 let ``NM-43: the chain projection is EXACTLY closed — all = chainSteps ∪ strategies, partitioned`` () =

--- a/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
@@ -14,9 +14,7 @@ type private FsResult<'a, 'b> = Microsoft.FSharp.Core.Result<'a, 'b>
 
 let private mustOk r = match r with Ok v -> v | Error es -> failwithf "fixture: %A" es
 let private betweenOk (a: Catalog) (b: Catalog) : CatalogDiff =
-    match CatalogDiff.between a b with
-    | FsResult.Ok d -> d
-    | FsResult.Error e -> failwithf "between: %A" e
+    CatalogDiff.between a b
 let private nm (s: string) : Name = Name.create s |> mustOk
 let private kKey (s: string) : SsKey = SsKey.synthesizedComposite "OS_RP_KIND" [ s ] |> mustOk
 let private aKey (s: string) : SsKey = SsKey.synthesizedComposite "OS_RP_ATTR" [ s ] |> mustOk

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegPropertyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegPropertyTests.fs
@@ -374,9 +374,8 @@ let ``rendition invariance: the B->A rename map is the IDENTITY — logical Name
     Prop.forAll (Arb.fromGen (genTransferCatalog true)) (fun model ->
         let logical = CatalogRendition.logical model
         let physical = CatalogRendition.physical model
-        match CatalogDiff.between logical physical with
-        | Error _ -> false
-        | Ok diff -> RenameProjection.renames diff |> List.isEmpty)
+        let diff = CatalogDiff.between logical physical
+        RenameProjection.renames diff |> List.isEmpty)
     |> Check.QuickThrowOnFailure
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/SchemaMigrationCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SchemaMigrationCanaryTests.fs
@@ -64,10 +64,7 @@ type SchemaMigrationCanaryTests(fixture: EphemeralContainerFixture) =
                             "INSERT INTO [dbo].[MIG_CUSTOMER] ([ID],[EMAIL]) VALUES (1, N'alice@example.com');"
 
                     // The implied emission differential: diff → minimal ALTER.
-                    let diff =
-                        match CatalogDiff.between source target with
-                        | Ok d -> d
-                        | Error e -> failwithf "between: %A" e
+                    let diff = CatalogDiff.between source target
                     let migration = SchemaMigrationEmitter.emit diff
 
                     // No fail-loud refusals — a pure widening is emittable.

--- a/sidecar/projection/tests/Projection.Tests/SchemaMigrationEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SchemaMigrationEmitterTests.fs
@@ -34,7 +34,7 @@ let private withCustomerName (f: Attribute -> Attribute) : Catalog =
 
 /// Emit the migration of `sampleCatalog → target`.
 let private migrationOf (target: Catalog) : Statement list * DiagnosticEntry list =
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
     let m = SchemaMigrationEmitter.emit diff
     m.Value, m.Entries
 
@@ -117,7 +117,7 @@ let ``migration: an identity facet change is refused fail-loud`` () =
 
 [<Fact>]
 let ``migration: an identical diff emits no statements and no diagnostics`` () =
-    let diff = CatalogDiff.between sampleCatalog sampleCatalog |> mustOk
+    let diff = CatalogDiff.between sampleCatalog sampleCatalog
     let m = SchemaMigrationEmitter.emit diff
     Assert.Empty(m.Value)
     Assert.Empty(m.Entries)
@@ -151,7 +151,7 @@ let ``S6.3: a simultaneously renamed AND reshaped attribute splits cleanly acros
     // is set (None → Some 256). One attribute, two orthogonal moves, one diff.
     let target =
         withCustomerName (fun a -> { a with Name = nm "FullName"; Length = Some 256 })
-    let diff = CatalogDiff.between sampleCatalog target |> mustOk
+    let diff = CatalogDiff.between sampleCatalog target
 
     // The diff itself records BOTH moves on the same attribute key.
     let ad = CatalogDiff.attributeDiffOf customerKey diff |> Option.get
@@ -228,7 +228,7 @@ let ``S10.4: a Computed facet change is refused fail-loud (no ALTER emitted)`` (
 // ---------------------------------------------------------------------------
 
 let private migrationBetween (source: Catalog) (target: Catalog) : Statement list * DiagnosticEntry list =
-    let m = SchemaMigrationEmitter.emit (CatalogDiff.between source target |> mustOk)
+    let m = SchemaMigrationEmitter.emit (CatalogDiff.between source target)
     m.Value, m.Entries
 
 let private catalogOf (kinds: Kind list) (seqs: Sequence list) : Catalog =
@@ -309,7 +309,7 @@ let ``C1 emit: a dropped sequence refuses fail-loud (migration.destructiveSequen
 // ---------------------------------------------------------------------------
 
 let private dropsBetween (source: Catalog) (target: Catalog) : Statement list * DiagnosticEntry list =
-    let m = SchemaMigrationEmitter.emitWith true (CatalogDiff.between source target |> mustOk)
+    let m = SchemaMigrationEmitter.emitWith true (CatalogDiff.between source target)
     m.Value, m.Entries
 
 let private noError (entries: DiagnosticEntry list) =

--- a/sidecar/projection/tests/Projection.Tests/SchemaMigrationEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SchemaMigrationEmitterTests.fs
@@ -138,7 +138,7 @@ let ``migration: a rename alone emits no ALTER (renames are the RefactorLog chan
 // is BOTH renamed (logical Name change → RefactorLog channel) AND reshaped (a
 // Length shape facet → ALTER COLUMN channel) in the same diff. The two
 // emission channels are disjoint by axis (RefactorLogEmitter reads
-// `AttributeDiff.Renamed`; SchemaMigrationEmitter reads `AttributeDiff.Changed`),
+// `AttributeDiff.Renamed`; SchemaMigrationEmitter reads `AttributeDiff.Reshaped`),
 // so the rename must ride the RefactorLog ONLY and the reshape the ALTER ONLY —
 // neither channel carries the other's content. A "skip the ALTER if the column
 // is also renamed" (or vice-versa) coupling would FAIL this test (the
@@ -156,7 +156,7 @@ let ``S6.3: a simultaneously renamed AND reshaped attribute splits cleanly acros
     // The diff itself records BOTH moves on the same attribute key.
     let ad = CatalogDiff.attributeDiffOf customerKey diff |> Option.get
     Assert.True(ad.Renamed |> Map.containsKey customerNameKey)
-    Assert.True(ad.Changed |> List.exists (fun c ->
+    Assert.True(ad.Reshaped |> List.exists (fun c ->
         c.AttributeKey = customerNameKey && Set.contains AttributeFacet.Length c.Facets))
 
     // SchemaMigration channel: exactly the ALTER COLUMN for the shape change,

--- a/sidecar/projection/tests/Projection.Tests/TotalityFunctor.fs
+++ b/sidecar/projection/tests/Projection.Tests/TotalityFunctor.fs
@@ -1,0 +1,72 @@
+module Projection.Tests.TotalityFunctor
+
+open Xunit
+
+/// THE TOTALITY FUNCTOR — the shared core of the four structurally-identical
+/// totality tests (`required ⇔ surveyed`, `code ⇔ copy`, `registered ⇔ executed`,
+/// `PredicateName ⇔ coverage`). Each proves the same bidirectional-subset +
+/// distinctness law over a closed set with a projection:
+///
+///   `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`
+///
+/// — the harvested surface (`X`) and the declared catalog (`Y`) coincide exactly,
+/// so neither can drift from the other by construction (no missing entry, no dead
+/// entry). The fourth assertion pins that the projection over the closed set's
+/// enumeration is injective — distinct keys, no two members colliding on one
+/// projection — the precondition that lets the two sets be compared as sets.
+///
+/// This functor captures ONLY that shared core. Each instantiating test keeps its
+/// own test-SPECIFIC extras (Voice's banned-word discipline, CapabilitySurvey's
+/// coarse-upper-bound invariant, RegisteredAllTransforms' skeleton-purity +
+/// overlay-exercise, ManifestPredicate's determinism + aggregation) verbatim.
+
+/// A totality specification: the two sets whose mutual containment is the law,
+/// the closed-set enumeration, and the projection whose distinctness gates the
+/// comparison. `'T` is the set element (must be comparable to form `Set`); `'M`
+/// is the closed-set member; `'K` is the (comparable) projection key.
+type TotalitySpec<'T, 'M, 'K when 'T : comparison and 'K : comparison> =
+    { /// The harvested / in-scope surface — the `X` of `X ⊆ Y ∧ Y ⊆ X`.
+      Left: Set<'T>
+      /// The declared catalog — the `Y` of `X ⊆ Y ∧ Y ⊆ X`.
+      Right: Set<'T>
+      /// Operator label for the `X` side, woven into failure messages.
+      LeftLabel: string
+      /// Operator label for the `Y` side, woven into failure messages.
+      RightLabel: string
+      /// The closed-set enumeration over which the projection is checked total.
+      Members: 'M list
+      /// The projection whose injectivity gates set-comparison.
+      Project: 'M -> 'K }
+
+/// The bidirectional-subset half of the law: `Left ⊆ Right` and `Right ⊆ Left`,
+/// then the equality they entail (`X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`). Every member of one
+/// surface is a member of the other and vice versa — no missing entry, no dead
+/// entry. Returns nothing; raises on the first violation.
+let assertBidirectionalSubset (spec: TotalitySpec<'T, 'M, 'K>) : unit =
+    let missing = Set.difference spec.Left spec.Right
+    Assert.True(
+        Set.isEmpty missing,
+        sprintf
+            "%s entries with no %s counterpart (%s ⊆ %s fails): %A"
+            spec.LeftLabel spec.RightLabel spec.LeftLabel spec.RightLabel (Set.toList missing))
+    let dead = Set.difference spec.Right spec.Left
+    Assert.True(
+        Set.isEmpty dead,
+        sprintf
+            "%s entries with no %s counterpart (%s ⊆ %s fails): %A"
+            spec.RightLabel spec.LeftLabel spec.RightLabel spec.LeftLabel (Set.toList dead))
+    // The two containments entail set equality — `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`.
+    Assert.Equal<Set<'T>>(spec.Left, spec.Right)
+
+/// The distinctness half of the law: the projection over the closed-set
+/// enumeration is injective — no two members collide on one key, so the surfaces
+/// above are honest sets (no silent de-duplication).
+let assertProjectionDistinct (spec: TotalitySpec<'T, 'M, 'K>) : unit =
+    let keys = spec.Members |> List.map spec.Project
+    Assert.Equal<'K list>(List.distinct keys, keys)
+
+/// The full totality core: the bidirectional-subset law and the projection's
+/// distinctness, in one call — `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y` with an injective key.
+let assertTotality (spec: TotalitySpec<'T, 'M, 'K>) : unit =
+    assertBidirectionalSubset spec
+    assertProjectionDistinct spec

--- a/sidecar/projection/tests/Projection.Tests/VerifyDataIntegrationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VerifyDataIntegrationTests.fs
@@ -93,8 +93,8 @@ type VerifyDataIntegrationTests(fixture: EphemeralContainerFixture) =
         Assert.Equal(1, report.RowCountDeltas.Length)
         let delta = List.head report.RowCountDeltas
         Assert.Equal(ssKeyOfTable contract "OSUSR_VD_ITEMS", delta.Kind)
-        Assert.Equal(3L, delta.Before)
-        Assert.Equal(6L, delta.After)
+        Assert.Equal(3L<row>, delta.Before)
+        Assert.Equal(6L<row>, delta.After)
         // No false positives: the untouched ORDERS table is absent, and the
         // inserted rows carry non-null NAME so no null-count divergence fires.
         Assert.Empty(report.NullCountDeltas)
@@ -127,9 +127,9 @@ type VerifyDataIntegrationTests(fixture: EphemeralContainerFixture) =
         let nullDelta =
             report.NullCountDeltas
             |> List.find (fun d -> d.Kind = ordersKey && d.Attribute = noteKey)
-        Assert.Equal(0L, nullDelta.Before)
-        Assert.Equal(1L, nullDelta.After)
+        Assert.Equal(0L<row>, nullDelta.Before)
+        Assert.Equal(1L<row>, nullDelta.After)
         // The row count moved too (2 -> 3 on ORDERS).
         let rowDelta = report.RowCountDeltas |> List.find (fun d -> d.Kind = ordersKey)
-        Assert.Equal(2L, rowDelta.Before)
-        Assert.Equal(3L, rowDelta.After)
+        Assert.Equal(2L<row>, rowDelta.Before)
+        Assert.Equal(3L<row>, rowDelta.After)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -4,6 +4,7 @@ open Xunit
 open Projection.Core
 open Projection.Pipeline
 open Projection.Cli
+open Projection.Tests.TotalityFunctor
 
 /// THE VOICE — the `code ⇔ copy` totality test (`THE_VOICE_INTEGRATION.md` §5/§7
 /// slice 1; `DECISIONS 2026-06-06`). The sibling of the registry's
@@ -151,28 +152,33 @@ let private samplePayload : Voice.Payload =
           "schemaWarnings", box "the After deployment carries an added index (verify.schema.indexAdded)" ]
 
 // ---------------------------------------------------------------------------
-// code ⇔ copy totality
+// code ⇔ copy totality — the `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y` core via the totality
+// functor: in-scope codes and voiced copy coincide exactly, codes distinct.
 // ---------------------------------------------------------------------------
 
-[<Fact>]
-let ``Voice totality: every in-scope LIVE code has a copy entry (code → copy)`` () =
-    let missing = Set.difference inScopeCodes voicedCodes
-    Assert.True(Set.isEmpty missing, sprintf "in-scope codes with no Voice copy: %A" (Set.toList missing))
+let private codeCopySpec : TotalitySpec<string, Voice.Copy, string> =
+    { Left = inScopeCodes
+      Right = voicedCodes
+      LeftLabel = "in-scope code"
+      RightLabel = "Voice copy entry"
+      Members = Voice.all
+      Project = fun c -> c.Code }
 
 [<Fact>]
-let ``Voice totality: every copy entry maps to an in-scope code (copy → code)`` () =
-    let extra = Set.difference voicedCodes inScopeCodes
-    Assert.True(Set.isEmpty extra, sprintf "Voice entries with no in-scope code: %A" (Set.toList extra))
+let ``Voice totality: code ⇔ copy is bidirectional (every in-scope LIVE code has copy, every copy maps to an in-scope code)`` () =
+    // `X ⊆ Y ∧ Y ⊆ X ⇒ X = Y`: in-scope codes (`code → copy`) and voiced copy
+    // (`copy → code`) coincide exactly — the operator copy cannot drift from the
+    // events by construction.
+    assertBidirectionalSubset codeCopySpec
+
+[<Fact>]
+let ``Voice totality: codes are distinct (the projection is injective)`` () =
+    assertProjectionDistinct codeCopySpec
 
 [<Fact>]
 let ``Voice totality: no copy is authored for a code the engine cannot emit`` () =
     let phantom = Set.difference voicedCodes knownEmittableCodes
     Assert.True(Set.isEmpty phantom, sprintf "Voice entries for non-emittable codes: %A" (Set.toList phantom))
-
-[<Fact>]
-let ``Voice totality: codes are distinct`` () =
-    let codes = Voice.all |> List.map (fun c -> c.Code)
-    Assert.Equal<string list>(List.distinct codes, codes)
 
 [<Fact>]
 let ``Voice totality: every entry cites a recognized THE_VOICE section`` () =

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -574,6 +574,7 @@ let private allGateLabels : Preflight.GateLabel list =
       Preflight.CdcTrackedSink
       Preflight.SchemaReadFailed
       Preflight.UndeclaredDestructiveChange
+      Preflight.MidWriteNotProtected
       Preflight.UnclassifiedRefusal ]
 
 [<Fact>]


### PR DESCRIPTION
Continues `THE_VECTOR.md` (the fidelity-amelioration program). Waves 0–1 (honesty + the Decision-readback keystone M1) landed in #620; this PR carries **Waves 2 and 3** plus a pre-existing-bug fix surfaced along the way. Every move is behavior-preserving where it claims to be; the engine gains the reversible-algebra laws and then gets measurably smaller.

## Wave 2 — the reversible algebra & the real-wire proof
- **M13** — `CatalogDiff.between` is now total (`Catalog -> Catalog -> CatalogDiff`; the vestigial `Result` dropped); `compose` reads the displacement directly. 13 src + ~120 test call sites adapted, downstream signatures preserved (minimal blast radius).
- **M11** — the triangle inequality made a theorem: `‖compose d1 d2‖ ≤ ‖d1‖ + ‖d2‖`. The norm is now a provable **metric** (strict churn-cancel + equality cases + a swept FsCheck property).
- **M12** — the groupoid **inverse**: `inverse d = between (target d) (source d)` + the freed rollback witness (`applyDiff (inverse d) (target d) = source d`) + the groupoid law. The partial groupoid is completed.
- **M3** — `genCatalogPair` + the swept change-algebra property: the T16 master equation + no-cheat base-threading + norm consistency over ~100 generated valid catalog pairs. The round-trip is raised from fixture- to property-witnessed.
- **M20** — the Transactionality honest-naming half: `GateLabel.MidWriteNotProtected` + its exit-9 classify arm + the pure `transactionalityViolations` gate. A mid-write crash is now a named refusal, not the generic exit-3 (the live atomic wrapper stays deferred per the recorded survey-gate).
- **M11/M12 axiom witnesses** — wired into `AxiomTests.fs` T13/T15 (the M16 citation gate verifies them).

## Wave 2 follow-on bugfix — option-C re-trust capability descent
The full Docker-pool run (which a comparison-primitive change demands) surfaced a **pre-existing** bug in the Wave-1 option-C follow-on: `restoreFkTrust` ran `ALTER … WITH CHECK CHECK CONSTRAINT` unconditionally, which fails on a **no-ALTER `ManagedDml` cloud sink** (SQL 1088), breaking the DML-only reverse-leg canary's "no ALTER in the write path" contract. Confirmed pre-existing on the base commit; fixed by **capability descent** (mirroring `SurrogateCapture.isCapabilityRefusal`): the re-trust descends on the ALTER-permission family to the existing named `FkTrustNotRestoredOnBulkLoad` tolerance, while a constraint conflict (547) still propagates loudly.

## Wave 3 — compression & idiom (the engine measurably smaller)
- **M7** — the diff `ChannelSpec`: four byte-identical per-channel builders + four patchers collapse to one `buildChannel`/`applyChannel` over four spec values; plus the zero-risk `ChannelDiff.Changed → Reshaped` rename. Net −26 LOC; behavior preserved by construction.
- **M8** — the `JsonWriting` seam: the `Utf8JsonWriter → MemoryStream → byte[] → JsonNode.Parse` dance, duplicated across 6 sites, gets one home in `PinnedWriting.fs`. **Byte-identical** (goldens + codec round-trips green).
- **M9** — the binding algebra adopts FsToolkit `validation { }` and one drift-proof `bindShapingTriple`. **Mechanism-only** — every path threads the same binding set, error order byte-identical; the §6 latent config divergences are left pre-existing for the operator to adjudicate (not unified by fiat).
- **M17** — the totality-test functor: four structurally-identical totality tests reduce to one `TotalityFunctor` + four ~10-line instantiations; every test-specific extra retained.
- **M6** — `[<Struct>]` on `SourceKey`/`AssignedKey` (the per-row remap hot path, mirroring `RowQuantum`).
- **M19** — `[<Measure>] row` on the data-norm deltas (the sibling of the shipped `ms` measure).

## Verification (integrator-authoritative)
- Debug + **Release** builds: **0 warnings / 0 errors**.
- Full pure pool: **green** (real durations).
- Full Docker pool: **246 / 246** (real durations — ReverseLegScale Tier-4 streaming ~63 s; not a no-op).
- `AxiomTests` 79/0 (incl. the M16 citation-resolution gate).
- `matrix-status.sh`: gate=PASS, rungs L1/L2/L3 = 5/4/5, tolerances 10 (3 open) — **byte-identical** (Waves 2–3 moved no tolerance, renamed no witness; the under-claim holds).
- `verifiability-gate.sh`: exit 0.

## Orchestration
Each wave's substantial moves were built by worktree-isolated implementer agents with one adversarial verifier each, integrated by cherry-pick (never text-diff-apply). One learning recorded in DECISIONS + the handoff: in a multi-wave session the implementers' worktrees branch off the session origin, not the advancing branch — benign for cherry-pick, but it makes a naively-based verifier raise false blockers (caught and disproven for M7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)