### PR TITLE
THE VECTOR Waves 4 & 5 — corollary cashes, the trust-quadrant type theorem, and the open fidelity adjudications closed

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -24264,3 +24264,154 @@ shrinks while every output byte and every law is unchanged.
   gated deepenings — M18 (`ChangeManifest.toJson`), M14 (the `Traversal` optic, after the compile-order split),
   M4 (`ConstraintState` DU, behind the store-migration story), M5 (digest projection) — plus the persisted-state
   -evolution discipline written down (NM-34 as the store-codec contract).**
+
+## 2026-06-16 — THE VECTOR Wave 4 BUILT: corollary cashes & the trust-quadrant type theorem (M18 / M5 / M4) + the persisted-state-evolution discipline (M14 honestly deferred)
+
+The last chapter of THE VECTOR's defined plan (`THE_VECTOR.md` §6 corollaries + Kind II; §7 Wave 4) — the
+**operator payoff**. Smaller than Waves 2–3 but with one mini-keystone (M4). Built inline (not orchestrated):
+the environment's Docker-no-op-on-Windows + the worktree-base scar from Wave 3 make a careful inline pass more
+reliable than a fan-out for moves that share `Catalog.fs` / the codec. All behavior-preserving on the wire.
+
+- **The cross-cutting prerequisite FIRST — the persisted-state-evolution discipline (codified).** Before any
+  serialized-form change, the contract is named: **NM-34 — a missing field reads as `None` / the additive default
+  — IS the store-codec contract.** Every durable surface (the catalog codec, the `LifecycleStore`/episode NDJSON,
+  the `CaptureJournal`) evolves *additively*: a new field is optional-on-read (older stores omit it → default);
+  a field is never repurposed or removed without a version stamp. **The gating checklist for any future move that
+  touches a serialized form:** (1) does an older store still decode (missing field → sensible default)? (2) does
+  the new code's output still decode on older code (additive only, or version-gated)? (3) is the round-trip
+  witnessed? This discipline GATES M4 and M5 — and both cleared it *without* needing a migration, see below.
+- **M18 — `ChangeManifest.toJson` (the CDC-norm made machine-queryable).** `ReportRun` had `render` (operator
+  prose) and no machine lens; the CDC-capture-count data norm (T15) flowed to the SSIS consumer as prose only.
+  `ReportRun.toJson` / `toJsonString` add the second lens over the same T1-ordered `ReportBundle` — a structured,
+  byte-deterministic document (timeline · episodeCount · pathLength · per-edge {from/to coordinates · schemaNorm ·
+  cdcCaptureCount · refactorLogRef · the 20 named move-channels · the name-sorted tolerance residual · the applied-
+  transforms with canonical `SsKey.serialize` identities}). Typed-`JsonNode` emission (pillar 1), mirroring
+  `ModelFidelity`'s sibling report codec. **`toJson` ONLY** — there is no read-back consumer (the `report` verb
+  reads the lifecycle STORE, not a recorded change-report), so per IR-grows-under-evidence the `fromJson` inverse
+  is deferred-with-trigger (a verb that reads a recorded change-report back materializes). Witness:
+  `ReportRunTests.fs` (5 facts — masthead, per-edge displacement + data norm, present-and-null Decision anchor,
+  the two provenance planes, byte-determinism).
+- **M5 — retire the `sprintf "%A"` policy digest (determinism-by-construction).** `VersionedPolicy.digestOf`'s
+  canonical representation was the F# structural printer — *determinism-by-luck* (compiler-version-dependent shape),
+  exactly the failure `TransformRegistry.digest` forbids (NM-60). Replaced with an explicit `canonicalToken`
+  projection: every axis projected field-by-field, every closed DU to a fixed token, every free-text / identity
+  field LENGTH-PREFIXED (`<utf8-byte-count>:value`, injective), sets sorted by serialized identity, lists in
+  operator order; hashed at the SHA256 boundary. **Changes the digest VALUE** vs the `%A` form, but **no digest is
+  persisted into episodes** (the Episode store records CDC counts, not policy digests — `Episode.fs DataObservation`),
+  and `GoldenEmissionTests` excludes the manifest's `VersionedPolicy` stamp — so the persisted-state checklist is
+  cleared (no migration). Witness: `VersionedPolicyTests` M5 facts (Tightening / UserMatching distinguished, same-id
+  config flip distinguished, Selection-set order-independence) + the 28 pre-existing digest tests still green.
+- **M4 — the `ConstraintState` DU (the trust-quadrant becomes a TYPE THEOREM). The mini-keystone.** The
+  `(HasDbConstraint, IsConstraintTrusted)` `bool × bool` quadrant — a 4-state space encoding a 3-state reality;
+  the illegal `(false, false)` ("untrusted without a constraint", G14) was *runtime-rejected* at the aggregate root.
+  Collapsed into a closed 3-variant `[<RequireQualifiedAccess>] ConstraintState` DU
+  (`NoDbConstraint | TrustedConstraint | UntrustedConstraint`) — **the illegal quadrant is now unrepresentable**, so
+  the prior runtime check became dead code and was retired; `isConstraintStateConsistent` is now a total type
+  theorem. This is the exact **`IndexUniqueness` (Slice 2a)** precedent — sibling quadrant→DU collapse on the same
+  record family — and the **`CapabilityProfile.of` archetype** shape (closed DU → derived projection → round-trip
+  law). **The wire stays byte-identical:** the codec keeps the legacy `(hasDbConstraint, isConstraintTrusted)`
+  boolean pair (`toLegacyBooleans` on write, `ofLegacyBooleans` on read) — so serialized catalogs round-trip
+  unchanged and the persisted-state checklist is cleared with **no migration**. The `CatalogDiff` `DbConstraint` /
+  `Trust` facets project through the booleans, preserving the C1 channel structure; the `DbConstraint`-before-`Trust`
+  `Set.fold` tag order makes the combined `NoDbConstraint → UntrustedConstraint` transition reconstruct exactly
+  (T16 round-trip preserved — `AxiomTests` 79/0). The cascade — ~6 `src` sites (codec, diff, PhysicalSchema, the
+  SSDT emitters, the OSSYS adapters) + ~22 test files — was compiler-guided (FS-warnings-as-errors as the
+  completeness backstop). The obsolete `NM-12: Catalog.create rejects the illegal quadrant` test was repurposed to
+  witness the M4 outcome (the legacy `(false,false)` normalizes to `NoDbConstraint` and the catalog *accepts* it —
+  there is no illegal state left to reject). New round-trip law in `ReferenceConstraintStateTests`:
+  `ofLegacyBooleans ∘ toLegacyBooleans = id` on every variant + the unrepresentability property.
+- **M14 — the `Traversal` optic — HONESTLY DEFERRED (trigger unfired).** M14 would unify the single-focus `Lens`
+  with the hand-rolled `Catalog.mapKinds` / `CatalogTraversal.mapKinds` bulk-map, but its named gate — *resolving the
+  compile-order split* between `Optics.fs` and `Catalog.fs` that is the duplication's cause — **has not fired**, and
+  resolving it is itself a non-trivial structural refactor with no independent forcing function. Per "not yet, and
+  here is the trigger," M14 stays deferred-with-trigger; its re-open condition is the compile-order split being
+  resolved for an independent reason. This deferral *is* M14's correct completion state.
+- **Witness (all integrator-authoritative, this tree).** Debug + **Release** 0/0 (no FS3511). **Full pure pool
+  3629/0** (210 skipped — the Docker no-ops + unfired-trigger skips). `AxiomTests` 79/0 (the change-algebra
+  round-trip survives the M4 facet projection). **`matrix-status.sh` regenerated BYTE-IDENTICALLY** (gate=PASS;
+  rungs L1/L2/L3 = 5/4/5; tolerances 10, 3 open) — M4 is a type refactor with a byte-identical wire and moves no
+  tolerance, so the under-claim is undisturbed (as the Wave-3 handoff predicted M4 *could* move a cell, the careful
+  regen confirms it does not). `verifiability-gate.sh` exit 0. **Docker canary pool 246/246** (scar #3 — a
+  comparison-primitive change ripples through every canary; M4 touches the `Reference` comparison + the codec, so
+  the full pool — not just `~Canary` — was the bar).
+- **Exit criterion (Wave 4) — MET.** The provenance ledger has its machine lens (M18); the digest is determinism-by
+  -construction (M5); the constraint-trust quadrant's illegal state is unrepresentable at the type (M4); the
+  persisted-state-evolution discipline is codified and every Wave-4 serialized-form change cleared its checklist
+  with no migration. **THE VECTOR's defined four-wave plan (§7) is fully cashed**, modulo the honestly-deferred M14.
+  The operator has chosen to continue past the defined plan: a **Wave 5** that closes the residual *open* fidelity
+  adjudications the treatise left dangling (the ReadSide authored-attribute round-trip, the transactionality T-VI
+  honesty, the permissions interim tolerance) — distinct from the moat, which stays cut with named triggers.
+
+## 2026-06-16 — THE VECTOR Wave 5 BUILT: the open fidelity adjudications closed (the authored-attribute round-trip RESOLVED + fixed; transactionality + permissions honestly named against the J5 evidence) + the totality synthesis
+
+Operator-authorized continuation **past** THE VECTOR's defined four-wave plan, to close the residual *open*
+fidelity adjudications that genuinely advance the full fidelity algebra (`THE_VECTOR.md` §3.3 / §5.1 / Appendix B)
+— as distinct from the moat, which stays cut with named triggers. The intent: the gap to the bullseye is not a
+field of missing features but a small, named set of places where the engine says more than it can show; Wave 5
+closes the last *buildable* such place and names the rest honestly.
+
+- **The ReadSide authored-*attribute* round-trip — ADJUDICATED (it failed) and FIXED.** The treatise's single
+  explicitly-open fidelity question (T-V/T-I, §3.3). **Resolved by reading the code:** the emitter persisted
+  `Projection.SsKey` only at the TABLE level (`SsdtDdlEmitter.fs:607`, Wave 4.1 kind recovery) — the COLUMN level
+  got only `Projection.LogicalName`, no SsKey — and ReadSide's `attributeSsKey` SYNTHESIZED the attribute key from
+  `READSIDE_ATTR + [schema;table;column]`. So an authored column **rename** changed the synthesized key and the
+  attribute landed in `Removed + Added`, not `Renamed` — the attribute-grain faithfulness leak. **The fix is the
+  treatise's prescription, NOT the echo-chamber's:** per-attribute identity emission + recovery (a per-column
+  `Projection.SsKey` extended property), **not** changing the flat-synthesis fallback (the four-lens "fix" the
+  adversarial layer killed — OSSYS `[module;entity]` vs ReadSide `[schema;table]` namespaces can't be reconciled by
+  segmentation). Built: (emit) column-level `Projection.SsKey` carrying `SsKey.serialize attr.SsKey`, gated with its
+  `Projection.LogicalName` sibling; (read) `recoverAttributeSsKey` (the attribute-grain twin of `recoverKindSsKey`)
+  threaded through `buildAttribute` AND `buildReference` (so a recovered FK's `SourceAttribute` MATCHES the
+  reconstructed attribute — the attribute-grain `6.A.5`), reading a new column-level branch of the `V2.SsKey`
+  result set (the SQL gained the `LEFT JOIN sys.columns` + dropped `minor_id = 0`, mirroring the LogicalName result
+  set). Graceful degradation preserved: a missing / malformed column property falls back to `READSIDE_ATTR`
+  synthesis, so non-V2 schemas read unchanged. **The goldens were re-blessed** (`GOLDEN_RECORD=1`): +700 lines
+  across 17 files, **all insertions**, each exactly a column-level `Projection.SsKey` `sp_addextendedproperty`
+  (`@level2type = N'COLUMN'`) — the additive identity annotation, no other drift (`git diff` confirmed). Witnesses:
+  `SsdtExtendedPropertyEmissionTests` (a statement-bounded regex asserts a COLUMN-level `Projection.SsKey` is
+  emitted) + the Docker canary `CanaryRoundTripTests."Wave 5: column Projection.SsKey persistence — ReadSide
+  recovers OssysOriginal ATTRIBUTE identities"` (an authored `OssysOriginal` attribute GUID survives emit → deploy
+  → read as itself, not a `READSIDE_ATTR` synthesis). *This closes the T-V/T-I attribute-grain adjudication: an
+  authored column rename now round-trips as `Renamed`.*
+- **Transactionality (T-VI) — the trigger fired and points AWAY from the giant wrapper; honestly named.** The live
+  atomic `BEGIN TRAN` wrapper was deferred on "whether the managed login permits one giant transaction vs forces
+  resumable-upsert" (`Preflight.fs`). The **J5 managed-environment run** (DECISIONS 2026-06-15) resolves it: the
+  managed login is **DML-only (no ALTER)**, the identity path is **AssignedBySink**, and the rollback channel is
+  **"DELETE by captured `[Id]`" (transaction ROLLBACK clean on small batches)** — i.e. the evidence points to the
+  **compensating-undo channel** (which `M12`'s groupoid `inverse` + the `CaptureJournal`'s captured keys already
+  model), and the giant-transaction-over-the-~288M-row-estate question is gated on the **still-open P7b
+  throughput**. So building a giant `BEGIN TRAN` wrapper now would be both premature and contrary to the evidence;
+  it **stays deferred** with the trigger sharpened. The honest naming (already half-present in the matrix footer)
+  was made precise: a mid-write crash is a *named* refusal (`GateLabel.MidWriteNotProtected`, Wave 2), the
+  compensating arm is the inverse, the wrapper is deferred on P7b. *No code beyond the footer — the correct outcome
+  is the honest disposition, not a speculative build.*
+- **Permissions (T-VI) — honestly named in the CORRECT home (a category error avoided).** The treatise proposed a
+  `PermissionsGatedNotProjected` `ToleratedDivergence`. **Examined against the code, that is the wrong home:**
+  `ToleratedDivergence` is for *round-trip divergences the canary absorbs*, and the matrix's `@ladder` axis is one
+  of the FIVE round-trip axes — but permissions is **not a round-trip axis** (the A2 pre-flight *gates* on grants
+  but there is no `Grant` IR facet, no `GRANT` in the `Statement` DU, no permission channel in `CatalogDiff`, no
+  readback). Forcing a non-round-trip dimension into the round-trip ladder / DU would itself misrepresent fidelity
+  — ironic for an honesty move. So the honest realization is in the matrix's existing **"unwitnessed sub-axes"
+  footer** (`matrix-status.sh`), strengthened to name precisely that permissions is *gated but not projected* (the
+  gate's existence must not be read as the axis being closed) and that the full axis fires only when a flow must
+  *publish* grants (the eject). *This is the discipline correcting the treatise — the named-erasure law applied to
+  the engine's own honesty surface.*
+- **The totality synthesis — written.** `THE_VECTOR_SYNTHESIS.md` — what the whole program (Waves 0–5) accomplished
+  and why it matters *per se* (the operator's capstone ask): the six waves are one instruction executed six times
+  (extend the named surfaces until claim = demonstration); the deeper point is that a system that can *prove* its
+  own correctness continuously is a different *kind* of object than one that is merely correct; and the refusals
+  (the killed echo-chamber, the deferred `SchemaMove` unification, the named-not-built moat) are the respect.
+- **Witness (integrator-authoritative, this tree).** Debug + **Release** 0/0. **Full pure pool 3631/0** (+2 vs
+  Wave 4: the column-SsKey emit test + the goldens re-blessed; the attribute-recovery canary is Docker-gated → in
+  the 210 skips). Goldens re-blessed (+700 additive lines, all column `Projection.SsKey`). **`matrix-status.sh`
+  gate=PASS** (rungs 5/4/5, tolerances 10/3-open — UNCHANGED; the footer gained the two T-VI dimension names, no
+  ladder cell moved — the attribute fix strengthens the *Identity* axis at the attribute grain without a tolerance
+  change). `verifiability-gate.sh` exit 0. **Docker canary pool 247/247** (246 + the new attribute-recovery canary,
+  0 skipped — it RAN and passed on a real database; no canary regressed from the new column-level emit, which every
+  canary now deploys + reads back).
+- **Exit criterion (Wave 5) — MET.** The last *buildable* open fidelity adjudication (authored-attribute identity
+  round-trip) is closed and witnessed; the two non-buildable T-VI dimensions (transactionality, permissions) are
+  named honestly against the evidence rather than built speculatively; the moat stays cut with named triggers; and
+  the totality synthesis is written. **THE VECTOR is complete** — the gap from the witnessed floor to the bullseye
+  is closed to within a small, named, trigger-gated remainder (the moat). The books are balanced, and the balance
+  is checkable.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,111 @@
+# Handoff addendum — 2026-06-16, THE VECTOR WAVE 5 LANDED — **THE VECTOR IS COMPLETE** (the last open fidelity adjudication closed: authored-attribute identity now round-trips at the attribute grain; transactionality + permissions honestly named against the J5 evidence; the totality synthesis written); the only remaining frontier is the moat, which stays cut with named triggers
+
+To the next agent.
+
+**THE VECTOR is complete.** The defined four-wave plan (Waves 0–4) plus the operator-authorized fifth wave (the
+residual OPEN fidelity adjudications) are all cashed. What remains is the **moat** — and the moat is *named, not
+unfinished*: each item is cut with a re-open trigger (`THE_VECTOR_EXECUTION_KICKOFF.md` §10). Per the engine's
+own discipline, naming a trigger-gated absence IS its completion. Read `THE_VECTOR_SYNTHESIS.md` for what the whole
+program accomplished and why it matters *per se*, and the 2026-06-16 "THE VECTOR Wave 5 BUILT" DECISIONS entry for
+the substance.
+
+**What Wave 5 closed.**
+1. **The ReadSide authored-*attribute* round-trip** (T-V/T-I — the treatise's single explicitly-open fidelity
+   question). Adjudicated (it failed — attributes were SYNTHESIZED `READSIDE_ATTR` from physical coordinates, so an
+   authored column rename landed in `Removed + Added`), then **fixed per the treatise's prescription, not the
+   echo-chamber's**: per-column `Projection.SsKey` emission (the attribute-grain sibling of the table-level kind
+   SsKey) + `recoverAttributeSsKey` threaded through `buildAttribute` AND `buildReference`. Goldens re-blessed
+   (+700 additive lines, all column `Projection.SsKey`). An authored column rename now round-trips as `Renamed`.
+2. **Transactionality** (T-VI) — the deferral trigger fired and points AWAY from a giant `BEGIN TRAN`: the J5
+   managed-env evidence (DML-only, AssignedBySink, rollback = DELETE-by-captured-key) favors the compensating-undo
+   channel (M12's `inverse`); the giant-transaction-over-estate is gated on the still-open P7b throughput. Named in
+   the matrix footer; **no speculative build** (the correct outcome).
+3. **Permissions** (T-VI) — named honestly in the **matrix footer**, NOT as a round-trip `ToleratedDivergence` (a
+   category error — permissions is gated by the A2 pre-flight but not a projected/diffed axis). The full axis fires
+   only at the eject (publish grants) — moat.
+
+**If you have appetite, the honest frontier is the MOAT** — and only when a trigger fires: a second `Ingest`
+source (DACPAC reader), a branching pass (`LineageTree` consumer), a flow that publishes grants (full permissions
+axis), a container pool (Docker N≥20 real-wire sweep), or a real divergence between the four move enumerations
+(`SchemaMove` unification). Building any of these *without* its trigger violates "IR grows under evidence" and
+dilutes the closed set of falsifiable cells the whole program strengthened. Don't.
+
+**Build-discipline scars (heed them).** `dotnet` is NOT on the bash PATH (`export
+PATH="$PATH:/c/Users/danny/AppData/Local/Microsoft/dotnet"` before `scripts/test.sh`). F# 9 nullness is on. A
+`bool×bool`→DU collapse keeps the wire byte-identical by projecting to the legacy pair at the codec boundary (the
+`IndexUniqueness` precedent — M4). Adding an identity extended property re-blesses the goldens (`GOLDEN_RECORD=1` +
+a DECISIONS note); confirm the `git diff` is additive-only before blessing.
+
+**State.** Branch `claude/vector-wave-4-5` (off `main` `6c28130f`). Waves 4 + 5 sit as working-tree changes (not
+yet committed — the operator drives commits). Debug + **Release** 0/0; **pure pool 3631/0**; `AxiomTests` 79/0;
+`matrix-status.sh` gate=PASS (5/4/5, 10 tolerances, 3 open — footer extended with the two T-VI dimension names, no
+ladder cell moved); `verifiability-gate.sh` exit 0; **Docker pool 247/247** (246 + the new attribute-recovery canary, 0 skipped;
+no canary regressed from the new column-level emit). Hold the spine: name every refusal, count every crossing,
+leave the books balanced.
+
+---
+
+# Handoff addendum — 2026-06-16, THE VECTOR WAVE 4 LANDED (the provenance ledger has its machine lens, the digest is determinism-by-construction, the constraint-trust quadrant is a type theorem — THE VECTOR's defined four-wave plan is fully cashed); your job is WAVE 5 — the residual OPEN fidelity adjudications (operator-authorized, past the defined plan)
+
+To the next agent.
+
+**Where you are.** THE VECTOR's defined plan (`THE_VECTOR.md` §7, Waves 0–4) is **fully cashed** modulo the
+honestly-deferred M14. Wave 4 landed M18 (`ChangeManifest.toJson` — the CDC-norm queryable), M5 (the policy digest
+is determinism-by-construction, no `sprintf "%A"`), and M4 (the `ConstraintState` DU — the illegal trust quadrant
+is now *unrepresentable*, a type theorem; wire byte-identical via the `IndexUniqueness` projection precedent, so no
+store migration). The persisted-state-evolution discipline is codified (NM-34 = the store-codec contract; the
+serialized-form gating checklist). Read the 2026-06-16 "THE VECTOR Wave 4 BUILT" DECISIONS entry — it is the
+substance; this letter points.
+
+**Your mission (Wave 5 — operator-authorized, past the defined plan).** The operator chose to continue past the
+four-wave plan to **close the residual OPEN fidelity adjudications** the treatise left dangling — the items that
+genuinely close an L-rung toward the full fidelity algebra, as distinct from the moat (which STAYS CUT with named
+triggers — do not build it). Three buildable items:
+1. **The ReadSide authored-schema *attribute* round-trip adjudication** (T-V/T-I — the treatise's single explicitly
+   -open fidelity question; §3.3 / §5.1 / Appendix B). `recoverKindSsKey` recovers authored *kind* identity via the
+   `V2.SsKey` extended property, but **attributes** are not covered — so on a V2-authored source an attribute rename
+   may land in `Removed + Added` rather than `Renamed`. RESOLVE IT: build a witness that determines whether authored
+   -attribute round-trip holds today; **if it fails**, the fix is per-attribute `V2.SsKey` extended-property emission
+   + recovery (`recoverAttributeSsKey`) — **NOT** changing the flat-synthesis fallback (that was the echo-chamber
+   regression the adversarial layer killed). If it already holds, name it and close the adjudication.
+2. **Transactionality completion** (T-VI). Wave 2 landed M20 (the `GateLabel.MidWriteNotProtected` naming) + M12
+   (the groupoid `inverse` — the compensating-undo prerequisite). The live atomic `BEGIN TRAN` wrapper was deferred
+   on "the managed-login grant survey resolves" — **check whether the J5 managed-env ledger fired that trigger**
+   (`J5_MANAGED_ENV_CAPABILITY_PLAYBOOK.md` + the j5 memory). If fired, build the atomic-or-compensating arm on
+   M12's inverse; if not, name it honestly-deferred with the precondition.
+3. **Permissions interim honesty** (T-VI). Add the `PermissionsGatedNotProjected` tolerance (the sixth matrix row at
+   L2-partial) — the honest-naming half the treatise endorses (§5.1), so the A2 pre-flight gate's existence stops
+   making a whole dimension *look* closed. NOT the full permissions axis (that needs the eject — moat).
+
+Then the operator wants **the totality synthesis**: what the whole Vector backlog accomplishes and why it matters
+per se. Write it as the capstone.
+
+**The moat stays cut (do NOT build).** DACPAC reader (needs a 2nd catalog source), `LineageTree` consumer (needs a
+branching pass), full Permissions axis (needs the eject), Docker N≥20 real-wire sweep (needs a container pool), the
+full `SchemaMove` unification (no fired divergence). Building these violates the stated intent; naming them IS the
+completion. See `THE_VECTOR_EXECUTION_KICKOFF.md` §10.
+
+**Build-discipline scars (heed them — they bit this session).**
+1. **`dotnet` is NOT on the bash PATH** — `scripts/test.sh` fails its build step unless you `export
+   PATH="$PATH:/c/Users/danny/AppData/Local/Microsoft/dotnet"` first (or build via PowerShell with the full path
+   `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe`).
+2. **F# 9 NULLNESS is on** — `JsonNode` indexers yield `JsonNode | null`; narrow with a match before `.GetValue`,
+   and assign JSON null per-branch to the nullable setter (don't unify a `null` into a non-null `JsonNode` value).
+3. **Closed-record field removal cascades widely** — M4's `(HasDbConstraint, IsConstraintTrusted)` → `ConstraintState`
+   touched ~22 test files. The single-assembly build (FS-warnings-as-errors) is the completeness backstop: build,
+   fix every flagged site, rebuild. Watch for **DU case-name collisions** (M4's `TrustedConstraint` collided with
+   `ProbeOutcome.TrustedConstraint` → `[<RequireQualifiedAccess>]` resolved it).
+4. **A `bool×bool`→DU collapse keeps the wire byte-identical** by projecting to the legacy boolean pair at the codec
+   boundary (the `IndexUniqueness` precedent) — that is why M4 needed no store migration and the goldens stayed green.
+
+**State.** Branch `claude/vector-wave-4-5` (off `main` `6c28130f` = the merged Wave-3 PR #622). Wave 4 sits as
+working-tree changes (not yet committed — the operator drives commits). Debug + **Release** 0/0; **pure pool
+3629/0**; `AxiomTests` 79/0; `matrix-status.sh` gate=PASS byte-identical (5/4/5, 10 tolerances, 3 open);
+`verifiability-gate.sh` exit 0; **Docker pool 246/246**. Hold the spine: name every refusal, count every crossing,
+leave the books balanced.
+
+---
+
 # Handoff addendum — 2026-06-15, THE VECTOR WAVE 3 LANDED (the engine is measurably smaller — the descriptor is data, the JSON dance has one home, the binding algebra is a CE, the totality proof is one functor); your job is WAVE 4 — the corollary cashes & the gated deepenings (the operator payoff)
 
 To the next agent.

--- a/sidecar/projection/NORTH_STAR.matrix.generated.md
+++ b/sidecar/projection/NORTH_STAR.matrix.generated.md
@@ -46,6 +46,20 @@ to be retired from `Tolerance.fs`. The generator under-claims; it never over-cla
 > FK-trust + unique-promotion through the general `PhysicalSchema.diff` comparator,
 > so the Decision axis is honestly faithful, not asserted.
 > L3 here is "a composition witness exists for the axis," not "faithful under every
-> spanning axis" (T-VI atomicity/permissions ride the debrief until cluster A names them).
+> spanning axis" (T-VI). The two T-VI dimensions that are NOT round-trip axes are named
+> here so the five-row ladder above is not read as the whole basis:
+> **(a) Transactionality/Rollback** — a mid-write crash is a *named* refusal
+> (`GateLabel.MidWriteNotProtected`, THE VECTOR Wave 2) and the compensating-undo arm is
+> the groupoid `inverse`; the live atomic `BEGIN TRAN` wrapper stays deferred — the J5
+> managed-env evidence (ROLLBACK clean, but DML-only + AssignedBySink + cleanup-by-captured
+> -key) points to the compensating channel, and the giant-transaction-over-estate is gated
+> on the still-open P7b throughput. **(b) Permissions** — the A2 pre-flight *gates* on
+> grants (it refuses a write-denied sink) but grants/roles/RLS are NOT a projected axis (no
+> `Grant` IR facet, no `GRANT` in the `Statement` DU, no permission channel in
+> `CatalogDiff`, no readback): the engine can *refuse* but cannot *project / diff /
+> round-trip* a permission decision, so the gate's existence must not be read as the axis
+> being closed. The full permissions axis fires only when a flow must *publish* grants (the
+> eject). Both are out-of-ladder by construction (a non-round-trip dimension is a category
+> error in a round-trip `ToleratedDivergence`), named here per THE VECTOR Wave 5 honesty.
 
 _Self-reported · gate=PASS · L2 axioms live/C/D=79/6/1 · rungs L1/L2/L3=5/4/5 of 5 · tolerances 10 (3 open)_

--- a/sidecar/projection/THE_VECTOR.md
+++ b/sidecar/projection/THE_VECTOR.md
@@ -36,7 +36,7 @@
 
 ---
 
-## Build addendum — 2026-06-15 (Waves 0–3 BUILT — the keystone landed, the reversible algebra completed, the engine compressed)
+## Build addendum — 2026-06-15/16 (Waves 0–5 BUILT — THE VECTOR is COMPLETE: the keystone landed, the reversible algebra completed, the engine compressed, the corollaries cashed, the open adjudications closed; the only remaining frontier is the named, trigger-gated moat. See `THE_VECTOR_SYNTHESIS.md`.)
 
 > The study below is now partly **executed**, not just proposed. Per the house dated-note discipline, this
 > supersedes the "still unbuilt" claim in the reconciliation addendum that follows.
@@ -67,9 +67,33 @@
 >   (the totality-test functor — one law, four ~10-line instantiations); M6 (`[<Struct>]` on `SourceKey`/`AssignedKey`);
 >   M19 (`[<Measure>] row` on the data-norm deltas). Net-smaller, every byte/law unchanged. Docker 246/246; matrix
 >   byte-identical (no tolerance moved). (DECISIONS 2026-06-15 "THE VECTOR Wave 3 BUILT".)
-> - **Still ahead.** Wave 4 — the corollary cashes & gated deepenings: M18 (`ChangeManifest.toJson`), M14 (the
->   `Traversal` optic, after the compile-order split), M4 (`ConstraintState` DU, behind the store-migration story),
->   M5 (digest projection) + the persisted-state-evolution discipline. The §6 move catalog stands for those.
+> - **Wave 4 — corollary cashes & the trust-quadrant type theorem — BUILT (2026-06-16).** M18
+>   (`ChangeManifest.toJson` — the CDC-norm made a machine-queryable contract for the SSIS consumer; `toJson` only,
+>   the `fromJson` inverse deferred-with-trigger absent a read-back consumer); M5 (the policy digest retires
+>   `sprintf "%A"` for an explicit length-prefixed `canonicalToken` projection — determinism-by-construction; not
+>   persisted into episodes, so no migration); M4 (the `ConstraintState` DU — the `(HasDbConstraint,
+>   IsConstraintTrusted)` quadrant's illegal `(false,false)` state is now **unrepresentable**, a type theorem
+>   promoting the prior runtime G14 check; the `IndexUniqueness` projection precedent keeps the wire byte-identical,
+>   so no store migration; T16 round-trip preserved via the `DbConstraint`-before-`Trust` facet order). The
+>   **persisted-state-evolution discipline** is codified (NM-34 as the store-codec contract; the serialized-form
+>   gating checklist) — both M4 and M5 cleared it with no migration. **M14 (the `Traversal` optic) HONESTLY
+>   DEFERRED** — its compile-order-split gate is unfired; "not yet, here is the trigger" is its completion state.
+>   Pure pool 3629/0; Docker 246/246; `AxiomTests` 79/0; matrix byte-identical (no tolerance moved). (DECISIONS
+>   2026-06-16 "THE VECTOR Wave 4 BUILT".) **THE VECTOR's defined four-wave plan is fully cashed.**
+> - **Wave 5 — the open fidelity adjudications — BUILT (2026-06-16, operator-authorized past the defined plan).**
+>   The **ReadSide authored-*attribute* round-trip** (T-V/T-I; §3.3/§5.1) — *adjudicated and FIXED*: the emitter
+>   persisted `Projection.SsKey` only at the table level and ReadSide synthesized `READSIDE_ATTR` for attributes, so
+>   an authored column rename landed in `Removed + Added`; the fix is the treatise's prescription (per-column
+>   `Projection.SsKey` emission + `recoverAttributeSsKey` through `buildAttribute`/`buildReference`), **NOT** the
+>   echo-chamber's flat-synthesis change; goldens re-blessed (+700 additive lines). **Transactionality** (T-VI) — the
+>   J5 evidence fires the trigger AWAY from a giant `BEGIN TRAN` (DML-only + AssignedBySink + compensating-undo via
+>   M12's inverse; giant-transaction-over-estate gated on the still-open P7b throughput), so the wrapper stays
+>   deferred and is named in the matrix footer. **Permissions** (T-VI) — named honestly in the matrix footer (gated
+>   by the A2 pre-flight but not a projected axis), **not** forced into a round-trip `ToleratedDivergence` (a
+>   category error — the discipline correcting the treatise). The **totality synthesis** is written
+>   (`THE_VECTOR_SYNTHESIS.md`). Pure pool 3631/0; Docker 247/247 (246 + the attribute-recovery canary); matrix gate=PASS (footer extended, no cell moved).
+>   (DECISIONS 2026-06-16 "THE VECTOR Wave 5 BUILT".) **THE VECTOR is complete — the gap from the witnessed floor to
+>   the bullseye is closed to within the named, trigger-gated moat.**
 
 ## Reconciliation addendum — 2026-06-15 (main moved; the study reconciled)
 

--- a/sidecar/projection/THE_VECTOR_SYNTHESIS.md
+++ b/sidecar/projection/THE_VECTOR_SYNTHESIS.md
@@ -1,0 +1,125 @@
+# THE VECTOR — Synthesis
+
+### What the backlog accomplished in totality, and why that matters *per se*
+
+> **What this is.** The closing reflection on THE VECTOR program (Waves 0–5, 2026-06-15/16) — written
+> when the defined four-wave plan was fully cashed and the operator-authorized fifth wave closed the last
+> open fidelity adjudications. `THE_VECTOR.md` derived *what* to do and *why*; the wave entries in
+> `DECISIONS.md` record *what was built*. This document answers the question underneath all of them: **what,
+> in sum, did the engine gain — and why does it matter not merely as a means to the eject, but in itself?**
+
+---
+
+## 1. The arc, in one line per wave
+
+The Vector was never a feature program. Every wave closed a gap between what the engine *claimed* and what
+it could *show* — and it did so by holding the engine to its own standard, in the last places that standard
+had not yet reached.
+
+- **Wave 0 — honesty.** Stopped the engine over-claiming on three of five axes. The matrix's under-claiming
+  mechanism was structurally inert on Decision/Identity/Time (no tolerance could tag them), so "faithful"
+  there was *unfalsifiable by construction*. Naming the honest tolerances + moving the guardrails in-assembly
+  restored the one guarantee the whole epistemic spine rests on: **the generator under-claims, never
+  over-claims.**
+- **Wave 1 — the keystone.** The Decision-readback adjunction (`PhysicalForeignKey.IsTrusted` + the
+  overlay-aware comparator). The fifth axis became *showable*: `NoCheckFk` / `EnforceUnique` decisions now
+  survive emit → deploy → read-back through the general comparator, witnessed on a real database. The honest
+  tolerance auto-retired into an earned green.
+- **Wave 2 — the reversible algebra.** The change algebra completed its defining structure: the groupoid
+  `inverse`, the triangle inequality made the norm a proven *metric*, the master equation swept over generated
+  displacements (fixture-witnessed → property-witnessed), and the destructive mid-write failure became a
+  *named* refusal rather than a generic exit code.
+- **Wave 3 — compression.** The engine got measurably smaller while every output byte and every law stayed
+  unchanged: the descriptor became data (the diff `ChannelSpec`), the JSON dance got one home, the binding
+  algebra a CE, the totality proof one functor. Subtraction as a form of fidelity — fewer places to drift.
+- **Wave 4 — the corollary cashes.** The provenance ledger gained its machine lens (`ChangeManifest.toJson` —
+  the CDC-norm became a queryable contract); the policy digest became determinism-by-*construction* (no
+  `sprintf "%A"`); and the constraint-trust quadrant's illegal state became **unrepresentable** — a runtime
+  invariant promoted to a type theorem, the wire kept byte-identical so nothing had to migrate.
+- **Wave 5 — the open adjudications.** The single explicitly-open fidelity question the treatise left
+  dangling — *does authored-attribute identity round-trip?* — was resolved by closing it: per-attribute
+  `Projection.SsKey` emission + recovery, so an authored column rename round-trips as `Renamed`, not
+  `Removed + Added`. Transactionality and permissions were named honestly against the J5 managed-environment
+  evidence rather than built speculatively.
+
+## 2. The through-line
+
+Read top to bottom, the six waves are one instruction, executed six times: **extend the named surfaces until
+what the engine claims and what the engine can demonstrate are the same set.** Not "build more" — *make the
+honest machine see further.*
+
+Every move is the same move wearing a different coat:
+
+| The convention that held the invariant | The structure it became |
+|---|---|
+| an axis marked faithful with no detector for its own erasure | a named tolerance, then an earned readback (Wave 0→1) |
+| a deepest law proven on a *fixture* | a law swept over *generated* displacements (Wave 2) |
+| a duplicated descriptor traversed four times | one descriptor-as-data, traversed once (Wave 3) |
+| a provenance norm surfaced as *prose only* | a typed, diffable machine contract (Wave 4, M18) |
+| a digest deterministic *by luck* (`%A`) | deterministic *by construction* (Wave 4, M5) |
+| an illegal state forbidden by a *runtime check* | an illegal state that *cannot be written down* (Wave 4, M4) |
+| an authored identity *synthesized* from coordinates on read-back | an authored identity *recovered* from a persisted property (Wave 5) |
+
+The engine's deepest aesthetic is "make illegal states unrepresentable and make every claim showable." The
+Vector is simply that aesthetic applied to the last few places it had not yet reached.
+
+## 3. Why it matters *per se* — not merely as a means
+
+It is easy to justify all of this *instrumentally*: the engine terminates at an **eject**, after which there
+is no upstream to re-derive from, so "we believe the schema is right" is a posture no one can hold once
+everyone stops looking — and the eject is precisely the moment everyone stops looking. By that argument the
+Vector matters because it lets the engine *replace* V1 rather than merely be *trusted* like V1. That is true,
+and it is the smaller truth.
+
+The larger truth — why it matters *in itself* — is this:
+
+**A system that can prove its own correctness, continuously and without a human re-auditing it, is a
+different *kind* of object than a system that is merely correct.** A correct-but-unprovable system degrades to
+conjecture the instant attention lapses; its correctness is a property of the observer's vigilance, not of
+the system. A self-proving system carries its truth internally — each value, by construction, *is* its own
+witness. The Vector's accomplishment is not that the engine became more correct (it was already, at the type
+level, one of the most disciplined systems one could read). It is that the engine became *more able to show
+that it is correct* — more of its claims became theorems it can demonstrate on demand, fewer rested on a
+comment, a grep, a printer's luck, or a human's memory. The gap between *being right* and *being able to
+prove you are right* is the gap between an artifact and an instrument. The Vector narrowed that gap on every
+axis it touched.
+
+This is why the **refusals** are the most important part of the program, and why they matter intrinsically
+rather than as caution. The Vector killed a four-lens convergence that was a regression in disguise (the
+ReadSide echo-chamber — segmentation cannot make a recovered key equal an authored one across different
+namespaces). It deferred the single most beautiful idea in the catalogue (the full `SchemaMove` unification)
+because its forcing function had not fired. It named the moat — the DACPAC reader, the `LineageTree`
+consumer, the full permissions axis, the giant-transaction wrapper — rather than building it, because a
+feature that is not a corollary of the adjunction *with a fired trigger* is the wrong feature, and building
+it would have *diluted* the very thing the rest of the program strengthened: the closedness of the set of
+falsifiable cells. A planning program that says "not yet, and here is the trigger" more often than it says
+"build this" is not being timid. It is treating the engine's central discipline — *the IR grows under
+evidence; a claim outrunning its proof is a defect* — as binding on itself. The discipline is the product.
+The refusals are the respect.
+
+## 4. The shape of the result
+
+After the Vector, the engine stands where its north star asked it to:
+
+- **Every round-trip axis is showable, not asserted.** Schema · Data · Identity (now at the attribute grain) ·
+  Time · Decision — each cell in the matrix is derived from a live witness or a named, closeable tolerance.
+  No green cell is unfalsifiable-by-construction.
+- **The change algebra is a complete, reversible, metric-bearing structure** whose master equation is
+  property-witnessed and whose destructive failure mode is a named refusal.
+- **The provenance ledger is a machine-queryable contract**, and the digest that stamps it is deterministic
+  by construction.
+- **The invariants the engine once held by convention are now held by type** — the trust quadrant's illegal
+  state cannot be written down; the constraint-state, the uniqueness, the orientation, the identity are all
+  closed values that carry their own truth.
+- **What remains open is *named*, with its trigger** — the moat is a ledger, not a silence. The engine knows
+  exactly what it has not yet built and exactly what would license building it.
+
+The masterwork was always the destination; the Vector was the distance from the witnessed floor to it. That
+distance is now closed to within a small, named, trigger-gated remainder — which is to say: the books are
+balanced, and the balance is checkable.
+
+---
+
+*Hold the spine. Name every refusal, count every crossing, and leave the books balanced.*
+
+*— Recorded at the close of THE VECTOR, Wave 5.*

--- a/sidecar/projection/scripts/matrix-status.sh
+++ b/sidecar/projection/scripts/matrix-status.sh
@@ -187,7 +187,21 @@ open_count=$(printf '%s\n' "$ladder_tags" | awk '$3=="OpenGap"' | grep -c . || t
   echo "> FK-trust + unique-promotion through the general \`PhysicalSchema.diff\` comparator,"
   echo "> so the Decision axis is honestly faithful, not asserted."
   echo "> L3 here is \"a composition witness exists for the axis,\" not \"faithful under every"
-  echo "> spanning axis\" (T-VI atomicity/permissions ride the debrief until cluster A names them)."
+  echo "> spanning axis\" (T-VI). The two T-VI dimensions that are NOT round-trip axes are named"
+  echo "> here so the five-row ladder above is not read as the whole basis:"
+  echo "> **(a) Transactionality/Rollback** — a mid-write crash is a *named* refusal"
+  echo "> (\`GateLabel.MidWriteNotProtected\`, THE VECTOR Wave 2) and the compensating-undo arm is"
+  echo "> the groupoid \`inverse\`; the live atomic \`BEGIN TRAN\` wrapper stays deferred — the J5"
+  echo "> managed-env evidence (ROLLBACK clean, but DML-only + AssignedBySink + cleanup-by-captured"
+  echo "> -key) points to the compensating channel, and the giant-transaction-over-estate is gated"
+  echo "> on the still-open P7b throughput. **(b) Permissions** — the A2 pre-flight *gates* on"
+  echo "> grants (it refuses a write-denied sink) but grants/roles/RLS are NOT a projected axis (no"
+  echo "> \`Grant\` IR facet, no \`GRANT\` in the \`Statement\` DU, no permission channel in"
+  echo "> \`CatalogDiff\`, no readback): the engine can *refuse* but cannot *project / diff /"
+  echo "> round-trip* a permission decision, so the gate's existence must not be read as the axis"
+  echo "> being closed. The full permissions axis fires only when a flow must *publish* grants (the"
+  echo "> eject). Both are out-of-ladder by construction (a non-round-trip dimension is a category"
+  echo "> error in a round-trip \`ToleratedDivergence\`), named here per THE VECTOR Wave 5 honesty."
   echo
   # Deterministic footer (T1): no wall-clock stamp — the artifact is a pure
   # function of the proof surfaces, so `git diff` on it = a coverage shift, and

--- a/sidecar/projection/src/Projection.Adapters.Osm/OssysJsonReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/OssysJsonReader.fs
@@ -237,7 +237,10 @@ module OssysJsonReader =
                     Result.success (Some
                         { Reference.create rKey rName srcKey tgtKey with
                             OnDelete        = rule
-                            HasDbConstraint = hasDbConstraint })
+                            // M4 — the JSON source carries only hasDbConstraint;
+                            // trust defaults to true (a reflected FK is trusted
+                            // unless IsNoCheck), normalized via the DU constructor.
+                            ConstraintState = ConstraintState.ofLegacyBooleans hasDbConstraint true })
                 | _ ->
                     // Propagate underlying errors via
                     // `propagateOrFallback` — uniform with the four

--- a/sidecar/projection/src/Projection.Adapters.Sql/LiveProfiler.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/LiveProfiler.fs
@@ -838,7 +838,7 @@ module LiveProfiler =
                                     { ReferenceKey = reference.SsKey
                                       HasOrphan    = orphanCount > 0L
                                       OrphanCount  = orphanCount
-                                      IsNoCheck    = not reference.IsConstraintTrusted
+                                      IsNoCheck    = not (Reference.isConstraintTrusted reference)
                                       ProbeStatus  = ProbeStatus.observed rowCount }
                                 | _ -> ambiguous
                             | _ -> ambiguous))

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -75,6 +75,32 @@ module ReadSide =
             "READSIDE_ATTR"
             (sprintf "%s.%s.%s" schema table column)
 
