### PR TITLE
sidecar/projection: follow-on D (streaming compensating-undo) + advanced synthetic-data program (design + F0a)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -24622,3 +24622,62 @@ D is the single remaining named follow-on; ship it with its canary.
 **Cross-references.** `src/Projection.Pipeline/{MovementSpec.fs (RevertPolicy), MovementSurface.fs (parse/render/derive),
 MigrationRun.fs (executeWithData* atomic)}`; `src/Projection.Cli/{RunFaces.fs, Program.fs}`; `MovementSurfaceTests` +
 `MovementIsomorphismTests`. M22 (the atomic envelope) + M23 (the data-leg revert) are the dispositions this re-homes.
+
+## 2026-06-16 (later still) — Follow-on D BUILT: the STREAMING reverse-leg's compensating-undo (M23's arm on the estate-scale path) — and a CORRECTED seam (the failure is a THROW, not a returned `Result.failure`); landed WITH its gate canary
+
+**What landed.** The one remaining named follow-on of the migrate "we can't go wrong" envelope. `writePlanStreaming`
+(the hundreds-of-millions-row path) now carries the M23 data-leg compensating-undo, mirroring the materialized
+`writePlan` arm: on a mid-stream crash the partial sink-minted rows are reverted (`--auto-revert` / `revert: auto`) or
+scripted (`revert: script`, the default) by a child-first `DELETE`-by-captured-key, then the original failure
+re-propagates. Reuses the M23 primitives `buildRevertScript` + `runRevert` VERBATIM — only the remap source differs.
+
+**The remap source: the off-box journal.** The streaming path's durable record of every sink-minted key is the
+`CaptureJournal` (NDJSON; only fully-committed chunks are appended — a crashed chunk is neither journaled nor captured).
+Two new `let private`s next to `buildRevertScript`/`runRevert`: `replayJournalToRemap (catalog) (journal)` rebuilds a
+`PackedSurrogateRemap` from the journal, mapping each record's root-string `Kind` back to the catalog `SsKey` (the
+inverse of the `SsKey.rootOriginal` the journal stores) and folding its `Pairs` in via `PackedSurrogateRemap.capture`
+(the same fold `CaptureJournal.spec`'s Apply runs at resume); `runRevertFromJournal` composes replay → buildRevertScript
+→ runRevert, with a `None`-journal safe no-op.
+
+**The seam CORRECTION (heed this — the instruction set was imprecise).** `FOLLOWON_STREAMING_REVERT.md` prescribed
+hanging the compensation off the streaming call site's `Error es` arm, on the claim that "the streaming path returns a
+`Result.failure` (not a throw, unlike `writePlan`)." **That is wrong for the failure D exists to compensate.** Per the
+`staged` CE (`RunSpine.fs`): a stage body that THROWS → `RunAborted (_, Some ex)`; one that RETURNS `Error e` →
+`RunStopped e`. `writePlanStreaming` re-throws on `RunAborted` (its line ~1790, `ExceptionDispatchInfo.Throw`) and
+returns `Result.failure` ONLY on `RunStopped` — which arises solely from the resume **source-drift** refusal. The
+canary's own forcing mechanism (a dropped sink column → `SqlBulkCopy` throws; confirmed by the existing
+`ReverseLegStreamingTests` resume test's `Assert.ThrowsAnyAsync`) is therefore an EXCEPTION, which an `Error`-arm-only
+revert would bypass entirely. So D's compensation hangs off a `try/with` wrapping the `writePlanStreaming` call in
+`runStreamingReconcilingWithRenames`: a crash reverts-then-re-raises; a NAMED `Error es` returns WITHOUT reverting —
+deliberately, because a source-drift refusal on resume wrote nothing new this run, so a DELETE-by-captured-key would
+destroy PRIOR-run committed rows (the one thing the undo must never do). This is the writing-the-canary-first discipline
+catching the spec: the floor test would have falsely passed against the wrong seam.
+
+**The threading.** `autoRevert`/`revertDir` added to `runStreamingReconcilingWithRenames` + `runStreamingReverseLegThroughConnections`;
+`runStreamingWithRenames` keeps its surface and passes the inert `false None` (the straight load names no policy); the
+RunFaces `ReverseLegRealization.Streaming` branch now passes the `revertAuto`/`revertOut` already derived via
+`RevertPolicy.toEngine` (previously only the `Materialized` branch consumed them). Both levers inert →
+byte-identical to the pre-D streaming realization.
+
+**The gate (§0 — non-negotiable, MET).** Two `TransferCanaryTests` "streaming data canary (D)" witnesses, mirroring the
+materialized Build-A pair, drive the streaming path into a forced mid-stream crash (USER streams + mints + journals,
+then ORDER's chunk crashes on a dropped `AMOUNT` column). A PRE-EXISTING sink USER row (minted before the transfer)
+makes the "pre-existing untouched" claim concrete: auto-revert OFF → the journal-replayed revert SCRIPT is written and
+all rows remain; auto-revert ON → only the journal-captured minted keys are DELETED and the pre-existing row survives.
+Both green on `projection-mssql-warm`.
+
+**Gates.** Debug + **Release** 0/0 (the `task { try … with … }` is FS3511-safe — single-value binds only); pure pool
+0 failed (3387 passed / 210 standing skips); **`TransferCanaryTests` 27/27** (the 2 new + 25 unregressed); lint clean
+(27 rules); `matrix-status.sh` gate=PASS, rungs 5/4/5, tolerances 10/3-open **UNCHANGED** (D is a compensation arm, not
+a fidelity/axiom dimension — it moves no ladder cell).
+
+**Still out of scope (the related minor follow-on, §4).** `migrate --with-data`'s DATA leg still does not carry
+`--auto-revert` (it routes through `Transfer.runWithRenamesWith`, not the `*ThroughConnections*` faces); its schema leg
+already honors `--atomic` via M24 follow-on C. A small, separate follow-on — not part of D.
+
+**Cross-references.** `src/Projection.Pipeline/TransferRun.fs` (`replayJournalToRemap`, `runRevertFromJournal`, the
+`runStreamingReconcilingWithRenames` try/with seam, the threaded streaming faces); `src/Projection.Cli/RunFaces.fs`
+(the Streaming branch); `tests/Projection.Tests/{TransferCanaryTests.fs (the two D canaries), ReverseLegStreamingTests.fs
+(callers threaded)}`; `FOLLOWON_STREAMING_REVERT.md` (the now-cashed instruction set); `RunSpine.fs` (the
+`RunAborted`/`RunStopped` mapping that grounds the seam correction). The migrate envelope (M21/M22/M23/M24 + D) is now
+complete; the remaining frontier is the named moat (`HOLDOUT_INVENTORY_2026_06_16.md`).

--- a/sidecar/projection/FOLLOWON_STREAMING_REVERT.md
+++ b/sidecar/projection/FOLLOWON_STREAMING_REVERT.md
@@ -1,9 +1,14 @@
-# Follow-on D — the streaming reverse-leg's compensating-undo (M23 arm), DEFERRED behind a canary gate
+# Follow-on D — the streaming reverse-leg's compensating-undo (M23 arm), ✅ BUILT (with its gate canary)
 
-> **Status: NOT BUILT — deferred behind a HARD gate (2026-06-16).** This is the one named follow-on left from the
-> migrate "we can't go wrong" envelope (M21/M22/M23/M24). The materialized transfer + both schema legs carry full
-> compensation; the **streaming** reverse-leg (`writePlanStreaming`, the estate-scale hundreds-of-millions-row path)
-> retains only its `CaptureJournal` resume-safety. This doc is the pickup-cold instruction set.
+> **Status: BUILT (2026-06-16, later still) — shipped WITH its deterministic streaming-failure canary.** See
+> `DECISIONS.md` "Follow-on D BUILT" for the substance. The migrate "we can't go wrong" envelope
+> (M21/M22/M23/M24 + D) is now complete. This doc is retained as the provenance of the instruction set, with ONE
+> correction recorded inline below (§2.2) and in DECISIONS: the streaming failure is a **THROW**, not a returned
+> `Result.failure`, so the compensation hangs off a `try/with` around the `writePlanStreaming` call (the exception
+> path), NOT the `Error es` match arm — which catches only the named resume source-drift refusal (and deliberately
+> must NOT revert, lest it delete prior-run committed rows). The §2 seams below are otherwise as built; the §3 canary
+> is realized as the two "streaming data canary (D)" witnesses in `TransferCanaryTests`. The §4 minor follow-on
+> (`migrate --with-data` DATA-leg revert) remains out of scope.
 
 ## 0 — The gate (read first; do not skip)
 

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,33 @@
+# Handoff addendum — 2026-06-16 (latest), THE ADVANCED SYNTHETIC-DATA PROGRAM is under way — follow-on D shipped, then the operator named a high-fidelity "fuzzing" program and SEVEN slices landed (F0a/F0b/F1/F0c-propose/F5a/F5b/F2, all gated, PR #625). The next move is F0c-I/O — the operator surface that ties the blessed loop together end-to-end
+
+To the next agent.
+
+**Read `THE_SYNTHETIC_DATA_FUZZING.md` first** (the §7 slice table is the live status). This session did two things: shipped **follow-on D** (the streaming reverse-leg compensating-undo — see the letter below; the migrate envelope is now complete), then the operator pivoted to **"what remains"**, where the headline finding was that **the σ synthetic-data emitter is already BUILT** (`THE_SYNTHETIC_DATA_DESIGN.md`, 2026-06-08) — the Faker deferral row + `HOLDOUT_INVENTORY` #10 are STALE. From that we co-designed an advanced program and built seven slices.
+
+**The spine you're standing on.** Synthesis is now `σ : Profile × Correction ⟶ Data` such that `π∘σ ≈ id MODULO the blessed Correction` — the engine's own core-adjunction shape ("identity, modulo named, closed erasures") applied to the synthesis section. Two planes, kept apart: **π / boundary** (heavy inference + Faker — may use float/RNG) and **pure-Core σ** (T1: no float/RNG/clock; Faker is seeded from σ's deterministic tokens at the boundary so determinism survives). The **blessed correction artifact** is the durable, operator-blessed override/intent hinge (the synthesis sibling of the RefactorLog + the Tolerance registry).
+
+**What landed (PR #625; each independently gated — Debug+Release 0/0, pure pool 0-failed, Docker `π∘σ≈id` canary green throughout):**
+- **F0a** `Correction` Core carrier + smart-ctor conflict refusal + `Profile ⊕ Correction` fold (`SyntheticCorrection.fs`).
+- **F0b** durable `CorrectionCodec` (round-trip law, A39 decode-refusal) — the artifact persists.
+- **F1** per-kind `VolumeTarget` (Absolute/Multiplier) — arbitrary scale, decoupled from the corpus.
+- **F0c-propose** pure heuristic `CorrectionProposer` — first-draft PII typing.
+- **F5a** σ ← captured `ForeignKeySelectivity` (rank-mapped FK skew).
+- **F5b** σ ← captured `JointDistribution` (correlated FK-tuple synthesis, L3).
+- **F2** `FakerRealization.realizePii` (Bogus, on Pipeline) — coherent fake person per row, seeded from row identity (referential consistency + determinism); Bogus stays OUTSIDE Core.
+
+**Your next move: F0c-I/O — the operator surface.** Everything above is reachable only programmatically / in tests. F0c-I/O makes the blessed loop real end-to-end: (1) durable WRITE (`CorrectionCodec.serialize` → file); (2) the `synth-correct <profile> --out` propose verb (`CorrectionProposer` → codec → file); (3) `correction: file:<path>` flow wiring threading the blessed `Correction` through the synthetic flow AND calling `FakerRealization.realizePii` between σ and the load. It is the **A44 compiler-guided cascade** — adding a field to `FlowSource`/`FlowRunOpts`/`MovementSpec`/`LoadOpts` ripples through the parse∘render isomorphism + ~16 literal sites; the build is your guide. Witness via `MovementSurfaceTests` (the A44 expressible⇔reachable proof). After F0c-I/O: **F3** (coverage corrections + L2-cov canary — the operator's "ensure all important values are included" ask), **F6** (distribution fitting — a `ShapeHint` π axis + richer `sampleNumeric`; the largest), **F4** (boundary rotation — needs a named threat model).
+
+**Scars that bit this session (heed them):**
+- **`dotnet` is NOT on PATH** (bash or PowerShell). Bash: `export PATH="$PATH:/c/Users/danny/AppData/Local/Microsoft/dotnet"`. PowerShell: call `C:\Users\danny\AppData\Local\Microsoft\dotnet\dotnet.exe` by full path. Build/test from the worktree root (`...\sidecar\projection`) — the `cwd` drifts; use absolute project paths in PowerShell.
+- **`lint-discipline.sh --ci` reports a long-standing ~209-site whole-tree baseline** (Run.fs/ReportRun.fs/EventProjection.fs etc. — pre-existing, none from this work). It is NOT the operative gate (that's the pre-commit scoped scan, which isn't installed in this worktree — run `scripts/install-hooks.sh` if you want it). Do **not** chase the baseline; just ensure your NEW files carry markers. **Core has a `core-sprintf` rule** (Targets don't) — a dynamic `ValidationError` message in Core needs a per-line `LINT-ALLOW: <substantive, ≥30-char, "terminal"/"boundary"-token>` (sprintf AND String.concat are both banned in Core). And **`lint | tail; echo $?` captures tail's exit, not lint's** — verify lint via a direct exit capture.
+- **Bogus determinism**: `Bogus.Person`'s ctor takes a locale string (not a Randomizer). Seed via the global `Bogus.Randomizer.Seed <- System.Random(seed)` immediately before `Bogus.Faker()`, per row (single-threaded realization → deterministic). `f.Person` is one cached coherent individual.
+- **Every σ change must keep the Docker `π∘σ≈id` canary green** — it asserts counts / zero-orphans / categorical-sets (NOT fan-out skew or FK values), and each σ addition (F1/F5a/F5b) is byte-identical when its evidence is absent. Run `scripts/test.sh focus 'Synthetic'` (warm container) after any σ touch.
+- **F# backtick test names cannot contain `@`** (FS1104 — "email has @" → "email has an at-sign").
+
+**State.** Branch `claude/thirsty-fermat-0612fd` → PR #625 (D + the 7 synthetic slices). Latest commit `fa15126a` (F2). Debug+Release 0/0; pure pool 3418 passed / 0 failed / 210 standing skips; Docker Synthetic* 55/55 incl. the canary + the new Faker tests. F2's realization is built but **not yet wired into the load** (F0c-I/O). Hold the spine: name every refusal, count every crossing, leave the books balanced — and don't chase the lint baseline.
+
+---
+
 # Handoff addendum — 2026-06-16 (later still), FOLLOW-ON D LANDED — the streaming reverse-leg's compensating-undo (M23's arm on `writePlanStreaming`, the estate-scale path) is built WITH its gate canary; the migrate "we can't go wrong" envelope (M21/M22/M23/M24 + D) is now COMPLETE. The frontier from here is the named moat only — do not build it without a fired trigger
 
 To the next agent.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,53 @@
+# Handoff addendum — 2026-06-16 (later still), FOLLOW-ON D LANDED — the streaming reverse-leg's compensating-undo (M23's arm on `writePlanStreaming`, the estate-scale path) is built WITH its gate canary; the migrate "we can't go wrong" envelope (M21/M22/M23/M24 + D) is now COMPLETE. The frontier from here is the named moat only — do not build it without a fired trigger
+
+To the next agent.
+
+**D is done, and it taught the instruction set a lesson — carry the lesson forward.** `FOLLOWON_STREAMING_REVERT.md`
+told you to hang the compensating-undo off the streaming call site's `Error es` arm, claiming the streaming path
+"returns a `Result.failure`, not a throw." **It throws.** Per the `staged` CE (`RunSpine.fs`): a stage body that THROWS
+→ `RunAborted (_, Some ex)` → `writePlanStreaming` re-raises (its `ExceptionDispatchInfo.Throw`, ~line 1790); one that
+RETURNS `Error e` → `RunStopped e` → the `Result.failure` you see at the call site — and that only ever comes from the
+resume **source-drift** refusal. The canary's own crash (a dropped sink column → `SqlBulkCopy` throws) is an exception,
+so an `Error`-arm-only revert would have compensated NOTHING. Writing the canary first is what surfaced this. The seam
+that shipped: a `try/with` around the `writePlanStreaming` call in `runStreamingReconcilingWithRenames` — a crash
+reverts-then-re-raises; a named `Error es` returns WITHOUT reverting (a drift refusal wrote nothing new this run, so a
+DELETE-by-captured-key would destroy PRIOR-run committed rows — never do that). If you ever revisit the streaming faces,
+**do not "simplify" the revert back onto the `Error` arm.**
+
+**What D is.** `replayJournalToRemap` + `runRevertFromJournal` (new `let private`s beside `buildRevertScript`/`runRevert`
+in `TransferRun.fs`) reconstruct the M23 remap from the off-box `CaptureJournal` (the streaming path's durable
+sink-minted-key ledger) and run the SAME `buildRevertScript` + `runRevert` the materialized arm runs. `autoRevert`/`revertDir`
+thread through `runStreamingReconcilingWithRenames` + `runStreamingReverseLegThroughConnections` (the straight-load
+`runStreamingWithRenames` passes inert `false None`); the RunFaces `Streaming` branch now passes the `revertAuto`/`revertOut`
+already derived via `RevertPolicy.toEngine`. Both levers inert → byte-identical to pre-D. The gate is two
+"streaming data canary (D)" witnesses in `TransferCanaryTests` (a pre-existing sink row proves the revert targets ONLY
+captured minted keys).
+
+**What remains is the MOAT, and it is named-not-unfinished.** Read `HOLDOUT_INVENTORY_2026_06_16.md` — the per-feature
+trigger-gated study. The only items the study flags as actionable now are **(#10) the Faker / synthetic-data emitter**
+(its trigger FIRED ~4 weeks ago — "bring to principal-PO"; the highest-confidence un-cashed trigger), **(#9)
+policy-version plane → Episode** (half-fired — M5 landed Wave 4; only the consumer-need remains), and **(#3) the
+CDC / OPEN-3 estate survey** (now runnable — J5 lifted the blocker). Everything else is honestly far / infra-gated
+(P7b, computed-column S7) / consumer-gated (`Tolerance` config). **Naming a trigger-gated absence IS its completion
+here — do not build moat without a fired trigger.** Surface the options to the operator; let them choose.
+
+**Build-discipline scars (unchanged, still bite).** `dotnet` is NOT on the bash/PowerShell PATH on this box (it lives
+at `C:\Users\danny\AppData\Local\Microsoft\dotnet`; `export PATH="$PATH:/c/Users/danny/AppData/Local/Microsoft/dotnet"`
+before `scripts/test.sh`). Never run the pure + Docker pools as one `dotnet test` (OOM). The warm container had been up
+11h this session — a batch of connection / pre-login failures means it died or its memory pool degraded
+(`scripts/warm-sql.sh restart`), NOT a regression (two `TransferCanaryTests` showed stale FAILED from a prior session
+and were 27/27 green on a fresh focused run). `static let` cannot follow members (FS0960). The streaming `try/with` is
+FS3511-safe only because it binds single values (no tuple `let!`, no `let rec` in `task`).
+
+**State.** Branch `claude/thirsty-fermat-0612fd` (a worktree off `main` `48af1895`, the merged PR #624 baseline). D +
+its canary + the docs (this letter, the DECISIONS "Follow-on D BUILT" entry, the `FOLLOWON_STREAMING_REVERT.md` status)
+sit as WORKING-TREE changes — the operator drives commits (the D code + its canary MUST commit together per the §0 gate).
+Debug + **Release** 0/0; pure pool 0 failed (3387 passed / 210 standing skips); **`TransferCanaryTests` 27/27**; lint
+clean (27 rules); `matrix-status.sh` gate=PASS, rungs 5/4/5, tolerances 10/3-open UNCHANGED. Hold the spine: name every
+refusal, count every crossing, leave the books balanced — and never ship a destructive op untested.
+
+---
+
 # Handoff addendum — 2026-06-16 (later still), M24 LANDED — the migrate dispositions are now CONFIG-BASED (sensible defaults, not command clutter): atomic derives ON for direct+FullRights; revert is a per-environment policy. Follow-on C done (atomic on migrate-with-data). Follow-on D (streaming compensating-undo) DEFERRED behind a canary gate
 
 To the next agent.

--- a/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
+++ b/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
@@ -1,7 +1,11 @@
 # THE_SYNTHETIC_DATA_FUZZING.md — high-fidelity, coverage-correcting, anonymizing synthesis governed by a blessed correction artifact
 
-> **Status: DESIGN (2026-06-16, operator co-design).** Not built. This is the design surface for the
-> *advanced* synthetic-data program the operator named: *"production-alike data at arbitrary sizes from
+> **Status: DESIGN + IN BUILD (2026-06-16, operator co-design).** The spine is built — **F0a** (the
+> blessed-correction Core substrate), **F0b** (the durable codec, round-trip law green), and **F1** (per-kind
+> arbitrary-scale volume) landed this session (see §7 for the per-slice status + commits). The remaining
+> slices (F0c operator surface, F2 Faker, F3 coverage, F4 boundary rotation, F5 evidence-wiring, F6 fitting)
+> are designed, not built. This is the design surface for the *advanced* synthetic-data program the operator
+> named: *"production-alike data at arbitrary sizes from
 > advanced at-scale inferences, professional distribution-analysis quality, round-robin rotation in
 > anonymizing ways, PII selection/fine-tuning + Faker assimilation for PII elements… extremely high
 > quality synthetic data (as much quality as can be naturally derived from the quality of the source)
@@ -183,26 +187,37 @@ property-test asserting the floor is met *and* that uncorrected columns still sa
 
 ---
 
-## 4. Anonymizing rotation — the third fidelity mode
+## 4. Anonymizing rotation — a BOUNDARY operation, not a Core-σ mode (corrected 2026-06-16)
 
-v1 has two value-fidelity modes (`ValueFidelityMode`, `SyntheticData.fs` :52): `Preserve` (emit real
-low-card reference values) and `Synthesize` (fresh tokens, never a real value). This program adds a third,
-pure-Core mode:
+> **Correctness revision.** An earlier draft made anonymizing rotation a third `ValueFidelityMode` in
+> pure-Core σ. That is a category error, and the reason is illuminating: **Core σ is marginal-only — it
+> never sees a real source row.** It rebuilds each row *independently* from the captured `Profile`
+> marginals, so the existing `Preserve` mode *already* emits real values with **no row-linkage to the
+> source** (a synthesized row's combination of values is assembled from independent per-column draws, not
+> copied from any real row). There is nothing in Core for a `Rotate` mode to anonymize that `Preserve`
+> hasn't already broken.
 
-- **`Rotate` — anonymizing permutation.** Emit *real* values but *permute their row-assignment* (a
-  deterministic shuffle, splitmix64-seeded) so the **column marginal is exact** while **row-linkage is
-  broken** — the value is real, but it no longer belongs to its original row. This is the "round-robin
-  rotation in anonymizing ways" the operator named: maximal marginal fidelity with linkage anonymization.
+**Where rotation genuinely lives: the boundary.** "Round-robin rotation in anonymizing ways" — *permute
+the real corpus rows so each emitted row keeps a real, internally-coherent value-combination but no longer
+belongs to its original subject* — operates over the **actual corpus rows**, which exist only on the
+π/boundary plane (the same plane as Faker, §5). So rotation is a **boundary realization** over real rows
+(a deterministic, seeded permutation that breaks the subject↔row linkage), governed by a blessed correction
+entry (e.g. a `Rotate` / `Anonymize` `FakerFieldSet` sibling), **not** a Core `ValueFidelityMode`. Its
+witness is a **linkage-breaking property** at the boundary: no emitted row reproduces a real subject's full
+quasi-identifier tuple, while each column's marginal is exact (rotation is a permutation).
 
-The privacy model gains a **linkage-breaking property test**: after `Rotate`, no synthetic row reproduces a
-real row's *combination* of rotated values (within the field-set), while each rotated column's marginal
-matches the source within ε. Stronger anonymization variants (k-anonymity over a quasi-identifier set;
-differential-privacy noise on numeric columns) are named here as **future `CoverageRule`/privacy variants,
-deferred until the operator names the threat model** — IR grows under evidence.
+This is the same discipline as Faker assimilation: **the heavy, corpus-touching work stays at the boundary;
+Core σ stays a pure marginal replay.** Core's contribution to anonymization is `Synthesize` (fresh tokens)
+and `Preserve` (real values, already linkage-free by independent synthesis); the corpus-rotation channel is
+boundary-only.
+
+Stronger anonymization variants (k-anonymity over a quasi-identifier set; differential-privacy noise on
+numeric columns) are named as **future boundary/evidence variants, deferred until the operator names the
+threat model** — IR grows under evidence.
 
 > **Open adjustment to confirm with the operator (privacy posture).** Whether the privacy bar is
-> linkage-breaking-rotation only, or extends to k-anonymity / DP-noise. The doc reserves the slots; the
-> threat model decides which fire.
+> linkage-breaking corpus-rotation only, or extends to k-anonymity / DP-noise. The doc reserves the slots;
+> the threat model decides which fire.
 
 ---
 
@@ -278,25 +293,27 @@ Sequenced so the **blessed-correction substrate lands first** (it is the spine e
 then the operator-priority quality work. Each slice is independently shippable, green, and carries its
 faithfulness-ladder witness.
 
-| # | Slice | Plane | Ships | Trigger / gate |
+| # | Slice | Plane | Ships | Status |
 |---|---|---|---|---|
-| **F0** | **Correction artifact substrate** | hinge | the typed `Correction` DU + smart ctors + durable codec (round-trip law) + `Profile ⊕ Correction` pure fold + `correction: file:<path>` flow wiring + `synth-correct` propose verb | the spine; the operator blesses the first artifact |
-| **F1** | **Explicit PII typing + volume targeting** | σ + config | `PiiClass` + `VolumeTarget` corrections consumed by σ; absolute-N / total-size volume | F0 |
-| **F2** | **Faker assimilation (boundary)** | boundary | seeded-deterministic Bogus realization over PII-typed columns; `FakerFieldSet` referential consistency | F1 (PII typing exists) |
-| **F3** | **Coverage corrections** | σ | `CoverageFloor` (exhaustive permutation / variety injection / distinct-floor) + the **L2-cov** canary | F0; an operator coverage need |
-| **F4** | **Anonymizing rotation** | σ | the `Rotate` `ValueFidelityMode` + the linkage-breaking privacy property | F0 |
-| **F5** | **Wire σ to captured evidence** | σ | consume `ForeignKeySelectivity` (skew) + `JointDistribution` (L3 correlation) | already-captured evidence (§6.3) |
-| **F6** | **Distribution enrichment** | π + σ | `ShapeHint` evidence axis (histograms / fitted families / multimodality) at π + richer `sampleNumeric` | the "professional fitting" need; largest |
+| **F0a** | **Correction Core substrate** | hinge | the `PiiKind` / `CorrectionEntry` closed DUs + smart-constructed `Correction` (conflict refusal) + the pure `Profile ⊕ Correction` fold onto `SyntheticConfig` (`SyntheticCorrection.fs`) | ✅ **landed** 2026-06-16 (`9e67158f`) |
+| **F0b** | **Durable CorrectionCodec** | hinge | total / deterministic / re-validating `Correction ↔ JSON` (`CorrectionCodec.fs`); round-trip law + A39 decode refusal | ✅ **landed** 2026-06-16 (`d530badd`) |
+| **F0c** | **Operator surface** | CLI / flow | `correction: file:<path>` flow wiring + the `synth-correct` propose verb (the A44 control-plane cascade) | ⬜ remaining |
+| **F1** | **Explicit PII typing + per-kind volume** | σ + config | `Pii` correction ⇒ Synthesize (F0a fold); `Volume` correction + `VolumeTarget` (Absolute/Multiplier) consumed by `rowCountFor` — arbitrary scale | ✅ **landed** 2026-06-16 (`147421de`) |
+| **F2** | **Faker assimilation (boundary)** | boundary | seeded-deterministic Bogus realization over PII-typed columns; `FakerFieldSet` referential consistency | ⬜ (F1 PII typing exists) |
+| **F3** | **Coverage corrections** | σ | `CoverageFloor` (exhaustive permutation / variety injection / distinct-floor) + the **L2-cov** canary | ⬜ (an operator coverage need) |
+| **F4** | **Anonymizing rotation** | **boundary** | corpus-row permutation (linkage-breaking) over real rows — **NOT** a Core `ValueFidelityMode` (§4 revision: `Preserve` is already linkage-free in marginal-only σ) | ⬜ (a named threat model) |
+| **F5** | **Wire σ to captured evidence** | σ | consume `ForeignKeySelectivity` (skew) + `JointDistribution` (L3 correlation) — evidence already captured | ⬜ (cheap; §6.3) |
+| **F6** | **Distribution enrichment** | π + σ | `ShapeHint` evidence axis (histograms / fitted families / multimodality) at π + richer `sampleNumeric` | ⬜ (the "professional fitting" lift; largest) |
 
-**Recommended first build:** **F0** (the correction-artifact substrate). It is the spine the operator's
-whole vision hangs on, it is the smallest coherent unit, and nothing downstream is well-shaped without it.
-F1 follows immediately (the first visible operator win: explicit PII typing + arbitrary scale).
+**Landed this session:** F0a + F0b + F1 — the blessed-correction spine (carrier + smart ctor + fold), its
+durable codec (round-trip law), and per-kind arbitrary-scale volume. The operator can author + bless a
+correction artifact (programmatically / by file) and drive PII typing + arbitrary scale through the existing σ.
 
-> **Note on the operator's "inference is the core" instinct.** F6 (professional fitting) is sequenced last
-> not because it is least important but because it is largest and depends on the substrate (F0) and the
-> evidence-wiring pattern (F5). If the operator wants the *fitting quality* proven earliest, F5 (wire σ to
-> the joint + selectivity evidence π already captures) is the cheapest way to demonstrate richer fidelity
-> before the heavier F6 — surface this when sequencing.
+**Recommended next:** **F5** (wire σ to the `ForeignKeySelectivity` + `JointDistribution` evidence π already
+captures) is the cheapest fidelity lift and demonstrates richer quality before the heavier F6; **F2** (Faker)
+is the highest-visibility production-alike PII win; **F0c** (flow wiring + `synth-correct` verb) is the
+operator-surface that makes the blessed loop end-to-end. F6 (professional fitting) is last — largest, and
+depends on F5's evidence-wiring pattern.
 
 ---
 

--- a/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
+++ b/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
@@ -1,11 +1,13 @@
 # THE_SYNTHETIC_DATA_FUZZING.md — high-fidelity, coverage-correcting, anonymizing synthesis governed by a blessed correction artifact
 
-> **Status: DESIGN + IN BUILD (2026-06-16, operator co-design).** The spine is built — **F0a** (the
-> blessed-correction Core substrate), **F0b** (the durable codec, round-trip law green), and **F1** (per-kind
-> arbitrary-scale volume) landed this session (see §7 for the per-slice status + commits). The remaining
-> slices (F0c operator surface, F2 Faker, F3 coverage, F4 boundary rotation, F5 evidence-wiring, F6 fitting)
-> are designed, not built. This is the design surface for the *advanced* synthetic-data program the operator
-> named: *"production-alike data at arbitrary sizes from
+> **Status: DESIGN + IN BUILD (2026-06-16, operator co-design).** Seven slices built this session (PR #625):
+> **F0a** (correction Core substrate), **F0b** (durable codec), **F1** (arbitrary-scale volume), **F0c-propose**
+> (heuristic PII proposer), **F5a** (FK-selectivity skew), **F5b** (joint-distribution correlation), and **F2**
+> (Faker boundary realization). See §7 for per-slice status + commits. **Remaining (designed, not built):
+> F0c-I/O** (the operator surface — durable write + `synth-correct` verb + flow wiring that ties F2 + the blessed
+> artifact into the load), **F3** (coverage), **F4** (boundary rotation), **F6** (distribution fitting). This is
+> the design surface for the *advanced* synthetic-data program the operator named: *"production-alike data at
+> arbitrary sizes from
 > advanced at-scale inferences, professional distribution-analysis quality, round-robin rotation in
 > anonymizing ways, PII selection/fine-tuning + Faker assimilation for PII elements… extremely high
 > quality synthetic data (as much quality as can be naturally derived from the quality of the source)
@@ -299,24 +301,32 @@ faithfulness-ladder witness.
 | **F0b** | **Durable CorrectionCodec** | hinge | total / deterministic / re-validating `Correction ↔ JSON` (`CorrectionCodec.fs`); round-trip law + A39 decode refusal | ✅ **landed** 2026-06-16 (`d530badd`) |
 | **F0c** | **Operator surface** | CLI / flow | `correction: file:<path>` flow wiring + the `synth-correct` propose verb (the A44 control-plane cascade) | ⬜ remaining |
 | **F1** | **Explicit PII typing + per-kind volume** | σ + config | `Pii` correction ⇒ Synthesize (F0a fold); `Volume` correction + `VolumeTarget` (Absolute/Multiplier) consumed by `rowCountFor` — arbitrary scale | ✅ **landed** 2026-06-16 (`147421de`) |
-| **F2** | **Faker assimilation (boundary)** | boundary | seeded-deterministic Bogus realization over PII-typed columns; `FakerFieldSet` referential consistency | ⬜ (F1 PII typing exists) |
+| **F2** | **Faker assimilation (boundary)** | boundary | `FakerRealization.realizePii` — seeded-deterministic Bogus realization over PII-typed columns (one coherent fake person per row → referential consistency); Bogus stays OUTSIDE Core | ✅ **landed** 2026-06-16 (Bogus dep) — wiring into the synthetic-load runner pends F0c-I/O |
 | **F3** | **Coverage corrections** | σ | `CoverageFloor` (exhaustive permutation / variety injection / distinct-floor) + the **L2-cov** canary | ⬜ (an operator coverage need) |
 | **F4** | **Anonymizing rotation** | **boundary** | corpus-row permutation (linkage-breaking) over real rows — **NOT** a Core `ValueFidelityMode` (§4 revision: `Preserve` is already linkage-free in marginal-only σ) | ⬜ (a named threat model) |
 | **F5a** | **Wire σ to `ForeignKeySelectivity`** | σ | rank-mapped skewed FK fan-out (was uniform) | ✅ **landed** 2026-06-16 (`3f552f45`) |
 | **F5b** | **Wire σ to `JointDistribution`** | σ | correlated FK-tuple synthesis (L3) — per-position rank-mapped, co-occurrence preserved on synthetic keys | ✅ **landed** 2026-06-16 |
 | **F6** | **Distribution enrichment** | π + σ | `ShapeHint` evidence axis (histograms / fitted families / multimodality) at π + richer `sampleNumeric` | ⬜ (the "professional fitting" lift; largest) |
 
-**Landed this session:** F0a + F0b + F1 + F0c-propose + F5a + F5b — the blessed-correction spine (carrier +
-smart ctor + fold), its durable codec (round-trip law), the heuristic PII proposer, per-kind arbitrary-scale
-volume, and σ wired to BOTH captured FK-fidelity axes (selectivity skew + joint correlation). The operator can
-author + bless a correction artifact (programmatically / by file), have a first draft proposed, and drive PII
-typing + arbitrary scale + skewed/correlated FK fan-out through σ.
+**Landed (2026-06-16, PR #625):** F0a + F0b + F1 + F0c-propose + F5a + F5b + **F2** — the blessed-correction
+spine (carrier + smart ctor + fold), its durable codec (round-trip law), the heuristic PII proposer, per-kind
+arbitrary-scale volume, σ wired to BOTH captured FK-fidelity axes (selectivity skew + joint correlation), and
+the Faker boundary realization (coherent fake person per row). The operator can author + bless a correction
+artifact (programmatically / by file), have a first draft proposed, drive PII typing + arbitrary scale +
+skewed/correlated FK fan-out through σ, and realize PII columns to production-alike fakes.
 
-**Recommended next:** **F2** (Faker, needs a Bogus NuGet dep) is the highest-visibility production-alike PII
-win; **F0c-I/O** (durable write + `synth-correct` verb + `correction: file:` flow wiring — the A44 cascade) is
-the operator-surface that makes the blessed loop end-to-end; **F3** (coverage corrections + L2-cov canary) is
-the "ensure all values included" quality gate. **F6** (professional distribution fitting) is last — largest,
-π + σ.
+**Remaining (designed, not built) — the honest frontier:**
+- **F0c-I/O** — the operator surface: durable write (`CorrectionCodec.serialize` → file), the `synth-correct`
+  propose verb (`CorrectionProposer` → codec → file), and `correction: file:<path>` flow wiring that threads the
+  blessed `Correction` into the synthetic-load runner (the A44 cascade through `FlowSource`/`FlowRunOpts`/
+  `MovementSpec`/`LoadOpts` + ~16 literal sites) AND calls `FakerRealization.realizePii` between σ and the load.
+  **This is what makes the whole loop operator-usable end-to-end** — until it lands, F2's realization and the
+  blessed artifact are reachable only programmatically (and in tests).
+- **F3** — coverage corrections (`CoverageFloor`: exhaustive permutation / variety injection / distinct-floor)
+  + the L2-cov canary — the "ensure all important values are included" quality gate.
+- **F4** — boundary anonymizing rotation (needs a named threat model; §4).
+- **F6** — professional distribution fitting (a `ShapeHint` evidence axis at π — histograms / fitted families /
+  multimodality — + richer `sampleNumeric` at σ). Largest; π + σ.
 
 ---
 

--- a/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
+++ b/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
@@ -1,0 +1,341 @@
+# THE_SYNTHETIC_DATA_FUZZING.md — high-fidelity, coverage-correcting, anonymizing synthesis governed by a blessed correction artifact
+
+> **Status: DESIGN (2026-06-16, operator co-design).** Not built. This is the design surface for the
+> *advanced* synthetic-data program the operator named: *"production-alike data at arbitrary sizes from
+> advanced at-scale inferences, professional distribution-analysis quality, round-robin rotation in
+> anonymizing ways, PII selection/fine-tuning + Faker assimilation for PII elements… extremely high
+> quality synthetic data (as much quality as can be naturally derived from the quality of the source)
+> from a massive production corpus."*
+>
+> **It builds on a BUILT floor.** `THE_SYNTHETIC_DATA_DESIGN.md` (BUILT 2026-06-08) is the v1 synthesis
+> capability: the pure-Core σ (`SyntheticData.generate`), the durable `ProfileCodec`, the `projection
+> profile` capture verb + `from: synthetic` flow, and the `π ∘ σ ≈ id` canary. This document is the v2
+> program *layered on top of* that floor — it does not rebuild it. Read that doc first; it owns the
+> built shapes this one extends.
+>
+> **Provenance.** Operator co-design this session: confirmed the two-plane framing (π/boundary inference +
+> Faker; pure-Core σ; Faker seeded from Core's deterministic tokens) with two named adjustments — (1) the
+> blessed *correction artifact* as a first-class durable surface, and (2) *coverage* as a named fidelity
+> axis that deliberately departs from source fidelity where the source corpus is patchy. Sits beside
+> `THE_SYNTHETIC_DATA_DESIGN.md` (the built floor), `THE_DATA_PRODUCERS.md` (the producer frame),
+> `WAVE_6_ALGEBRA.md` (the torsor / faithfulness ladder), and `DECISIONS.md` (the durable-artifact +
+> named-divergence precedents: RefactorLog, Tolerance, the golden blessing, A41 OperatorIntent).
+
+---
+
+## 0. The one idea — synthesis *modulo blessed corrections*
+
+The engine's soul is one adjunction: **`Ingest ∘ Project = identity`, modulo *named, closed* erasures**
+(`CLAUDE.md` §1). v1 synthesis already lives inside that frame: σ is the approximate right-inverse (the
+*section*) of profiling, `π ∘ σ ≈ id_Profile` (within sampling ε) — `THE_SYNTHETIC_DATA_DESIGN.md` §1.
+
+The v1 section is **faithful**: it reproduces the source's profile, skew and all. The operator's program
+adds a deliberate, *governed* departure from faithfulness:
+
+```
+σ : Profile × Correction ⟶ Data       such that   π ∘ σ ≈ id_Profile   MODULO the blessed Correction
+```
+
+The **Correction** is a durable, operator-blessed artifact that records every intentional departure from
+naive fidelity — coverage widening, PII replacement, anonymizing rotation, distribution overrides — each
+**named** (a coded, reviewable entry), each **closed** (the artifact is the complete enumeration; nothing
+diverges silently). That is *exactly* the core adjunction's "named, closed erasures," applied to the
+synthesis section. The Correction is the synthesis-side sibling of the **RefactorLog** (durable
+schema-intent) and the **Tolerance** registry (named, accepted diff divergences): a place where operator
+judgment is recorded once, blessed, version-controlled, and replayed deterministically — *intent furnished
+into the codebase*, not re-litigated per run.
+
+**The correctness theorem becomes two-armed, and both are canaries:**
+- **Fidelity (unchanged where uncorrected):** `π ∘ σ ≈ id` on every column/axis the Correction does not touch.
+- **Correction (held where blessed):** every Correction entry's *intent* is met — a coverage floor is
+  reached, a PII column emits no real value, a rotation breaks row-linkage — and the departure from fidelity
+  is *exactly* the blessed set, never more.
+
+---
+
+## 1. The two planes (confirmed) + the artifact between them
+
+The program spans two planes the engine already keeps apart; the Correction artifact is the **blessed hinge**
+between them.
+
+```
+   π  (INFERENCE plane — the boundary)              CORRECTION (the blessed hinge)            σ  (SYNTHESIS plane — pure Core)
+   ───────────────────────────────────             ──────────────────────────────           ───────────────────────────────
+   LiveProfiler over the massive corpus    ──P──▶   capture → REVIEW → bless → replay  ──▶    SyntheticData.generate
+   streaming SQL aggregation; float OK              durable, version-controlled,              pure; T1 byte-deterministic;
+   distribution fitting; PII detection              operator-blessed override/intent          decimal-only; splitmix64
+   (the corpus never leaves this plane)             (the named-divergence closure)            (consumes Profile ⊕ Correction)
+                                                                                                       │
+                                                                                              realized rows (raw form)
+                                                                                                       │
+                                                                            BOUNDARY realization: seeded-deterministic Faker
+                                                                            assimilation over PII-typed / field-set columns
+```
+
+- **π — inference (boundary).** `LiveProfiler` (`src/Projection.Adapters.Sql/LiveProfiler.fs`, `attach`
+  :1231) over the production corpus via streaming SQL. This plane may use `float`, heavy statistics, and
+  SQL-side aggregation freely — it is an *adapter*, not Core. Its output is the bounded `Profile` summary;
+  **the corpus never enters Core.** This is the home for *at-scale inference*, *professional distribution
+  fitting*, and *PII detection*.
+- **σ — synthesis (pure Core).** `SyntheticData.generate` (`src/Projection.Core/SyntheticData.fs`) is a
+  **pure, T1-byte-deterministic replay** — no `float`, no `System.Random`, no clock (splitmix64 +
+  `decimal`; design §4). It consumes `Profile ⊕ Correction` and samples deterministically. It never
+  computes statistics and never calls Faker.
+- **Correction — the blessed hinge.** A durable typed artifact (the new surface this program introduces)
+  layered between π and σ. σ consumes the *corrected* evidence; the corpus and the heavy compute stay on
+  the π side.
+- **Faker realization (boundary).** σ emits deterministic placeholder *tokens* for PII / replaced
+  field-sets (as it already does: `syn:<attrhash>:<bucket>`, `SyntheticData.fs` :270). A boundary pass maps
+  each token → a realistic value via **Bogus seeded from the deterministic token**, so Faker never enters
+  Core, `π∘σ≈id` and T1 still hold in Core, and the operator gets production-alike PII. (Confirmed design
+  decision — see §5.)
+
+---
+
+## 2. The blessed correction artifact (the load-bearing new concept)
+
+### 2.1 What it is
+
+A durable, reviewable, version-controlled, operator-**blessed** record of every judgment call layered onto
+the captured `Profile` to govern synthesis. It is to synthesis what the **RefactorLog** is to schema
+evolution and what **Tolerance** is to diffing: the place intent is recorded once and replayed
+deterministically. It *furnishes intent into the codebase* — an operator (or the next agent) reads it and
+sees exactly why synthetic output departs from the raw source shape.
+
+### 2.2 The capture → review → bless → replay loop
+
+```
+projection profile <env> --out legacy.profile.json            # π: capture the raw evidence (BUILT)
+projection synth-correct legacy.profile.json --out corr.json  # propose a correction artifact from heuristics (NEW)
+#   (operator REVIEWS + EDITS corr.json: PII typing, coverage floors, rotation, Faker field-sets)
+#   (operator BLESSES it — the artifact becomes a trusted, version-controlled input)
+flow: { from: synthetic, profile: file:legacy.profile.json, correction: file:corr.json, to: cloud-uat }   # σ replay (extend)
+```
+
+The artifact is **proposed by heuristics, perfected by the operator, then blessed** — mirroring the golden
+blessing discipline (`GOLDEN_RECORD=1` + a DECISIONS note). A blessed artifact is a durable input; a re-run
+consumes it verbatim, so judgment calls are never re-litigated.
+
+### 2.3 The typed shape (sketch — IR grows under evidence; build per-axis as a consumer lands)
+
+A closed set of **named correction entries**, each `[<RequireQualifiedAccess>]`, smart-constructed,
+keyed by `SsKey` (never by name lookup) — so a correction is unforgeable and survives rename (drift-by-SsKey,
+design §6). Each entry is a *named divergence* with its rationale (the RefactorLog/Tolerance discipline):
+
+| Correction entry | What it overrides | Why (the named departure) |
+|---|---|---|
+| `PiiClass of SsKey × PiiKind` | the coarse hybrid-by-cardinality proxy (`SyntheticData.fs` :254) | explicit PII typing (`Email` / `PersonName` / `Phone` / `Address` / `FreeText` / `Reference` / `None`) drives realization |
+| `CoverageFloor of SsKey × CoverageRule` | the source's frequency shape | "include all important values even if patchy/absent in source" — exhaustive permutation, variety injection, or a minimum distinct-count floor |
+| `Fidelity of SsKey × ValueFidelityMode` | the per-column preserve/synthesize/**rotate** decision | operator override of the default fidelity mode (adds the new `Rotate` mode, §4) |
+| `FakerFieldSet of SsKey list × FakerProfile` | several columns at once | coherent field-set replacement (e.g. `{First, Last, Email}` → one fake *person*, referentially consistent) |
+| `Volume of SsKey × VolumeTarget` | the `Scale`-over-observed default (`SyntheticData.fs` :463) | absolute-N / total-corpus-size / multiplier targeting (§3) |
+| `DistributionOverride of SsKey × ShapeHint` | the captured numeric/categorical shape | operator-supplied or fitted shape (parametric family, histogram) — §6 |
+
+`SyntheticConfig` (the v1 inline config, `SyntheticData.fs` :62) becomes the *un-blessed default layer*;
+the Correction artifact is the *blessed override layer* on top. `effectiveEvidence = Profile ⊕ Correction`
+is a **pure** fold (the corpus stays on the π side), so σ's determinism is untouched.
+
+### 2.4 Codec + canary discipline (inherited)
+
+The Correction artifact gets the same treatment as `ProfileCodec` (`src/Projection.Targets.Json/ProfileCodec.fs`):
+a **total, SsKey-stable, re-validating** durable codec with the universal round-trip law
+`∀ c. deserialize (serialize c) = Ok c` (FsCheck over a constructed-valid generator + a real example). The
+artifact is declarative, hand-editable JSON; never a hand-authored wire format in tests.
+
+---
+
+## 3. Coverage as a named fidelity axis (the quality gate)
+
+### 3.1 The problem the operator named
+
+The production source skews to *patchy representational coverage* — it over-represents some members and
+under-represents or omits others. Naive σ faithfully reproduces this skew (`π∘σ≈id`), which is *wrong* for
+fields where the operator needs the full space exercised (a test/preview that never sees a rare-but-valid
+Status is a weak preview). **Coverage is a distinct quality from distributional fidelity**, and where they
+conflict, the operator — via a blessed `CoverageFloor` — chooses coverage.
+
+### 3.2 The faithfulness-ladder extension
+
+v1 has L1 (loads / structural) / L2 (re-profiles to ≈P) / L3 (joint — out of v1). This program adds a
+**coverage rung** between L2 and L3:
+
+- **L1 — it loads.** Structural integrity exact (unchanged).
+- **L2 — fidelity.** Per-column marginals reproduced within ε *where uncorrected*.
+- **L2-cov — coverage.** Every blessed `CoverageFloor` is met: all enumerated values appear; the
+  variety/permutation target is reached; the minimum distinct-count holds. **This is a deliberate, named
+  departure from L2** — the Correction artifact records exactly where, so the divergence is closed, not silent.
+- **L3 — joint structure.** Inter-column correlation (the `JointDistribution` axis already exists — §6).
+
+### 3.3 The three coverage mechanisms (the operator's words, made precise)
+
+- **Exhaustive permutations.** For a column (or a field-set) whose value-domain is known/important,
+  *enumerate the full domain* (or the cross-product of a field-set) instead of frequency-sampling — every
+  value/combination gets at least one row. Bounded by a named cap (a refusal when the cross-product
+  explodes, never a silent truncation).
+- **Additional variety.** Inject values *not present* in the source — from a declared domain or
+  Faker-generated — to widen coverage past the patchy corpus. The privacy contract is *strengthened* by
+  this (injected values are by construction not real source values).
+- **Selective Faker replacement of field-sets.** Replace a whole field-set with coherent Faker variety
+  (§5), breaking from the source's patchy real values entirely where the operator blesses it.
+
+Each mechanism is a `CoverageRule` variant on a `CoverageFloor` correction entry; each ships with a
+property-test asserting the floor is met *and* that uncorrected columns still satisfy L2.
+
+---
+
+## 4. Anonymizing rotation — the third fidelity mode
+
+v1 has two value-fidelity modes (`ValueFidelityMode`, `SyntheticData.fs` :52): `Preserve` (emit real
+low-card reference values) and `Synthesize` (fresh tokens, never a real value). This program adds a third,
+pure-Core mode:
+
+- **`Rotate` — anonymizing permutation.** Emit *real* values but *permute their row-assignment* (a
+  deterministic shuffle, splitmix64-seeded) so the **column marginal is exact** while **row-linkage is
+  broken** — the value is real, but it no longer belongs to its original row. This is the "round-robin
+  rotation in anonymizing ways" the operator named: maximal marginal fidelity with linkage anonymization.
+
+The privacy model gains a **linkage-breaking property test**: after `Rotate`, no synthetic row reproduces a
+real row's *combination* of rotated values (within the field-set), while each rotated column's marginal
+matches the source within ε. Stronger anonymization variants (k-anonymity over a quasi-identifier set;
+differential-privacy noise on numeric columns) are named here as **future `CoverageRule`/privacy variants,
+deferred until the operator names the threat model** — IR grows under evidence.
+
+> **Open adjustment to confirm with the operator (privacy posture).** Whether the privacy bar is
+> linkage-breaking-rotation only, or extends to k-anonymity / DP-noise. The doc reserves the slots; the
+> threat model decides which fire.
+
+---
+
+## 5. Faker assimilation — boundary, seeded-deterministic, referentially consistent
+
+**The decision (confirmed framing).** Faker (Bogus, `Bogus` NuGet — the .NET Faker) uses an RNG and is
+therefore **forbidden in Core** (T1). It lives at the **boundary realization** layer:
+
+1. Core σ emits a **deterministic placeholder token** for every PII-typed / Faker-field-set column (it
+   already emits exactly this shape for `Synthesize`: `syn:<attrhash>:<bucket>`, `SyntheticData.fs` :270).
+2. A boundary pass (`Projection.Adapters.*` or the realization layer) maps each token → a realistic value
+   via **Bogus seeded from the token** (`new Faker { Random = new Randomizer(seedFromToken) }`). Same token
+   → same fake value → **determinism preserved**, so `π∘σ≈id` and T1 hold in Core, and the canary still passes.
+
+**Referential consistency (the operator's "field-set" emphasis).** A `FakerFieldSet` correction binds
+several columns to one fake *entity* (e.g. `{FirstName, LastName, Email}` → one coherent fake person; the
+email derives from the name). The token therefore encodes the **entity identity** (the row's PK-derived
+`SYNTH_ROW` SsKey, `SyntheticData.fs` :451), so the *same* fake person appears consistently wherever that
+entity is referenced across tables — coherence across the FK graph, not per-column noise.
+
+**Locale / format control** rides the `FakerProfile` on the correction entry (locale, format mask,
+nullability already from the profile). All of it is boundary config; **Core stays pure.**
+
+---
+
+## 6. Corpus / at-scale handling (the selected adjustment)
+
+### 6.1 π over a massive corpus (boundary; the existing EvidenceCache discipline)
+
+The inference plane already follows *discover-once, derive-pure* (`LiveProfiler` → `EvidenceCache`,
+CLAUDE.md §6). For a *massive* corpus this plane owns the at-scale concerns, all SQL-side / `float`-OK:
+
+- **Streaming aggregation** — marginals, moments, and distinct-value frequencies computed by SQL
+  `GROUP BY` / window aggregates, never by materializing the corpus.
+- **Sampling strategy** — a named, blessed sampling rule (full-scan vs. TABLESAMPLE vs. top-N-by-frequency)
+  when full aggregation is too costly; the sampling fact is *recorded in the Profile* (no silent
+  approximation).
+- **`IsTruncated` thresholds** — the categorical/joint/FK-selectivity axes already carry `IsTruncated`
+  (`Profile.fs` :341/:872/:936); a capped vocabulary is *named* (truncation ⇒ synthesize, never reproduce
+  an unseen tail). The cap becomes a blessed knob.
+- **Professional distribution fitting** — histograms, fitted parametric families (normal / lognormal /
+  Pareto / empirical-CDF), multimodality. `NumericDistribution` today carries percentiles + `Mean/StdDev/CV`
+  (`Profile.fs` :434/:407); the program **enriches the evidence axis** with a fitted-shape carrier
+  (`ShapeHint`) computed on the π side, consumed by σ's numeric sampler (`sampleNumeric`,
+  `SyntheticData.fs` :298, today a percentile-segment interpolation).
+
+### 6.2 σ extrapolation *beyond* the source size (pure Core)
+
+"Arbitrary sizes" means generating **more rows than the corpus**. Volume targeting moves from `Scale ×
+observed` (`SyntheticData.fs` :463) to a `VolumeTarget` correction: **absolute-N**, **total-corpus-size**,
+or **multiplier**. Up-sizing past the observed distinct-value set forces the coverage question (§3): beyond
+the observed support, σ either resamples the fitted shape (more of the same distribution) or widens via a
+blessed `CoverageFloor` (variety injection / Faker). Each path is **named** in the Correction; never a
+silent fabrication.
+
+### 6.3 Already-captured-but-unconsumed evidence (cheap wins)
+
+A grounding finding: **the profiler already captures more than σ consumes.** Two "advanced" capabilities
+are *"teach σ to read evidence π already captures,"* not net-new inference:
+
+- **`ForeignKeySelectivity`** (`Profile.fs` :866) — captured; σ ignores it and draws FK fan-out
+  uniform-random (`SyntheticData.fs` :421). Wiring σ to it yields realistic skewed FK fan-out.
+- **`JointDistribution`** (`Profile.fs` :927) — captured; σ ignores it (it samples columns independently).
+  Wiring σ to it yields L3 correlated synthesis.
+
+These are lower-cost than the framing first suggested and should sequence early among the σ-side work.
+
+---
+
+## 7. The slice plan (IR grows under evidence; each slice ships with its canary)
+
+Sequenced so the **blessed-correction substrate lands first** (it is the spine every later slice hangs on),
+then the operator-priority quality work. Each slice is independently shippable, green, and carries its
+faithfulness-ladder witness.
+
+| # | Slice | Plane | Ships | Trigger / gate |
+|---|---|---|---|---|
+| **F0** | **Correction artifact substrate** | hinge | the typed `Correction` DU + smart ctors + durable codec (round-trip law) + `Profile ⊕ Correction` pure fold + `correction: file:<path>` flow wiring + `synth-correct` propose verb | the spine; the operator blesses the first artifact |
+| **F1** | **Explicit PII typing + volume targeting** | σ + config | `PiiClass` + `VolumeTarget` corrections consumed by σ; absolute-N / total-size volume | F0 |
+| **F2** | **Faker assimilation (boundary)** | boundary | seeded-deterministic Bogus realization over PII-typed columns; `FakerFieldSet` referential consistency | F1 (PII typing exists) |
+| **F3** | **Coverage corrections** | σ | `CoverageFloor` (exhaustive permutation / variety injection / distinct-floor) + the **L2-cov** canary | F0; an operator coverage need |
+| **F4** | **Anonymizing rotation** | σ | the `Rotate` `ValueFidelityMode` + the linkage-breaking privacy property | F0 |
+| **F5** | **Wire σ to captured evidence** | σ | consume `ForeignKeySelectivity` (skew) + `JointDistribution` (L3 correlation) | already-captured evidence (§6.3) |
+| **F6** | **Distribution enrichment** | π + σ | `ShapeHint` evidence axis (histograms / fitted families / multimodality) at π + richer `sampleNumeric` | the "professional fitting" need; largest |
+
+**Recommended first build:** **F0** (the correction-artifact substrate). It is the spine the operator's
+whole vision hangs on, it is the smallest coherent unit, and nothing downstream is well-shaped without it.
+F1 follows immediately (the first visible operator win: explicit PII typing + arbitrary scale).
+
+> **Note on the operator's "inference is the core" instinct.** F6 (professional fitting) is sequenced last
+> not because it is least important but because it is largest and depends on the substrate (F0) and the
+> evidence-wiring pattern (F5). If the operator wants the *fitting quality* proven earliest, F5 (wire σ to
+> the joint + selectivity evidence π already captures) is the cheapest way to demonstrate richer fidelity
+> before the heavier F6 — surface this when sequencing.
+
+---
+
+## 8. Disciplines to hold (do not break without writing the amendment first)
+
+- **T1 byte-determinism in Core.** σ stays pure: no `float`, no `System.Random`, no clock. All heavy
+  statistics and all Faker live on the **boundary**; Core consumes their *summaries* (Profile ⊕ Correction),
+  which are `decimal`/typed. Faker is seeded from σ's deterministic token so realization stays reproducible.
+- **Named, closed divergences.** Every departure from `π∘σ≈id` is a *blessed Correction entry* with a code
+  + rationale (the RefactorLog/Tolerance/`SyntheticDiagnostic` precedent, `SyntheticData.fs` :90). The
+  Correction artifact is the *complete* enumeration — coverage/PII/rotation never diverge silently.
+- **The privacy contract holds and strengthens.** The `Synthesize` guarantee (no real high-card value
+  emitted, true by construction via the per-attribute namespace, `SyntheticData.fs` :270) extends to PII
+  typing, variety injection (injected ≠ real), and `Rotate` (linkage-breaking). Each carries a property test.
+- **Two-armed canary as the forcing function.** Ship each slice with its faithfulness witness: fidelity
+  (`π∘σ≈id` where uncorrected) *and* correction (the blessed intent met, and the divergence exactly the
+  blessed set). Lives in the warm Docker pool beside `SyntheticCanaryTests`.
+- **Codec discipline.** The Correction artifact round-trips under the universal law
+  (`deserialize ∘ serialize = id`), FsCheck over a constructed-valid generator; declarative test inputs,
+  never hand-authored wire.
+- **IR grows under evidence.** Build F0 first, then per-slice against a real consumer/blessing. Do **not**
+  add Profile axes, Correction variants, or knobs ahead of a consumer — the `JointDistribution`/`ForeignKeySelectivity`
+  "captured but unconsumed" gap is the cautionary precedent (evidence outran its consumer).
+- **Domain-first naming (pillar 8).** Concept-shaped names — `Correction`, `CoverageFloor`, `PiiClass`,
+  `FakerProfile`, `ValueFidelityMode.Rotate` — not `Helper`/`Manager`/`Processor`. The vocabulary must
+  mirror the operator's: *correction*, *coverage*, *blessing*, *rotation*, *assimilation*.
+- **Test pools never concurrent** (`scripts/test.sh fast` vs. the warm Docker canary; no-swap host OOM);
+  commit each slice green.
+
+---
+
+## 9. Why this matters (the operator's outcome)
+
+It turns synthetic data from a *faithful but skew-inheriting* preview into a **governed, high-quality
+corpus the operator authors intent over**: production-alike PII (Faker, coherent across the FK graph),
+*full* coverage of important value-spaces even where the source is patchy (the quality gate the source
+cannot supply itself), anonymization that keeps marginals exact while breaking linkage, and arbitrary
+scale — all reproducible (seeded, pure), all *blessed* (the judgment calls persist, version-controlled,
+re-litigation-free), and all *named* (every departure from the source is a closed, reviewable Correction
+entry). It is "extremely high quality synthetic data, as much as the source quality allows — and, where
+the source quality is lacking, exactly the corrections you blessed to make up the difference" — made an
+engine capability with a two-armed fidelity theorem behind it.

--- a/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
+++ b/sidecar/projection/THE_SYNTHETIC_DATA_FUZZING.md
@@ -302,18 +302,21 @@ faithfulness-ladder witness.
 | **F2** | **Faker assimilation (boundary)** | boundary | seeded-deterministic Bogus realization over PII-typed columns; `FakerFieldSet` referential consistency | ⬜ (F1 PII typing exists) |
 | **F3** | **Coverage corrections** | σ | `CoverageFloor` (exhaustive permutation / variety injection / distinct-floor) + the **L2-cov** canary | ⬜ (an operator coverage need) |
 | **F4** | **Anonymizing rotation** | **boundary** | corpus-row permutation (linkage-breaking) over real rows — **NOT** a Core `ValueFidelityMode` (§4 revision: `Preserve` is already linkage-free in marginal-only σ) | ⬜ (a named threat model) |
-| **F5** | **Wire σ to captured evidence** | σ | consume `ForeignKeySelectivity` (skew) + `JointDistribution` (L3 correlation) — evidence already captured | ⬜ (cheap; §6.3) |
+| **F5a** | **Wire σ to `ForeignKeySelectivity`** | σ | rank-mapped skewed FK fan-out (was uniform) | ✅ **landed** 2026-06-16 (`3f552f45`) |
+| **F5b** | **Wire σ to `JointDistribution`** | σ | correlated FK-tuple synthesis (L3) — per-position rank-mapped, co-occurrence preserved on synthetic keys | ✅ **landed** 2026-06-16 |
 | **F6** | **Distribution enrichment** | π + σ | `ShapeHint` evidence axis (histograms / fitted families / multimodality) at π + richer `sampleNumeric` | ⬜ (the "professional fitting" lift; largest) |
 
-**Landed this session:** F0a + F0b + F1 — the blessed-correction spine (carrier + smart ctor + fold), its
-durable codec (round-trip law), and per-kind arbitrary-scale volume. The operator can author + bless a
-correction artifact (programmatically / by file) and drive PII typing + arbitrary scale through the existing σ.
+**Landed this session:** F0a + F0b + F1 + F0c-propose + F5a + F5b — the blessed-correction spine (carrier +
+smart ctor + fold), its durable codec (round-trip law), the heuristic PII proposer, per-kind arbitrary-scale
+volume, and σ wired to BOTH captured FK-fidelity axes (selectivity skew + joint correlation). The operator can
+author + bless a correction artifact (programmatically / by file), have a first draft proposed, and drive PII
+typing + arbitrary scale + skewed/correlated FK fan-out through σ.
 
-**Recommended next:** **F5** (wire σ to the `ForeignKeySelectivity` + `JointDistribution` evidence π already
-captures) is the cheapest fidelity lift and demonstrates richer quality before the heavier F6; **F2** (Faker)
-is the highest-visibility production-alike PII win; **F0c** (flow wiring + `synth-correct` verb) is the
-operator-surface that makes the blessed loop end-to-end. F6 (professional fitting) is last — largest, and
-depends on F5's evidence-wiring pattern.
+**Recommended next:** **F2** (Faker, needs a Bogus NuGet dep) is the highest-visibility production-alike PII
+win; **F0c-I/O** (durable write + `synth-correct` verb + `correction: file:` flow wiring — the A44 cascade) is
+the operator-surface that makes the blessed loop end-to-end; **F3** (coverage corrections + L2-cov canary) is
+the "ensure all values included" quality gate. **F6** (professional distribution fitting) is last — largest,
+π + σ.
 
 ---
 

--- a/sidecar/projection/src/Projection.Cli/RunFaces.fs
+++ b/sidecar/projection/src/Projection.Cli/RunFaces.fs
@@ -902,7 +902,11 @@ let runReverseLegTransfer
             // (`narrateDropExit`). A non-reconciling run carries an empty
             // reconciliation, so the halt never fires (byte-identical straight load).
             | ReverseLegRealization.Streaming journal ->
-                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation)
+                // D — the streaming arm now carries the same per-environment revert
+                // policy the materialized branch consumes (`revertAuto`/`revertOut`
+                // derived above via `RevertPolicy.toEngine`): a mid-stream crash
+                // reverts (auto) or scripts (script) the partial sink-minted rows.
+                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation revertAuto revertOut)
                     .GetAwaiter().GetResult()
             | ReverseLegRealization.Materialized ->
                 (Transfer.runReverseLegThroughConnectionsWith sinkCapability.IdentityPolicy mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation revertAuto revertOut)

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -60,6 +60,7 @@
     <Compile Include="UserIdentity.fs" />
     <Compile Include="Profile.fs" />
     <Compile Include="SyntheticData.fs" />
+    <Compile Include="SyntheticCorrection.fs" />
     <Compile Include="Policy.fs" />
     <Compile Include="EmissionMode.fs" />
     <Compile Include="SurrogateRemap.fs" />

--- a/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
@@ -1,0 +1,138 @@
+namespace Projection.Core
+
+/// THE_SYNTHETIC_DATA_FUZZING.md §2 — the blessed *correction artifact*'s Core
+/// carrier (slice F0). A durable, operator-blessed override/intent layer on top
+/// of the captured `Profile` / default `SyntheticConfig`. Each entry is a NAMED
+/// divergence from naive fidelity — the synthesis sibling of the RefactorLog
+/// (durable schema-intent) and the `Tolerance` registry (named, accepted
+/// divergences). Keyed by `SsKey` (drift-stable; A1 survives rename — NEVER a
+/// name lookup), so a blessed correction follows its column across a rename.
+///
+/// **Why it exists.** v1 synthesis (`THE_SYNTHETIC_DATA_DESIGN.md`) is a
+/// *faithful* section of profiling (`π ∘ σ ≈ id`): it reproduces the source's
+/// skew. The correction artifact records the operator's deliberate, governed
+/// departures from that faithfulness (PII typing, fidelity overrides; coverage /
+/// rotation / Faker land in later slices), turning the theorem into
+/// `π ∘ σ ≈ id MODULO the blessed Correction` — the engine's core-adjunction
+/// shape ("identity, modulo named, closed erasures") applied to the section.
+///
+/// **F0 scope (IR grows under evidence).** The carrier ships the two entries
+/// that map onto TODAY's `SyntheticConfig` consumer — `Pii` and `Fidelity` — so
+/// the fold (`applyToConfig`) drives the EXISTING σ with ZERO σ change. The
+/// remaining entries named in the design (`CoverageFloor`, `FakerFieldSet`,
+/// `Volume`, `DistributionOverride`) land with their own slices, each with its
+/// σ/boundary consumer. The durable codec + flow wiring + propose verb (the rest
+/// of F0's surface) are the next increment (F0b).
+
+/// §2.3 / §5 — explicit PII classification for a column. Supersedes the coarse
+/// hybrid-by-cardinality proxy (`SyntheticData.valueFidelityFor`). `None` = the
+/// column is not PII. The fine-grained kinds drive the boundary Faker
+/// realization (slice F2); F0 consumes only the is-PII-ness (any kind other than
+/// `None` ⇒ synthesize fresh tokens, never a real value — the privacy contract).
+[<RequireQualifiedAccess>]
+type PiiKind =
+    | None
+    | Email
+    | PersonName
+    | Phone
+    | Address
+    | FreeText
+    | Reference
+
+/// §2.3 — one NAMED correction entry. Closed DU; grows under evidence (a new
+/// variant lands with its σ/boundary consumer, never speculatively).
+[<RequireQualifiedAccess>]
+type CorrectionEntry =
+    /// Explicit PII typing for a column → drives Synthesize / Faker realization.
+    | Pii of column: SsKey * kind: PiiKind
+    /// Operator override of a column's value-fidelity mode (Preserve / Synthesize).
+    | Fidelity of column: SsKey * mode: ValueFidelityMode
+
+/// §2 — the blessed correction artifact: a set of named correction entries
+/// layered onto the captured `Profile` / default `SyntheticConfig`. Smart-
+/// constructed (private case): a column carries at most one entry in any one
+/// *conflict class*, so the blessed intent on an axis is unambiguous — a
+/// conflicting double-correction is a named refusal, never a last-write-wins
+/// silent pick.
+type Correction =
+    private { Entries : CorrectionEntry list }
+
+[<RequireQualifiedAccess>]
+module Correction =
+
+    /// The empty correction — the identity of `applyToConfig` (a config folded
+    /// through `empty` is byte-unchanged: blessing nothing changes nothing).
+    let empty : Correction = { Entries = [] }
+
+    /// The conflict CLASS + column an entry occupies. Entries sharing a (class,
+    /// column) conflict. `Pii` and `Fidelity` share the FIDELITY class — both
+    /// determine the per-column value-fidelity decision, so a column may carry
+    /// one OR the other, not both. Future axes (coverage, volume) get their own
+    /// class, so they never conflict with a fidelity correction on the same column.
+    let private conflictKey (entry: CorrectionEntry) : string * SsKey =
+        match entry with
+        | CorrectionEntry.Pii (col, _)      -> "fidelity", col
+        | CorrectionEntry.Fidelity (col, _) -> "fidelity", col
+
+    /// Smart constructor. Refuses a conflicting double-correction (two entries in
+    /// the same conflict class for one column); a blessed artifact's intent must
+    /// be unambiguous. Order-independent: the entries are a set of decisions, not
+    /// a sequence.
+    let create (entries: CorrectionEntry list) : Result<Correction> =
+        let conflicts =
+            entries
+            |> List.map conflictKey
+            |> List.groupBy id
+            |> List.choose (fun (key, group) -> if List.length group > 1 then Some key else Option.None)
+        match conflicts with
+        | [] -> Result.success { Entries = entries }
+        | (axis, col) :: _ ->
+            Result.failureOf
+                (ValidationError.create
+                    "synthetic.correction.conflict"
+                    (String.concat "" [
+                        "conflicting "; axis; " corrections for column "; SsKey.serialize col
+                        " — a column carries at most one correction per axis "
+                        "(a blessed artifact's intent must be unambiguous)" ]))
+
+    /// The entries, in construction order (a stable projection for codecs /
+    /// diagnostics; the SEMANTICS are order-independent — see `applyToConfig`).
+    let entries (correction: Correction) : CorrectionEntry list = correction.Entries
+
+    let isEmpty (correction: Correction) : bool = List.isEmpty correction.Entries
+
+    /// §2.3 — fold the blessed corrections onto a default `SyntheticConfig`, the
+    /// PURE hinge `Profile ⊕ Correction` (the corpus stays on the π side, so σ's
+    /// T1 determinism is untouched). F0 translates the two fidelity-class entries
+    /// onto the config's `Preserve`/`Synthesize` column sets (resolving each
+    /// `SsKey` → its logical `Name` by the drift-stable catalog join):
+    ///   • `Pii (_, kind)` with `kind ≠ None` ⇒ Synthesize (never a real PII value).
+    ///   • `Fidelity (_, Synthesize | Preserve)` ⇒ the named set, verbatim.
+    /// A column whose `SsKey` resolves to no attribute (B-only / stale) is a
+    /// no-op — the correction simply does not bind (drift-by-SsKey, design §6).
+    /// Order-independent: the smart ctor forbids same-class collisions, so no
+    /// column lands in both sets. `applyToConfig empty` is the identity.
+    let applyToConfig (catalog: Catalog) (correction: Correction) (config: SyntheticConfig) : SyntheticConfig =
+        let nameOf (col: SsKey) : string option =
+            Catalog.allKinds catalog
+            |> List.tryPick (fun k ->
+                k.Attributes
+                |> List.tryFind (fun a -> a.SsKey = col)
+                |> Option.map (fun a -> Name.value a.Name))
+        correction.Entries
+        |> List.fold (fun (cfg: SyntheticConfig) entry ->
+            match entry with
+            | CorrectionEntry.Pii (col, kind) ->
+                match kind with
+                | PiiKind.None -> cfg
+                | _ ->
+                    match nameOf col with
+                    | Some name -> { cfg with SynthesizeColumns = Set.add name cfg.SynthesizeColumns }
+                    | Option.None -> cfg
+            | CorrectionEntry.Fidelity (col, mode) ->
+                match nameOf col with
+                | Option.None -> cfg
+                | Some name ->
+                    match mode with
+                    | ValueFidelityMode.Synthesize -> { cfg with SynthesizeColumns = Set.add name cfg.SynthesizeColumns }
+                    | ValueFidelityMode.Preserve   -> { cfg with PreserveColumns   = Set.add name cfg.PreserveColumns }) config

--- a/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
@@ -96,10 +96,7 @@ module Correction =
             Result.failureOf
                 (ValidationError.create
                     "synthetic.correction.conflict"
-                    (String.concat "" [
-                        "conflicting "; axis; " corrections for column "; SsKey.serialize col
-                        " — a column carries at most one correction per axis "
-                        "(a blessed artifact's intent must be unambiguous)" ]))
+                    (sprintf "conflicting %s corrections for column %s — a column carries at most one correction per axis (a blessed artifact's intent must be unambiguous)" axis (SsKey.serialize col)))  // LINT-ALLOW: terminal operator-facing diagnostic text at the ValidationError message boundary; no structured / SQL / typed-AST artifact applies to a free-text refusal reason
 
     /// The entries, in construction order (a stable projection for codecs /
     /// diagnostics; the SEMANTICS are order-independent — see `applyToConfig`).

--- a/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
@@ -47,6 +47,9 @@ type CorrectionEntry =
     | Pii of column: SsKey * kind: PiiKind
     /// Operator override of a column's value-fidelity mode (Preserve / Synthesize).
     | Fidelity of column: SsKey * mode: ValueFidelityMode
+    /// §6.2 (slice F1) — a per-KIND volume target (absolute / multiplier),
+    /// generating at arbitrary scale decoupled from the source corpus size.
+    | Volume of kind: SsKey * target: VolumeTarget
 
 /// §2 — the blessed correction artifact: a set of named correction entries
 /// layered onto the captured `Profile` / default `SyntheticConfig`. Smart-
@@ -73,6 +76,9 @@ module Correction =
         match entry with
         | CorrectionEntry.Pii (col, _)      -> "fidelity", col
         | CorrectionEntry.Fidelity (col, _) -> "fidelity", col
+        // Volume is keyed by KIND, in its own class — it never conflicts with a
+        // fidelity correction on a column (different class AND different SsKey space).
+        | CorrectionEntry.Volume (kind, _)  -> "volume", kind
 
     /// Smart constructor. Refuses a conflicting double-correction (two entries in
     /// the same conflict class for one column); a blessed artifact's intent must
@@ -135,4 +141,9 @@ module Correction =
                 | Some name ->
                     match mode with
                     | ValueFidelityMode.Synthesize -> { cfg with SynthesizeColumns = Set.add name cfg.SynthesizeColumns }
-                    | ValueFidelityMode.Preserve   -> { cfg with PreserveColumns   = Set.add name cfg.PreserveColumns }) config
+                    | ValueFidelityMode.Preserve   -> { cfg with PreserveColumns   = Set.add name cfg.PreserveColumns }
+            | CorrectionEntry.Volume (kind, target) ->
+                // §6.2 — keyed by KIND SsKey; rowCountFor consults it directly (no
+                // Name resolution). A kind not in the catalog simply never generates,
+                // so a stale Volume target is inert (drift-by-SsKey).
+                { cfg with VolumeByKind = Map.add kind target cfg.VolumeByKind }) config

--- a/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticCorrection.fs
@@ -147,3 +147,42 @@ module Correction =
                 // Name resolution). A kind not in the catalog simply never generates,
                 // so a stale Volume target is inert (drift-by-SsKey).
                 { cfg with VolumeByKind = Map.add kind target cfg.VolumeByKind }) config
+
+
+/// THE_SYNTHETIC_DATA_FUZZING.md §2.2 (slice F0c-propose) — propose a FIRST-DRAFT
+/// `Correction` from the catalog: heuristic PII typing by column-name stem, for the
+/// operator to review / fine-tune / BLESS. Pure (no I/O, no clock); the durable
+/// artifact and the CLI `synth-correct` verb that writes it are the remaining F0c
+/// I/O work. Conservative by design — it UNDER-claims (only well-known PII stems
+/// classify; everything else stays unclassified), so the operator ADDS what the
+/// heuristic misses rather than having to UNDO over-claims. The blessed artifact
+/// is the operator's, never the heuristic's.
+[<RequireQualifiedAccess>]
+module CorrectionProposer =
+
+    /// Lowercased-substring → `PiiKind`, most-specific first. Only canonical PII
+    /// column-name stems classify; an unmatched name is `PiiKind.None` (no entry).
+    let private classify (logical: string) : PiiKind =
+        let n = logical.ToLowerInvariant()
+        let has (sub: string) : bool = n.Contains sub
+        if   has "email" || has "e_mail" then PiiKind.Email
+        elif has "phone" || has "mobile" then PiiKind.Phone
+        elif has "address" || has "street" || has "postal" || has "zip" then PiiKind.Address
+        elif has "firstname" || has "lastname" || has "fullname" || has "surname" || has "givenname" then PiiKind.PersonName
+        else PiiKind.None
+
+    /// Propose the PII-typing corrections for a catalog — one `Pii` entry per
+    /// attribute whose name matches a PII stem. Attribute `SsKey`s are distinct,
+    /// so the smart ctor always succeeds (the `Error` arm is unreachable; the
+    /// defensive `empty` keeps the proposer total).
+    let propose (catalog: Catalog) : Correction =
+        let entries =
+            Catalog.allKinds catalog
+            |> List.collect (fun k -> k.Attributes)
+            |> List.choose (fun a ->
+                match classify (Name.value a.Name) with
+                | PiiKind.None -> Option.None
+                | kind         -> Some (CorrectionEntry.Pii (a.SsKey, kind)))
+        match Correction.create entries with
+        | Ok c    -> c
+        | Error _ -> Correction.empty

--- a/sidecar/projection/src/Projection.Core/SyntheticData.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticData.fs
@@ -384,6 +384,26 @@ module SyntheticData =
             kind.References
             |> List.map (fun ref -> ref.SourceAttribute, ref.TargetKind)
             |> Map.ofList
+        // §6.3 (F5) — SourceAttribute → ReferenceKey, for the captured FK
+        // selectivity lookup. The selectivity's count-DESC frequencies weight the
+        // SYNTHETIC parent pool BY RANK (the most-referenced synthetic parent ←
+        // the highest source frequency), reproducing the fan-out SKEW without the
+        // real parent keys the synthetic pool does not share. `None` (no evidence
+        // / all-zero support) keeps the uniform draw — byte-identical to pre-F5.
+        let refKeyByAttr =
+            kind.References
+            |> List.map (fun ref -> ref.SourceAttribute, ref.SsKey)
+            |> Map.ofList
+        let fkSelectivityWeights (sourceAttr: SsKey) (poolLen: int) : int64 list option =
+            match Map.tryFind sourceAttr refKeyByAttr with
+            | None -> None
+            | Some refKey ->
+                match Profile.tryFindForeignKeySelectivity refKey profile with
+                | Some sel when not (List.isEmpty sel.Frequencies) ->
+                    let counts = sel.Frequencies |> List.map snd |> List.toArray
+                    let weights = [ for i in 0 .. poolLen - 1 -> if i < counts.Length then counts.[i] else 0L ]
+                    if weights |> List.sumBy (fun c -> if c > 0L then c else 0L) > 0L then Some weights else None
+                | _ -> None
         // NM-21 — name the unsatisfiable FKs once per kind (row-independent):
         // a non-nullable FK column whose target PK pool is empty is forced to
         // NULL below; σ now emits a `synthetic.fk.unsatisfiable` diagnostic so
@@ -432,8 +452,18 @@ module SyntheticData =
                                 // surfaces it but Core no longer emits it silently.
                                 None
                             else
-                                let j = int (nextDraw () % uint64 (List.length pool))
-                                Some pool.[j]
+                                // §6.3 (F5) — selectivity-weighted draw when the skew
+                                // evidence is present; uniform otherwise (byte-identical
+                                // to pre-F5). Both consume exactly one Rng draw, so the
+                                // stream stays in lockstep regardless of which path runs.
+                                match fkSelectivityWeights attr.SsKey (List.length pool) with
+                                | Some weights ->
+                                    let j, s = weightedIndex weights state
+                                    state <- s
+                                    Some pool.[min j (List.length pool - 1)]
+                                | None ->
+                                    let j = int (nextDraw () % uint64 (List.length pool))
+                                    Some pool.[j]
                         else
                             let nulled, s = drawsNull profile attr.SsKey state
                             state <- s

--- a/sidecar/projection/src/Projection.Core/SyntheticData.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticData.fs
@@ -404,6 +404,60 @@ module SyntheticData =
                     let weights = [ for i in 0 .. poolLen - 1 -> if i < counts.Length then counts.[i] else 0L ]
                     if weights |> List.sumBy (fun c -> if c > 0L then c else 0L) > 0L then Some weights else None
                 | _ -> None
+        // §6.3 (F5b) — the kind's captured FK JOINT distribution, if any. σ draws
+        // a correlated FK-TUPLE per row (preserving which parent-combinations
+        // co-occur) instead of drawing each FK independently. Self-contained from
+        // the joint alone: per tuple-position, the real values rank by descending
+        // marginal frequency, and each drawn component maps to the synthetic parent
+        // pool BY RANK (the same discipline as F5a) — so the co-occurrence STRUCTURE
+        // is reproduced on synthetic keys without the real keys the pool lacks. The
+        // tuple key is `String.Join("|", "<tag>:<value>" parts)` in reference order
+        // (LiveProfiler `projectTupleKeys`); null rows were excluded at capture.
+        // `None` (no joint evidence) → each FK draws independently — byte-identical
+        // to pre-F5b. The returned thunk advances the Rng by exactly ONE draw.
+        let jointDraw : (Rng -> Map<SsKey, string> * Rng) option =
+            profile.JointDistributions
+            |> List.tryFind (fun j -> j.KindKey = kind.SsKey)
+            |> Option.bind (fun j ->
+                let decoded =
+                    j.Frequencies
+                    |> List.choose (fun (key, c) ->
+                        let parts = key.Split('|')
+                        if c > 0L && parts.Length = List.length j.AttributeKeys then Some (parts, c) else None)
+                if List.isEmpty decoded then None
+                else
+                    let posCount = List.length j.AttributeKeys
+                    let rankMaps =
+                        [ for p in 0 .. posCount - 1 ->
+                            decoded
+                            |> List.groupBy (fun (parts, _) -> parts.[p])
+                            |> List.map (fun (partVal, grp) -> partVal, grp |> List.sumBy snd)
+                            |> List.sortWith (fun (vA, cA) (vB, cB) ->
+                                let c = compare cB cA in if c <> 0 then c else compare vA vB)
+                            |> List.mapi (fun rank (partVal, _) -> partVal, rank)
+                            |> Map.ofList ]
+                    let posPools =
+                        j.AttributeKeys
+                        |> List.map (fun attrKey ->
+                            match Map.tryFind attrKey fkByAttr with
+                            | Some target -> pkPools |> Map.tryFind target |> Option.defaultValue []
+                            | None        -> [])
+                    let weights = decoded |> List.map snd
+                    let tuples = decoded |> List.map fst |> List.toArray
+                    let attrKeys = j.AttributeKeys
+                    Some (fun (r: Rng) ->
+                        let idx, r' = weightedIndex weights r
+                        let parts = tuples.[min idx (tuples.Length - 1)]
+                        let assignment =
+                            attrKeys
+                            |> List.mapi (fun p attrKey ->
+                                let pool = posPools.[p]
+                                let rank = rankMaps.[p] |> Map.tryFind parts.[p] |> Option.defaultValue 0
+                                let v = if List.isEmpty pool then "" else pool.[min rank (List.length pool - 1)]
+                                attrKey, v)
+                            |> List.filter (fun (_, v) -> v <> "")
+                            |> Map.ofList
+                        assignment, r'))
         // NM-21 — name the unsatisfiable FKs once per kind (row-independent):
         // a non-nullable FK column whose target PK pool is empty is forced to
         // NULL below; σ now emits a `synthetic.fk.unsatisfiable` diagnostic so
@@ -425,6 +479,12 @@ module SyntheticData =
             let v, s = draw state in state <- s; v
         let rows =
           [ for i in 0 .. rowCount - 1 ->
+            // §6.3 F5b — draw the row's correlated FK tuple ONCE (when a joint
+            // exists); the joint FK columns below take their value from it.
+            let jointAssignment =
+                match jointDraw with
+                | Some draw -> let m, s = draw state in state <- s; m
+                | None      -> Map.empty
             let cells =
                 kind.Attributes
                 |> List.choose (fun attr ->
@@ -452,18 +512,22 @@ module SyntheticData =
                                 // surfaces it but Core no longer emits it silently.
                                 None
                             else
-                                // §6.3 (F5) — selectivity-weighted draw when the skew
-                                // evidence is present; uniform otherwise (byte-identical
-                                // to pre-F5). Both consume exactly one Rng draw, so the
-                                // stream stays in lockstep regardless of which path runs.
-                                match fkSelectivityWeights attr.SsKey (List.length pool) with
-                                | Some weights ->
-                                    let j, s = weightedIndex weights state
-                                    state <- s
-                                    Some pool.[min j (List.length pool - 1)]
+                                // §6.3 — precedence: a correlated JOINT value (F5b,
+                                // drawn once for the row above) wins; else the
+                                // selectivity-weighted skew (F5a); else uniform
+                                // (byte-identical to pre-F5). The joint path already
+                                // consumed its Rng draw, so it does not draw again here.
+                                match Map.tryFind attr.SsKey jointAssignment with
+                                | Some v -> Some v
                                 | None ->
-                                    let j = int (nextDraw () % uint64 (List.length pool))
-                                    Some pool.[j]
+                                    match fkSelectivityWeights attr.SsKey (List.length pool) with
+                                    | Some weights ->
+                                        let j, s = weightedIndex weights state
+                                        state <- s
+                                        Some pool.[min j (List.length pool - 1)]
+                                    | None ->
+                                        let j = int (nextDraw () % uint64 (List.length pool))
+                                        Some pool.[j]
                         else
                             let nulled, s = drawsNull profile attr.SsKey state
                             state <- s

--- a/sidecar/projection/src/Projection.Core/SyntheticData.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticData.fs
@@ -53,29 +53,43 @@ type ValueFidelityMode =
     | Preserve
     | Synthesize
 
+/// THE_SYNTHETIC_DATA_FUZZING.md §6.2 — the per-kind volume target (slice F1):
+/// generate at ARBITRARY scale, decoupled from the source corpus row count.
+/// `Absolute` sets an exact synthetic row count for the kind; `Multiplier`
+/// scales the observed `RowCount`. A kind with no target falls back to the
+/// config's global `Scale`, so existing callers are byte-identical.
+[<RequireQualifiedAccess>]
+type VolumeTarget =
+    | Absolute of rows: int
+    | Multiplier of factor: decimal
+
 /// The hybrid-by-cardinality policy (design §2.1) plus the volume axis
 /// (design §7). `PreserveCardinalityMax` is τ — categoricals with
 /// `DistinctCount ≤ τ` and not truncated are preserved; the rest are
 /// synthesized. `PreserveColumns` / `SynthesizeColumns` are per-column
 /// overrides keyed by the attribute's logical `Name` text. `Scale` is the
-/// volume factor over the profiled `RowCount` per kind (1.0 = full).
+/// global volume factor over the profiled `RowCount` per kind (1.0 = full);
+/// `VolumeByKind` is the per-kind override (FUZZING §6.2, slice F1) — empty =
+/// every kind uses `Scale`.
 type SyntheticConfig = {
     PreserveCardinalityMax : int64
     PreserveColumns        : Set<string>
     SynthesizeColumns      : Set<string>
     Scale                  : decimal
+    VolumeByKind           : Map<SsKey, VolumeTarget>
 }
 
 [<RequireQualifiedAccess>]
 module SyntheticConfig =
 
     /// The conservative default (design §2.1: "default τ conservative,
-    /// recommend ≤ 50"): τ = 50, no overrides, full scale.
+    /// recommend ≤ 50"): τ = 50, no overrides, full scale, no per-kind volume.
     let defaultConfig : SyntheticConfig =
         { PreserveCardinalityMax = 50L
           PreserveColumns        = Set.empty
           SynthesizeColumns      = Set.empty
-          Scale                  = 1M }
+          Scale                  = 1M
+          VolumeByKind           = Map.empty }
 
 
 /// NM-21 — a named lineage event σ emits when a **non-nullable** FK column
@@ -465,8 +479,12 @@ module SyntheticData =
             kind.Attributes
             |> List.choose (fun a -> Profile.tryFindColumn a.SsKey profile |> Option.map (fun c -> c.RowCount))
             |> function [] -> 0L | xs -> List.max xs
-        let scaled = decimal observed * config.Scale
-        max 0 (int (System.Decimal.Truncate scaled))
+        // §6.2 — a per-kind VolumeTarget overrides the global Scale (slice F1);
+        // absent, the observed × Scale default holds (byte-identical to pre-F1).
+        match Map.tryFind kind.SsKey config.VolumeByKind with
+        | Some (VolumeTarget.Absolute rows)     -> max 0 rows
+        | Some (VolumeTarget.Multiplier factor) -> max 0 (int (System.Decimal.Truncate (decimal observed * factor)))
+        | None                                  -> max 0 (int (System.Decimal.Truncate (decimal observed * config.Scale)))
 
     /// Pass 1 — mint every kind's PK pool (raw PK values, one per generated
     /// row). PKs are independent of FKs, so this completes before any row is

--- a/sidecar/projection/src/Projection.Pipeline/FakerRealization.fs
+++ b/sidecar/projection/src/Projection.Pipeline/FakerRealization.fs
@@ -1,0 +1,100 @@
+namespace Projection.Pipeline
+
+// LINT-ALLOW-FILE: Faker boundary realization — Bogus (RNG-based) lives OUTSIDE
+//   Core (T1). This post-σ pass rewrites PII-typed columns to coherent realistic
+//   values, seeded deterministically per row identity. The "string work" here is
+//   realistic-value GENERATION at the realization boundary, not SQL/structure
+//   emission — the typed-AST / built-in-obligation disciplines do not apply.
+// LINT-ALLOW-FILE-MUTATION: the FNV seed accumulator + the per-row Bogus global
+//   seed set are realization-layer mutation; synthesis realization is sequential,
+//   so the set-then-construct is deterministic per row.
+
+open Projection.Core
+
+/// THE_SYNTHETIC_DATA_FUZZING.md §5 (slice F2) — the Faker boundary realization.
+/// σ (Core) emits deterministic placeholder tokens for PII-typed columns (it never
+/// emits a real value — the privacy contract); this pass, OUTSIDE Core, rewrites
+/// those columns to coherent realistic values via Bogus, **seeded from the ROW's
+/// identity** so (a) the same row yields ONE consistent fake person across its PII
+/// columns (referential consistency — the email derives from the same person as the
+/// name), and (b) the output is reproducible (same dataset → same fakes). Bogus
+/// never enters Core, so σ's T1 determinism is untouched; this is the boundary the
+/// design reserves for it.
+[<RequireQualifiedAccess>]
+module FakerRealization =
+
+    /// A stable, host-independent `int` seed from an `SsKey` (FNV-1a over the
+    /// serialized key, truncated). Deterministic — the realization replays.
+    let private seedOf (key: SsKey) : int =
+        let s = SsKey.serialize key
+        let mutable h = 2166136261u
+        for ch in s do h <- (h ^^^ uint32 (uint16 ch)) * 16777619u
+        int h
+
+    /// A deterministically-seeded `Bogus.Faker` for one row. The global
+    /// `Randomizer.Seed` is set immediately before construction; synthesis
+    /// realization is single-threaded, so the set-then-construct yields a faker
+    /// whose generation depends only on this row's seed (reproducible).
+    let private fakerOf (seed: int) : Bogus.Faker =
+        Bogus.Randomizer.Seed <- System.Random(seed)
+        Bogus.Faker()
+
+    /// PiiKind → a coherent fake value from a row's faker. `f.Person` is one
+    /// cached individual, so a row's Email / FullName / Phone / Address all
+    /// describe the SAME person (referential consistency). `Reference` (a real
+    /// reference value, preserved) and `None` are no-ops.
+    let private fieldOf (f: Bogus.Faker) (kind: PiiKind) : string option =
+        match kind with
+        | PiiKind.Email      -> Some f.Person.Email
+        | PiiKind.PersonName -> Some f.Person.FullName
+        | PiiKind.Phone      -> Some f.Person.Phone
+        | PiiKind.Address    -> Some f.Person.Address.Street
+        | PiiKind.FreeText   -> Some (f.Lorem.Sentence())
+        | PiiKind.Reference  -> None
+        | PiiKind.None       -> None
+
+    /// The PII-typed attribute keys from a Correction (skipping `None`).
+    let private piiColumns (correction: Correction) : Map<SsKey, PiiKind> =
+        Correction.entries correction
+        |> List.choose (function
+            | CorrectionEntry.Pii (col, kind) when kind <> PiiKind.None -> Some (col, kind)
+            | _ -> None)
+        |> Map.ofList
+
+    /// Rewrite every PII-typed column's cell to a coherent fake value, seeded from
+    /// the row's identity (referential consistency + determinism). Columns with no
+    /// PII typing are untouched; a `Reference`/`None` typing is a no-op; a cell
+    /// absent from the row (NULL) stays absent. Empty PII set → the dataset
+    /// verbatim (byte-identical to no realization).
+    let realizePii
+        (catalog: Catalog)
+        (correction: Correction)
+        (dataset: Map<SsKey, StaticRow list>)
+        : Map<SsKey, StaticRow list> =
+        let pii = piiColumns correction
+        if Map.isEmpty pii then dataset
+        else
+            // attribute → (logical Name = the StaticRow.Values key, PiiKind).
+            let piiByName : (Name * PiiKind) list =
+                Catalog.allKinds catalog
+                |> List.collect (fun k -> k.Attributes)
+                |> List.choose (fun a ->
+                    match Map.tryFind a.SsKey pii with
+                    | Some kind -> Some (a.Name, kind)
+                    | None      -> Option.None)
+            if List.isEmpty piiByName then dataset
+            else
+                dataset
+                |> Map.map (fun _ rows ->
+                    rows
+                    |> List.map (fun row ->
+                        let faker = fakerOf (seedOf row.Identifier)
+                        let values =
+                            piiByName
+                            |> List.fold (fun (acc: Map<Name, string>) (colName, kind) ->
+                                if Map.containsKey colName acc then
+                                    match fieldOf faker kind with
+                                    | Some v      -> Map.add colName v acc
+                                    | Option.None -> acc
+                                else acc) row.Values
+                        { row with Values = values }))

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -61,6 +61,7 @@
     <Compile Include="ReportRun.fs" />
     <Compile Include="TransferSpec.fs" />
     <Compile Include="ModelResolution.fs" />
+    <Compile Include="FakerRealization.fs" />
     <Compile Include="SyntheticLoadRun.fs" />
     <Compile Include="ProfileCaptureRun.fs" />
     <Compile Include="MovementSpec.fs" />
@@ -74,6 +75,10 @@
   <ItemGroup>
     <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <!-- F2 (THE_SYNTHETIC_DATA_FUZZING §5) — the Faker boundary realization.
+         Bogus is RNG-based, so it lives OUTSIDE Core (T1); FakerRealization seeds
+         it deterministically per row identity, so the realization is reproducible. -->
+    <PackageReference Include="Bogus" Version="35.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -392,6 +392,41 @@ module Transfer =
                         with _ -> ()
         }
 
+    /// D — the STREAMING arm's remap source for the data-leg compensating-undo.
+    /// The materialized `writePlan` reverts from an in-memory `PackedSurrogateRemap`;
+    /// the estate-scale streaming path's durable record of every sink-minted key is
+    /// the off-box `CaptureJournal` (NDJSON, only fully-committed chunks appended —
+    /// a crashed chunk is neither journaled nor captured). Replay every journaled
+    /// chunk's `(source → assigned)` pairs back into a fresh remap, mapping each
+    /// record's root-string `Kind` to the catalog's `SsKey` (the inverse of the
+    /// `SsKey.rootOriginal` the journal stores). The per-record capture mirrors
+    /// `CaptureJournal.spec`'s Apply (the journal grain's effectful remap fold the
+    /// resume path uses); reconstructed here over ALL kinds rather than one at a time.
+    let private replayJournalToRemap (catalog: Catalog) (journal: CaptureJournal) : PackedSurrogateRemap =
+        let remap = PackedSurrogateRemap.create ()
+        let rootToKey =
+            Catalog.allKinds catalog
+            |> List.map (fun k -> SsKey.rootOriginal k.SsKey, k.SsKey)
+            |> Map.ofList
+        for KeyValue (_, record) in CaptureJournal.load journal do
+            match Map.tryFind record.Kind rootToKey with
+            | Some ssKey -> record.Pairs |> Array.iter (fun p -> if p.Length = 2 then PackedSurrogateRemap.capture ssKey p[0] p[1] remap)
+            | None -> ()
+        remap
+
+    /// D — act on the streaming reverse-leg's compensating-undo after a partial
+    /// load: reconstruct the remap from the journal, then run the SAME M23
+    /// `buildRevertScript` + `runRevert` the materialized arm runs (only the remap
+    /// source differs — journal-replayed vs in-memory). A `None` journal is a safe
+    /// no-op: with no journal there are no recorded captures to revert (streaming
+    /// execute requires `--journal` anyway, so on a real run `journal` is `Some`).
+    let private runRevertFromJournal (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) (journal: CaptureJournal option) (autoRevert: bool) (revertDir: string option) : Task<unit> =
+        task {
+            match journal with
+            | Some j -> do! runRevert sink autoRevert revertDir (buildRevertScript catalog plan (replayJournalToRemap catalog j))
+            | None   -> ()
+        }
+
     let private writePlan (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) (autoRevert: bool) (revertArtifactDir: string option) : Task<(SsKey * UnresolvedReference) list * LaneDescent list> =
         task {
             let assignedBySinkKinds =
@@ -1829,6 +1864,13 @@ module Transfer =
         (sinkContract: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         (journalDirectory: string option)
+        // D — the streaming arm of the data-leg compensating-undo (M23 on the
+        // estate-scale path). On a mid-stream crash the partial sink-minted rows
+        // are reverted (autoRevert) or scripted (revertDir), reconstructing the
+        // remap from the off-box journal. Both inert (false / None) → byte-identical
+        // to the pre-D streaming realization.
+        (autoRevert: bool)
+        (revertDir: string option)
         : Task<Result<TransferReport>> =
         task {
             let diff = CatalogDiff.between sourceContract sinkContract
@@ -1964,7 +2006,31 @@ module Transfer =
                                         (List.length addressDrift)
                                         (addressDrift |> List.truncate 1 |> List.map (fun f -> System.IO.Path.GetFileName f |> nonNull) |> String.concat ", ")))
                         else
-                        match! writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds with
+                        // D — the streaming data-leg compensating-undo. A mid-stream
+                        // chunk crash RE-RAISES out of `writePlanStreaming` (its
+                        // `RunAborted (_, Some ex)` branch re-throws — unlike the
+                        // materialized arm, whose own failure point is the same
+                        // exception branch but is INSIDE `writePlan`). The streaming
+                        // failure manifests as a thrown exception, NOT a returned
+                        // `Result.failure` — so the compensation hangs off a `with`,
+                        // not the `Error` match arm. Replay the off-box journal into a
+                        // remap and run the SAME M23 revert the materialized arm runs,
+                        // then re-raise the ORIGINAL crash. A NAMED `Error es` (the
+                        // resume source-drift refusal) returns below WITHOUT reverting:
+                        // that run only skipped/replayed journaled chunks and wrote
+                        // nothing new, so deleting by captured key would destroy
+                        // PRIOR-run committed rows — the one thing the undo must never do.
+                        let! streamed =
+                            task {
+                                try
+                                    let! r = writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds
+                                    return r
+                                with ex ->
+                                    do! runRevertFromJournal sink sinkContract plan journal autoRevert revertDir
+                                    System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                                    return Unchecked.defaultof<_>
+                            }
+                        match streamed with
                         | Error es -> return Result.failure es
                         | Ok (totals, skips, descents) ->
                             let kinds =
@@ -2008,7 +2074,10 @@ module Transfer =
         (sinkContract: Catalog)
         (journalDirectory: string option)
         : Task<Result<TransferReport>> =
-        runStreamingReconcilingWithRenames mode allowCdc false source sink sourceContract sinkContract Map.empty journalDirectory
+        // The straight load supplies the inert revert levers (`false None`) the
+        // caller did not name — D's compensating-undo is reachable only through the
+        // reconciling / reverse-leg faces that carry the per-environment policy.
+        runStreamingReconcilingWithRenames mode allowCdc false source sink sourceContract sinkContract Map.empty journalDirectory false None
 
     /// The streaming reverse leg through the `TransferConnections`
     /// apparatus (D9) — the bounded-memory sibling of
@@ -2030,6 +2099,11 @@ module Transfer =
         (logicalSourceContract: Catalog)
         (physicalSinkContract: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
+        // D — the per-environment revert policy, collapsed at the RunFaces face
+        // (`RevertPolicy.toEngine`) to (autoRevert, dir); previously only the
+        // materialized reverse-leg face consumed them.
+        (autoRevert: bool)
+        (revertDir: string option)
         : Task<Result<TransferReport>> =
         task {
             match! ConnectionResolver.openSubstrate connections.Source with
@@ -2040,7 +2114,7 @@ module Transfer =
                 | Error es -> return Result.failure es
                 | Ok sink ->
                     use sink = sink
-                    return! runStreamingReconcilingWithRenames mode allowCdc allowDrops source sink logicalSourceContract physicalSinkContract reconciliation journalDirectory
+                    return! runStreamingReconcilingWithRenames mode allowCdc allowDrops source sink logicalSourceContract physicalSinkContract reconciliation journalDirectory autoRevert revertDir
         }
 
     /// Run a *reconciling* Transfer — the operator's headline case

--- a/sidecar/projection/src/Projection.Targets.Json/CorrectionCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CorrectionCodec.fs
@@ -1,0 +1,154 @@
+namespace Projection.Targets.Json
+
+open System.Text.Json
+open Projection.Core
+
+/// Round-trippable `Correction ↔ JSON` codec — the durable, blessed correction
+/// artifact (THE_SYNTHETIC_DATA_FUZZING.md §2.4, slice F0b). The propose step
+/// (`synth-correct`) writes it; the operator reviews / edits / BLESSES it; the
+/// synthetic flow reads it (`correction: file:<path>`). Sibling to `ProfileCodec`
+/// — the `Profile` (fidelity evidence) and the `Correction` (blessed intent)
+/// both persist by the same realize/ingest idiom.
+///
+/// **Total** — every `CorrectionEntry` variant + every `PiiKind` / `ValueFidelityMode`
+/// arm is encoded (the inventory is the totality contract; a missed arm would be
+/// a silent drop, forbidden). **Deterministic (T1)** — fixed write order, `SsKey`
+/// via `SsKey.serialize`. **Re-validating (A39)** — decode rebuilds through
+/// `Correction.create`, so a decoded artifact re-proves the
+/// no-conflicting-double-correction invariant and surfaces a `Result<Correction>`
+/// (a hand-edited artifact with a duplicated fidelity correction is REFUSED on
+/// load, not silently last-write-wins).
+///
+/// **The universal law** (`∀ c. deserialize (serialize c) = Ok c`) is the codec
+/// discipline's keystone, tested over a constructed-valid generator.
+[<RequireQualifiedAccess>]
+module CorrectionCodec =
+
+    [<Literal>]
+    let version : int = 1
+
+    // ======================================================================
+    // ENCODE
+    // ======================================================================
+
+    let private wSsKeyVal (jw: Utf8JsonWriter) (k: SsKey) : unit = jw.WriteStringValue (SsKey.serialize k)
+
+    let private piiKindString (kind: PiiKind) : string =
+        match kind with
+        | PiiKind.None       -> "none"
+        | PiiKind.Email      -> "email"
+        | PiiKind.PersonName -> "personName"
+        | PiiKind.Phone      -> "phone"
+        | PiiKind.Address    -> "address"
+        | PiiKind.FreeText   -> "freeText"
+        | PiiKind.Reference  -> "reference"
+
+    let private fidelityString (mode: ValueFidelityMode) : string =
+        match mode with
+        | ValueFidelityMode.Preserve   -> "preserve"
+        | ValueFidelityMode.Synthesize -> "synthesize"
+
+    let private wEntry (jw: Utf8JsonWriter) (entry: CorrectionEntry) : unit =
+        jw.WriteStartObject()
+        match entry with
+        | CorrectionEntry.Pii (col, kind) ->
+            jw.WriteString("entry", "pii")
+            jw.WritePropertyName "column"
+            wSsKeyVal jw col
+            jw.WriteString("pii", piiKindString kind)
+        | CorrectionEntry.Fidelity (col, mode) ->
+            jw.WriteString("entry", "fidelity")
+            jw.WritePropertyName "column"
+            wSsKeyVal jw col
+            jw.WriteString("mode", fidelityString mode)
+        jw.WriteEndObject()
+
+    let private wCorrection (jw: Utf8JsonWriter) (correction: Correction) : unit =
+        jw.WriteStartObject()
+        jw.WriteNumber("version", version)
+        jw.WritePropertyName "entries"
+        jw.WriteStartArray()
+        for entry in Correction.entries correction do wEntry jw entry
+        jw.WriteEndArray()
+        jw.WriteEndObject()
+
+    /// `Correction → JSON`. Deterministic (T1).
+    let serialize (correction: Correction) : string =
+        JsonWriting.writeToString (fun jw -> wCorrection jw correction)
+
+    // ======================================================================
+    // DECODE — rebuilt through `Correction.create` (A39 re-validation).
+    // ======================================================================
+
+    let private fail (code: string) (msg: string) : Result<'a> =
+        Result.failureOf (ValidationError.create code msg)
+
+    let private asString (el: JsonElement) : Result<string> =
+        if el.ValueKind = JsonValueKind.String then
+            match el.GetString() with
+            | null -> fail "correctionCodec.expectedString" "string element returned null"
+            | s -> Ok s
+        else fail "correctionCodec.expectedString" (sprintf "expected string, got %A" el.ValueKind)
+
+    let private prop (el: JsonElement) (name: string) : Result<JsonElement> =
+        match el.TryGetProperty name with
+        | true, v -> Ok v
+        | _ -> fail "correctionCodec.missingField" (sprintf "missing field '%s'" name)
+
+    let private field (el: JsonElement) (name: string) (read: JsonElement -> Result<'a>) : Result<'a> =
+        prop el name |> Result.bind read
+
+    let private listField (el: JsonElement) (name: string) (read: JsonElement -> Result<'a>) : Result<'a list> =
+        match el.TryGetProperty name with
+        | true, v when v.ValueKind = JsonValueKind.Array ->
+            v.EnumerateArray() |> Seq.map read |> Result.collect
+        | true, v -> fail "correctionCodec.expectedArray" (sprintf "field '%s': expected array, got %A" name v.ValueKind)
+        | _ -> Ok []
+
+    let private readSsKey (el: JsonElement) : Result<SsKey> =
+        asString el |> Result.bind SsKey.deserialize
+
+    let private readPiiKind (el: JsonElement) : Result<PiiKind> =
+        asString el
+        |> Result.bind (function
+            | "none"       -> Ok PiiKind.None
+            | "email"      -> Ok PiiKind.Email
+            | "personName" -> Ok PiiKind.PersonName
+            | "phone"      -> Ok PiiKind.Phone
+            | "address"    -> Ok PiiKind.Address
+            | "freeText"   -> Ok PiiKind.FreeText
+            | "reference"  -> Ok PiiKind.Reference
+            | o -> fail "correctionCodec.piiKind.unknown" (sprintf "unknown PiiKind '%s'" o))
+
+    let private readFidelity (el: JsonElement) : Result<ValueFidelityMode> =
+        asString el
+        |> Result.bind (function
+            | "preserve"   -> Ok ValueFidelityMode.Preserve
+            | "synthesize" -> Ok ValueFidelityMode.Synthesize
+            | o -> fail "correctionCodec.fidelity.unknown" (sprintf "unknown ValueFidelityMode '%s'" o))
+
+    let private readEntry (el: JsonElement) : Result<CorrectionEntry> =
+        field el "entry" asString
+        |> Result.bind (function
+            | "pii" ->
+                field el "column" readSsKey
+                |> Result.bind (fun col ->
+                    field el "pii" readPiiKind
+                    |> Result.map (fun kind -> CorrectionEntry.Pii (col, kind)))
+            | "fidelity" ->
+                field el "column" readSsKey
+                |> Result.bind (fun col ->
+                    field el "mode" readFidelity
+                    |> Result.map (fun mode -> CorrectionEntry.Fidelity (col, mode)))
+            | o -> fail "correctionCodec.entry.unknown" (sprintf "unknown correction entry '%s'" o))
+
+    let private readCorrection (el: JsonElement) : Result<Correction> =
+        listField el "entries" readEntry |> Result.bind Correction.create
+
+    /// `JSON → Correction`. Total parser; re-proves the conflict invariant.
+    let deserialize (json: string) : Result<Correction> =
+        let parsed = try Ok (JsonDocument.Parse json) with ex -> fail "correctionCodec.parse" ex.Message
+        parsed
+        |> Result.bind (fun doc ->
+            use doc = doc
+            readCorrection doc.RootElement)

--- a/sidecar/projection/src/Projection.Targets.Json/CorrectionCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CorrectionCodec.fs
@@ -1,5 +1,6 @@
 namespace Projection.Targets.Json
 
+open System.Globalization
 open System.Text.Json
 open Projection.Core
 
@@ -48,6 +49,19 @@ module CorrectionCodec =
         | ValueFidelityMode.Preserve   -> "preserve"
         | ValueFidelityMode.Synthesize -> "synthesize"
 
+    let private inv (d: decimal) : string = d.ToString(CultureInfo.InvariantCulture)
+
+    let private wVolumeTarget (jw: Utf8JsonWriter) (target: VolumeTarget) : unit =
+        jw.WriteStartObject()
+        match target with
+        | VolumeTarget.Absolute rows ->
+            jw.WriteString("target", "absolute")
+            jw.WriteNumber("rows", rows)
+        | VolumeTarget.Multiplier factor ->
+            jw.WriteString("target", "multiplier")
+            jw.WriteString("factor", inv factor)
+        jw.WriteEndObject()
+
     let private wEntry (jw: Utf8JsonWriter) (entry: CorrectionEntry) : unit =
         jw.WriteStartObject()
         match entry with
@@ -61,6 +75,12 @@ module CorrectionCodec =
             jw.WritePropertyName "column"
             wSsKeyVal jw col
             jw.WriteString("mode", fidelityString mode)
+        | CorrectionEntry.Volume (kind, target) ->
+            jw.WriteString("entry", "volume")
+            jw.WritePropertyName "kind"
+            wSsKeyVal jw kind
+            jw.WritePropertyName "target"
+            wVolumeTarget jw target
         jw.WriteEndObject()
 
     let private wCorrection (jw: Utf8JsonWriter) (correction: Correction) : unit =
@@ -127,6 +147,27 @@ module CorrectionCodec =
             | "synthesize" -> Ok ValueFidelityMode.Synthesize
             | o -> fail "correctionCodec.fidelity.unknown" (sprintf "unknown ValueFidelityMode '%s'" o))
 
+    let private asInt (el: JsonElement) : Result<int> =
+        if el.ValueKind = JsonValueKind.Number then
+            match el.TryGetInt32() with
+            | true, n -> Ok n
+            | _ -> fail "correctionCodec.expectedInt" "number is not an int32"
+        else fail "correctionCodec.expectedInt" (sprintf "expected number, got %A" el.ValueKind)
+
+    let private asDecimal (el: JsonElement) : Result<decimal> =
+        asString el
+        |> Result.bind (fun s ->
+            match System.Decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture) with
+            | true, d -> Ok d
+            | _ -> fail "correctionCodec.expectedDecimal" (sprintf "not an invariant-culture decimal: '%s'" s))
+
+    let private readVolumeTarget (el: JsonElement) : Result<VolumeTarget> =
+        field el "target" asString
+        |> Result.bind (function
+            | "absolute"   -> field el "rows" asInt |> Result.map VolumeTarget.Absolute
+            | "multiplier" -> field el "factor" asDecimal |> Result.map VolumeTarget.Multiplier
+            | o -> fail "correctionCodec.volumeTarget.unknown" (sprintf "unknown VolumeTarget '%s'" o))
+
     let private readEntry (el: JsonElement) : Result<CorrectionEntry> =
         field el "entry" asString
         |> Result.bind (function
@@ -140,6 +181,11 @@ module CorrectionCodec =
                 |> Result.bind (fun col ->
                     field el "mode" readFidelity
                     |> Result.map (fun mode -> CorrectionEntry.Fidelity (col, mode)))
+            | "volume" ->
+                field el "kind" readSsKey
+                |> Result.bind (fun kind ->
+                    field el "target" readVolumeTarget
+                    |> Result.map (fun target -> CorrectionEntry.Volume (kind, target)))
             | o -> fail "correctionCodec.entry.unknown" (sprintf "unknown correction entry '%s'" o))
 
     let private readCorrection (el: JsonElement) : Result<Correction> =

--- a/sidecar/projection/src/Projection.Targets.Json/Projection.Targets.Json.fsproj
+++ b/sidecar/projection/src/Projection.Targets.Json/Projection.Targets.Json.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="JsonEmitter.fs" />
     <Compile Include="CatalogCodec.fs" />
     <Compile Include="ProfileCodec.fs" />
+    <Compile Include="CorrectionCodec.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sidecar/projection/tests/Projection.Tests/CorrectionCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CorrectionCodecTests.fs
@@ -56,6 +56,13 @@ let ``round-trip: a mixed multi-entry correction (Pii + Fidelity, distinct colum
     Assert.True(roundTrips (corr entries))
 
 [<Fact>]
+let ``round-trip: both VolumeTarget arms (absolute + multiplier)`` () =
+    let entries =
+        [ CorrectionEntry.Volume (aKey 0, VolumeTarget.Absolute 100)
+          CorrectionEntry.Volume (aKey 1, VolumeTarget.Multiplier 2.5M) ]
+    Assert.True(roundTrips (corr entries))
+
+[<Fact>]
 let ``A39: decode REFUSES a hand-edited artifact with a conflicting double-correction`` () =
     // Two pii entries for the SAME column — a valid `serialize` could never
     // produce this (the smart ctor forbids it), but a hand edit can. Decode
@@ -97,7 +104,11 @@ let private genEntry (i: int) : Gen<CorrectionEntry> =
                           PiiKind.Address; PiiKind.FreeText; PiiKind.Reference ]
                 return CorrectionEntry.Pii (col, k) }
           gen { let! m = Gen.elements [ ValueFidelityMode.Preserve; ValueFidelityMode.Synthesize ]
-                return CorrectionEntry.Fidelity (col, m) } ]
+                return CorrectionEntry.Fidelity (col, m) }
+          gen { let! rows = Gen.choose (0, 100000)
+                return CorrectionEntry.Volume (col, VolumeTarget.Absolute rows) }
+          gen { let! r = Gen.choose (1, 500)
+                return CorrectionEntry.Volume (col, VolumeTarget.Multiplier (decimal r / 10M)) } ]
 
 // Distinct column index per entry → conflict-free by construction, so
 // `Correction.create` always succeeds (the law is over VALID corrections).

--- a/sidecar/projection/tests/Projection.Tests/CorrectionCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CorrectionCodecTests.fs
@@ -1,0 +1,116 @@
+module Projection.Tests.CorrectionCodecTests
+
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open Projection.Core
+open Projection.Targets.Json
+
+// THE_SYNTHETIC_DATA_FUZZING.md §2.4 (slice F0b) — the blessed correction
+// artifact's durable round-trip law `∀ c. deserialize (serialize c) = Ok c`
+// (the codec discipline over a constructed-valid generator), example anchors
+// covering every CorrectionEntry / PiiKind / ValueFidelityMode arm, and the
+// A39 decode re-validation (a hand-edited artifact with a conflicting double
+// correction is REFUSED on load).
+
+let private value (r: Result<'a>) : 'a = Result.value r
+let private aKey (i: int) : SsKey = SsKey.synthesizedComposite "CORR_ATTR" [ string i ] |> value
+
+let private corr (entries: CorrectionEntry list) : Correction = Correction.create entries |> value
+
+let private roundTrips (c: Correction) : bool =
+    match CorrectionCodec.deserialize (CorrectionCodec.serialize c) with
+    | Ok c' -> c' = c
+    | Error _ -> false
+
+// ---------------------------------------------------------------------------
+// Example anchors — pinpoint which arm regressed.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``round-trip: the empty correction`` () =
+    Assert.True(roundTrips Correction.empty)
+
+[<Fact>]
+let ``round-trip: every PiiKind arm`` () =
+    let kinds =
+        [ PiiKind.None; PiiKind.Email; PiiKind.PersonName; PiiKind.Phone
+          PiiKind.Address; PiiKind.FreeText; PiiKind.Reference ]
+    // distinct column per entry → no fidelity-class conflict.
+    let entries = kinds |> List.mapi (fun i k -> CorrectionEntry.Pii (aKey i, k))
+    Assert.True(roundTrips (corr entries))
+
+[<Fact>]
+let ``round-trip: every ValueFidelityMode arm`` () =
+    let entries =
+        [ CorrectionEntry.Fidelity (aKey 0, ValueFidelityMode.Preserve)
+          CorrectionEntry.Fidelity (aKey 1, ValueFidelityMode.Synthesize) ]
+    Assert.True(roundTrips (corr entries))
+
+[<Fact>]
+let ``round-trip: a mixed multi-entry correction (Pii + Fidelity, distinct columns)`` () =
+    let entries =
+        [ CorrectionEntry.Pii (aKey 0, PiiKind.Email)
+          CorrectionEntry.Fidelity (aKey 1, ValueFidelityMode.Preserve)
+          CorrectionEntry.Pii (aKey 2, PiiKind.Reference) ]
+    Assert.True(roundTrips (corr entries))
+
+[<Fact>]
+let ``A39: decode REFUSES a hand-edited artifact with a conflicting double-correction`` () =
+    // Two pii entries for the SAME column — a valid `serialize` could never
+    // produce this (the smart ctor forbids it), but a hand edit can. Decode
+    // must re-prove the invariant and refuse.
+    let col = SsKey.serialize (aKey 0)
+    let json =
+        sprintf
+            """{"version":1,"entries":[{"entry":"pii","column":"%s","pii":"email"},{"entry":"pii","column":"%s","pii":"phone"}]}"""
+            col col
+    match CorrectionCodec.deserialize json with
+    | Ok _ -> Assert.Fail("expected a synthetic.correction.conflict refusal on decode")
+    | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "synthetic.correction.conflict")
+
+[<Fact>]
+let ``decode REFUSES an unknown entry tag (no silent drop)`` () =
+    let col = SsKey.serialize (aKey 0)
+    let json = sprintf """{"version":1,"entries":[{"entry":"coverage","column":"%s"}]}""" col
+    match CorrectionCodec.deserialize json with
+    | Ok _ -> Assert.Fail("expected an unknown-entry refusal")
+    | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "correctionCodec.entry.unknown")
+
+// ---------------------------------------------------------------------------
+// The universal law over a constructed-valid generator.
+// ---------------------------------------------------------------------------
+
+let rec private seqGen (gs: Gen<'a> list) : Gen<'a list> =
+    match gs with
+    | [] -> Gen.constant []
+    | g :: rest -> gen { let! x = g
+                         let! xs = seqGen rest
+                         return x :: xs }
+
+let private genEntry (i: int) : Gen<CorrectionEntry> =
+    let col = aKey i
+    Gen.oneof
+        [ gen { let! k =
+                    Gen.elements
+                        [ PiiKind.None; PiiKind.Email; PiiKind.PersonName; PiiKind.Phone
+                          PiiKind.Address; PiiKind.FreeText; PiiKind.Reference ]
+                return CorrectionEntry.Pii (col, k) }
+          gen { let! m = Gen.elements [ ValueFidelityMode.Preserve; ValueFidelityMode.Synthesize ]
+                return CorrectionEntry.Fidelity (col, m) } ]
+
+// Distinct column index per entry → conflict-free by construction, so
+// `Correction.create` always succeeds (the law is over VALID corrections).
+let private genCorrection : Gen<Correction> =
+    gen {
+        let! n = Gen.choose (0, 8)
+        let! entries = seqGen [ for i in 0 .. n - 1 -> genEntry i ]
+        return corr entries
+    }
+
+type CorrectionArb =
+    static member Correction() : Arbitrary<Correction> = Arb.fromGen genCorrection
+
+[<Property(Arbitrary = [| typeof<CorrectionArb> |])>]
+let ``law: deserialize (serialize c) = Ok c`` (c: Correction) : bool =
+    roundTrips c

--- a/sidecar/projection/tests/Projection.Tests/FakerRealizationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FakerRealizationTests.fs
@@ -1,0 +1,78 @@
+module Projection.Tests.FakerRealizationTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.IRBuilders
+open Projection.Tests.Fixtures
+
+// THE_SYNTHETIC_DATA_FUZZING.md §5 (slice F2) — the Faker boundary realization:
+// PII-typed columns are rewritten to coherent realistic values, seeded per row
+// identity (referential consistency + determinism); Bogus stays OUTSIDE Core.
+
+let private name (s: string) : Name = Name.create s |> Result.value
+let private mkOk r = match r with Ok v -> v | Error es -> invalidOp (sprintf "fixture: %A" (es: ValidationError list))
+
+let private attr (key: SsKey) (logical: string) : Attribute =
+    { Attribute.create key (name logical) Text with
+        Column = ColumnRealization.create (logical.ToUpperInvariant()) true |> Result.value }
+
+let private emailKey  = attrKey ["P"; "Email"]
+let private nameKey   = attrKey ["P"; "FullName"]
+let private statusKey = attrKey ["P"; "Status"]
+let private kKey      = kindKey ["P"]
+
+let private catalog : Catalog =
+    let person =
+        Kind.create kKey (name "Person") (mkTableId "dbo" "PERSON")
+            [ attr emailKey "Email"; attr nameKey "FullName"; attr statusKey "Status" ]
+    Catalog.create [ mkModule (modKey "M") (name "M") [ person ] ] [] |> mkOk
+
+let private correction : Correction =
+    Correction.create
+        [ CorrectionEntry.Pii (emailKey, PiiKind.Email)
+          CorrectionEntry.Pii (nameKey,  PiiKind.PersonName) ] |> mkOk
+
+let private rowId (i: int) : SsKey = SsKey.synthesizedComposite "FK_ROW" [ string i ] |> mkOk
+
+let private dataset : Map<SsKey, StaticRow list> =
+    let row i =
+        { Identifier = rowId i
+          Values = Map.ofList [ name "Email", "syn:x:0"; name "FullName", "syn:y:0"; name "Status", "Active" ] }
+    Map.ofList [ kKey, [ row 0; row 1; row 2 ] ]
+
+let private valuesOf (m: Map<SsKey, StaticRow list>) (col: string) : string list =
+    m.[kKey] |> List.choose (fun (r: StaticRow) -> Map.tryFind (name col) r.Values)
+
+[<Fact>]
+let ``F2: PII columns realize to Faker shapes (email has an at-sign, name non-empty); non-PII untouched`` () =
+    let realized = FakerRealization.realizePii catalog correction dataset
+    Assert.All(valuesOf realized "Email",    fun e -> Assert.Contains("@", e))
+    Assert.All(valuesOf realized "FullName", fun n -> Assert.False(System.String.IsNullOrWhiteSpace n))
+    Assert.All(valuesOf realized "Status",   fun s -> Assert.Equal("Active", s))   // non-PII untouched
+
+[<Fact>]
+let ``F2: privacy — the synthesized token is replaced (no syn: token survives in a PII column)`` () =
+    let realized = FakerRealization.realizePii catalog correction dataset
+    Assert.All(valuesOf realized "Email",    fun e -> Assert.False(e.StartsWith "syn:"))
+    Assert.All(valuesOf realized "FullName", fun n -> Assert.False(n.StartsWith "syn:"))
+
+[<Fact>]
+let ``F2: determinism — the same dataset realizes byte-identically`` () =
+    let a = FakerRealization.realizePii catalog correction dataset
+    let b = FakerRealization.realizePii catalog correction dataset
+    Assert.Equal<Map<SsKey, StaticRow list>>(a, b)
+
+[<Fact>]
+let ``F2: distinct rows (distinct seeds) yield distinct fake identities`` () =
+    let realized = FakerRealization.realizePii catalog correction dataset
+    let pairs =
+        realized.[kKey]
+        |> List.map (fun r -> Map.find (name "Email") r.Values, Map.find (name "FullName") r.Values)
+    Assert.Equal(3, pairs.Length)
+    Assert.True(pairs |> List.distinct |> List.length >= 2, "distinct rows should yield distinct fake identities")
+
+[<Fact>]
+let ``F2: an empty correction returns the dataset verbatim`` () =
+    let realized = FakerRealization.realizePii catalog Correction.empty dataset
+    Assert.Equal<Map<SsKey, StaticRow list>>(dataset, realized)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -129,6 +129,7 @@
     <Compile Include="AttributeDistributionTests.fs" />
     <Compile Include="SyntheticDataTests.fs" />
     <Compile Include="SyntheticCorrectionTests.fs" />
+    <Compile Include="FakerRealizationTests.fs" />
     <Compile Include="PolicyTests.fs" />
     <Compile Include="PolicyExprTests.fs" />
     <Compile Include="VersionedPolicyTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -304,6 +304,7 @@
     <Compile Include="JsonEmitterTests.fs" />
     <Compile Include="CatalogCodecTests.fs" />
     <Compile Include="ProfileCodecTests.fs" />
+    <Compile Include="CorrectionCodecTests.fs" />
     <Compile Include="DistributionsEmitterTests.fs" />
     <Compile Include="SiblingEmitterContractTests.fs" />
     <Compile Include="DiagnosticsEndToEndTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -128,6 +128,7 @@
     <Compile Include="ProfileTests.fs" />
     <Compile Include="AttributeDistributionTests.fs" />
     <Compile Include="SyntheticDataTests.fs" />
+    <Compile Include="SyntheticCorrectionTests.fs" />
     <Compile Include="PolicyTests.fs" />
     <Compile Include="PolicyExprTests.fs" />
     <Compile Include="VersionedPolicyTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegStreamingTests.fs
@@ -201,7 +201,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.Execute true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                            logicalContract physicalContract this.reconcileCustomerByEmail None false None
                     let report = ReverseLegFixtures.value reportR
                     Assert.Empty(report.SkippedReferences)
                     Assert.Empty(report.UnmatchedIdentities)
@@ -243,7 +243,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.Execute true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                            logicalContract physicalContract this.reconcileCustomerByEmail None false None
                     // AC-I5 / NM-31 on the streaming arm: a PRE-write refusal by
                     // name, not a post-write drop.
                     match reportR with
@@ -283,7 +283,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.DryRun true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail None
+                            logicalContract physicalContract this.reconcileCustomerByEmail None false None
                     let report = ReverseLegFixtures.value reportR
                     Assert.Equal(Transfer.DryRun, report.Mode)
 

--- a/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
@@ -1,0 +1,108 @@
+module Projection.Tests.SyntheticCorrectionTests
+
+open Xunit
+open Projection.Core
+open Projection.Tests.IRBuilders
+open Projection.Tests.Fixtures
+
+// ---------------------------------------------------------------------------
+// THE_SYNTHETIC_DATA_FUZZING.md §2 / §2.3 / §6 — slice F0, the blessed
+// correction-artifact Core substrate. The smart-ctor conflict refusal, the
+// pure `Profile ⊕ Correction` fold onto `SyntheticConfig` (PII typing +
+// fidelity overrides → the existing Preserve/Synthesize sets, ZERO σ change),
+// the empty-correction identity, drift-by-SsKey no-op, and order-independence.
+// ---------------------------------------------------------------------------
+
+let private name (s: string) : Name = Name.create s |> Result.value
+
+let private mkOk r =
+    match r with
+    | Ok v -> v
+    | Error es ->
+        let codes = es |> List.map (fun (e: ValidationError) -> e.Code) |> String.concat ", "
+        invalidOp (sprintf "fixture construction failed: %s" codes)
+
+let private attr (key: SsKey) (logical: string) : Attribute =
+    { Attribute.create key (name logical) Text with
+        Column = ColumnRealization.create (logical.ToUpperInvariant()) true |> Result.value }
+
+let private emailKey  = attrKey ["C"; "Email"]
+let private nameKey   = attrKey ["C"; "FullName"]
+let private statusKey = attrKey ["C"; "Status"]
+let private absentKey = attrKey ["C"; "Ghost"]   // deliberately NOT in the catalog
+
+let private catalog : Catalog =
+    let customer =
+        Kind.create (kindKey ["C"]) (name "Customer") (mkTableId "dbo" "CUSTOMER")
+            [ attr emailKey  "Email"
+              attr nameKey   "FullName"
+              attr statusKey "Status" ]
+    Catalog.create [ mkModule (modKey "M") (name "M") [ customer ] ] [] |> mkOk
+
+[<Fact>]
+let ``F0/§2: an empty correction is the identity of applyToConfig`` () =
+    let cfg = SyntheticConfig.defaultConfig
+    let got = Correction.applyToConfig catalog Correction.empty cfg
+    Assert.Equal<Set<string>>(cfg.SynthesizeColumns, got.SynthesizeColumns)
+    Assert.Equal<Set<string>>(cfg.PreserveColumns, got.PreserveColumns)
+    Assert.Equal(cfg.PreserveCardinalityMax, got.PreserveCardinalityMax)
+    Assert.Equal(cfg.Scale, got.Scale)
+
+[<Fact>]
+let ``F0/§2.3: a PII typing (kind <> None) routes the column to Synthesize (never a real value)`` () =
+    let corr = Correction.create [ CorrectionEntry.Pii (emailKey, PiiKind.Email) ] |> mkOk
+    let got = Correction.applyToConfig catalog corr SyntheticConfig.defaultConfig
+    Assert.Contains("Email", got.SynthesizeColumns)
+    Assert.DoesNotContain("Email", got.PreserveColumns)
+
+[<Fact>]
+let ``F0/§2.3: PiiKind.None does not bind (the column is not PII)`` () =
+    let corr = Correction.create [ CorrectionEntry.Pii (emailKey, PiiKind.None) ] |> mkOk
+    let got = Correction.applyToConfig catalog corr SyntheticConfig.defaultConfig
+    Assert.DoesNotContain("Email", got.SynthesizeColumns)
+    Assert.DoesNotContain("Email", got.PreserveColumns)
+
+[<Fact>]
+let ``F0/§2.3: a Fidelity override routes Preserve/Synthesize to the named config sets`` () =
+    let corr =
+        Correction.create
+            [ CorrectionEntry.Fidelity (statusKey, ValueFidelityMode.Preserve)
+              CorrectionEntry.Fidelity (nameKey,   ValueFidelityMode.Synthesize) ]
+        |> mkOk
+    let got = Correction.applyToConfig catalog corr SyntheticConfig.defaultConfig
+    Assert.Contains("Status", got.PreserveColumns)
+    Assert.Contains("FullName", got.SynthesizeColumns)
+
+[<Fact>]
+let ``F0/§2: create refuses a conflicting double-correction in the fidelity class`` () =
+    // Pii + Fidelity on the SAME column both determine fidelity → conflict.
+    match Correction.create
+              [ CorrectionEntry.Pii (emailKey, PiiKind.Email)
+                CorrectionEntry.Fidelity (emailKey, ValueFidelityMode.Preserve) ] with
+    | Ok _ -> Assert.Fail("expected a synthetic.correction.conflict refusal")
+    | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "synthetic.correction.conflict")
+
+[<Fact>]
+let ``F0/§2: create accepts fidelity corrections on DISTINCT columns`` () =
+    let r =
+        Correction.create
+            [ CorrectionEntry.Pii (emailKey, PiiKind.Email)
+              CorrectionEntry.Fidelity (statusKey, ValueFidelityMode.Preserve) ]
+    Assert.True((match r with Ok _ -> true | Error _ -> false))
+
+[<Fact>]
+let ``F0/§6: a correction whose SsKey is absent from the catalog is a no-op (drift-by-SsKey)`` () =
+    let corr = Correction.create [ CorrectionEntry.Pii (absentKey, PiiKind.Email) ] |> mkOk
+    let got = Correction.applyToConfig catalog corr SyntheticConfig.defaultConfig
+    Assert.Empty(got.SynthesizeColumns)
+    Assert.Empty(got.PreserveColumns)
+
+[<Fact>]
+let ``F0/§2.3: applyToConfig is order-independent (corrections are a set of decisions)`` () =
+    let entries =
+        [ CorrectionEntry.Pii (emailKey, PiiKind.Email)
+          CorrectionEntry.Fidelity (statusKey, ValueFidelityMode.Preserve) ]
+    let got1 = Correction.applyToConfig catalog (Correction.create entries |> mkOk) SyntheticConfig.defaultConfig
+    let got2 = Correction.applyToConfig catalog (Correction.create (List.rev entries) |> mkOk) SyntheticConfig.defaultConfig
+    Assert.Equal<Set<string>>(got1.SynthesizeColumns, got2.SynthesizeColumns)
+    Assert.Equal<Set<string>>(got1.PreserveColumns, got2.PreserveColumns)

--- a/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
@@ -132,3 +132,18 @@ let ``F1/§2: a Volume (kind) and a fidelity (column) correction on the same SsK
             [ CorrectionEntry.Volume (emailKey, VolumeTarget.Absolute 10)
               CorrectionEntry.Pii (emailKey, PiiKind.Email) ]
     Assert.True((match r with Ok _ -> true | Error _ -> false))
+
+[<Fact>]
+let ``F0c-propose: heuristic PII typing classifies known stems and leaves the rest unclassified`` () =
+    // The fixture catalog has Email (→ Email), FullName (→ PersonName), Status (→ none).
+    let entries = Correction.entries (CorrectionProposer.propose catalog)
+    Assert.Contains(entries, fun e -> e = CorrectionEntry.Pii (emailKey, PiiKind.Email))
+    Assert.Contains(entries, fun e -> e = CorrectionEntry.Pii (nameKey, PiiKind.PersonName))
+    Assert.DoesNotContain(entries, fun e -> match e with CorrectionEntry.Pii (k, _) -> k = statusKey | _ -> false)
+
+[<Fact>]
+let ``F0c-propose: a proposed correction drives Synthesize for the typed PII columns`` () =
+    let cfg = Correction.applyToConfig catalog (CorrectionProposer.propose catalog) SyntheticConfig.defaultConfig
+    Assert.Contains("Email", cfg.SynthesizeColumns)
+    Assert.Contains("FullName", cfg.SynthesizeColumns)
+    Assert.DoesNotContain("Status", cfg.SynthesizeColumns)

--- a/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticCorrectionTests.fs
@@ -106,3 +106,29 @@ let ``F0/§2.3: applyToConfig is order-independent (corrections are a set of dec
     let got2 = Correction.applyToConfig catalog (Correction.create (List.rev entries) |> mkOk) SyntheticConfig.defaultConfig
     Assert.Equal<Set<string>>(got1.SynthesizeColumns, got2.SynthesizeColumns)
     Assert.Equal<Set<string>>(got1.PreserveColumns, got2.PreserveColumns)
+
+[<Fact>]
+let ``F1/§6.2: a Volume correction lands in VolumeByKind (keyed by kind, no name resolution)`` () =
+    let k = kindKey ["C"]
+    let corr = Correction.create [ CorrectionEntry.Volume (k, VolumeTarget.Absolute 500) ] |> mkOk
+    let got = Correction.applyToConfig catalog corr SyntheticConfig.defaultConfig
+    match Map.tryFind k got.VolumeByKind with
+    | Some (VolumeTarget.Absolute 500) -> ()
+    | other -> Assert.Fail(sprintf "expected Some (Absolute 500), got %A" other)
+
+[<Fact>]
+let ``F1/§2: two Volume corrections for one kind conflict`` () =
+    let k = kindKey ["C"]
+    match Correction.create
+              [ CorrectionEntry.Volume (k, VolumeTarget.Absolute 1)
+                CorrectionEntry.Volume (k, VolumeTarget.Multiplier 2M) ] with
+    | Ok _ -> Assert.Fail("expected a synthetic.correction.conflict refusal")
+    | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "synthetic.correction.conflict")
+
+[<Fact>]
+let ``F1/§2: a Volume (kind) and a fidelity (column) correction on the same SsKey do NOT conflict (distinct classes)`` () =
+    let r =
+        Correction.create
+            [ CorrectionEntry.Volume (emailKey, VolumeTarget.Absolute 10)
+              CorrectionEntry.Pii (emailKey, PiiKind.Email) ]
+    Assert.True((match r with Ok _ -> true | Error _ -> false))

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -137,6 +137,22 @@ let ``volume scales by the configured factor`` () =
     Assert.Equal(125, m.[ordKey].Length)
 
 [<Fact>]
+let ``F1: an Absolute VolumeTarget overrides the profiled RowCount for its kind only`` () =
+    let cfg' = { cfg with VolumeByKind = Map.ofList [ custKey, VolumeTarget.Absolute 7 ] }
+    let m = SyntheticData.generate catalog profile cfg' 1UL
+    Assert.Equal(7, m.[custKey].Length)     // arbitrary scale, decoupled from the observed 100
+    Assert.Equal(250, m.[ordKey].Length)    // untargeted kind keeps the observed RowCount
+
+[<Fact>]
+let ``F1: a Multiplier VolumeTarget scales the observed count and ignores the global Scale`` () =
+    // ordKey is targeted (×2 over observed 250 = 500, Scale ignored); custKey is
+    // untargeted, so it still honors the global Scale (100 × 0.5 = 50).
+    let cfg' = { cfg with Scale = 0.5M; VolumeByKind = Map.ofList [ ordKey, VolumeTarget.Multiplier 2M ] }
+    let m = SyntheticData.generate catalog profile cfg' 1UL
+    Assert.Equal(500, m.[ordKey].Length)
+    Assert.Equal(50, m.[custKey].Length)
+
+[<Fact>]
 let ``PK uniqueness holds across the generated population`` () =
     let m = SyntheticData.generate catalog profile cfg 3UL
     let custIds = valuesOf m custKey "Id"

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -153,6 +153,39 @@ let ``F1: a Multiplier VolumeTarget scales the observed count and ignores the gl
     Assert.Equal(50, m.[custKey].Length)
 
 [<Fact>]
+let ``F5: a skewed ForeignKeySelectivity reproduces the fan-out skew (rank-0 parent dominates)`` () =
+    // A dedicated profile: 3 customers, 300 orders, and a heavily-skewed
+    // selectivity on Order→Customer (rank-0 parent carries 280/300 of the
+    // children). σ maps the count-DESC frequencies onto the synthetic pool BY
+    // RANK, so the rank-0 synthetic customer ("1") must dominate the FK values —
+    // far above the ~100 a uniform draw over 3 parents would give.
+    let f5Profile =
+        { Profile.empty with
+            Columns = [ col custId 3L 0L; col ordId 300L 0L ]
+            ForeignKeySelectivities =
+                [ ForeignKeySelectivity.create ordRefC [ ("a", 280L); ("b", 15L); ("c", 5L) ] 3L false (probe 300L) |> mkOk ] }
+    let m = SyntheticData.generate catalog f5Profile cfg 42UL
+    let custIds = valuesOf m custKey "Id"
+    Assert.Equal(3, custIds.Length)
+    let ordCustVals = valuesOf m ordKey "CustomerId"
+    Assert.Equal(300, ordCustVals.Length)                       // no null budget → every FK drawn
+    let top = List.head custIds                                  // rank-0 synthetic parent
+    let topCount = ordCustVals |> List.filter (fun v -> v = top) |> List.length
+    Assert.True(topCount > 200, sprintf "expected the rank-0 parent to dominate (>200/300), got %d" topCount)
+
+[<Fact>]
+let ``F5: with no selectivity evidence the FK draw stays uniform (no parent dominates)`` () =
+    // The same shape WITHOUT a selectivity: the uniform draw spreads ~evenly, so
+    // no single parent approaches the skewed case's dominance — the byte-identical
+    // pre-F5 behavior holds when the evidence is absent.
+    let noSelProfile =
+        { Profile.empty with Columns = [ col custId 3L 0L; col ordId 300L 0L ] }
+    let m = SyntheticData.generate catalog noSelProfile cfg 42UL
+    let ordCustVals = valuesOf m ordKey "CustomerId"
+    let maxShare = [ "1"; "2"; "3" ] |> List.map (fun p -> ordCustVals |> List.filter (fun v -> v = p) |> List.length) |> List.max
+    Assert.True(maxShare < 160, sprintf "expected a roughly uniform spread (<160/300 for the top parent), got %d" maxShare)
+
+[<Fact>]
 let ``PK uniqueness holds across the generated population`` () =
     let m = SyntheticData.generate catalog profile cfg 3UL
     let custIds = valuesOf m custKey "Id"

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -186,6 +186,45 @@ let ``F5: with no selectivity evidence the FK draw stays uniform (no parent domi
     Assert.True(maxShare < 160, sprintf "expected a roughly uniform spread (<160/300 for the top parent), got %d" maxShare)
 
 [<Fact>]
+let ``F5b: a JointDistribution preserves FK co-occurrence in the synthetic data (correlated, not independent)`` () =
+    // Booking has FKs to two DISTINCT parents (Customer, Region). The joint says
+    // customer-rank-0 ALWAYS co-occurs with region-rank-0 and rank-1 with rank-1
+    // (never crossed). σ must reproduce that pairing on the synthetic keys.
+    let jCustK   = kindKey ["JC"]
+    let jCustIdK = attrKey ["JC"; "Id"]
+    let jRegK    = kindKey ["JR"]
+    let jRegIdK  = attrKey ["JR"; "Id"]
+    let jBkK     = kindKey ["JB"]
+    let jBkIdK   = attrKey ["JB"; "Id"]
+    let jBkCustK = attrKey ["JB"; "CustomerId"]
+    let jBkRegK  = attrKey ["JB"; "RegionId"]
+    let jCustomer = Kind.create jCustK (name "JCustomer") (mkTableId "dbo" "JCUST")   [ attr jCustIdK "Id" Integer true false ]
+    let jRegion   = Kind.create jRegK  (name "JRegion")   (mkTableId "dbo" "JREGION") [ attr jRegIdK  "Id" Integer true false ]
+    let jBooking =
+        { Kind.create jBkK (name "JBooking") (mkTableId "dbo" "JBOOK")
+            [ attr jBkIdK   "Id"         Integer true  false
+              attr jBkCustK "CustomerId" Integer false false
+              attr jBkRegK  "RegionId"   Integer false false ] with
+            References =
+                [ Reference.create (refKey ["JB"; "Customer"]) (name "Customer") jBkCustK jCustK
+                  Reference.create (refKey ["JB"; "Region"])   (name "Region")   jBkRegK  jRegK ] }
+    let jCat = Catalog.create [ mkModule (modKey "JM") (name "JM") [ jCustomer; jRegion; jBooking ] ] [] |> mkOk
+    let jProf =
+        { Profile.empty with
+            Columns = [ col jCustIdK 2L 0L; col jRegIdK 2L 0L; col jBkIdK 200L 0L ]
+            JointDistributions =
+                [ JointDistribution.create jBkK [ jBkCustK; jBkRegK ]
+                    [ ("i:500|i:700", 100L); ("i:501|i:701", 100L) ] 2L false (probe 200L) |> mkOk ] }
+    let m = SyntheticData.generate jCat jProf cfg 7UL
+    let pairs =
+        m.[jBkK] |> List.map (fun r -> Map.tryFind (name "CustomerId") r.Values, Map.tryFind (name "RegionId") r.Values)
+    // Every booking pairs equal-rank parents (both "1" or both "2") — never crossed.
+    Assert.All(pairs, fun (c, rg) -> Assert.Equal(c, rg))
+    // Both correlated combinations actually appear (the draw isn't degenerate).
+    Assert.Contains(pairs, fun p -> p = (Some "1", Some "1"))
+    Assert.Contains(pairs, fun p -> p = (Some "2", Some "2"))
+
+[<Fact>]
 let ``PK uniqueness holds across the generated population`` () =
     let m = SyntheticData.generate catalog profile cfg 3UL
     let custIds = valuesOf m custKey "Id"

--- a/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferCanaryTests.fs
@@ -545,6 +545,107 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
                             })
                 }))
 
+    // -- D — the STREAMING arm of the data-leg compensating-undo ------------
+    //
+    // The estate-scale sibling of the materialized "Build A" canaries above, and
+    // the GATE for follow-on D (a wrong DELETE-by-captured-key at 10⁸ rows is
+    // unrecoverable, so it must not land untested). The streaming reverse leg
+    // (`runStreamingReconcilingWithRenames`, the hundreds-of-millions-row path)
+    // mints USER's surrogates as it streams and journals each completed chunk's
+    // captured (source → assigned) pairs to the off-box CaptureJournal. ORDER's
+    // load then CRASHES (its sink AMOUNT column was dropped). On a streaming crash
+    // `writePlanStreaming` RE-RAISES (it returns `Result.failure` ONLY on a NAMED
+    // resume-drift refusal) — so D's compensation hangs off the EXCEPTION path,
+    // not an `Error` match arm: it replays the journal into a remap and runs the
+    // SAME M23 `buildRevertScript`/`runRevert` the materialized arm runs. A
+    // PRE-EXISTING sink USER row (minted before the transfer) proves the revert
+    // targets ONLY the captured minted keys — never pre-existing data. Two modes
+    // mirror the materialized pair.
+
+    [<Fact>]
+    member _.``streaming data canary (D): a failed streaming load with auto-revert OFF writes the journal-replayed revert script and leaves the sink (pre-existing rows untouched)`` () =
+        if not (TransferCanaryFixtures.skipIfNoDocker "XferStreamRevertScript") then () else
+        let dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "v2-stream-revert-script-" + System.Guid.NewGuid().ToString("N").Substring(0, 8))
+        let journalDir = System.IO.Path.Combine(dir, "journal")
+        let scriptPath = System.IO.Path.Combine(dir, "transfer-revert.sql")
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "XferStreamRevScriptSrc" (fun src _ ->
+                task {
+                    do! Deploy.executeBatch src TransferCanaryFixtures.assignedBySinkDdl
+                    do! Deploy.executeBatch src TransferCanaryFixtures.assignedBySinkSourceSeed
+                    return!
+                        fixture.WithEphemeralDatabase "XferStreamRevScriptSink" (fun sink _ ->
+                            task {
+                                do! Deploy.executeBatch sink TransferCanaryFixtures.assignedBySinkDdl
+                                // A PRE-EXISTING minted USER row (the sink mints ID 1);
+                                // the streaming load then mints 2,3 for the source users.
+                                do! Deploy.executeBatch sink "INSERT INTO [dbo].[OSUSR_AS_USER] ([EMAIL]) VALUES (N'preexisting@x');"
+                                // Force ORDER's chunk write to crash AFTER USER streams + journals.
+                                do! Deploy.executeBatch sink "ALTER TABLE [dbo].[OSUSR_AS_ORDER] DROP COLUMN [AMOUNT];"
+                                let! contractR = ReadSide.read src
+                                let contract = TransferCanaryFixtures.value contractR
+                                let! threw =
+                                    task {
+                                        try
+                                            let! _ =
+                                                Transfer.runStreamingReconcilingWithRenames
+                                                    Transfer.Execute true false src sink contract contract Map.empty
+                                                    (Some journalDir) false (Some dir)
+                                            return false
+                                        with _ -> return true
+                                    }
+                                Assert.True(threw, "the streaming transfer should have crashed on the dropped AMOUNT column")
+                                // The precise journal-replayed revert script was written (default = no auto-delete).
+                                Assert.True(System.IO.File.Exists scriptPath, sprintf "expected a revert script at %s" scriptPath)
+                                let script = System.IO.File.ReadAllText scriptPath
+                                Assert.Contains("DELETE FROM", script)
+                                Assert.Contains("OSUSR_AS_USER", script)
+                                // The minted USER rows REMAIN (the operator runs the script):
+                                // 1 pre-existing + 2 minted = 3, and the pre-existing row is intact.
+                                let! total = TransferCanaryFixtures.countRows sink "[dbo].[OSUSR_AS_USER]"
+                                Assert.Equal(3, total)
+                                let! preexisting = TransferCanaryFixtures.countRows sink "[dbo].[OSUSR_AS_USER] WHERE [EMAIL] = N'preexisting@x'"
+                                Assert.Equal(1, preexisting)
+                            })
+                }))
+
+    [<Fact>]
+    member _.``streaming data canary (D): a failed streaming load with auto-revert ON deletes the journal-captured minted rows and leaves pre-existing rows`` () =
+        if not (TransferCanaryFixtures.skipIfNoDocker "XferStreamRevertAuto") then () else
+        let journalDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "v2-stream-revert-auto-" + System.Guid.NewGuid().ToString("N").Substring(0, 8))
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "XferStreamRevAutoSrc" (fun src _ ->
+                task {
+                    do! Deploy.executeBatch src TransferCanaryFixtures.assignedBySinkDdl
+                    do! Deploy.executeBatch src TransferCanaryFixtures.assignedBySinkSourceSeed
+                    return!
+                        fixture.WithEphemeralDatabase "XferStreamRevAutoSink" (fun sink _ ->
+                            task {
+                                do! Deploy.executeBatch sink TransferCanaryFixtures.assignedBySinkDdl
+                                do! Deploy.executeBatch sink "INSERT INTO [dbo].[OSUSR_AS_USER] ([EMAIL]) VALUES (N'preexisting@x');"
+                                do! Deploy.executeBatch sink "ALTER TABLE [dbo].[OSUSR_AS_ORDER] DROP COLUMN [AMOUNT];"
+                                let! contractR = ReadSide.read src
+                                let contract = TransferCanaryFixtures.value contractR
+                                let! threw =
+                                    task {
+                                        try
+                                            let! _ =
+                                                Transfer.runStreamingReconcilingWithRenames
+                                                    Transfer.Execute true false src sink contract contract Map.empty
+                                                    (Some journalDir) true None
+                                            return false
+                                        with _ -> return true
+                                    }
+                                Assert.True(threw, "the streaming transfer should have crashed on the dropped AMOUNT column")
+                                // --auto-revert executed the journal-replayed DELETE-by-captured-key:
+                                // the sink-minted USER rows (2,3) are gone; ONLY the pre-existing row remains.
+                                let! total = TransferCanaryFixtures.countRows sink "[dbo].[OSUSR_AS_USER]"
+                                Assert.Equal(1, total)
+                                let! preexisting = TransferCanaryFixtures.countRows sink "[dbo].[OSUSR_AS_USER] WHERE [EMAIL] = N'preexisting@x'"
+                                Assert.Equal(1, preexisting)
+                            })
+                }))
+
     // Option C — the NoCheckFk-PRESERVATION witness (the fidelity guard on the
     // re-trust step). A source FK deployed UNTRUSTED (a NoCheckFk decision — the
     // very thing M1 made faithful) must survive a DEFAULT (re-trust ON) transfer


### PR DESCRIPTION
Two related-but-distinct bodies of work from one session (combined per operator decision).

## 1 — Follow-on D: the streaming reverse-leg's compensating-undo (`a56eddb3`)

The last named follow-on of the migrate "we can't go wrong" envelope (M21/M22/M23/M24). `writePlanStreaming` now carries the M23 data-leg compensating-undo: a mid-stream crash **reverts** (`--auto-revert`) or **scripts** (default) the partial sink-minted rows, reconstructing the remap from the off-box `CaptureJournal`, then re-propagates the failure. Both levers off → byte-identical. **Seam correction:** the streaming path *throws* on a crash (not `Result.failure`), so D hangs off a `try/with` on the crash path; the named source-drift refusal does **not** revert. Two `TransferCanaryTests` witnesses; `TransferCanaryTests` 27/27.

## 2 — Advanced synthetic-data program: design + 7 build slices

Centered on the **blessed correction artifact** (`π∘σ ≈ id modulo the blessed Correction` — the core-adjunction shape applied to synthesis) and **coverage as a named fidelity axis**. Design: `THE_SYNTHETIC_DATA_FUZZING.md`.

Landed, each independently gated (Debug+Release 0/0; pure pool 0-failed → 3418 passed; Docker Synthetic* 55/55 incl. the π∘σ≈id canary):

- **F0a** (`9e67158f`) — `Correction` Core substrate (closed DUs, smart-ctor conflict refusal, pure `Profile ⊕ Correction` fold).
- **F0b** (`d530badd`) — durable `CorrectionCodec` (total / deterministic / A39-re-validating).
- **F1** (`147421de`) — per-kind `VolumeTarget` → arbitrary scale.
- **F0c-propose** (`d2cd6014`) — heuristic `CorrectionProposer` (first-draft PII typing).
- **F5a** (`3f552f45`) — σ ← captured `ForeignKeySelectivity` (rank-mapped FK skew).
- **F5b** (`ea6a826d`) — σ ← captured `JointDistribution` (correlated FK-tuple synthesis, L3).
- **F2** (`fa15126a`) — `FakerRealization.realizePii` (Bogus dep on Pipeline) — coherent fake person per row, seeded from row identity; Bogus stays OUTSIDE Core.

Determinism preserved throughout (each σ change is byte-identical when its evidence is absent; Faker seeded from σ's deterministic tokens at the boundary). **Remaining (designed, not built):** F0c-I/O (durable write + `synth-correct` verb + flow wiring that ties F2 + the blessed artifact into the load — the A44 cascade), F3 (coverage + L2-cov canary), F4 (boundary rotation), F6 (distribution fitting). See `THE_SYNTHETIC_DATA_FUZZING.md` §7 + `HANDOFF.md`.

Note: the σ synthetic-data emitter was already BUILT (2026-06-08) — the Faker deferral row + hold-out #10 overstate it as un-cashed. Whole-tree `lint-discipline.sh` reports a ~209-site pre-existing baseline (not from this work; the gate is the scoped pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)