+    /// Recover an attribute's SsKey from the persisted COLUMN-level
+    /// `Projection.SsKey` extended property when present (THE VECTOR Wave 5;
+    /// A1: identity survives rename), else the `READSIDE_ATTR` synthesis above
+    /// (pre-V2-emission / non-V2 schemas, or a malformed stored value — a
+    /// synthesized key is always valid, so a bad value degrades gracefully).
+    /// The attribute-grain sibling of `recoverKindSsKey`. Shared by
+    /// `buildAttribute` (an attribute's own identity) and `buildReference`
+    /// (an FK's **source-attribute** identity) so a reconstructed FK's
+    /// `SourceAttribute` MATCHES the reconstructed attribute's `SsKey` — the
+    /// same internal-resolution guarantee `recoverKindSsKey` gives the target
+    /// kind. Without it, an authored column rename changes the synthesized
+    /// `READSIDE_ATTR` key and the attribute lands in `Removed + Added` rather
+    /// than `Renamed` (the §5.1 T-V/T-I attribute-grain faithfulness gap).
+    let private recoverAttributeSsKey
+        (columnSsKeys: Map<string * string * string, string>)
+        (schema: string)
+        (table: string)
+        (column: string)
+        : Result<SsKey> =
+        match Map.tryFind (schema, table, column) columnSsKeys with
+        | Some serialized ->
+            match SsKey.deserialize serialized with
+            | Ok recovered -> Result.success recovered
+            | Error _ -> attributeSsKey schema table column
+        | None -> attributeSsKey schema table column
+
     /// Per-column metadata row read from INFORMATION_SCHEMA.COLUMNS.
     /// Carries every axis V2's IR cares about (post-session-32):
     /// type name, nullability, length, precision, scale.
@@ -639,6 +665,7 @@ module ReadSide =
 
     let private buildAttribute
         (columnLogicalNames: Map<string * string * string, string>)
+        (columnSsKeys: Map<string * string * string, string>)
         (row: ColumnRow)
         (primaryKeySet: Set<string * string * string>)
         (identitySet: Set<string * string * string>)
@@ -647,7 +674,9 @@ module ReadSide =
         match result with
         | Error errors -> Result.failure errors
         | Ok ptype ->
-            match attributeSsKey row.Schema row.Table row.Column with
+            // THE VECTOR Wave 5 — recover the persisted attribute SsKey (column
+            // `Projection.SsKey`) instead of synthesizing `READSIDE_ATTR`.
+            match recoverAttributeSsKey columnSsKeys row.Schema row.Table row.Column with
             | Error errors -> Result.failure errors
             | Ok attrKey ->
                 // Slice D.1.b — hydrate Attribute.Name from the
@@ -1056,6 +1085,7 @@ module ReadSide =
         (tableLogicalNames: Map<string * string, string>)
         (columnLogicalNames: Map<string * string * string, string>)
         (tableSsKeys: Map<string * string, string>)
+        (columnSsKeys: Map<string * string * string, string>)
         (schema: string)
         (table: string)
         (columnRows: list<ColumnRow>)
@@ -1069,7 +1099,7 @@ module ReadSide =
         let attrResults =
             columnRows
             |> Bench.iterMap "readside.buildAttribute" (fun row ->
-                buildAttribute columnLogicalNames row primaryKeySet identitySet)
+                buildAttribute columnLogicalNames columnSsKeys row primaryKeySet identitySet)
         result {
             let! attributes = Result.aggregate attrResults
             // Wave 4.1 — recover the persisted SsKey (see `recoverKindSsKey`).
@@ -1134,13 +1164,18 @@ module ReadSide =
     /// reconstructed Catalog's References resolve internally.
     let private buildReference
         (tableSsKeys: Map<string * string, string>)
+        (columnSsKeys: Map<string * string * string, string>)
         (fk: FkRow)
         : Result<Reference> =
         // Chapter-3.6: `result { }` CE replaces the prior 4-deep
         // nested-match chain. Same short-circuit semantics; reads
         // as the algebraic spec.
         result {
-            let! srcAttrKey = attributeSsKey fk.SourceSchema fk.SourceTable fk.SourceColumn
+            // THE VECTOR Wave 5 — recover the persisted source-attribute SsKey
+            // (column `Projection.SsKey`) the same way buildAttribute does, so
+            // the FK's SourceAttribute MATCHES the reconstructed attribute's
+            // SsKey (the attribute-grain sibling of the 6.A.5 target-kind fix).
+            let! srcAttrKey = recoverAttributeSsKey columnSsKeys fk.SourceSchema fk.SourceTable fk.SourceColumn
             // 6.A.5 — recover the target kind's SsKey the same way buildKind
             // does (persisted V2.SsKey, else synthesis) so the FK resolves
             // against the reconstructed target Kind in PhysicalSchema.
@@ -1175,6 +1210,7 @@ module ReadSide =
     /// (schema, table) coordinates. Per session-31 Session B.
     let private attachReferences
         (tableSsKeys: Map<string * string, string>)
+        (columnSsKeys: Map<string * string * string, string>)
         (fkGroups: Map<string * string, FkRow list>)
         (k: Kind)
         : Result<Kind> =
@@ -1182,7 +1218,7 @@ module ReadSide =
         | None -> Result.success k
         | Some fks ->
             result {
-                let! refs = fks |> List.map (buildReference tableSsKeys) |> Result.aggregate
+                let! refs = fks |> List.map (buildReference tableSsKeys columnSsKeys) |> Result.aggregate
                 return { k with References = refs }
             }
 
@@ -1393,7 +1429,8 @@ module ReadSide =
               * list<FkRow>
               * Map<string * string, string>
               * Map<string * string * string, string>
-              * Map<string * string, string>> =
+              * Map<string * string, string>
+              * Map<string * string * string, string>> =
         task {
             use _ = Bench.scope "readside.readSchemaCombined"
             use cmd = cnn.CreateCommand()
@@ -1448,13 +1485,14 @@ module ReadSide =
                    AND ep.name IN (N'Projection.LogicalName', N'V2.LogicalName') \
                    AND t.is_ms_shipped = 0; \
                  SELECT \
-                    SCHEMA_NAME(t.schema_id), t.name, \
+                    SCHEMA_NAME(t.schema_id), t.name, c.name, \
                     CAST(ep.value AS NVARCHAR(MAX)) \
                  FROM sys.extended_properties ep \
                  JOIN sys.tables t ON t.object_id = ep.major_id \
+                 LEFT JOIN sys.columns c \
+                   ON c.object_id = ep.major_id AND c.column_id = ep.minor_id \
                  WHERE ep.class = 1 \
                    AND ep.name IN (N'Projection.SsKey', N'V2.SsKey') \
-                   AND ep.minor_id = 0 \
                    AND t.is_ms_shipped = 0"
             use! reader = cmd.ExecuteReaderAsync()
 
@@ -1538,15 +1576,26 @@ module ReadSide =
                         let column = reader.GetString 2
                         columnLogical[(schema, table, column)] <- value)
 
-            // Result set 6: V2.SsKey extended properties (Wave 4.1).
-            // Table-level only (minor_id = 0); the serialized identity
-            // recovered here lets buildKind deserialize the original SsKey
-            // instead of synthesizing READSIDE_KIND (A1: identity survives
-            // rename).
+            // Result set 6: V2.SsKey extended properties. Column 2
+            // (sys.columns.name) is NULL for table-level entries (LEFT JOIN);
+            // when present, the row is column-level. The TABLE serialized
+            // identity lets buildKind deserialize the original kind SsKey
+            // instead of synthesizing READSIDE_KIND (Wave 4.1); the COLUMN
+            // serialized identity lets buildAttribute recover the original
+            // attribute SsKey instead of synthesizing READSIDE_ATTR (THE VECTOR
+            // Wave 5 — A1: identity survives rename, now at the attribute grain).
             let! _ = reader.NextResultAsync()
             let tableSsKeys = System.Collections.Generic.Dictionary<string * string, string>()
+            let columnSsKeys = System.Collections.Generic.Dictionary<string * string * string, string>()
             do! drainRows reader (fun reader ->
-                    tableSsKeys[(reader.GetString 0, reader.GetString 1)] <- reader.GetString 2)
+                    let schema = reader.GetString 0
+                    let table = reader.GetString 1
+                    let value = reader.GetString 3
+                    if reader.IsDBNull 2 then
+                        tableSsKeys[(schema, table)] <- value
+                    else
+                        let column = reader.GetString 2
+                        columnSsKeys[(schema, table, column)] <- value)
 
             return
                 List.ofSeq columnRows,
@@ -1555,7 +1604,8 @@ module ReadSide =
                 List.ofSeq fkRows,
                 tableLogical |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq,
                 columnLogical |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq,
-                tableSsKeys |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
+                tableSsKeys |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq,
+                columnSsKeys |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
         }
 
     /// Wave-3 slice 3.1 — names every user table the deployed database is
@@ -1734,13 +1784,13 @@ module ReadSide =
                 // by one `SqlCommand` instead of 4 separate
                 // `ExecuteReaderAsync` calls. ~150-300ms saved per
                 // canary-readback on the warm container.
-                let! columnRows, primaryKeySet, identitySet, fkRows, tableLogicalNames, columnLogicalNames, tableSsKeys =
+                let! columnRows, primaryKeySet, identitySet, fkRows, tableLogicalNames, columnLogicalNames, tableSsKeys, columnSsKeys =
                     readSchemaCombined cnn
                 let kindResults =
                     columnRows
                     |> List.groupBy (fun row -> row.Schema, row.Table)
                     |> Bench.iterMap "readside.kindGroup" (fun ((schema, table), rows) ->
-                        buildKind tableLogicalNames columnLogicalNames tableSsKeys schema table rows primaryKeySet identitySet)
+                        buildKind tableLogicalNames columnLogicalNames tableSsKeys columnSsKeys schema table rows primaryKeySet identitySet)
                 match Result.aggregate kindResults with
                 | Error errors -> return Result.failure errors
                 | Ok kinds ->
@@ -1750,7 +1800,7 @@ module ReadSide =
                         |> Map.ofList
                     let kindsWithRefsResults =
                         kinds
-                        |> Bench.iterMap "readside.attachReferences" (attachReferences tableSsKeys fkGroups)
+                        |> Bench.iterMap "readside.attachReferences" (attachReferences tableSsKeys columnSsKeys fkGroups)
                     match Result.aggregate kindsWithRefsResults with
                     | Error errors -> return Result.failure errors
                     | Ok kindsWithRefs0 ->

--- a/sidecar/projection/src/Projection.Core/Catalog.fs
+++ b/sidecar/projection/src/Projection.Core/Catalog.fs
@@ -691,6 +691,89 @@ type Attribute = {
 }
 
 
+/// The constraint-state of a `Reference` (M4 — THE VECTOR §6 Kind II).
+/// Collapses the `(HasDbConstraint, IsConstraintTrusted)` `bool × bool`
+/// quadrant — a 4-state space encoding a 3-state semantic reality — into a
+/// closed DU. The illegal quadrant `(HasDbConstraint = false,
+/// IsConstraintTrusted = false)` ("untrusted without a constraint", the G14
+/// debrief finding) typechecked but is semantically impossible: trust is only
+/// meaningful when a DB constraint exists (`¬trusted ⟹ hasDbConstraint`). The
+/// DU forbids it by construction — promoting the prior *runtime* invariant
+/// (`Reference.isConstraintStateConsistent` + the aggregate-root rejection) to
+/// a *type theorem*. Mirrors `IndexUniqueness` (Slice 2a), the sibling
+/// quadrant→DU collapse on the same record family, and follows the archetype
+/// `CapabilityProfile.of` precedent (closed DU → derived projection →
+/// round-trip law).
+///
+/// **Ordering carries semantics**: a trusted constraint is "stronger than" an
+/// untrusted one is "stronger than" no constraint. Strategy / emission
+/// surfaces pattern-match the variant directly; sites that need the boolean
+/// projection use `ConstraintState.hasDbConstraint` / `isConstraintTrusted`.
+/// The codec keeps the legacy boolean pair on the wire (`toLegacyBooleans` on
+/// write, `ofLegacyBooleans` on read) so serialized catalogs round-trip
+/// byte-identically — no store migration (the `IndexUniqueness` wire precedent).
+///
+/// `[<RequireQualifiedAccess>]` — the `TrustedConstraint` case name otherwise
+/// collides with `ProbeOutcome.TrustedConstraint`; qualification also makes the
+/// variants unforgeable at every match site.
+[<RequireQualifiedAccess>]
+type ConstraintState =
+    /// No backing SQL Server FK constraint — the reference is logical-only (an
+    /// OutSystems-model FK with no `FOREIGN KEY` clause). Trust is N/A
+    /// (vacuously trusted). Boolean projection: `(false, true)`. The
+    /// `Reference.create` default (V1's COALESCE-to-0 `HasFK`).
+    | NoDbConstraint
+    /// A real, TRUSTED FK constraint — created normally, or re-validated after
+    /// a `WITH NOCHECK` insert. Boolean projection: `(true, true)`. The V1
+    /// default for a reflected constraint.
+    | TrustedConstraint
+    /// A real but UNTRUSTED FK constraint (`WITH NOCHECK` — created over
+    /// existing unvalidated rows). Boolean projection: `(true, false)`; fires
+    /// the post-CREATE-TABLE NOCHECK alter (`SsdtDdlEmitter.untrustedFkAlters`).
+    /// Carries from V1 `#FkReality.IsNoCheck = 1`.
+    | UntrustedConstraint
+
+[<RequireQualifiedAccess>]
+module ConstraintState =
+
+    /// True iff a real DB constraint backs the reference (`Trusted` /
+    /// `Untrusted`). Sites that only need the boolean "is there a constraint?"
+    /// projection use this without pattern-matching.
+    let hasDbConstraint (s: ConstraintState) : bool =
+        match s with
+        | ConstraintState.TrustedConstraint | ConstraintState.UntrustedConstraint -> true
+        | ConstraintState.NoDbConstraint -> false
+
+    /// True iff the constraint is trusted. `NoDbConstraint` is *vacuously*
+    /// trusted (trust is N/A absent a constraint) — the canonical `(false,
+    /// true)` projection.
+    let isConstraintTrusted (s: ConstraintState) : bool =
+        match s with
+        | ConstraintState.UntrustedConstraint -> false
+        | ConstraintState.NoDbConstraint | ConstraintState.TrustedConstraint -> true
+
+    /// Build a `ConstraintState` from the legacy `(hasDbConstraint,
+    /// isConstraintTrusted)` boolean pair. Adapters reading external formats
+    /// (V1 JSON, SQL reflection rows, the codec) project their booleans through
+    /// this helper to reach the typed surface. The illegal combination
+    /// `(false, false)` ("untrusted without a constraint") normalizes to
+    /// `NoDbConstraint` — a constraint-less reference is vacuously trusted (the
+    /// prior `Reference.withConstraintState` normalization, now total and at the
+    /// type level).
+    let ofLegacyBooleans (hasDbConstraint: bool) (isConstraintTrusted: bool) : ConstraintState =
+        match hasDbConstraint, isConstraintTrusted with
+        | false, _     -> ConstraintState.NoDbConstraint
+        | true,  true  -> ConstraintState.TrustedConstraint
+        | true,  false -> ConstraintState.UntrustedConstraint
+
+    /// The legacy `(hasDbConstraint, isConstraintTrusted)` boolean pair — the
+    /// derived projection the codec writes to the wire. Round-trip law:
+    /// `ofLegacyBooleans ∘ toLegacyBooleans = id` on every variant (witnessed in
+    /// `ReferenceConstraintStateTests`).
+    let toLegacyBooleans (s: ConstraintState) : bool * bool =
+        hasDbConstraint s, isConstraintTrusted s
+
+
 /// A directional reference (A10). Symmetry, if needed by a target surface,
 /// is introduced by the symmetric-closure pass and the resulting reference
 /// carries a `Derived` SsKey with reason `"inverse"`.
@@ -717,19 +800,6 @@ type Reference = {
     /// otherwise. Slice η emitters consume this flag to gate User-
     /// FK column rewriting at row-emission time.
     IsUserFk        : bool
-    /// True iff this reference is backed by a real SQL Server FK
-    /// constraint (a `FOREIGN KEY ... REFERENCES` clause). V1's
-    /// `hasDbConstraint` int-flag (COALESCE'd from
-    /// `outsystems_model_export.sql:730` HasFK column). When false,
-    /// the reference exists only at the OutSystems model level
-    /// (logical-only FK); when true, a corresponding DB constraint
-    /// materializes the reference at the storage layer.
-    ///
-    /// Chapter 4.6 slice α — IR fidelity lift retiring chapter 4.4's
-    /// `HasLogicalForeignKeyWithoutDbConstraint` +
-    /// `HasLogicalForeignKeyWithDbConstraint` always-false
-    /// PredicateName variants.
-    HasDbConstraint : bool
     /// Optional ON UPDATE referential action. `None` = unstated (V1
     /// default; SQL Server emits no ON UPDATE clause, server-default
     /// NO ACTION applies). `Some action` = operator-supplied explicit
@@ -739,17 +809,17 @@ type Reference = {
     ///
     /// Slice 5.13.fk-features-emit (matrix row 58 cash-out).
     OnUpdate        : ReferenceAction option
-    /// Whether the FK constraint is currently TRUSTED at the deployed
-    /// target (i.e., the FK was created normally OR re-validated after
-    /// a WITH NOCHECK insert). `true` (default) preserves V1's default
-    /// emission shape. `false` carries from V1's
-    /// `#FkReality.IsNoCheck = 1` and triggers a post-CREATE-TABLE
-    /// `ALTER TABLE ... WITH NOCHECK CHECK CONSTRAINT [<fk>]`
-    /// statement so V2's emission round-trips against a deployed
-    /// target carrying NOCHECK'd FKs.
-    ///
-    /// Slice 5.13.fk-features-emit (matrix row 59 cash-out).
-    IsConstraintTrusted : bool
+    /// The constraint-state of this reference (M4 — THE VECTOR §6 Kind II):
+    /// the `ConstraintState` DU that replaced the prior `(HasDbConstraint,
+    /// IsConstraintTrusted)` boolean pair (chapter 4.6 slice α IR lift +
+    /// slice 5.13.fk-features-emit row 59). `NoDbConstraint` = logical-only
+    /// FK (V1's COALESCE-to-0 `HasFK`); `TrustedConstraint` = a real trusted
+    /// constraint (the V1 default); `UntrustedConstraint` = `WITH NOCHECK`
+    /// (from V1 `#FkReality.IsNoCheck = 1`), firing the post-CREATE-TABLE
+    /// NOCHECK alter. The illegal "untrusted without a constraint" quadrant is
+    /// unrepresentable. Boolean-projection sites use `Reference.hasDbConstraint`
+    /// / `Reference.isConstraintTrusted`.
+    ConstraintState : ConstraintState
 }
 
 
@@ -1255,36 +1325,42 @@ module Reference =
             TargetKind          = targetKind
             OnDelete            = NoAction
             IsUserFk            = false
-            HasDbConstraint     = false
             OnUpdate            = None
-            IsConstraintTrusted = true
+            ConstraintState     = ConstraintState.NoDbConstraint
         }
 
-    /// G14 — the constraint-state invariant. Trust is only meaningful when a
-    /// DB constraint exists: an *untrusted* (`WITH NOCHECK`) reference must be
-    /// backed by a real constraint, since the emitter's NOCHECK alter
-    /// (`SsdtDdlEmitter.untrustedFkAlters`) fires on `not IsConstraintTrusted`
-    /// and would otherwise target a non-existent constraint. Formally
-    /// `¬IsConstraintTrusted ⟹ HasDbConstraint`. The illegal quadrant the
-    /// debrief (G14) names is `(HasDbConstraint=false ∧ IsConstraintTrusted=false)`
-    /// — "untrusted without a constraint." (The `(false, true)` default is the
-    /// canonical *vacuous-trust* no-constraint state, the boolean projection of
-    /// a `NoDbConstraint` variant — consistent.)
-    let isConstraintStateConsistent (r: Reference) : bool =
-        r.IsConstraintTrusted || r.HasDbConstraint
+    /// Boolean projection: is this reference backed by a real DB constraint?
+    /// (M4 — the derived `(HasDbConstraint, _)` accessor over the
+    /// `ConstraintState` DU; sites that read the old field now call this.)
+    let hasDbConstraint (r: Reference) : bool =
+        ConstraintState.hasDbConstraint r.ConstraintState
 
-    /// The sanctioned way to set the `(HasDbConstraint, IsConstraintTrusted)`
-    /// pair from external evidence (V1 JSON / ReadSide / codec). Normalizes the
-    /// illegal quadrant to the canonical vacuous-trust state: a reference with
-    /// no DB constraint is `IsConstraintTrusted = true` (trust is N/A), never
-    /// independently untrusted. Routing every producer through this makes the
-    /// illegal quadrant unreachable in practice (witnessed in
-    /// `ReferenceConstraintStateTests`).
+    /// Boolean projection: is this reference's constraint trusted?
+    /// (M4 — the derived `(_, IsConstraintTrusted)` accessor; `NoDbConstraint`
+    /// projects to vacuously-trusted `true`.)
+    let isConstraintTrusted (r: Reference) : bool =
+        ConstraintState.isConstraintTrusted r.ConstraintState
+
+    /// G14 — the constraint-state invariant, now a **theorem** rather than a
+    /// runtime check: `¬trusted ⟹ hasDbConstraint` holds for every
+    /// `ConstraintState` variant by construction (the illegal "untrusted
+    /// without a constraint" quadrant is unrepresentable since M4). Retained as
+    /// a total predicate (always `true`) so the witness in
+    /// `ReferenceConstraintStateTests` and the aggregate-root proof read
+    /// explicitly rather than vacuously.
+    let isConstraintStateConsistent (r: Reference) : bool =
+        match r.ConstraintState with
+        | ConstraintState.NoDbConstraint | ConstraintState.TrustedConstraint | ConstraintState.UntrustedConstraint -> true
+
+    /// The sanctioned way to set the constraint-state from the legacy
+    /// `(hasDbConstraint, isConstraintTrusted)` boolean pair external evidence
+    /// supplies (V1 JSON / ReadSide / codec). Delegates to
+    /// `ConstraintState.ofLegacyBooleans`, which normalizes the illegal
+    /// `(false, false)` quadrant to `NoDbConstraint` (vacuous trust). Since M4
+    /// the illegal quadrant is unrepresentable at the type, so this is total by
+    /// construction (witnessed in `ReferenceConstraintStateTests`).
     let withConstraintState (hasDbConstraint: bool) (isConstraintTrusted: bool) (r: Reference) : Reference =
-        if hasDbConstraint then
-            { r with HasDbConstraint = true; IsConstraintTrusted = isConstraintTrusted }
-        else
-            { r with HasDbConstraint = false; IsConstraintTrusted = true }
+        { r with ConstraintState = ConstraintState.ofLegacyBooleans hasDbConstraint isConstraintTrusted }
 
     /// The reserved SsKey derivation reason the symmetric-closure pass
     /// stamps on synthesized inverse references (the first reserved
@@ -1791,18 +1867,14 @@ module Catalog =
                                     "Reference %A on Kind %A has TargetKind %A absent from the catalog."
                                     r.SsKey k.SsKey r.TargetKind))
                     // NM-12 — G14: the illegal trust quadrant
-                    // (HasDbConstraint=false ∧ IsConstraintTrusted=false) is
-                    // unreachable at the aggregate root. Every ingest boundary
-                    // (ReadSide / codec / V1) normalizes through
-                    // `Reference.withConstraintState`; `Catalog.create` rejects
-                    // anything that bypassed it, so the quadrant cannot enter the IR.
-                    if not (Reference.isConstraintStateConsistent r) then
-                        refAcc.Add(
-                            ValidationError.create
-                                "catalog.reference.illegalConstraintState"
-                                (sprintf
-                                    "Reference %A on Kind %A is in the illegal constraint-state quadrant (HasDbConstraint=false, IsConstraintTrusted=false); an untrusted constraint requires the constraint to exist. Set it through Reference.withConstraintState."
-                                    r.SsKey k.SsKey))
+                    // (HasDbConstraint=false ∧ IsConstraintTrusted=false) is now
+                    // UNREPRESENTABLE — `Reference.ConstraintState` is a closed
+                    // 3-variant DU (M4 — THE VECTOR §6 Kind II), so the prior
+                    // runtime rejection here became dead code and was retired.
+                    // The invariant `¬trusted ⟹ hasDbConstraint` is a type
+                    // theorem (`Reference.isConstraintStateConsistent` is now
+                    // total `true`); the witness moved to the round-trip law in
+                    // `ReferenceConstraintStateTests`.
                 for idx in k.Indexes do
                     for col in idx.Columns do
                         if not (Set.contains col.Attribute attrKeys) then

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -328,8 +328,11 @@ module CatalogDiff =
           if s.OnDelete <> t.OnDelete then ReferenceFacet.OnDelete
           if s.OnUpdate <> t.OnUpdate then ReferenceFacet.OnUpdate
           if s.IsUserFk <> t.IsUserFk then ReferenceFacet.UserFk
-          if s.HasDbConstraint <> t.HasDbConstraint then ReferenceFacet.DbConstraint
-          if s.IsConstraintTrusted <> t.IsConstraintTrusted then ReferenceFacet.Trust ]
+          // M4 — the two facets project the `ConstraintState` DU back to its
+          // boolean dimensions, preserving the channel structure the C1 diff +
+          // the SSDT migration emitter (`ReferenceFacet.Trust`) depend on.
+          if Reference.hasDbConstraint s <> Reference.hasDbConstraint t then ReferenceFacet.DbConstraint
+          if Reference.isConstraintTrusted s <> Reference.isConstraintTrusted t then ReferenceFacet.Trust ]
         |> Set.ofList
 
     let private changedIndexFacets (s: Index) (t: Index) : Set<IndexFacet> =
@@ -398,8 +401,19 @@ module CatalogDiff =
         | ReferenceFacet.OnDelete        -> { dest with OnDelete = src.OnDelete }
         | ReferenceFacet.OnUpdate        -> { dest with OnUpdate = src.OnUpdate }
         | ReferenceFacet.UserFk          -> { dest with IsUserFk = src.IsUserFk }
-        | ReferenceFacet.DbConstraint    -> { dest with HasDbConstraint = src.HasDbConstraint }
-        | ReferenceFacet.Trust           -> { dest with IsConstraintTrusted = src.IsConstraintTrusted }
+        // M4 — set one boolean dimension of the `ConstraintState` DU per facet,
+        // preserving the other from `dest`, then renormalize through
+        // `ofLegacyBooleans`. The `DbConstraint`-before-`Trust` tag order (the
+        // `Set.fold` iteration order) makes the combined `NoDbConstraint →
+        // UntrustedConstraint` transition reconstruct exactly: a lone `Trust`
+        // facet never targets a `NoDbConstraint` dest (it always co-occurs with
+        // a `DbConstraint` facet), and `DbConstraint` lands first.
+        | ReferenceFacet.DbConstraint    ->
+            { dest with ConstraintState =
+                            ConstraintState.ofLegacyBooleans (Reference.hasDbConstraint src) (Reference.isConstraintTrusted dest) }
+        | ReferenceFacet.Trust           ->
+            { dest with ConstraintState =
+                            ConstraintState.ofLegacyBooleans (Reference.hasDbConstraint dest) (Reference.isConstraintTrusted src) }
 
     let private applyIndexFacet (src: Index) (facet: IndexFacet) (dest: Index) : Index =
         match facet with

--- a/sidecar/projection/src/Projection.Core/Passes/SymmetricClosure.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/SymmetricClosure.fs
@@ -95,9 +95,8 @@ module SymmetricClosure =
                     sourceKind.SsKey
                   with
                     IsUserFk            = r.IsUserFk
-                    HasDbConstraint     = r.HasDbConstraint
                     OnUpdate            = r.OnUpdate
-                    IsConstraintTrusted = r.IsConstraintTrusted }
+                    ConstraintState     = r.ConstraintState }
 
     let private hasInverseAlready (refs: Reference list) (key: SsKey) : bool =
         refs |> List.exists (fun r -> r.SsKey = key)

--- a/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
+++ b/sidecar/projection/src/Projection.Core/PhysicalSchema.fs
@@ -670,7 +670,7 @@ module PhysicalSchema =
                         // Mirrors the emitter's NOCHECK predicate
                         // (`SsdtDdlEmitter.untrustedFkAlters`) so the source
                         // projection and the read-back agree.
-                        IsTrusted = r.IsConstraintTrusted && not (Set.contains r.SsKey overlay.NoCheckFk)
+                        IsTrusted = Reference.isConstraintTrusted r && not (Set.contains r.SsKey overlay.NoCheckFk)
                     }
             | _ ->
                 // Dropped: the source attribute is unresolvable, the target

--- a/sidecar/projection/src/Projection.Core/Strategies/ForeignKeyRules.fs
+++ b/sidecar/projection/src/Projection.Core/Strategies/ForeignKeyRules.fs
@@ -275,7 +275,7 @@ module ForeignKeyRules =
             //    is enforced before and regardless of every remaining
             //    gate. Reads the IR flag directly; the dead
             //    TrustedConstraint probe approximation is retired.
-            if reference.HasDbConstraint then
+            if Reference.hasDbConstraint reference then
                 mkDecision
                     (ForeignKeyOutcome.EnforceConstraint
                         DatabaseConstraintPresent)

--- a/sidecar/projection/src/Projection.Core/VersionedPolicy.fs
+++ b/sidecar/projection/src/Projection.Core/VersionedPolicy.fs
@@ -1,9 +1,11 @@
 namespace Projection.Core
 
-// LINT-ALLOW-FILE: terminal version-string + policy-digest projection. `%d.%d.%d` semantic-
-//   version rendering and the `%A` policy representation feed the content hash;
-//   the typed version + policy records remain the structure. Per
-//   `DECISIONS 2026-05-09 — Built-in obligation`.
+// LINT-ALLOW-FILE: terminal version-string + policy-digest projection. `%d.%d.%d`
+//   semantic-version rendering and the explicit per-field policy token projection
+//   (M5 — `appendField` / `appendLP`, replacing the former `%A` representation)
+//   feed the content hash at the SHA256 boundary; the typed version + policy
+//   records remain the structure. Per `DECISIONS 2026-05-09 — Built-in obligation`
+//   and the M5 determinism-by-construction move (THE VECTOR §6 Kind II).
 
 open System
 open System.Security.Cryptography
@@ -110,19 +112,188 @@ module SemVer =
 [<RequireQualifiedAccess>]
 module VersionedPolicy =
 
-    /// Compute the hex SHA-256 content digest for a given policy. The
-    /// canonical representation is the F# structural printer; the digest
-    /// is deterministic for the same runtime version. Consumers comparing
-    /// digests across runtime upgrades should treat inequality as
-    /// "possibly changed" rather than "definitely changed" — the digest
-    /// is a snapshot ID, not a cross-version stability guarantee.
+    // -----------------------------------------------------------------
+    // M5 (THE VECTOR §6 Kind II) — the canonical policy projection.
+    //
+    // The digest's canonical representation was `sprintf "%A" policy` —
+    // determinism-by-LUCK: the F# structural printer's shape depends on the
+    // compiler version, exactly the failure the neighbouring
+    // `TransformRegistry.digest` forbids (NM-60). This is determinism-by-
+    // CONSTRUCTION: every field projected explicitly, every closed DU to a
+    // fixed token, every free-text / identity field LENGTH-PREFIXED
+    // (`<utf8-byte-count>:value`) so the encoding is injective — no crafted
+    // name / id / value can forge a different policy that serializes to the
+    // same buffer. Sets are sorted by their serialized identity (order-
+    // independent); the intervention + delete-scope lists preserve operator
+    // order (registration order is itself information). This CHANGES the
+    // digest VALUE versus the prior `%A` form; no digest is pinned cross-
+    // process (the docstring already warned "snapshot ID, not a cross-version
+    // stability guarantee"; `GoldenEmissionTests` excludes the manifest's
+    // VersionedPolicy stamp — verified), so the change is internal.
+    // -----------------------------------------------------------------
+
+    /// Append a variable-length field LENGTH-PREFIXED (`<utf8-byte-count>:value`)
+    /// — the injective free-text encoding `TransformRegistry.appendLenPrefixed`
+    /// established (NM-60). The byte count (not char count) defeats multibyte
+    /// confusion; the prefix makes the structural delimiters unforgeable.
+    let private appendLP (sb: StringBuilder) (value: string) : unit =
+        sb.Append(Encoding.UTF8.GetByteCount value) |> ignore
+        sb.Append(':') |> ignore
+        sb.Append(value) |> ignore
+
+    /// Append a `|tag=token` segment whose token is drawn from a fixed set
+    /// (a closed-DU case name or a bool) — no length prefix needed.
+    let private appendField (sb: StringBuilder) (tag: string) (token: string) : unit =
+        sb.Append('|') |> ignore
+        sb.Append(tag) |> ignore
+        sb.Append('=') |> ignore
+        sb.Append(token) |> ignore
+
+    let private boolTok (b: bool) : string = if b then "T" else "F"
+
+    /// A sorted, counted, length-prefixed projection of an SsKey set — order-
+    /// independent (a set has no order) via the sorted serialized identities.
+    let private appendSsKeySet (sb: StringBuilder) (keys: SsKey Set) : unit =
+        let sorted = keys |> Set.toList |> List.map SsKey.serialize |> List.sort
+        sb.Append(List.length sorted) |> ignore
+        for k in sorted do
+            sb.Append(';') |> ignore
+            appendLP sb k
+
+    let private appendSelection (sb: StringBuilder) (s: SelectionPolicy) : unit =
+        match s with
+        | IncludeAll       -> appendField sb "sel" "All"
+        | IncludeOnly keys -> appendField sb "sel" "Only"; appendSsKeySet sb keys
+        | ExcludeOnly keys -> appendField sb "sel" "Excl"; appendSsKeySet sb keys
+
+    let private dataCompositionTok (c: DataComposition) : string =
+        match c with
+        | AllRemaining    -> "AllRemaining"
+        | AllExceptStatic -> "AllExceptStatic"
+        | AllData         -> "AllData"
+
+    let private dataVerificationTok (v: DataVerification) : string =
+        match v with
+        | DataVerification.Standard            -> "Standard"
+        | DataVerification.ValidateBeforeApply -> "ValidateBeforeApply"
+
+    let private appendEmission (sb: StringBuilder) (e: EmissionPolicy) : unit =
+        appendField sb "emSchema" (boolTok e.EmitSchema)
+        appendField sb "emData"   (boolTok e.EmitData)
+        appendField sb "emDiag"   (boolTok e.EmitDiagnostics)
+        appendField sb "dataComp" (dataCompositionTok e.DataComposition)
+        appendField sb "platAuto" (boolTok e.IncludePlatformAutoIndexes)
+        (match e.DeleteScope with
+         | None -> appendField sb "delScope" "None"
+         | Some ds ->
+             appendField sb "delScope" "Some"
+             sb.Append(List.length ds.Terms) |> ignore
+             for t in ds.Terms do
+                 sb.Append(';') |> ignore
+                 appendLP sb t.Column
+                 appendLP sb t.Value)
+        appendField sb "elegant"   (boolTok e.RenderConstraintsElegant)
+        appendField sb "identAnn"  (boolTok e.EmitIdentityAnnotations)
+        appendField sb "dataVerif" (dataVerificationTok e.DataVerification)
+
+    let private insertionTok (i: InsertionPolicy) : string =
+        // Qualified cases — `Merge` otherwise resolves to `PolicyExpr.Merge`.
+        match i with
+        | InsertionPolicy.SchemaOnly        -> "SchemaOnly"
+        | InsertionPolicy.InsertNew         -> "InsertNew"
+        | InsertionPolicy.Merge             -> "Merge"
+        | InsertionPolicy.TruncateAndInsert -> "TruncateAndInsert"
+
+    let private overrideActionTok (a: OverrideAction) : string =
+        match a with
+        | KeepNullable -> "KeepNullable"
+
+    let private appendIntervention (sb: StringBuilder) (i: TighteningIntervention) : unit =
+        match i with
+        | Nullability (id, cfg) ->
+            appendField sb "tv" "Nullability"
+            appendLP sb id
+            sb.Append(";nb=")  |> ignore
+            appendLP sb (cfg.NullBudget.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            sb.Append(";amr=") |> ignore; sb.Append(boolTok cfg.AllowMandatoryRelaxation) |> ignore
+            sb.Append(";ov=")  |> ignore; sb.Append(List.length cfg.Overrides) |> ignore
+            for o in cfg.Overrides do
+                sb.Append('{') |> ignore
+                appendLP sb (SsKey.serialize o.AttributeKey)
+                sb.Append(',') |> ignore
+                sb.Append(overrideActionTok o.Action) |> ignore
+                sb.Append('}') |> ignore
+        | UniqueIndex (id, cfg) ->
+            appendField sb "tv" "UniqueIndex"
+            appendLP sb id
+            sb.Append(";scu=") |> ignore; sb.Append(boolTok cfg.EnforceSingleColumnUnique) |> ignore
+            sb.Append(";mcu=") |> ignore; sb.Append(boolTok cfg.EnforceMultiColumnUnique) |> ignore
+        | ForeignKey (id, cfg) ->
+            appendField sb "tv" "ForeignKey"
+            appendLP sb id
+            sb.Append(";ec=")  |> ignore; sb.Append(boolTok cfg.EnableCreation) |> ignore
+            sb.Append(";acs=") |> ignore; sb.Append(boolTok cfg.AllowCrossSchema) |> ignore
+            sb.Append(";acc=") |> ignore; sb.Append(boolTok cfg.AllowCrossCatalog) |> ignore
+            sb.Append(";tmd=") |> ignore; sb.Append(boolTok cfg.TreatMissingDeleteRuleAsIgnore) |> ignore
+            sb.Append(";anc=") |> ignore; sb.Append(boolTok cfg.AllowNoCheckCreation) |> ignore
+        | CategoricalUniqueness (id, cfg) ->
+            appendField sb "tv" "CategoricalUniqueness"
+            appendLP sb id
+            sb.Append(";md=") |> ignore; sb.Append(string cfg.MinDistinctCountForUniqueness) |> ignore
+
+    let private appendTightening (sb: StringBuilder) (t: TighteningPolicy) : unit =
+        appendField sb "tight" (string (List.length t.Interventions))
+        for i in t.Interventions do
+            sb.Append('[') |> ignore
+            appendIntervention sb i
+            sb.Append(']') |> ignore
+
+    let rec private appendUserMatching (sb: StringBuilder) (u: UserMatchingStrategy) : unit =
+        match u with
+        | ByEmail -> appendField sb "um" "ByEmail"
+        | BySsKey -> appendField sb "um" "BySsKey"
+        | ManualOverride m ->
+            appendField sb "um" "ManualOverride"
+            let pairs =
+                m |> Map.toList
+                |> List.map (fun (s, t) -> SourceUserId.value s, TargetUserId.value t)
+                |> List.sortBy fst
+            sb.Append(List.length pairs) |> ignore
+            for (s, t) in pairs do
+                sb.Append(';') |> ignore; sb.Append(s) |> ignore; sb.Append("->") |> ignore; sb.Append(t) |> ignore
+        | FallbackToSystemUser (fallback, primary) ->
+            appendField sb "um" "Fallback"
+            sb.Append(";fb=") |> ignore; sb.Append(TargetUserId.value fallback) |> ignore
+            sb.Append(";primary=(") |> ignore
+            appendUserMatching sb primary
+            sb.Append(')') |> ignore
+
+    /// The canonical, injective string projection of a whole `Policy` — the
+    /// five axes, each field explicit. The digest hashes THIS.
+    let private canonicalToken (policy: Policy) : string =
+        // Instance-local StringBuilder mutation only, sealed at this function's
+        // exit; mirrors `TransformRegistry.digest`'s accumulator. No consumer
+        // reads the buffer — only the resulting bytes feed SHA256.
+        let sb = StringBuilder()
+        appendSelection sb policy.Selection
+        appendEmission sb policy.Emission
+        appendField sb "ins" (insertionTok policy.Insertion)
+        appendTightening sb policy.Tightening
+        appendUserMatching sb policy.UserMatching
+        sb.ToString()
+
+    /// Compute the hex SHA-256 content digest for a given policy. The canonical
+    /// representation is the explicit `canonicalToken` projection (M5);
+    /// structurally-equal policies hash equal, by construction rather than by
+    /// the F# printer's luck. Consumers comparing digests across runtime
+    /// upgrades should still treat inequality as "possibly changed" rather than
+    /// "definitely changed" — the digest is a snapshot ID; cross-version
+    /// stability now rests on the projection (stable) rather than on `%A`.
     let digestOf (policy: Policy) : string =
         use _ = Bench.scope "ir.policy.digestOf"
-        let repr = sprintf "%A" policy
-        let bytes = Encoding.UTF8.GetBytes repr
-        use sha = SHA256.Create()
-        let hash = sha.ComputeHash bytes
-        hash |> Array.map (fun b -> b.ToString "x2") |> String.concat ""
+        let bytes = Encoding.UTF8.GetBytes (canonicalToken policy)
+        let hash = SHA256.HashData bytes
+        System.Convert.ToHexString(hash).ToLowerInvariant()
 
     // -----------------------------------------------------------------
     // Bump classification (H-085 SemVer semantics)

--- a/sidecar/projection/src/Projection.Pipeline/ReportRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/ReportRun.fs
@@ -1,5 +1,6 @@
 namespace Projection.Pipeline
 
+open System.Text.Json.Nodes
 open Projection.Core
 
 // THE_CLI.md §8 / F4 — the migration-team change bundle. `report <flow>` reads
@@ -89,3 +90,111 @@ module ReportRun =
                       yield sprintf "      accepted under tolerance: %s" names
                   if not (List.isEmpty m.AppliedTransforms) then
                       yield sprintf "      applied transforms recorded: %d overlay row(s)" (List.length m.AppliedTransforms) ]
+
+    // ----------------------------------------------------------------------
+    // The machine lens (M18 / THE VECTOR §5.2) — the change report as a
+    // structured, byte-deterministic JSON document, the sibling of `render`.
+    // The engine treats human / machine as two lenses on one typed value; the
+    // CDC-capture-count data norm (T15) is a real measured value that flowed
+    // to `render` as prose ONLY. `toJson` gives the SSIS consumer the second
+    // lens — a contract they can diff sprint-over-sprint, the engine's #1
+    // fidelity surface made queryable. Typed-AST emission (`JsonNode`), not
+    // string-building (pillar 1). Deterministic: the bundle's manifests are
+    // already T1-ordered (oldest→newest), the residual is name-sorted, the
+    // applied-transforms are pre-sorted at their source.
+    //
+    // `toJson` ONLY — there is no read-back consumer (`report` reads the
+    // durable lifecycle STORE, not a recorded change-report). Per IR-grows-
+    // under-evidence a `fromJson` inverse is deferred-with-trigger: a verb that
+    // reads a recorded change-report back materializes. The `ModelFidelity`
+    // codec (which DOES carry `fromJson`) earned its inverse from the `report`
+    // verb's `fidelity.json` read-back; this surface has no such consumer yet.
+
+    let private coordinateNode (c: EpisodeCoordinate) : JsonObject =
+        let version = JsonObject()
+        version.["ordinal"] <- JsonValue.Create (Version.ordinal c.Version)
+        version.["label"] <- JsonValue.Create (Version.label c.Version)
+        let o = JsonObject()
+        o.["version"] <- version
+        o.["environment"] <- JsonValue.Create (Environment.name c.Environment)
+        o.["at"] <- JsonValue.Create (c.At.ToString("o", System.Globalization.CultureInfo.InvariantCulture))
+        o
+
+    /// All twenty orthogonal move-channels (π) of the displacement, named —
+    /// the schema norm `‖δ‖` is their sum (T15), so a consumer can both read
+    /// the total and attribute it to its channels.
+    let private channelsNode (c: CatalogDiff.ChannelCounts) : JsonObject =
+        let o = JsonObject()
+        o.["renamedKinds"]      <- JsonValue.Create c.RenamedKinds
+        o.["addedKinds"]        <- JsonValue.Create c.AddedKinds
+        o.["removedKinds"]      <- JsonValue.Create c.RemovedKinds
+        o.["changedKinds"]      <- JsonValue.Create c.ChangedKinds
+        o.["addedAttributes"]   <- JsonValue.Create c.AddedAttributes
+        o.["removedAttributes"] <- JsonValue.Create c.RemovedAttributes
+        o.["renamedAttributes"] <- JsonValue.Create c.RenamedAttributes
+        o.["changedAttributes"] <- JsonValue.Create c.ChangedAttributes
+        o.["addedReferences"]   <- JsonValue.Create c.AddedReferences
+        o.["removedReferences"] <- JsonValue.Create c.RemovedReferences
+        o.["renamedReferences"] <- JsonValue.Create c.RenamedReferences
+        o.["changedReferences"] <- JsonValue.Create c.ChangedReferences
+        o.["addedIndexes"]      <- JsonValue.Create c.AddedIndexes
+        o.["removedIndexes"]    <- JsonValue.Create c.RemovedIndexes
+        o.["renamedIndexes"]    <- JsonValue.Create c.RenamedIndexes
+        o.["changedIndexes"]    <- JsonValue.Create c.ChangedIndexes
+        o.["addedSequences"]    <- JsonValue.Create c.AddedSequences
+        o.["removedSequences"]  <- JsonValue.Create c.RemovedSequences
+        o.["renamedSequences"]  <- JsonValue.Create c.RenamedSequences
+        o.["changedSequences"]  <- JsonValue.Create c.ChangedSequences
+        o
+
+    let private manifestNode (m: ChangeManifest) : JsonObject =
+        let o = JsonObject()
+        o.["from"]            <- coordinateNode m.From
+        o.["to"]              <- coordinateNode m.To
+        o.["schemaNorm"]      <- JsonValue.Create m.SchemaNorm
+        o.["cdcCaptureCount"] <- JsonValue.Create m.CdcCaptureCount
+        // A `None` Decision anchor renders as an explicit JSON null (a stable
+        // key the consumer can read), assigned through the nullable setter.
+        (match m.RefactorLogRef with
+         | Some r -> o.["refactorLogRef"] <- JsonValue.Create r
+         | None   -> o.["refactorLogRef"] <- null)
+        o.["channels"]        <- channelsNode m.Channels
+        // The tolerance residual — the equivalence-up-to-quotient under which
+        // this edge's displacement was deemed faithful (named, sorted).
+        let residual = JsonArray()
+        for d in m.ToleranceResidual do residual.Add(JsonValue.Create (ToleratedDivergence.name d))
+        o.["toleranceResidual"] <- residual
+        // The applied-transforms outcome — the per-artifact overlay enumeration
+        // (`SsKey × OverlayAxis option`); the identity is the canonical
+        // length-prefixed `SsKey.serialize` form (the same on-disk identity the
+        // store uses), a `None` axis for a skeleton-only row.
+        let applied = JsonArray()
+        for (key, axis) in m.AppliedTransforms do
+            let a = JsonObject()
+            a.["ssKey"] <- JsonValue.Create (SsKey.serialize key)
+            (match axis with
+             | Some ax -> a.["axis"] <- JsonValue.Create (OverlayAxis.name ax)
+             | None    -> a.["axis"] <- null)
+            applied.Add(a)
+        o.["appliedTransforms"] <- applied
+        o
+
+    /// Serialize the assembled change bundle to its structured document — the
+    /// machine-read sibling of `render`. Counts pre-computed (path length, per-
+    /// edge norm + channels) so a downstream reader gets the shape without
+    /// re-deriving it from the store.
+    let toJson (bundle: ReportBundle) : JsonObject =
+        let root = JsonObject()
+        root.["timeline"]     <- JsonValue.Create bundle.Timeline
+        root.["episodeCount"] <- JsonValue.Create bundle.EpisodeCount
+        root.["pathLength"]   <- JsonValue.Create bundle.PathLength
+        let changes = JsonArray()
+        for m in bundle.Manifests do changes.Add(manifestNode m)
+        root.["changes"] <- changes
+        root
+
+    /// Render the bundle to a pretty-printed JSON string (the artifact body) —
+    /// mirrors `ModelFidelity.toJsonString`, the sibling report codec.
+    let toJsonString (bundle: ReportBundle) : string =
+        let opts = System.Text.Json.JsonSerializerOptions(WriteIndented = true)
+        (toJson bundle).ToJsonString(opts)

--- a/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
@@ -329,9 +329,12 @@ module CatalogCodec =
         wField jw "targetKind" wSsKey r.TargetKind
         wField jw "onDelete" wReferenceAction r.OnDelete
         jw.WriteBoolean("isUserFk", r.IsUserFk)
-        jw.WriteBoolean("hasDbConstraint", r.HasDbConstraint)
+        // M4 — the `ConstraintState` DU projects to the legacy boolean pair on
+        // the wire (`IndexUniqueness`'s `(isUnique, isPrimaryKey)` precedent), so
+        // serialized catalogs round-trip byte-identically (no store migration).
+        jw.WriteBoolean("hasDbConstraint", Reference.hasDbConstraint r)
         wOpt jw "onUpdate" wReferenceAction r.OnUpdate
-        jw.WriteBoolean("isConstraintTrusted", r.IsConstraintTrusted)
+        jw.WriteBoolean("isConstraintTrusted", Reference.isConstraintTrusted r)
         jw.WriteEndObject()
 
     let private wIndex (jw: Utf8JsonWriter) (i: Index) : unit =
@@ -785,9 +788,10 @@ module CatalogCodec =
                 { Reference.create ssKey name sourceAttribute targetKind with
                     OnDelete = onDelete
                     IsUserFk = isUserFk
-                    HasDbConstraint = hasDbConstraint
                     OnUpdate = onUpdate
-                    IsConstraintTrusted = isConstraintTrusted }
+                    // M4 — reconstruct the DU from the legacy boolean pair
+                    // (`ofLegacyBooleans` normalizes the illegal quadrant).
+                    ConstraintState = ConstraintState.ofLegacyBooleans hasDbConstraint isConstraintTrusted }
         }
 
     let private readIndex (el: JsonElement) : Result<Index> =

--- a/sidecar/projection/src/Projection.Targets.SSDT/ManifestEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ManifestEmitter.fs
@@ -312,12 +312,12 @@ module PredicateName =
             // `Reference.HasDbConstraint : bool`. Kind has a
             // logical-only FK iff any of its references is
             // unbacked by a DB constraint.
-            k.References |> List.exists (fun r -> not r.HasDbConstraint)
+            k.References |> List.exists (fun r -> not (Reference.hasDbConstraint r))
         | PredicateName.HasLogicalForeignKeyWithDbConstraint ->
             // Chapter 4.6 slice α — sibling: kind has a DB-constraint-
             // backed FK iff any of its references is DB-constraint
             // backed.
-            k.References |> List.exists (fun r -> r.HasDbConstraint)
+            k.References |> List.exists (fun r -> Reference.hasDbConstraint r)
 
 
 /// Slice β (chapter 4.4) — per-table predicate satisfaction entry.

--- a/sidecar/projection/src/Projection.Targets.SSDT/SchemaMigrationEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SchemaMigrationEmitter.fs
@@ -237,7 +237,7 @@ module SchemaMigrationEmitter =
                     (fun (stmts, refusals) r ->
                         match SsdtDdlEmitter.foreignKeyDefOf targetCatalog targetKind r with
                         | Some fk ->
-                            let trust = if not r.IsConstraintTrusted then nocheckSteps fk else []
+                            let trust = if not (Reference.isConstraintTrusted r) then nocheckSteps fk else []
                             stmts @ (Statement.AlterTableAddForeignKey (table, fk) :: trust), refusals
                         | None ->
                             stmts,
@@ -252,7 +252,7 @@ module SchemaMigrationEmitter =
                 |> List.fold
                     (fun (stmts, refusals) (change: ReferenceChange) ->
                         match Map.tryFind change.ReferenceKey refByKey with
-                        | Some r when change.Facets = Set.singleton ReferenceFacet.Trust && not r.IsConstraintTrusted ->
+                        | Some r when change.Facets = Set.singleton ReferenceFacet.Trust && not (Reference.isConstraintTrusted r) ->
                             match SsdtDdlEmitter.foreignKeyDefOf targetCatalog targetKind r with
                             | Some fk -> stmts @ nocheckSteps fk, refusals
                             | None -> stmts, refusals
@@ -260,7 +260,7 @@ module SchemaMigrationEmitter =
                             // DROP the old constraint (source name), ADD the new.
                             match sourceFkName change.ReferenceKey, SsdtDdlEmitter.foreignKeyDefOf targetCatalog targetKind r with
                             | Some oldName, Some newFk ->
-                                let trust = if not r.IsConstraintTrusted then nocheckSteps newFk else []
+                                let trust = if not (Reference.isConstraintTrusted r) then nocheckSteps newFk else []
                                 stmts @ [ Statement.AlterTableDropConstraint (table, oldName); Statement.AlterTableAddForeignKey (table, newFk) ] @ trust, refusals
                             | _ -> stmts, refusals
                         | _ ->

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
@@ -285,7 +285,7 @@ module SsdtDdlEmitter =
                     // ALTER TABLE NOCHECK statement emitted by
                     // `untrustedFkAlters` (sibling helper below).
                     OnUpdate            = r.OnUpdate |> Option.map toReferenceActionSql
-                    IsConstraintTrusted = r.IsConstraintTrusted
+                    IsConstraintTrusted = Reference.isConstraintTrusted r
                 }
         | _ -> None
 
@@ -624,6 +624,17 @@ module SsdtDdlEmitter =
                 if emitIdentityAnnotations then
                     yield Statement.SetExtendedProperty (
                         ColumnProperty (table, columnName), "Projection.LogicalName", Some (Name.value attr.Name))
+
+                    // THE VECTOR Wave 5 — `Projection.SsKey` at the COLUMN level
+                    // (the attribute-grain sibling of the table-level kind SsKey,
+                    // SsdtDdlEmitter ~607). Closes the authored-attribute round-trip
+                    // gap (§3.3/§5.1): ReadSide recovers the persisted attribute
+                    // identity via `recoverAttributeSsKey` instead of synthesizing
+                    // `READSIDE_ATTR` from physical coordinates, so an authored
+                    // column RENAME round-trips as `Renamed` (identity survives,
+                    // A1) rather than `Removed + Added`. Gated with its sibling.
+                    yield Statement.SetExtendedProperty (
+                        ColumnProperty (table, columnName), "Projection.SsKey", Some (SsKey.serialize attr.SsKey))
 
                 for ep in attr.ExtendedProperties do
                     yield Statement.SetExtendedProperty (
@@ -1023,7 +1034,7 @@ module SsdtDdlEmitter =
             |> List.choose (fun r ->
                 if Set.contains r.SsKey overlay.DropFk then
                     let severity, code, message =
-                        if r.HasDbConstraint then
+                        if Reference.hasDbConstraint r then
                             DiagnosticSeverity.Warning,
                             "decision.fkDropped",
                             "Foreign key dropped by decision: a tightening Decision (DoNotEnforce) removed this FK constraint at emission. The source enforced it; the emitted schema does not."

--- a/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CanaryRoundTripTests.fs
@@ -587,7 +587,7 @@ let ``6.A.5 (schema round-trip): a UNIQUE index + a NOCHECK FK survive deploy / 
             //     (not the create-default true).
             let childBack = kindByTable "OSUSR_RT5_CHILD"
             match childBack.References with
-            | [ r ] -> Assert.False(r.IsConstraintTrusted, "NOCHECK FK must read back untrusted, not the create-default true")
+            | [ r ] -> Assert.False(Reference.isConstraintTrusted r, "NOCHECK FK must read back untrusted, not the create-default true")
             | rs -> Assert.Fail(sprintf "expected exactly one reconstructed FK, got %d" (List.length rs))
         | None -> Assert.Fail "deploy produced no reconstructed catalog"
 
@@ -706,7 +706,7 @@ let ``E3: Ingest(deploy(Project(C, overlay))) reproduces the decision overlay on
                   mkAttr parentFkAttr "ParentId" false false Integer ]
               with References =
                     [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with
-                          HasDbConstraint = true; IsConstraintTrusted = false } ] }
+                          ConstraintState = ConstraintState.UntrustedConstraint } ] }
         let catalog =
             match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_F2"; Name = nameSafe "F2Mod"; Kinds = [ parent; child ]; IsActive = true; ExtendedProperties = [] } ] [] with
             | Ok c -> c | Error e -> failwithf "catalog %A" e
@@ -734,7 +734,7 @@ let ``E3: Ingest(deploy(Project(C, overlay))) reproduces the decision overlay on
             // (3) FK-trust: the NOCHECK source FK reads back untrusted.
             let childBack = kindByTable "OSUSR_F2_CHILD"
             match childBack.References with
-            | [ r ] -> Assert.False(r.IsConstraintTrusted, "NOCHECK FK must read back untrusted, not the create-default true")
+            | [ r ] -> Assert.False(Reference.isConstraintTrusted r, "NOCHECK FK must read back untrusted, not the create-default true")
             | rs -> Assert.Fail(sprintf "expected exactly one reconstructed FK, got %d" (List.length rs))
         | None -> Assert.Fail "deploy produced no reconstructed catalog"
 
@@ -776,7 +776,7 @@ let ``6.A.6 (schema round-trip): an untrusted FK survives emit / deploy / ReadSi
               // = true is required, else the catalog smart-constructor rejects
               // the illegal (constraint-absent ∧ untrusted) quadrant
               // (catalog.reference.illegalConstraintState).
-              with References = [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with HasDbConstraint = true; IsConstraintTrusted = false } ] }
+              with References = [ { Reference.create refKeyV (nameSafe "Parent") parentFkAttr parentKey with ConstraintState = ConstraintState.UntrustedConstraint } ] }
         let catalog =
             match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_RT6"; Name = nameSafe "Rt6Mod"; Kinds = [ parent; child ]; IsActive = true; ExtendedProperties = [] } ] [] with
             | Ok c -> c | Error e -> failwithf "catalog %A" e
@@ -791,7 +791,7 @@ let ``6.A.6 (schema round-trip): an untrusted FK survives emit / deploy / ReadSi
             // the emit→deploy→ReadSide round-trip is now faithful on FK-trust.
             Assert.Equal(1, (PhysicalSchema.ofCatalog c).ForeignKeys |> Set.count)
             match childBack.References with
-            | [ r ] -> Assert.False(r.IsConstraintTrusted, "emitted FK must read back untrusted (WITH NOCHECK reproduced)")
+            | [ r ] -> Assert.False(Reference.isConstraintTrusted r, "emitted FK must read back untrusted (WITH NOCHECK reproduced)")
             | rs -> Assert.Fail(sprintf "expected exactly one reconstructed FK, got %d" (List.length rs))
         | None -> Assert.Fail "deploy produced no reconstructed catalog"
 
@@ -838,6 +838,55 @@ let ``4.1: V2.SsKey persistence — ReadSide recovers OssysOriginal identities (
                 // a READSIDE_KIND synthesis.
                 Assert.Equal<SsKey>(custKey, k.SsKey)
             | None -> Assert.Fail "OSUSR_SSK_CUSTOMER not found in reconstructed catalog"
+        | None -> Assert.Fail "deploy produced no reconstructed catalog"
+
+/// THE VECTOR Wave 5 — the ATTRIBUTE-grain sibling of the kind-level Wave-4.1
+/// witness above. After emit (which now persists COLUMN-level `Projection.SsKey`)
+/// → deploy → read, the recovered ATTRIBUTE SsKeys must be the authored
+/// `OssysOriginal` GUIDs — recovered from the persisted column extended
+/// property via `recoverAttributeSsKey`, NOT `Synthesized "READSIDE_ATTR"` from
+/// physical coordinates. This closes the §5.1 / §3.3 T-V/T-I attribute-grain
+/// faithfulness gap (the adjudication the treatise left open): with the
+/// attribute identity preserved across the wire, an authored column RENAME
+/// round-trips as `Renamed` rather than `Removed + Added`.
+[<Fact>]
+let ``Wave 5: column Projection.SsKey persistence — ReadSide recovers OssysOriginal ATTRIBUTE identities (A1 at the attribute grain)`` () =
+    if skipIfNoDocker "v2sskey-attribute-persistence-roundtrip" then
+        let custKey    = SsKey.ossysOriginal (System.Guid.Parse "33333333-3333-3333-3333-333333333333")
+        let custIdKey  = SsKey.ossysOriginal (System.Guid.Parse "44444444-4444-4444-4444-444444444444")
+        let custCodeKey = SsKey.ossysOriginal (System.Guid.Parse "55555555-5555-5555-5555-555555555555")
+        let customer =
+            Kind.create custKey (nameSafe "Customer")
+                (mkTableId "dbo" "OSUSR_SSK_ATTR_CUSTOMER")
+                [ { Attribute.create custIdKey (nameSafe "Id") Integer with
+                      Column = ColumnRealization.create ("ID") (false) |> Result.value
+                      IsPrimaryKey = true; IsMandatory = true }
+                  { Attribute.create custCodeKey (nameSafe "Code") Integer with
+                      Column = ColumnRealization.create ("CODE") (true) |> Result.value } ]
+        let catalog =
+            match Catalog.create [ { SsKey = ssKeySafe "OS_MOD_SSK_ATTR"; Name = nameSafe "SskAttrMod"; Kinds = [ customer ]; IsActive = true; ExtendedProperties = [] } ] [] with
+            | Ok c -> c | Error e -> failwithf "catalog %A" e
+
+        let sql = SsdtDdlEmitter.statements catalog |> Render.toText
+        let readback = (Deploy.runWithReadback sql).GetAwaiter().GetResult()
+        Assert.True(readback.Report.Ok, sprintf "deploy: %A" readback.Report.Errors)
+        match readback.Reconstructed with
+        | Some reconstructed ->
+            let recovered =
+                reconstructed.Modules
+                |> List.collect (fun m -> m.Kinds)
+                |> List.tryFind (fun k -> TableId.tableText k.Physical = "OSUSR_SSK_ATTR_CUSTOMER")
+            match recovered with
+            | Some k ->
+                let attrKeyByName name =
+                    k.Attributes
+                    |> List.tryFind (fun a -> Name.value a.Name = name)
+                    |> Option.map (fun a -> a.SsKey)
+                // The recovered ATTRIBUTE identities are the persisted OssysOriginal
+                // GUIDs, not a READSIDE_ATTR synthesis from physical coordinates.
+                Assert.Equal<SsKey option>(Some custIdKey, attrKeyByName "Id")
+                Assert.Equal<SsKey option>(Some custCodeKey, attrKeyByName "Code")
+            | None -> Assert.Fail "OSUSR_SSK_ATTR_CUSTOMER not found in reconstructed catalog"
         | None -> Assert.Fail "deploy produced no reconstructed catalog"
 
 // ---------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests/CascadeShockZoneTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CascadeShockZoneTests.fs
@@ -41,7 +41,7 @@ let private mkRefCascade (ownerKey: SsKey) (targetKey: SsKey) : Reference =
     let refKey  = synthKey ownerRoot "ref"
     { Reference.create refKey (Name.create "fk" |> Result.value) attrKey targetKey with
         OnDelete        = Cascade
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 
 // Linear cascade chain: D → C → B → A. From D's perspective, deleting
 // any ancestor in {C, B, A} cascade-kills D. |Reachable from D| = 3.

--- a/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
@@ -149,8 +149,7 @@ let private richCatalog () : Catalog =
             OnDelete = ReferenceAction.SetNull
             OnUpdate = Some ReferenceAction.Cascade
             IsUserFk = false
-            HasDbConstraint = true
-            IsConstraintTrusted = false }
+            ConstraintState = ConstraintState.UntrustedConstraint }
 
     let richIndex =
         { Index.create (key 15) (nm "IX_Patron_Name") [ { Attribute = nameAttr; Direction = IndexColumnDirection.Descending } ] with
@@ -200,7 +199,7 @@ let private richCatalog () : Catalog =
         { Reference.create (key 22) (nm "PatronFk") visitPatronAttr patronKey with
             OnDelete = ReferenceAction.Restrict
             OnUpdate = Some ReferenceAction.NoAction
-            HasDbConstraint = true }
+            ConstraintState = ConstraintState.TrustedConstraint }
 
     let visit =
         { Kind.create visitKey (nm "Visit") (tableId "dbo" "Visit") [ visitPatron ] with
@@ -449,19 +448,24 @@ let ``decode re-proves the A39 aggregate invariant (dangling FK target)`` () =
     |> expectError "dangling FK target — A39 re-validation on decode"
 
 [<Fact>]
-let ``NM-12: Catalog.create rejects the illegal constraint-state quadrant`` () =
-    // A self-reference in the illegal (no-constraint, untrusted) quadrant, set via
-    // a raw record-`with` that bypasses `withConstraintState`. The aggregate root
-    // must refuse it (G14), so the quadrant cannot enter the IR by any path.
+let ``NM-12 / M4: the illegal constraint-state quadrant is unrepresentable — the legacy (false,false) pair normalizes to NoDbConstraint and the catalog accepts it`` () =
+    // Pre-M4 this quadrant (constraint-absent ∧ untrusted) was rejected at runtime
+    // by Catalog.create. Since M4 it is UNREPRESENTABLE — `ConstraintState` is a
+    // closed 3-variant DU with no illegal member. The only ingest path for the
+    // legacy boolean pair is `withConstraintState` / `ofLegacyBooleans`, which
+    // normalizes `(false, false)` to `NoDbConstraint` (vacuous trust). The catalog
+    // therefore accepts the normalized reference — there is no illegal state left
+    // to reject (the runtime check became dead code and was retired).
     let attr = Attribute.create (key 1) (nm "Col") PrimitiveType.Text
-    let badRef =
-        { Reference.create (key 2) (nm "FK_self") attr.SsKey (key 3) with
-            HasDbConstraint = false; IsConstraintTrusted = false }
-    let kind = { Kind.create (key 3) (nm "K") (tableId "dbo" "K") [ attr ] with References = [ badRef ] }
+    let normalizedRef =
+        Reference.create (key 2) (nm "FK_self") attr.SsKey (key 3)
+        |> Reference.withConstraintState false false
+    Assert.Equal(ConstraintState.NoDbConstraint, normalizedRef.ConstraintState)
+    let kind = { Kind.create (key 3) (nm "K") (tableId "dbo" "K") [ attr ] with References = [ normalizedRef ] }
     let m = { SsKey = key 1000; Name = nm "M"; Kinds = [ kind ]; IsActive = true; ExtendedProperties = [] }
     match Catalog.create [ m ] [] with
-    | Ok _ -> Assert.True(false, "expected Catalog.create to reject the illegal constraint-state quadrant")
-    | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "catalog.reference.illegalConstraintState")
+    | Ok _ -> ()
+    | Error es -> Assert.True(false, sprintf "Catalog.create must accept the normalized reference; got %A" es)
 
 [<Fact>]
 let ``NM-14: Catalog.create rejects a (Type, SqlStorage) mismatch`` () =

--- a/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ComprehensiveCanaryTests.fs
@@ -820,11 +820,10 @@ module ComprehensiveCanaryTests =
                 IsMandatory = true }
         let bRefA =
             { Reference.create (mkSs "REF-B-A") (mkNm "FK_B_A") bAKeyAttr aKey with
-                HasDbConstraint     = true
-                IsConstraintTrusted = false }
+                ConstraintState = ConstraintState.UntrustedConstraint }
         let bSelfRef =
             { Reference.create (mkSs "REF-B-SELF") (mkNm "FK_B_Self") bIdAttrKey bKey with
-                HasDbConstraint = true }
+                ConstraintState = ConstraintState.TrustedConstraint }
         let kindB =
             { Kind.create bKey (mkNm "B")
                 (TableId.create "dbo" "OSUSR_CANARY_B" |> Result.value)

--- a/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
@@ -45,8 +45,8 @@ let private invoice  = kindOf ["Invoice"]  "OSUSR_INVOICE"  [ pk ["Invoice"] "ID
 
 // A has a NULLABLE FK to B (deferrable); B has a NON-NULLABLE FK to A
 // (cannot defer → diagnostic). Together a 2-cycle.
-let private aBRef = { Reference.create (mkKey ["A"; "BRef"]) (mkName "BRef") (mkKey ["A"; "B_ID"]) bKey with HasDbConstraint = true }
-let private bARef = { Reference.create (mkKey ["B"; "ARef"]) (mkName "ARef") (mkKey ["B"; "A_ID"]) aKey with HasDbConstraint = true }
+let private aBRef = { Reference.create (mkKey ["A"; "BRef"]) (mkName "BRef") (mkKey ["A"; "B_ID"]) bKey with ConstraintState = ConstraintState.TrustedConstraint }
+let private bARef = { Reference.create (mkKey ["B"; "ARef"]) (mkName "ARef") (mkKey ["B"; "A_ID"]) aKey with ConstraintState = ConstraintState.TrustedConstraint }
 let private kindA = kindOf ["A"] "OSUSR_A" [ pk ["A"] "ID" false; fkAttr ["A"] "B_ID" true ]  [ aBRef ]
 let private kindB = kindOf ["B"] "OSUSR_B" [ pk ["B"] "ID" false; fkAttr ["B"] "A_ID" false ] [ bARef ]
 

--- a/sidecar/projection/tests/Projection.Tests/DecisionEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DecisionEmissionTests.fs
@@ -305,7 +305,7 @@ let ``decision-drop audit splits by HasDbConstraint: Warning fkDropped for sourc
               mkAttr (akey "B.AId2") "AId2" false ]
           with References =
                 [ { Reference.create refToA (nm "A") (akey "B.AId") aKey
-                      with HasDbConstraint = true }
+                      with ConstraintState = ConstraintState.TrustedConstraint }
                   Reference.create refToA2 (nm "A") (akey "B.AId2") aKey ] }
     let catalog =
         match Catalog.create [ { SsKey = kkey "Mod"; Name = nm "FdMod"; Kinds = [ a; b ]; IsActive = true; ExtendedProperties = [] } ] [] with

--- a/sidecar/projection/tests/Projection.Tests/DeployableReferenceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DeployableReferenceTests.fs
@@ -110,7 +110,7 @@ let ``fixture guard: closure mints two inverses on User, inheriting HasDbConstra
         |> List.find (fun k -> k.SsKey = userKey)
     let inverses = user.References |> List.filter Reference.isInverse
     Assert.Equal(2, List.length inverses)
-    Assert.All(inverses, fun r -> Assert.True r.HasDbConstraint)
+    Assert.All(inverses, fun r -> Assert.True (Reference.hasDbConstraint r))
     Assert.All(inverses, fun r -> Assert.False (Reference.isDeployable r))
 
 // ---------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests/FkRealityRowsetRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FkRealityRowsetRoundTripTests.fs
@@ -224,13 +224,13 @@ let ``A.4.7'-prelude.row17-18: V1 #FkReality.UpdateAction = "SET_DEFAULT" degrad
 let ``A.4.7'-prelude.row17-18: ReferenceRow.IsConstraintTrusted = true populates Reference.IsConstraintTrusted = true`` () =
     let cat = parseToCatalog (buildBundle (fkReferenceRow None true))
     let reference = findOrderReference cat
-    Assert.True(reference.IsConstraintTrusted)
+    Assert.True(Reference.isConstraintTrusted reference)
 
 [<Fact>]
 let ``A.4.7'-prelude.row17-18: ReferenceRow.IsConstraintTrusted = false populates Reference.IsConstraintTrusted = false (NOCHECK state preserved)`` () =
     let cat = parseToCatalog (buildBundle (fkReferenceRow None false))
     let reference = findOrderReference cat
-    Assert.False(reference.IsConstraintTrusted)
+    Assert.False(Reference.isConstraintTrusted reference)
 
 // ---------------------------------------------------------------------------
 // Combined: both axes together (the production cutover scenario where
@@ -243,4 +243,4 @@ let ``A.4.7'-prelude.row17-18: both OnUpdate and IsConstraintTrusted round-trip 
         parseToCatalog (buildBundle (fkReferenceRow (Some "CASCADE") false))
     let reference = findOrderReference cat
     Assert.Equal(Some Cascade, reference.OnUpdate)
-    Assert.False(reference.IsConstraintTrusted)
+    Assert.False(Reference.isConstraintTrusted reference)

--- a/sidecar/projection/tests/Projection.Tests/ForeignKeyRulesTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ForeignKeyRulesTests.fs
@@ -102,7 +102,7 @@ let ``missingTarget: target kind absent from catalog ⇒ DoNotEnforce(MissingTar
 // ---------------------------------------------------------------------------
 
 let private sourceBackedRef : Reference =
-    { orderRef with HasDbConstraint = true }
+    { orderRef with ConstraintState = ConstraintState.ofLegacyBooleans true (Reference.isConstraintTrusted orderRef) }
 
 [<Fact>]
 let ``hasDbConstraint: source-backed reference ⇒ EnforceConstraint(DatabaseConstraintPresent) with no profile at all`` () =
@@ -149,7 +149,7 @@ let ``hasDbConstraint: MissingTarget outranks the carve-out (a scoped export can
     let danglingTargetKey = ssKey "OS_KIND_NoSuchKind"
     let danglingBacked : Reference =
         { Reference.create (ssKey "OS_REF_Order_DanglingBacked") (name "Dangling") orderCustomerFkKey danglingTargetKey
-            with HasDbConstraint = true }
+            with ConstraintState = ConstraintState.TrustedConstraint }
     let cfg = mkConfig true true true
     let decision = decide cfg sampleCatalog order danglingBacked Profile.empty
     Assert.Equal(

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Assignment.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Assignment.sql
@@ -27,6 +27,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'ProjectId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
@@ -34,7 +41,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'ResourceId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Role',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'Role'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
     @level2type = N'COLUMN', @level2name = N'Role'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
@@ -24,7 +24,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Heap',
+    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Message',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Heap',
+    @level2type = N'COLUMN', @level2name = N'Message'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Heap.Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
     @level2type = N'COLUMN', @level2name = N'Message'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
@@ -102,6 +102,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
@@ -109,7 +116,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Amount',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Amount'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'Amount'
@@ -130,6 +151,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
@@ -137,7 +165,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'DueDate'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ExternalKey',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'ExternalKey'
@@ -158,7 +200,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'FreeText'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'IsActive',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'IsActive'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'IsActive'
@@ -172,7 +228,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Notes'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'OccurredOn',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'OccurredOn'
@@ -186,7 +256,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Payload'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tally',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Tally'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'Tally'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
@@ -29,6 +29,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
@@ -36,7 +43,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'At'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UserId',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'UserId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
     @level2type = N'COLUMN', @level2name = N'UserId'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Customer.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Customer.sql
@@ -26,7 +26,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:111:Customer.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Customer',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Customer',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Customer.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
     @level2type = N'COLUMN', @level2name = N'Name'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
@@ -66,7 +66,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AltCustomerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'AltCustomerId'
@@ -80,7 +94,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CustomerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'CustomerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'CustomerId'
@@ -94,6 +122,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'ParentId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
@@ -101,7 +136,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Subject'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UpdatedBy',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'UpdatedBy'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.EnterpriseCustomerRelationshipManagementProfileSnapshot.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.EnterpriseCustomerRelationshipManagementProfileSnapshot.sql
@@ -23,3 +23,10 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
     @level2type = N'COLUMN', @level2name = N'Id'
 
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
+    @level2type = N'COLUMN', @level2name = N'Id'
+

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.InterdepartmentalResourceAllocationAuthorizationLedger.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.InterdepartmentalResourceAllocationAuthorizationLedger.sql
@@ -28,7 +28,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
     @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
@@ -32,7 +32,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:User.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Email',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Email'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:User.Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
     @level2type = N'COLUMN', @level2name = N'Email'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
@@ -27,6 +27,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:Country.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
@@ -34,7 +41,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Country.Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Label',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Label'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Country.Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
     @level2type = N'COLUMN', @level2name = N'Label'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionA.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionA.sql
@@ -29,6 +29,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
@@ -36,7 +43,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'PartnerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
     @level2type = N'COLUMN', @level2name = N'PartnerId'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionB.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionB.sql
@@ -29,6 +29,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
@@ -36,7 +43,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'PartnerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
     @level2type = N'COLUMN', @level2name = N'PartnerId'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.ScopedLookup.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.ScopedLookup.sql
@@ -27,6 +27,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
@@ -34,7 +41,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'TenantId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Value',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'Value'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
     @level2type = N'COLUMN', @level2name = N'Value'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Tier.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Tier.sql
@@ -32,7 +32,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:Tier.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Tier',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Tier',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Tier.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
     @level2type = N'COLUMN', @level2name = N'Name'

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
@@ -27,6 +27,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'ProjectId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
@@ -34,7 +41,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'ResourceId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Role',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Assignment',
+    @level2type = N'COLUMN', @level2name = N'Role'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
     @level2type = N'COLUMN', @level2name = N'Role'
@@ -72,6 +93,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
@@ -79,7 +107,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'At'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UserId',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'UserId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
     @level2type = N'COLUMN', @level2name = N'UserId'
@@ -115,6 +157,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:Country.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
@@ -122,7 +171,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Country.Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Label',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Label'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Country.Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
     @level2type = N'COLUMN', @level2name = N'Label'
@@ -157,7 +220,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:111:Customer.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Customer',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Customer',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Customer.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
     @level2type = N'COLUMN', @level2name = N'Name'
@@ -185,6 +262,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S
 GO
 
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
     @level2type = N'COLUMN', @level2name = N'Id'
@@ -259,7 +343,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AltCustomerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'AltCustomerId'
@@ -273,7 +371,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CustomerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'CustomerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'CustomerId'
@@ -287,6 +399,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'ParentId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
@@ -294,7 +413,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Subject'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UpdatedBy',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'UpdatedBy'
@@ -327,7 +460,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Heap',
+    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Message',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Heap',
+    @level2type = N'COLUMN', @level2name = N'Message'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Heap.Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
     @level2type = N'COLUMN', @level2name = N'Message'
@@ -364,7 +511,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
     @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
@@ -402,6 +563,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
@@ -409,7 +577,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionA',
+    @level2type = N'COLUMN', @level2name = N'PartnerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
     @level2type = N'COLUMN', @level2name = N'PartnerId'
@@ -447,6 +629,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
@@ -454,7 +643,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'RegionB',
+    @level2type = N'COLUMN', @level2name = N'PartnerId'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
     @level2type = N'COLUMN', @level2name = N'PartnerId'
@@ -565,6 +768,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
@@ -572,7 +782,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Amount',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Amount'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'Amount'
@@ -593,6 +817,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
@@ -600,7 +831,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'DueDate'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ExternalKey',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'ExternalKey'
@@ -621,7 +866,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'FreeText'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'IsActive',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'IsActive'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'IsActive'
@@ -635,7 +894,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Notes'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'OccurredOn',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'OccurredOn'
@@ -649,7 +922,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Payload'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tally',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Tally'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'Tally'
@@ -705,6 +992,13 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
@@ -712,7 +1006,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'TenantId'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Value',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScopedLookup',
+    @level2type = N'COLUMN', @level2name = N'Value'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
     @level2type = N'COLUMN', @level2name = N'Value'
@@ -753,7 +1061,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:Tier.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Tier',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Tier',
+    @level2type = N'COLUMN', @level2name = N'Name'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Tier.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
     @level2type = N'COLUMN', @level2name = N'Name'
@@ -794,7 +1116,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:User.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Email',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Email'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:User.Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
     @level2type = N'COLUMN', @level2name = N'Email'

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
@@ -37,7 +37,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
     @level2type = N'COLUMN', @level2name = N'Code'

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
@@ -37,7 +37,21 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value
 
 GO
 
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id'
+
+GO
+
 EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Code'
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
     @level2type = N'COLUMN', @level2name = N'Code'

--- a/sidecar/projection/tests/Projection.Tests/JunctionDeferredTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/JunctionDeferredTests.fs
@@ -33,7 +33,7 @@ let private mkRef (ownerKey: SsKey) (targetKey: SsKey) (name: string) : Referenc
     let attrKey = synthKey (SsKey.rootOriginal ownerKey) name
     let refKey  = synthKey (SsKey.rootOriginal ownerKey) (name + "_ref")
     { Reference.create refKey (Name.create name |> Result.value) attrKey targetKey with
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 
 let private buildJunctionCatalog () : Catalog =
     let author =

--- a/sidecar/projection/tests/Projection.Tests/LiveProfilerIntegrationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LiveProfilerIntegrationTests.fs
@@ -154,8 +154,7 @@ module private LiveProfilerFixtures =
                 IsMandatory  = true }
         let fkReference =
             { Reference.create childFkKey (mkName "FK_Parent") childParentAttrKey itemsKindKey with
-                HasDbConstraint = true
-                IsConstraintTrusted = true }
+                ConstraintState = ConstraintState.TrustedConstraint }
         { Kind.create childKindKey (mkName "Children")
             (TableId.create "dbo" "OSUSR_LP_CHILDREN" |> Result.value)
             [ idAttr; parentAttr ]

--- a/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmCatalogReaderDifferentialTests.fs
@@ -346,7 +346,7 @@ let private expectedReferenceCatalog : Catalog =
               { Attribute.create userAccountIdAttrKey (mkName "AccountId") Integer with Column = ColumnRealization.create ("ACCOUNTID") (false) |> Result.value; IsMandatory = true; SqlStorage = Some SqlStorageType.BigInt }
           ]
           References = [
-              { Reference.create userAccountReferenceKey (mkName "AccountId") userAccountIdAttrKey accountKindKey with HasDbConstraint = true }
+              { Reference.create userAccountReferenceKey (mkName "AccountId") userAccountIdAttrKey accountKindKey with ConstraintState = ConstraintState.TrustedConstraint }
           ]
           Indexes    = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
     { Modules = [

--- a/sidecar/projection/tests/Projection.Tests/OssysComprehensiveFixtureTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysComprehensiveFixtureTests.fs
@@ -107,7 +107,7 @@ let ``Referential actions: Cascade, SetNull, and NoAction all resolve`` () =
 let ``Untrusted (WITH NOCHECK) FK lands with IsConstraintTrusted=false`` () =
     withCatalog "comp-untrusted-fk" (fun catalog ->
         let movement = kindNamed "StockMovement" catalog
-        Assert.False((refNamed "SupplierId" movement).IsConstraintTrusted))
+        Assert.False(Reference.isConstraintTrusted (refNamed "SupplierId" movement)))
 
 [<Fact>]
 let ``ON UPDATE CASCADE flows into Reference.OnUpdate`` () =

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -163,6 +163,7 @@
     <Compile Include="PreflightTests.fs" />
     <Compile Include="PreflightAllTests.fs" />
     <Compile Include="ModelFidelityTests.fs" />
+    <Compile Include="ReportRunTests.fs" />
     <Compile Include="CompareTests.fs" />
     <Compile Include="CanaryResidualTests.fs" />
     <Compile Include="RenameProjectionTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/QueryHintPassTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/QueryHintPassTests.fs
@@ -29,7 +29,7 @@ let private mkRef (ownerKey: SsKey) (targetKey: SsKey) (attrName: string) : Refe
     let attrKey = kindAttrKey ownerKey attrName
     let refKey  = kindAttrKey ownerKey (attrName + "_ref")
     { Reference.create refKey (Name.create attrName |> Result.value) attrKey targetKey with
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 
 let private mkIndex (ownerKey: SsKey) (name: string) (attrKey: SsKey) (fillFactor: int option) : Index =
     let col = IndexColumn.create attrKey Ascending

--- a/sidecar/projection/tests/Projection.Tests/ReconciliationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReconciliationTests.fs
@@ -165,7 +165,7 @@ let private orderKey = mkKey [ "Order" ]
 let private userIdKey = mkKey [ "Order"; "USER_ID" ]
 let private orderUserRef =
     { Reference.create (mkKey [ "Order"; "UserRef" ]) (mkName "UserRef") userIdKey userKey with
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 let private orderKind : Kind =
     { Kind.create orderKey (mkName "Order") (TableId.create "dbo" "OSUSR_ORDER" |> Result.value)
         [ { Attribute.create (mkKey [ "Order"; "ID" ]) (mkName "ID") Integer with

--- a/sidecar/projection/tests/Projection.Tests/ReferenceConstraintStateTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReferenceConstraintStateTests.fs
@@ -29,21 +29,24 @@ let ``G14: the illegal quadrant (no constraint, untrusted) normalizes to vacuous
     // guard canonicalizes it to (no constraint, trusted) rather than leaving a
     // NOCHECK marker on a non-existent constraint.
     let r = baseRef |> Reference.withConstraintState false false
-    Assert.False(r.HasDbConstraint)
-    Assert.True(r.IsConstraintTrusted)
+    Assert.Equal(ConstraintState.NoDbConstraint, r.ConstraintState)
+    Assert.False(Reference.hasDbConstraint r)
+    Assert.True(Reference.isConstraintTrusted r)
     Assert.True(Reference.isConstraintStateConsistent r)
 
 [<Fact>]
 let ``G14: a real untrusted (NOCHECK) constraint is preserved`` () =
     let r = baseRef |> Reference.withConstraintState true false
-    Assert.True(r.HasDbConstraint)
-    Assert.False(r.IsConstraintTrusted)
+    Assert.Equal(ConstraintState.UntrustedConstraint, r.ConstraintState)
+    Assert.True(Reference.hasDbConstraint r)
+    Assert.False(Reference.isConstraintTrusted r)
     Assert.True(Reference.isConstraintStateConsistent r)
 
 [<Fact>]
 let ``G14: a real trusted constraint is preserved`` () =
     let r = baseRef |> Reference.withConstraintState true true
-    Assert.True(r.HasDbConstraint && r.IsConstraintTrusted)
+    Assert.Equal(ConstraintState.TrustedConstraint, r.ConstraintState)
+    Assert.True(Reference.hasDbConstraint r && Reference.isConstraintTrusted r)
     Assert.True(Reference.isConstraintStateConsistent r)
 
 [<Property>]
@@ -53,5 +56,45 @@ let ``G14: withConstraintState always yields a consistent reference`` (hasDb: bo
 [<Property>]
 let ``G14: withConstraintState is idempotent`` (hasDb: bool) (trusted: bool) =
     let once = baseRef |> Reference.withConstraintState hasDb trusted
-    let twice = once |> Reference.withConstraintState once.HasDbConstraint once.IsConstraintTrusted
+    let twice = once |> Reference.withConstraintState (Reference.hasDbConstraint once) (Reference.isConstraintTrusted once)
     once = twice
+
+// ---------------------------------------------------------------------------
+// M4 (THE VECTOR §6 Kind II) — the `ConstraintState` DU is the promotion of the
+// G14 invariant from a runtime check to a TYPE THEOREM. The illegal quadrant is
+// now unrepresentable (the DU has no fourth variant); the legacy boolean pair is
+// a derived projection that round-trips. Mirrors the `Archetype.grant ∘ ofGrant
+// = id` precedent.
+// ---------------------------------------------------------------------------
+
+let private allStates =
+    [ ConstraintState.NoDbConstraint
+      ConstraintState.TrustedConstraint
+      ConstraintState.UntrustedConstraint ]
+
+[<Fact>]
+let ``M4: the boolean projection matches each variant's documented (hasDb, trusted) pair`` () =
+    Assert.Equal<(bool * bool) list>(
+        [ (false, true); (true, true); (true, false) ],
+        allStates |> List.map ConstraintState.toLegacyBooleans)
+
+[<Fact>]
+let ``M4: round-trip law — ofLegacyBooleans (toLegacyBooleans s) = s for every variant`` () =
+    for s in allStates do
+        let (hasDb, trusted) = ConstraintState.toLegacyBooleans s
+        Assert.Equal(s, ConstraintState.ofLegacyBooleans hasDb trusted)
+
+[<Property>]
+let ``M4: ofLegacyBooleans normalizes any boolean pair into a representable state (no illegal quadrant)`` (hasDb: bool) (trusted: bool) =
+    // Every boolean pair — including the legacy illegal (false, false) — maps to
+    // one of the three legal variants; there is no fourth state to land in.
+    List.contains (ConstraintState.ofLegacyBooleans hasDb trusted) allStates
+
+[<Property>]
+let ``M4: ofLegacyBooleans is the left inverse on legal pairs, normalizing on the illegal one`` (hasDb: bool) (trusted: bool) =
+    // toLegacyBooleans ∘ ofLegacyBooleans is the identity on the THREE legal pairs
+    // and maps the illegal (false, false) to the canonical (false, true).
+    let s = ConstraintState.ofLegacyBooleans hasDb trusted
+    let (h2, t2) = ConstraintState.toLegacyBooleans s
+    if hasDb then (h2 = hasDb && t2 = trusted)        // legal pairs survive unchanged
+    else (h2 = false && t2 = true)                    // (false, _) normalizes to vacuous trust

--- a/sidecar/projection/tests/Projection.Tests/ReferenceHasDbConstraintTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReferenceHasDbConstraintTests.fs
@@ -77,7 +77,7 @@ let ``Adapter pickup: parseReference captures hasDbConstraint = 1 as HasDbConstr
     | Ok catalog ->
         let widget = Catalog.allKinds catalog |> List.find (fun k -> Name.value k.Name = "Widget")
         Assert.Single widget.References |> ignore
-        Assert.True widget.References.[0].HasDbConstraint
+        Assert.True (Reference.hasDbConstraint widget.References.[0])
     | Error errs ->
         Assert.Fail (sprintf "parseJsonString failed: %A" errs)
 
@@ -87,7 +87,7 @@ let ``Adapter pickup: parseReference captures hasDbConstraint = 0 as HasDbConstr
     match parseJson envelope with
     | Ok catalog ->
         let widget = Catalog.allKinds catalog |> List.find (fun k -> Name.value k.Name = "Widget")
-        Assert.False widget.References.[0].HasDbConstraint
+        Assert.False (Reference.hasDbConstraint widget.References.[0])
     | Error errs ->
         Assert.Fail (sprintf "parseJsonString failed: %A" errs)
 
@@ -133,7 +133,7 @@ let ``Adapter pickup: missing hasDbConstraint defaults to false (V1 COALESCE par
     match parseJson envelope with
     | Ok catalog ->
         let widget = Catalog.allKinds catalog |> List.find (fun k -> Name.value k.Name = "Widget")
-        Assert.False widget.References.[0].HasDbConstraint
+        Assert.False (Reference.hasDbConstraint widget.References.[0])
     | Error errs ->
         Assert.Fail (sprintf "parseJsonString failed: %A" errs)
 
@@ -147,7 +147,7 @@ let private mkRef (hasDb: bool) : Reference =
         (mkName "FK")
         (mkKey "Attr.A")
         (mkKey "K.Target")
-      with HasDbConstraint = hasDb }
+      with ConstraintState = ConstraintState.ofLegacyBooleans hasDb true }
 
 let private mkKindWith (label: string) (refs: Reference list) : Kind =
     let baseKind =
@@ -215,5 +215,5 @@ let ``SymmetricClosure: inverse Reference inherits HasDbConstraint from the forw
             (mkKey "K.Source")
           with
             IsUserFk        = r.IsUserFk
-            HasDbConstraint = r.HasDbConstraint }
-    Assert.Equal (r.HasDbConstraint, inverse.HasDbConstraint)
+            ConstraintState = r.ConstraintState }
+    Assert.Equal (Reference.hasDbConstraint r, Reference.hasDbConstraint inverse)

--- a/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
@@ -170,7 +170,7 @@ let private rpOrderKind (ownerName: string) (ownerCol: string) : Kind =
       with
         References =
             [ { Reference.create (aKey "Order.OwnerRef") (nm "OwnerRef") rpOwnerAttrKey rpUserKey with
-                  HasDbConstraint = true } ] }
+                  ConstraintState = ConstraintState.TrustedConstraint } ] }
 
 let private rpCatOf (k: Kind list) : Catalog =
     IRBuilders.mkCatalog [ IRBuilders.mkModule (kKey "Mod") (nm "M") k ]

--- a/sidecar/projection/tests/Projection.Tests/ReportRunTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReportRunTests.fs
@@ -1,0 +1,148 @@
+module Projection.Tests.ReportRunTests
+
+open System
+open System.Text.Json
+open System.Text.Json.Nodes
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+
+// M18 (THE VECTOR §5.2) — the change report's MACHINE lens. `ReportRun.render`
+// surfaces the per-edge displacement as operator prose; `ReportRun.toJson` is
+// its byte-deterministic sibling — the contract the SSIS consumer diffs sprint-
+// over-sprint. These tests pin the second lens against the same substrate the
+// human lens reads (the `ChangeManifestTests` chain: rename customer→Patron at
+// E1, back at E2; net displacement zero, path length 2).
+
+type private FsResult<'a, 'b> = Microsoft.FSharp.Core.Result<'a, 'b>
+
+let private mustResultOk (r: Result<'a>) : 'a =
+    match r with
+    | Ok v -> v
+    | Error es -> Assert.Fail(sprintf "%A" es); Unchecked.defaultof<'a>
+
+let private mustOk (r: FsResult<'a, 'b>) : 'a =
+    match r with
+    | FsResult.Ok v -> v
+    | FsResult.Error err -> Assert.Fail(sprintf "%A" err); Unchecked.defaultof<'a>
+
+// -- JSON navigation, null-narrowed (F# nullness: every indexer yields
+//    `JsonNode | null`; `nn` is the single assert-non-null gate the rest reuse).
+let private nn (n: JsonNode | null) : JsonNode =
+    match n with
+    | null -> Assert.Fail "unexpected JSON null"; Unchecked.defaultof<JsonNode>
+    | x -> x
+
+let private obj (n: JsonNode | null) : JsonObject = (nn n) :?> JsonObject
+let private arr (n: JsonNode | null) : JsonArray = (nn n) :?> JsonArray
+let private child (o: JsonObject) (key: string) : JsonObject = obj o.[key]
+let private getInt (o: JsonObject) (key: string) : int = (nn o.[key]).GetValue<int>()
+let private getStr (o: JsonObject) (key: string) : string = (nn o.[key]).GetValue<string>()
+
+let private nameOf (s: string) : Name = Name.create s |> mustResultOk
+let private ver (o: int) (l: string) : Version = Version.create o l |> mustResultOk
+let private tl (name: string) : Timeline = Timeline.create name |> mustResultOk
+let private at (iso: string) : DateTimeOffset = DateTimeOffset.Parse(iso, System.Globalization.CultureInfo.InvariantCulture)
+let private coord o lbl day = EpisodeCoordinate.create (ver o lbl) Environment.Dev (at (sprintf "2026-06-%02dT09:00:00+00:00" day))
+
+let private renamedKind : Kind = { customer with Name = nameOf "Patron" }
+let private renamedModule : Module = { salesModule with Kinds = [ renamedKind; order; country ] }
+let private renamedCatalog : Catalog = IRBuilders.mkCatalog [ renamedModule ]
+
+let private e0 = Episode.ofSchema (coord 0 "1.0.0" 1) sampleCatalog
+let private e1 =
+    Episode.create (coord 1 "1.1.0" 8) renamedCatalog Profile.empty (Some "reflog#1") (DataObservation.create 120 (Some "lsn:0x10"))
+let private e2 =
+    Episode.create (coord 2 "1.2.0" 15) sampleCatalog Profile.empty (Some "reflog#2") (DataObservation.create 95 None)
+
+let private chain : EpisodicLifecycle =
+    EpisodicLifecycle.genesis (tl "dev") e0
+    |> (fun lc -> EpisodicLifecycle.append e1 lc |> mustResultOk)
+    |> (fun lc -> EpisodicLifecycle.append e2 lc |> mustResultOk)
+
+let private bundle : ReportRun.ReportBundle = ReportRun.fromChain chain |> mustOk
+let private root () : JsonObject = ReportRun.toJson bundle
+
+// ===========================================================================
+// M18 — the machine lens carries the bundle masthead + one node per edge
+// ===========================================================================
+
+[<Fact>]
+let ``M18: toJson carries the bundle masthead (timeline, episode count, path length)`` () =
+    let o = root ()
+    Assert.Equal("dev", getStr o "timeline")
+    Assert.Equal(3, getInt o "episodeCount")
+    // Path length is the sum of edge norms — rename + rename-back = 2.
+    Assert.Equal(2, getInt o "pathLength")
+
+[<Fact>]
+let ``M18: toJson emits one change node per edge, with the displacement + data norm`` () =
+    let changes = arr (root ()).["changes"]
+    Assert.Equal(2, changes.Count)
+    let edge0 = obj changes.[0]
+    // The schema displacement: one renamed kind, norm 1.
+    Assert.Equal(1, getInt edge0 "schemaNorm")
+    Assert.Equal(1, getInt (child edge0 "channels") "renamedKinds")
+    // The realized data movement is the To-episode's CDC capture count.
+    Assert.Equal(120, getInt edge0 "cdcCaptureCount")
+    // The Decision anchor is the To-episode's refactorlog reference.
+    Assert.Equal("reflog#1", getStr edge0 "refactorLogRef")
+    // The endpoints carry the version coordinates (the SSIS consumer keys on them).
+    Assert.Equal(0, getInt (child (child edge0 "from") "version") "ordinal")
+    Assert.Equal(1, getInt (child (child edge0 "to") "version") "ordinal")
+
+[<Fact>]
+let ``M18: an absent Decision anchor renders as JSON null (a stable key)`` () =
+    // Build a bundle whose only edge has no refactorlog reference.
+    let e1b = Episode.create (coord 3 "1.3.0" 22) renamedCatalog Profile.empty None (DataObservation.create 0 None)
+    let chain2 =
+        EpisodicLifecycle.genesis (tl "dev") e1
+        |> (fun lc -> EpisodicLifecycle.append e1b lc |> mustResultOk)
+    let b2 = ReportRun.fromChain chain2 |> mustOk
+    let edge0 = obj (arr (ReportRun.toJson b2).["changes"]).[0]
+    let isJsonNull =
+        match edge0.["refactorLogRef"] with
+        | null -> true
+        | n -> n.GetValueKind() = JsonValueKind.Null
+    Assert.True(isJsonNull, "refactorLogRef must be present-and-null when the To-episode has no anchor")
+
+// ===========================================================================
+// M18 — the second lens surfaces the two provenance planes the prose does
+// ===========================================================================
+
+[<Fact>]
+let ``M18: toJson surfaces the To-episode tolerance residual + applied-transforms`` () =
+    let tolerances =
+        Tolerance.strict
+        |> Tolerance.withDivergence ToleratedDivergence.HeaderCommentsOmitted
+        |> Tolerance.withDivergence ToleratedDivergence.IndexOptionsUnreflected
+    let appliedTransforms : (SsKey * OverlayAxis option) list =
+        [ customerKey, Some Tightening; orderKey, None ]
+    let e1p = e1 |> Episode.withProvenance tolerances appliedTransforms
+    let chainP =
+        EpisodicLifecycle.genesis (tl "dev") e0
+        |> (fun lc -> EpisodicLifecycle.append e1p lc |> mustResultOk)
+    let b = ReportRun.fromChain chainP |> mustOk
+    let edge0 = obj (arr (ReportRun.toJson b).["changes"]).[0]
+    // The residual is name-sorted (the displacement's accepted-equivalence set).
+    let residual = arr edge0.["toleranceResidual"] |> Seq.map (fun n -> (nn n).GetValue<string>()) |> List.ofSeq
+    Assert.Equal<string list>(
+        [ ToleratedDivergence.name ToleratedDivergence.HeaderCommentsOmitted
+          ToleratedDivergence.name ToleratedDivergence.IndexOptionsUnreflected ],
+        residual)
+    // The applied-transforms carry the canonical SsKey + the overlay axis (or null).
+    let applied = arr edge0.["appliedTransforms"] |> Seq.map obj |> List.ofSeq
+    Assert.Equal(2, List.length applied)
+    Assert.Equal(SsKey.serialize customerKey, getStr applied.[0] "ssKey")
+    Assert.Equal("Tightening", getStr applied.[0] "axis")
+    Assert.True(isNull applied.[1].["axis"], "a skeleton-only row carries a null axis")
+
+// ===========================================================================
+// M18 — the machine lens is byte-deterministic (T1 — the artifact body is
+// diffable sprint-over-sprint, which is the entire point of the second lens)
+// ===========================================================================
+
+[<Fact>]
+let ``M18: toJsonString is byte-deterministic across renderings`` () =
+    Assert.Equal(ReportRun.toJsonString bundle, ReportRun.toJsonString bundle)

--- a/sidecar/projection/tests/Projection.Tests/SchemaComplexityPassTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SchemaComplexityPassTests.fs
@@ -24,7 +24,7 @@ let private mkRef (ownerKey: SsKey) (targetKey: SsKey) : Reference =
     let attrKey = synthKey (SsKey.rootOriginal ownerKey) "fk"
     let refKey  = synthKey (SsKey.rootOriginal ownerKey) "fk_ref"
     { Reference.create refKey (Name.create "fk" |> Result.value) attrKey targetKey with
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 
 let private mkSimpleKind (key: SsKey) : Kind =
     Kind.create

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterPropertyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterPropertyTests.fs
@@ -255,9 +255,8 @@ let private fkChildKind (onUpdate: ReferenceAction option) (trusted: bool) : Kin
     let reference =
         { Reference.create fkRefKey (mkName "FkToParent") fkChildFkKey fkParentKey with
             OnDelete            = Cascade
-            HasDbConstraint     = true
             OnUpdate            = onUpdate
-            IsConstraintTrusted = trusted }
+            ConstraintState     = ConstraintState.ofLegacyBooleans true trusted }
     { Kind.create fkChildKey (mkName "PropFkChild")
         (mkTableId "dbo" "OSUSR_PFC_CHILD")
         [ { Attribute.create fkChildPkKey (mkName "Id") Integer with

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
@@ -1017,9 +1017,8 @@ let private fkFeaturesBKind (onUpdate: ReferenceAction option) (trusted: bool) :
         { Reference.create
             fkFeaturesCrossRef (mkName "FkToA") fkFeaturesBFkAttr fkFeaturesAKey with
             OnDelete            = Cascade
-            HasDbConstraint     = true
             OnUpdate            = onUpdate
-            IsConstraintTrusted = trusted }
+            ConstraintState     = ConstraintState.ofLegacyBooleans true trusted }
     { Kind.create
         fkFeaturesBKey
         (mkName "BKind")

--- a/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtExtendedPropertyEmissionTests.fs
@@ -230,6 +230,22 @@ let ``NM-70: default (emit) renders the Projection.SsKey + Projection.LogicalNam
     Assert.Contains("@name = N'Projection.LogicalName'", body)
 
 [<Fact>]
+let ``THE VECTOR Wave 5: Projection.SsKey is emitted at the COLUMN level (the attribute-grain identity ReadSide recovers)`` () =
+    // The attribute-grain sibling of the table-level kind SsKey (Wave 4.1).
+    // The column-level Projection.SsKey carries the serialized attribute identity
+    // so ReadSide recovers it via `recoverAttributeSsKey` instead of synthesizing
+    // READSIDE_ATTR — closing the authored-attribute round-trip gap (§5.1).
+    let body = customerSsdtBodyWithIdentityAnnotations true sampleCatalog
+    // A COLUMN-level extended-property block names @level2type = N'COLUMN'; assert
+    // a Projection.SsKey statement carries one WITHIN ONE STATEMENT (the negative
+    // lookahead forbids crossing into the next sp_addextendedproperty, so a
+    // table-level SsKey can't false-match a later column property's @level2type).
+    Assert.Matches(
+        System.Text.RegularExpressions.Regex(
+            @"@name = N'Projection\.SsKey',(?:(?!sp_addextendedproperty)[\s\S])*?@level2type = N'COLUMN'"),
+        body)
+
+[<Fact>]
 let ``NM-70: emit-on path is byte-identical to the default emitSlices body`` () =
     // The gate's `true` branch must not perturb the default emission.
     let gated   = customerSsdtBodyWithIdentityAnnotations true sampleCatalog

--- a/sidecar/projection/tests/Projection.Tests/StaticSeedsRemapTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/StaticSeedsRemapTests.fs
@@ -59,7 +59,7 @@ let private orderUserIdAttr =
 
 let private orderUserRef =
     { Reference.create (mkKey ["Order"; "UserRef"]) (mkName "UserRef") (mkKey ["Order"; "USER_ID"]) userKey with
-        HasDbConstraint = true }
+        ConstraintState = ConstraintState.TrustedConstraint }
 
 let private mkOrderRow (rowKey: string) (id: string) (userId: string) : StaticRow =
     { Identifier = mkKey ["Order"; "Row"; rowKey]

--- a/sidecar/projection/tests/Projection.Tests/VersionedPolicyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VersionedPolicyTests.fs
@@ -56,6 +56,48 @@ let ``H-085: changing Insertion produces a different digest`` () =
     Assert.NotEqual<string>(VersionedPolicy.digestOf p1, VersionedPolicy.digestOf p2)
 
 // ---------------------------------------------------------------------------
+// M5 (THE VECTOR §6 Kind II) — the canonical projection is determinism-by-
+// CONSTRUCTION: every axis (including the two `%A` could only reach
+// structurally — Tightening interventions and the recursive UserMatching) is
+// projected explicitly, and a same-id config flip changes the digest.
+// ---------------------------------------------------------------------------
+
+let private fkIntervention (id: string) (enableCreation: bool) : TighteningIntervention =
+    ForeignKey (id, ForeignKeyTighteningConfig.create enableCreation false false false false)
+
+[<Fact>]
+let ``M5: changing Tightening (registering an intervention) produces a different digest`` () =
+    let p1 = Policy.empty
+    let p2 = { Policy.empty with Tightening = { Interventions = [ fkIntervention "v1-style-fk" true ] } }
+    Assert.NotEqual<string>(VersionedPolicy.digestOf p1, VersionedPolicy.digestOf p2)
+
+[<Fact>]
+let ``M5: changing UserMatching produces a different digest`` () =
+    let p1 = Policy.empty                                   // ByEmail (the default)
+    let p2 = { Policy.empty with UserMatching = BySsKey }
+    Assert.NotEqual<string>(VersionedPolicy.digestOf p1, VersionedPolicy.digestOf p2)
+
+[<Fact>]
+let ``M5: a same-id intervention config flip changes the digest (material, not cosmetic)`` () =
+    // Same intervention id, different config — the `%A` form caught this only
+    // incidentally; the explicit projection makes it structural.
+    let p1 = { Policy.empty with Tightening = { Interventions = [ fkIntervention "fk" true  ] } }
+    let p2 = { Policy.empty with Tightening = { Interventions = [ fkIntervention "fk" false ] } }
+    Assert.NotEqual<string>(VersionedPolicy.digestOf p1, VersionedPolicy.digestOf p2)
+
+[<Fact>]
+let ``M5: the digest is order-independent on Selection sets (a set has no order)`` () =
+    // Set equality makes the two policies equal; the projection sorts the
+    // serialized identities, so the digest is stable regardless of insertion
+    // order — the property the `%A` set-printer happened to satisfy, now by
+    // construction.
+    let s1 = Set.ofList [ customerKey; orderKey ]
+    let s2 = Set.ofList [ orderKey; customerKey ]
+    let p1 = { Policy.empty with Selection = IncludeOnly s1 }
+    let p2 = { Policy.empty with Selection = IncludeOnly s2 }
+    Assert.Equal<string>(VersionedPolicy.digestOf p1, VersionedPolicy.digestOf p2)
+
+// ---------------------------------------------------------------------------
 // SemVer.applyBump — the version-bump algebra
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
@
Completes **THE VECTOR** amelioration program. Wave 4 cashes the defined plans corollaries; **Wave 5** (operator-authorized, past the plan) closes the residual *open* fidelity adjudications and names the rest honestly. THE VECTORs defined four-wave plan plus the open-adjudication wave are now fully cashed; the only remaining frontier is the **named, trigger-gated moat**.

## Wave 4 — corollary cashes & the trust-quadrant type theorem
- **M18** `ChangeManifest.toJson` — the CDC-norm provenance ledger gains its machine lens (a byte-deterministic contract the SSIS consumer diffs sprint-over-sprint). `toJson` only; the `fromJson` inverse is deferred-with-trigger (no read-back consumer).
- **M5** — `VersionedPolicy.digestOf` retires `sprintf "%A"` (determinism-by-*luck*) for an explicit length-prefixed `canonicalToken` projection (determinism-by-*construction*).
- **M4** — the `(HasDbConstraint, IsConstraintTrusted)` quadrant collapses into a closed `ConstraintState` DU; the illegal `(false,false)` state is now **unrepresentable** — a type theorem replacing the runtime G14 check. The codec keeps the legacy boolean pair on the wire (the `IndexUniqueness` precedent), so serialized catalogs round-trip **byte-identically — no store migration**. The persisted-state-evolution discipline is codified (NM-34 as the store-codec contract). **M14** honestly deferred (gate unfired).

## Wave 5 — the open fidelity adjudications
- **The ReadSide authored-attribute round-trip (T-V/T-I)** — adjudicated (it *failed*: attributes were synthesized `READSIDE_ATTR` from physical coordinates, so an authored column rename landed in `Removed + Added`) and **fixed per the treatises prescription, not the echo-chambers**: per-column `Projection.SsKey` emission + `recoverAttributeSsKey` threaded through `buildAttribute` **and** `buildReference`. Goldens re-blessed (**+700 lines, all additive** column-level `Projection.SsKey`). An authored column rename now round-trips as `Renamed`.
- **Transactionality (T-VI)** — the J5 managed-env evidence fires the trigger *away* from a giant `BEGIN TRAN` (DML-only, AssignedBySink, compensating-undo via M12s `inverse`); the wrapper stays deferred, named in the matrix footer.
- **Permissions (T-VI)** — named in the matrix footer (gated by the A2 pre-flight, not a projected axis), **not** a round-trip `ToleratedDivergence` (a category error).
- **`THE_VECTOR_SYNTHESIS.md`** — what the whole program accomplished and why it matters *per se*.

## Verification
| Gate | Result |
|---|---|
| Release + Debug build | 0/0 |
| Pure pool | 3631/0 |
| `AxiomTests` | 79/0 |
| `matrix-status.sh` | gate=PASS (5/4/5, 10 tolerances/3 open, footer extended, no ladder cell moved) |
| `verifiability-gate.sh` | exit 0 |
| Docker canary pool | **247/247** (246 + the new attribute-recovery canary, 0 skipped) |

63 files changed (61 modified, 2 new: `THE_VECTOR_SYNTHESIS.md`, `ReportRunTests.fs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@