### PR TITLE
Docs: Milestone 5 — data-portability scoped subsetting & transfer (design + specs)

### DIFF
--- a/docs/architecture/concerns/ROADMAP.md
+++ b/docs/architecture/concerns/ROADMAP.md
@@ -191,4 +191,39 @@ The current `01-topological-ordering.md` (569 lines) contains content for ALL st
 
 ---
 
+## 🚚 Data Portability (Milestone 5) — Scoped Referential Subsetting & Transfer
+
+A feature family that **reuses** the topological-ordering, SCC/cycle, and
+dynamic-extraction primitives above to lift a use-case-scoped, referentially-complete
+row subset between environments, with collision-safe surrogate remapping for DML-only
+on-prem targets.
+
+#### data-portability-closure-selector (M5.0)
+- **Future Namespace**: `DataPortability`
+- **Pipeline Stage**: Stage 1 (Selection) + Stage 2 (Snapshot)
+- **Reuses**: `SqlDynamicEntityDataProvider` BFS/closure walk, `RelationshipModel` graph
+- **New**: `data-portability.json` config, per-edge directives, key-scoped closure, completeness invariant
+- **Status**: 🚧 Specified ([M5.0](../../implementation-specs/M5.0-data-portability-closure-selector.md))
+
+#### capture-and-remap-loader (M5.1)
+- **Future Class**: `CaptureRemapLoadGenerator`
+- **Pipeline Stage**: Stage 5 (Emission) + Stage 6 (Insertion)
+- **Reuses**: `EntityDependencySorter`, `PhasedDynamicEntityInsertGenerator` (two-phase cycles), `#UserRemap`/`OUTPUT` idiom
+- **New**: replaces `SET IDENTITY_INSERT` with `#Map_*` capture-and-remap (DML-only)
+- **Status**: 🚧 Specified ([M5.1](../../implementation-specs/M5.1-capture-and-remap-loader.md))
+
+#### natural-key-resolution (M5.2)
+- **Future Class**: `NaturalKeyResolver`
+- **Reuses**: `UniqueCandidateProfile` / `CompositeUniqueCandidateProfile`
+- **New**: declared + profile-inferred natural keys → reuse-vs-insert
+- **Status**: 🚧 Specified ([M5.2](../../implementation-specs/M5.2-natural-key-resolution.md))
+
+#### golden-transfer-verification (M5.3)
+- **Future Class**: `DataSliceMaterializer`
+- **Reuses**: `MultiTargetSqlDataProfiler`, `Osm.LoadHarness`
+- **New**: golden/transfer duality, post-load verification (counts, new-orphan delta)
+- **Status**: 🚧 Specified ([M5.3](../../implementation-specs/M5.3-golden-transfer-verification.md))
+
+---
+
 **Last updated**: 2025-01-23

--- a/docs/data-portability-glossary.md
+++ b/docs/data-portability-glossary.md
@@ -1,0 +1,116 @@
+# Data Portability — Glossary
+
+This glossary anchors the (deliberately abstract) vocabulary used to describe the
+data-portability feature to concrete engineering terms and code locations in this
+repository. It exists so reviewers can translate the "what" into the "where."
+
+Legend: ✅ already implemented · 🟡 partial / embryonic · ❌ new work.
+
+---
+
+**Axiom-satisfying subset** — A slice that is itself a *valid* database fragment:
+every foreign key resolves within the slice, every `NOT NULL` holds, every declared
+`UNIQUE` / natural key holds. The enforceable form of this is the **closure
+completeness invariant** (no dangling FK). ❌ New (the invariant check); the FK
+graph it checks against is ✅ (`RelationshipModel`, `ForeignKeyTargetIndex`).
+
+**Baseline / resettable** — A committed, versioned golden dataset an environment
+can be reset to. Analogous to today's static seeds, but for use-case-scoped
+*dynamic* rows. 🟡 Static seeds exist (`StaticSeedSqlBuilder`); scoped dynamic
+golden datasets are ❌.
+
+**Blast radius (one-node-extra)** — The bounded frontier of the closure: pull what
+referential integrity requires (and at most one controlled extra hop), not the
+whole transitive graph. Encoded as the per-edge `stop` directive being the default.
+❌ New (the directive system).
+
+**Capture-and-remap** — The load strategy required by the DML-only target: insert a
+row *without* its primary key, let the server auto-number it, **capture** the
+assigned key (`OUTPUT inserted.<pk>` / `SCOPE_IDENTITY()`), and **remap** dependent
+child FKs to the captured key before inserting them. Replaces
+`SET IDENTITY_INSERT`. ❌ New; templated on the ✅ `#UserRemap` /
+`OUTPUT … INTO #Changes` idiom in `SqlScriptEmitter.cs`.
+
+**Closure (referential closure)** — The transitive set of rows reachable from the
+roots by following configured FK edges, terminating when no new rows are
+discovered. *Upward* closure (parents/enums/lookups) is what makes a slice valid;
+*downward* closure (children) is optional context. 🟡 An embryonic upward walk to
+**static** parents exists in `SqlDynamicEntityDataProvider.TrackParentRequirements`;
+key-scoped, dynamic-parent, and downward closure are ❌.
+
+**Closure engine / selector** — The component that takes roots + per-edge config and
+produces the closed row set. ❌ New; built atop the ✅ BFS queue
+(`extractionQueue` / `enqueued` / `processed`) already in
+`SqlDynamicEntityDataProvider`.
+
+**Condensation / SCC** — The strongly-connected-component contraction of the FK
+graph; cycles become single nodes for ordering. ✅ Implemented via Tarjan
+(`EntityDependencySorter.cs:1374`).
+
+**Data-portability config** — The versioned `data-portability.json` defining slices:
+roots (entity + predicate), per-edge directives, and natural keys. The namesake of
+branch `claude/data-portability-config-v8fziu`. ❌ New; mirrors the ✅
+`CircularDependencyOptions` / `TighteningOptions` config-deserialization pattern.
+
+**Edge directive** — Per-relationship traversal rule: `up` (follow to parent),
+`down` (follow to children, bounded by `maxDepth`), or `stop` (frontier). May carry
+a predicate. ❌ New.
+
+**Feedback arc set** — The minimal set of (weak) FK edges whose removal makes a
+cyclic component acyclic, so a load order exists. ✅ Implemented
+(`EntityDependencySorter.FindMinimumFeedbackArcSet`).
+
+**Golden dataset** — A materialized, committed slice used as a baseline. See
+*Baseline*. The "both" decision: a transfer can be *promoted* to a golden dataset.
+❌ New.
+
+**Haecceity / suchness** — The actual row *values* (as opposed to schema). Captured
+today by live extraction (`SqlDynamicEntityDataProvider.ExtractTableAsync`,
+`StaticEntityRow`). ✅ for capture; scoping it is ❌.
+
+**Holon / holonic** — A part that is simultaneously a self-contained whole. Here: a
+slice that is both a fragment *of* the catalog and a valid database *in itself*.
+Conceptual framing for the closure-completeness invariant.
+
+**Identity remapping** — Translating source surrogate keys to target keys so the
+slice merges into a populated target without PK collisions. 🟡 Exists for **User**
+only, via a *precomputed* inventory map (`UatUsers`); generalizing to all entities
+with *at-insert-time* capture is ❌.
+
+**Implicature of consequence** — Everything a chosen row *requires* to be valid: its
+referential closure. See *Closure*.
+
+**Map table (`#Map_*`)** — A per-entity temp table holding `SourceId → TargetId`
+(+ natural-key columns) populated during load; children join it to resolve FKs.
+❌ New; generalizes the ✅ `#UserRemap` / `#Changes` temp tables.
+
+**Natural / business key** — The columns that identify "the same entity" across
+environments independent of the surrogate PK (e.g. `Email`, `Code`, `ExternalRef`).
+Drives reuse-vs-insert and is the `#Map_*` join handle. 🟡 Static seeds match on PK;
+declared per-entity natural keys for dynamic entities are ❌. Profile-inferred
+candidates come from ✅ `UniqueCandidateProfile`.
+
+**Phased (two-phase) load** — Insert cyclic/nullable FK rows with the FK `NULL`,
+then `UPDATE` once the partner key exists. ✅ Implemented
+(`PhasedDynamicEntityInsertGenerator`); the chosen cycle strategy.
+
+**Profiling / statistical modeling** — Measuring environments (row counts, null
+density, uniqueness, FK reality/orphans), used for sizing, natural-key inference,
+and post-load verification. ✅ `MultiTargetSqlDataProfiler`, `ProfileSnapshot`.
+
+**Roots** — The seed rows that define a use case: an entity plus a `WHERE`
+predicate. ❌ New (predicates); entity seeding is 🟡 (`SeedInitialEntities`,
+currently whole-table by module/entity filter).
+
+**Slice** — A single named, use-case-scoped, referentially-closed set of rows,
+defined by one `slices[]` entry in the config. ❌ New.
+
+**Topological order / well-quasi-ordered** — A child-after-parent load order with no
+infinite descending chains and a defined story for cycles. ✅ Kahn's algorithm
+(`EntityDependencySorter.TopologicalSort`) + SCC handling.
+
+**Touchpoints** — Every table/column/FK a use case references; derivable from the
+relationship graph. ✅ (`RelationshipModel`, `ForeignKeyTargetIndex`).
+
+**Transfer (operational)** — An on-demand, transient lift-and-shift of a slice
+between live environments (vs a committed golden dataset). ❌ New.

--- a/docs/design-data-portability-subsetting.md
+++ b/docs/design-data-portability-subsetting.md
@@ -5,6 +5,15 @@
 > grounded gap analysis showing how much of the required machinery **already
 > ships** in this repository.
 
+> **Document set.** This is the design overview. See also:
+> [`data-portability-glossary.md`](./data-portability-glossary.md) (vocabulary →
+> code anchors); the [`data-slice` verb](./verbs/data-slice.md) (operator-facing
+> contract); and the Milestone 5 implementation specs —
+> [M5.0 closure selector](./implementation-specs/M5.0-data-portability-closure-selector.md),
+> [M5.1 capture-and-remap loader](./implementation-specs/M5.1-capture-and-remap-loader.md),
+> [M5.2 natural-key resolution](./implementation-specs/M5.2-natural-key-resolution.md),
+> [M5.3 golden/transfer & verification](./implementation-specs/M5.3-golden-transfer-verification.md).
+
 ## 1. The idea, de-abstracted
 
 Certain sections of the application should be **baselineable and resettable**:
@@ -213,6 +222,44 @@ NULL, capture keys, then `UPDATE` the FK once the partner's key exists.
 - **D4 — Golden/transfer duality + verification.** Promote a transfer to a
   committed golden dataset; post-load verification via the profiler (expected
   closure counts, zero new orphans).
+
+## 6a. Decision tree: which mode am I using?
+
+```
+Do you need the data in another live environment right now?
+├─ Yes, transient lift-and-shift ............ TRANSFER  (emit load.capture-remap.sql, apply)
+└─ No, I want a reviewable baseline
+   ├─ First time capturing it ............... GOLDEN    (--golden writes a committed dataset)
+   └─ Already extracted a good transfer ..... PROMOTE   (--promote, no re-query)
+
+Is the target already populated?
+├─ Yes ..... natural key REQUIRED (declared or profile-confirmed) → reuse-vs-insert (M5.2/M5.1)
+└─ No ...... insert-only path may proceed without a confirmed key
+
+Does the closure contain an FK cycle?
+└─ Always handled by the existing two-phase insert-then-update (M5.1 reuses PhasedDynamicEntityInsertGenerator)
+```
+
+## 6b. Implementation checklist (by milestone)
+
+**M5.0 — closure selector**
+- [ ] `DataPortabilityOptions` records + `DataPortabilityOptionsDeserializer` (mirror `CircularDependencyConfigDeserializer`)
+- [ ] Root predicates plumbed into `SqlDynamicEntityDataProvider.ExtractTableAsync`
+- [ ] `DataSliceSelector`: key-scoped up-closure (static **and** dynamic parents), bounded down-closure, `stop` frontier
+- [ ] `ClosureReport` + completeness invariant (no dangling mandatory FK)
+
+**M5.1 — capture-and-remap loader**
+- [ ] `CaptureRemapLoadGenerator` (no `IDENTITY_INSERT`; `#Stage_*`/`#Map_*`; `OUTPUT` capture; FK resolve by join)
+- [ ] Two-phase cycles via reused `PhasedDynamicEntityInsertGenerator` shape, resolving through partner maps
+
+**M5.2 — natural keys**
+- [ ] `NaturalKeyResolver` (declared) + validation against the model
+- [ ] Profile-inferred proposals from `UniqueCandidateProfile` / `CompositeUniqueCandidateProfile`
+
+**M5.3 — golden/transfer + verification**
+- [ ] `DataSliceMaterializer` (transfer/golden) + deterministic golden writer
+- [ ] Promote path; post-load `SliceVerificationReport` via `MultiTargetSqlDataProfiler`
+- [ ] LoadHarness apply+verify driver
 
 ## 7. Open questions
 

--- a/docs/design-data-portability-subsetting.md
+++ b/docs/design-data-portability-subsetting.md
@@ -1,0 +1,226 @@
+# Data Portability: Use-Case-Scoped Referential Subsetting & Transfer
+
+> Status: Design / elicitation. Branch `claude/data-portability-config-v8fziu`.
+> This document captures the intent, the locked decisions, and — crucially — a
+> grounded gap analysis showing how much of the required machinery **already
+> ships** in this repository.
+
+## 1. The idea, de-abstracted
+
+Certain sections of the application should be **baselineable and resettable**:
+there is a *golden* set of rows for a given use case that we want to lift out of
+one environment and land in another with high fidelity — preserving not just the
+rows themselves but everything they referentially imply, so the slice is a
+self-consistent, standalone-valid database fragment.
+
+Translated into the vocabulary of this codebase:
+
+| Gesture | Concrete meaning |
+| --- | --- |
+| "golden config data in its suchness" | A curated set of **actual rows** (values), not just schema. |
+| "...and its implicature of consequence" | Plus the **referential closure** those rows require (parents, enums, lookups). |
+| "know all the touchpoints" | Enumerate every table/column/FK a use case touches — already derivable from the `RelationshipModel` / `ForeignKeyTargetIndex` graph. |
+| "statistical modeling to profile environments" | `MultiTargetSqlDataProfiler` / `ProfileSnapshot` — row counts, FK reality, orphans, uniqueness. |
+| "sensible distillation / transfer a *subset*" | **Scoped subsetting**: reduce whole tables to a use-case-relevant row set. (New.) |
+| "one-node-extra-blast-radius" | Bounded closure: pull what is needed for validity (and one controlled hop), not the whole transitive graph. |
+| "user remapping and other congruencies" | Generalized **identity remapping** across all identity entities (today: User only). |
+| "axiom-satisfying holonic subset" | The slice is itself a valid DB: every FK resolves, every NOT NULL / UNIQUE holds *within the slice*. |
+| "well-quasi-ordered" | A load order with no infinite descending chains and a defined story for FK cycles — **already implemented**. |
+
+## 2. Locked decisions (from elicitation)
+
+1. **Closure depth** — *Configurable per relationship*. Each FK edge declares its
+   traversal: follow-up (parent), follow-down (children), or stop; with optional
+   predicates and depth caps. This config is the namesake of this branch.
+2. **Artifact** — *Both*. The slice **definition** (config) is versioned/committed;
+   running it yields either a committed golden dataset **or** an on-demand transfer.
+   A transfer can be promoted to a golden baseline.
+3. **Identity on import** — *Remap surrogate keys, collision-safe*, **under an
+   on-prem DML-only constraint**: no `IDENTITY_INSERT` rights; identity columns
+   auto-number on insert. Therefore the loader must insert without the PK,
+   **capture the server-assigned key**, and **hoist it into topologically-ordered
+   referents** before their FKs are inserted.
+4. **Natural key (reuse-vs-insert)** — *Declared natural key per entity*, with
+   *profile-inferred + operator-confirmed* enablement (reuse `UniqueCandidateProfile`
+   to propose match columns).
+5. **FK cycles at load** — *Two-phase insert-then-update* — **already implemented**
+   (`PhasedDynamicEntityInsertGenerator`).
+6. **Load vehicle** — *Both*: a self-contained T-SQL artifact (temp mapping tables,
+   DML-only) **and** a harness driver/verifier — but build on the existing
+   implementation rather than greenfield.
+
+## 3. Gap analysis — what already ships
+
+The headline finding: **the hard ordering primitives and an embryonic closure
+walk already exist and are tested.** The feature is an assembly + two swaps, not a
+new system.
+
+### 3.1 Already implemented (reuse as-is)
+
+- **Topological load order** — Kahn's algorithm.
+  `src/Osm.Emission/Seeds/EntityDependencySorter.cs:482` (`TopologicalSort`).
+- **Cycle handling (your chosen strategy)** — Tarjan SCC
+  (`EntityDependencySorter.cs:1374`), Weak/Cascade/Other edge-strength
+  classification, minimum **feedback-arc-set** search, and **two-phase
+  insert-then-update** for cyclic nullable FKs
+  (`src/Osm.Emission/PhasedDynamicEntityInsertGenerator.cs:88`).
+- **Manual cycle ordering** — z-index `CircularDependencyOptions` / `AllowedCycle`
+  / `TableOrdering.Position`.
+- **Live, batched row extraction** — `SqlDynamicEntityDataProvider.ExtractTableAsync`
+  (`src/Osm.Pipeline/DynamicData/SqlDynamicEntityDataProvider.cs:575`):
+  `SELECT … FROM … ORDER BY pk OFFSET/FETCH`, checksums, telemetry.
+- **Embryonic referential-closure walk** — same provider runs a BFS over
+  relationships (`extractionQueue` / `enqueued` / `processed`, line 99+);
+  `TrackParentRequirements` (line 279) resolves each relationship's **parent** and
+  auto-enqueues it, with a parent-requirement tracker that distinguishes
+  AutoLoad vs RequiresVerification (`StaticSeedParentHandlingMode`).
+- **Generalized-remap template** — `#UserRemap` temp-table idiom + in-memory
+  transformation map for User FKs (`src/Osm.Pipeline/UatUsers/SqlScriptEmitter.cs`,
+  `ModelUserSchemaGraphFactory.cs`).
+- **Natural-key matching (partial)** — static seeds MERGE on key columns
+  (`StaticSeedSqlBuilder`); global bootstrap emits all entities in global topo order.
+- **Cross-environment profiling** — `MultiTargetSqlDataProfiler`,
+  `UniqueCandidateProfile` (the source of profile-inferred natural keys).
+
+### 3.2 The load-bearing conflict
+
+The existing **dynamic** loader preserves source PKs via `SET IDENTITY_INSERT`
+— `PhasedDynamicEntityInsertGenerator.cs:216`:
+
+```csharp
+var hasIdentity = columns.Any(column => column.IsIdentity);
+if (hasIdentity)
+{
+    sb.AppendLine($"SET IDENTITY_INSERT [{schema}].[{tableName}] ON;");
+    ...
+```
+
+This is exactly the permission the on-prem DML target lacks. The static-seed and
+`#UserRemap` paths already avoid `IDENTITY_INSERT` (M1.0 even asserts its
+absence), but the dynamic path — the one that would carry a use-case slice —
+hard-depends on it. **The dynamic identity strategy must change from
+*preserve-via-IDENTITY_INSERT* to *capture-and-remap*.**
+
+### 3.3 What is genuinely new
+
+1. **Scoped selection / closure config (the keystone).** Today extraction is
+   whole-table — the SELECT at `SqlDynamicEntityDataProvider.cs:593` has **no
+   WHERE clause**, and the closure walk only follows **up** edges to **static**
+   parents (line 302 skips non-static parents) and pulls the **entire** parent
+   table. The feature needs:
+   - **Root predicates** — `WHERE` on root entities (the "use case").
+   - **Closure by referenced keys** — pull only parent rows actually referenced
+     (`WHERE ParentPK IN (selected child FK values)`), recursively — not whole tables.
+   - **Dynamic parents** — follow up edges to dynamic parents too, not just static.
+   - **Down edges** — optionally follow children (`follow-down`), bounded.
+   - **Per-edge directives** — follow-up / follow-down / stop, predicates, depth caps.
+2. **Capture-and-remap identity strategy** — generalize `#UserRemap` from
+   "User only, precomputed inventory map" to "every identity entity, map populated
+   at insert time via `OUTPUT inserted.<pk>` / `SCOPE_IDENTITY()` into per-entity
+   `#Map_*` temp tables; children resolve FKs by join."
+3. **Natural-key declaration per entity** — the connective tissue: since the
+   surrogate is gone at load time, both the `#Map_*` join handle and the
+   reuse-vs-insert decision key on a declared (+ profile-inferred) natural key.
+
+## 4. Proposed closure config schema (sketch)
+
+A versioned `data-portability.json` (sibling to `default-tightening.json`):
+
+```jsonc
+{
+  "slices": [
+    {
+      "name": "order-fulfillment-golden",
+      "roots": [
+        { "entity": "Order", "predicate": "Status = 'Template' AND IsArchived = 0" }
+      ],
+      "edges": {
+        // default for any edge not named below
+        "$default": "stop",
+        "Order.CustomerId":      { "direction": "up" },                 // pull referenced parent rows
+        "Order.StatusId":        { "direction": "up" },                 // enum/lookup closure
+        "OrderLine.OrderId":     { "direction": "down", "maxDepth": 1 } // one controlled hop of children
+      },
+      "naturalKeys": {
+        "Customer": ["ExternalRef"],
+        "OrderStatus": ["Code"]
+        // entities without a declared key fall back to profile-inferred + confirm
+      }
+    }
+  ]
+}
+```
+
+Semantics: BFS from root rows; for each visited row, for each FK edge, apply the
+edge directive. `up` adds the referenced parent rows; `down` adds child rows
+matching the parent keys (bounded by `maxDepth`); `stop` is the frontier (the
+"one-node-extra-blast-radius" default). Closure terminates when no new rows are
+discovered. Completeness invariant: no FK in the resulting set may dangle — every
+referenced parent is present, or the column is nullable and nulled.
+
+## 5. Capture-and-remap load idiom (replacing IDENTITY_INSERT)
+
+Per identity entity, emit a mapping temp table; insert without the PK; capture the
+server-assigned key via `OUTPUT`; resolve child FKs by joining their staged source
+keys against the parent maps. Pure DML, no `IDENTITY_INSERT`. Shape:
+
+```sql
+-- Parent: Customer (natural key: ExternalRef)
+CREATE TABLE #Map_Customer (SourceId INT, TargetId INT, ExternalRef NVARCHAR(50));
+
+-- Reuse existing target rows by natural key (collision-safe merge into populated target)
+INSERT INTO #Map_Customer (SourceId, TargetId, ExternalRef)
+SELECT s.SourceId, t.[Id], s.ExternalRef
+FROM #Staging_Customer s
+JOIN [dbo].[Customer] t ON t.[ExternalRef] = s.ExternalRef;
+
+-- Insert the genuinely-new rows, capturing the auto-numbered key
+INSERT INTO [dbo].[Customer] ([ExternalRef], [Name] /* non-identity cols */)
+OUTPUT inserted.[Id], s.SourceId INTO #Map_Customer (TargetId, SourceId)   -- see note
+SELECT s.[ExternalRef], s.[Name]
+FROM #Staging_Customer s
+WHERE NOT EXISTS (SELECT 1 FROM #Map_Customer m WHERE m.SourceId = s.SourceId);
+
+-- Child: Order — resolve CustomerId FK via the parent map, in topological order
+INSERT INTO [dbo].[Order] ([CustomerId], [Status] /* ... */)
+OUTPUT inserted.[Id], s.SourceId INTO #Map_Order (TargetId, SourceId)
+SELECT m.TargetId, s.[Status]
+FROM #Staging_Order s
+JOIN #Map_Customer m ON m.SourceId = s.[CustomerId];
+```
+
+> Note: `OUTPUT … INTO` cannot reference non-inserted source columns directly; the
+> production emitter will stage source keys alongside (e.g. via a `MERGE … OUTPUT`
+> that exposes both `inserted` and source, or a deterministic per-batch correlation).
+> This is the one mechanical detail to nail down in implementation; the existing
+> `SqlScriptEmitter` (`#UserRemap`) and `PhasedDynamicEntityInsertGenerator`
+> (two-phase cycles) are the reuse surfaces.
+
+FK cycles reuse the **existing** two-phase path: insert the cyclic (nullable) FK as
+NULL, capture keys, then `UPDATE` the FK once the partner's key exists.
+
+## 6. Suggested milestones
+
+- **D1 — Closure config + selector.** Add `data-portability.json` parsing; extend
+  `SqlDynamicEntityDataProvider` with root predicates and per-edge directives
+  (key-scoped parent pull, dynamic parents, bounded children). Reuse the existing
+  BFS/queue. Output: a scoped `DynamicEntityDataset` + closure-completeness check.
+- **D2 — Capture-and-remap emitter.** New emission path that drops
+  `IDENTITY_INSERT` and emits `#Map_*` capture + FK-resolve-by-join, generalizing
+  `#UserRemap`. Reuse `EntityDependencySorter` ordering and the two-phase cycle path.
+- **D3 — Natural keys.** Declared keys in config + profile-inferred proposals from
+  `UniqueCandidateProfile`; wire into reuse-vs-insert.
+- **D4 — Golden/transfer duality + verification.** Promote a transfer to a
+  committed golden dataset; post-load verification via the profiler (expected
+  closure counts, zero new orphans).
+
+## 7. Open questions
+
+- **Row source confirmed**: live `SELECT … WHERE` against the source DB (the
+  provider already does live batched reads; predicates are the only addition).
+- **`OUTPUT … INTO` source-key correlation** — exact mechanism (staged correlation
+  vs `MERGE … OUTPUT`) — see §5 note.
+- **Composite / non-integer identities** — natural keys may be composite; map
+  tables must generalize beyond a single `INT` surrogate.
+- **Determinism for golden baselines** — stable ordering + stable selection given
+  the same source, so committed datasets diff cleanly.

--- a/docs/implementation-specs/M5.0-data-portability-closure-selector.md
+++ b/docs/implementation-specs/M5.0-data-portability-closure-selector.md
@@ -1,0 +1,275 @@
+# M5.0: Data Portability — Scoped Referential Closure Selector
+
+**Date**: 2026-06-18
+**Status**: Specification (design)
+**Priority**: 🔴 Critical Path (keystone of the feature)
+
+> Part of Milestone 5 (Data Portability). See the design overview
+> [`docs/design-data-portability-subsetting.md`](../design-data-portability-subsetting.md)
+> and the [glossary](../data-portability-glossary.md).
+
+---
+
+## Executive Summary
+
+### The Specific Problem
+
+We want to lift a **use-case-scoped subset** of rows out of one environment and
+land it in another such that the subset is *referentially complete* — a standalone
+valid database fragment. Today the dynamic-data path is **all-or-nothing**:
+
+- `SqlDynamicEntityDataProvider.ExtractTableAsync` emits an unfiltered
+  `SELECT {cols} FROM {table} ORDER BY {pk} OFFSET/FETCH` — **no `WHERE` clause**
+  (`src/Osm.Pipeline/DynamicData/SqlDynamicEntityDataProvider.cs:593`).
+- The referential closure walk (`extractionQueue` / `enqueued` / `processed` at
+  line 99+; `TrackParentRequirements` at line 279) follows up-edges **only to
+  `IsStatic` parents** (line 302) and **auto-loads the whole parent table**.
+
+So there is no way to say "the templates for *this* order workflow, plus exactly
+the customers/enums/lookups those rows reference."
+
+### Recommended Solution
+
+Introduce a versioned **`data-portability.json`** config that declares *slices*
+(roots + per-relationship traversal directives + natural keys), and a **closure
+selector** that drives the *existing* BFS with that config to produce a bounded,
+referentially-closed `DynamicEntityDataset`, plus a **closure-completeness report**.
+
+This spec covers the **config + selection/closure** only. The load-side identity
+strategy is [M5.1](./M5.1-capture-and-remap-loader.md); natural-key resolution is
+[M5.2](./M5.2-natural-key-resolution.md); golden/transfer + verification is
+[M5.3](./M5.3-golden-transfer-verification.md).
+
+### MVP Scope
+
+- Config parsing + validation for `data-portability.json`.
+- Root predicates (parameterized `WHERE`).
+- Per-edge directives: `up` (key-scoped parent pull), `down` (bounded children),
+  `stop` (frontier — the default).
+- Up-closure to **dynamic** parents, not just static.
+- Closure-completeness invariant check (no dangling FK in the result).
+
+Deferred: `down` depth > 1 by default, sampling integration, golden materialization.
+
+---
+
+## Data Models
+
+### `data-portability.json` (config contract)
+
+```jsonc
+{
+  "slices": [
+    {
+      "name": "order-fulfillment-golden",
+      "roots": [
+        { "entity": "Order", "predicate": "Status = 'Template' AND IsArchived = 0" }
+      ],
+      "edges": {
+        "$default": "stop",
+        "Order.CustomerId":  { "direction": "up" },
+        "Order.StatusId":    { "direction": "up" },
+        "OrderLine.OrderId": { "direction": "down", "maxDepth": 1 }
+      },
+      "naturalKeys": {           // consumed by M5.2; parsed here
+        "Customer": ["ExternalRef"],
+        "OrderStatus": ["Code"]
+      }
+    }
+  ]
+}
+```
+
+Edge keys are `"<Entity>.<ViaAttribute>"` (logical names), matching
+`RelationshipModel.ViaAttribute`. A bare string value (`"stop"` / `"up"` /
+`"down"`) is shorthand for `{ "direction": "<value>" }`. `predicate` strings are
+emitted verbatim into a parameterized `WHERE` (see Security below).
+
+### Domain records (new) — `src/Osm.Domain/Configuration/`
+
+Mirror the established option-record shape (immutable `record`, `Result<T>`
+factory) used by `CircularDependencyOptions` and `ModuleFilterOptions`:
+
+```csharp
+public sealed record DataPortabilityOptions
+{
+    public ImmutableArray<DataSliceOptions> Slices { get; init; } = ImmutableArray<DataSliceOptions>.Empty;
+    public static Result<DataPortabilityOptions> Create(ImmutableArray<DataSliceOptions> slices);
+}
+
+public sealed record DataSliceOptions
+{
+    public string Name { get; init; }
+    public ImmutableArray<SliceRoot> Roots { get; init; }
+    public ImmutableDictionary<string, EdgeDirective> Edges { get; init; }   // key: "Entity.ViaAttribute"
+    public EdgeDirective DefaultEdge { get; init; }                          // from "$default"
+    public ImmutableDictionary<string, ImmutableArray<string>> NaturalKeys { get; init; }
+    public static Result<DataSliceOptions> Create(...);
+}
+
+public sealed record SliceRoot(string Entity, string? Predicate);
+
+public enum EdgeDirection { Stop, Up, Down }
+public sealed record EdgeDirective(EdgeDirection Direction, int MaxDepth = 1, string? Predicate = null);
+```
+
+### Deserializer (new) — `src/Osm.Json/Configuration/DataPortabilityOptionsDeserializer.cs`
+
+Follow `CircularDependencyConfigDeserializer` exactly: `JsonDocument.Parse` →
+`DeserializeFromDocument(JsonElement)` → per-slice `Result<T>` accumulation →
+domain `Create(...)`. Reuse the `SerializerOptions` style from
+`TighteningOptionsDeserializer` (case-insensitive, skip comments, allow trailing
+commas). Every failure path returns `Result<DataPortabilityOptions>.Failure(
+ValidationError.Create("config.dataPortability.<...>", "<message>"))`.
+
+---
+
+## Implementation Scope
+
+### Change 1 — Config record + deserializer + validation
+
+- Add the four records above to `src/Osm.Domain/Configuration/`.
+- Add `DataPortabilityOptionsDeserializer` to `src/Osm.Json/Configuration/`.
+- Validation rules (each its own `ValidationError` code):
+  - `slices` non-empty; slice `name` unique and non-blank.
+  - each root `entity` resolves in the `OsmModel` (defer to selector if model not
+    available at parse time; otherwise validate eagerly).
+  - each edge key is `"Entity.Attribute"`; `direction` ∈ {stop, up, down};
+    `maxDepth >= 1`.
+  - predicates are non-empty when present (semantic validity is the DB's job).
+
+### Change 2 — Predicate-aware extraction
+
+Extend `SqlDynamicEntityDataProvider` so a per-entity **row filter** can be passed
+into `ExtractTableAsync`. The current SELECT (line 593) becomes:
+
+```
+SELECT {selectList} FROM {schemaQualifiedName}
+WHERE {predicate}                       -- omitted when no predicate
+ORDER BY {orderClause}
+OFFSET @offset ROWS FETCH NEXT @fetch ROWS ONLY;
+```
+
+For **roots**, `{predicate}` is the slice root predicate. For **up-closure**,
+`{predicate}` is a generated key membership filter (Change 3).
+
+### Change 3 — Closure selector (the keystone)
+
+New `DataSliceSelector` (in `src/Osm.Pipeline/DataPortability/`) that owns the BFS
+and replaces today's hardcoded "static parents only, whole table" rule:
+
+1. **Seed** the queue with root extractions (Change 2 predicate), instead of the
+   module/entity-filter seeding in `SeedInitialEntities`.
+2. For each extracted table, for each `RelationshipModel`, look up the
+   `EdgeDirective` (`"<Entity>.<ViaAttribute>"`, else `$default`):
+   - `up` — collect the distinct non-null FK values from the just-extracted rows;
+     enqueue the **parent** entity (static *or* dynamic — drop the `IsStatic`
+     gate at line 302) with a key-membership predicate
+     `[{parentPk}] IN ({collected values})`, batched to respect parameter limits.
+   - `down` — enqueue child entities whose FK references the current entity, with
+     predicate `[{childFk}] IN ({current pk values})`, bounded by `maxDepth`.
+   - `stop` — frontier; do not traverse.
+3. **Dedupe** by (entity, key) so the same parent row pulled via two paths is
+   extracted once. Reuse `enqueued`/`processed` plus a per-entity visited-key set.
+4. Terminate when the queue drains (closure fixed point).
+
+Output: a `DynamicEntityDataset` (existing type:
+`record DynamicEntityDataset(ImmutableArray<StaticEntityTableData> Tables)`) plus a
+`ClosureReport`.
+
+### Change 4 — Closure-completeness invariant
+
+After selection, verify the **axiom**: for every extracted row and every
+mandatory FK, the referenced parent key is present in the selected set (or the FK
+is nullable and will be nulled at load). Emit a `ClosureReport`:
+
+```csharp
+public sealed record ClosureReport(
+    string SliceName,
+    ImmutableArray<SliceTableStat> Tables,        // entity, rowCount, pulledVia (root|up|down)
+    ImmutableArray<DanglingForeignKey> Dangling,  // entity, viaAttribute, missingParentKeys (sample)
+    bool IsComplete);
+```
+
+A non-empty `Dangling` with mandatory edges fails the slice (actionable error
+naming the entity, the edge, and a sample of missing keys).
+
+---
+
+## Codebase Integration Guide
+
+### Existing infrastructure (leverage these)
+
+| Concern | Reuse | Location |
+| --- | --- | --- |
+| BFS queue / visited sets | `extractionQueue`, `enqueued`, `processed` | `SqlDynamicEntityDataProvider.cs:99` |
+| Parent resolution | `EntityLookup.ResolveRelationship` (logical → constraint → physical) | `SqlDynamicEntityDataProvider.cs:426` |
+| Batched live read + checksum | `ExtractTableAsync` | `SqlDynamicEntityDataProvider.cs:575` |
+| Row/column/table types | `StaticEntityTableData`, `StaticEntityRow`, `StaticEntitySeedColumn` (has `IsPrimaryKey`/`IsIdentity`/`IsNullable`) | `Osm.Emission/Seeds/StaticEntitySeedScriptGenerator.cs:207` |
+| FK graph | `RelationshipModel` (`ViaAttribute`, `TargetEntity`, `TargetPhysicalName`, `ActualConstraints`) | `Osm.Domain/Model/` |
+| Config pattern | `CircularDependencyConfigDeserializer`, `TighteningOptionsDeserializer` | `Osm.Json/...` |
+
+### Required changes
+
+1. `SqlDynamicEntityDataProvider` — parameterize `ExtractTableAsync` with an
+   optional predicate + key-membership generator; expose a seeding hook so the
+   selector controls the queue rather than `SeedInitialEntities`.
+2. New `DataSliceSelector` orchestrating the closure per the algorithm above.
+3. New config records + deserializer + validation.
+4. New `ClosureReport` + completeness check.
+
+### Implementation order
+
+1. Config records + deserializer + unit tests (fixture JSON → options).
+2. Predicate plumbing into `ExtractTableAsync`.
+3. `DataSliceSelector` up-closure (key-scoped, dynamic parents).
+4. Down-closure (bounded).
+5. Completeness invariant + `ClosureReport`.
+
+---
+
+## Security
+
+Root and edge `predicate` strings are operator-authored config, not end-user
+input, but they are interpolated into SQL. Constraints:
+
+- Predicates apply only to the slice's own entities and run read-only.
+- Key-membership filters use **parameters** (`@k0, @k1, …`), never literal
+  interpolation of data values, batched under the 2100-parameter limit.
+- Document that predicates are trusted config (same trust level as
+  `default-tightening.json`); no dynamic SQL beyond the templated `WHERE`.
+
+---
+
+## Test Scenarios
+
+**Unit (fixture-first, no live DB):**
+- Deserialize a valid `data-portability.json` → `DataPortabilityOptions`; assert
+  roots, edges (including `$default`), natural keys.
+- Each validation failure path → specific `ValidationError.Code`.
+- Selector over a fixture model + fixture row provider: a root with one `up` edge
+  pulls only referenced parent rows (not the whole table); `stop` halts; `down`
+  respects `maxDepth`.
+- Diamond closure (two paths to one parent) extracts the parent once.
+- Completeness: a missing mandatory parent surfaces in `Dangling` and fails.
+
+**Integration (live SQL, opt-in):**
+- `SqlDynamicEntityDataProviderIntegrationTests` analog: scoped extraction against
+  a seeded DB returns the expected closed set + a clean `ClosureReport`.
+
+---
+
+## Success Criteria
+
+- [ ] `data-portability.json` parses/validates via `Result<T>` with coded errors.
+- [ ] Root predicates produce a filtered `SELECT`.
+- [ ] Up-closure pulls only referenced parent rows, for static **and** dynamic parents.
+- [ ] `down` and `stop` directives behave per config; `$default` applies elsewhere.
+- [ ] Closure reaches a fixed point and dedupes shared parents.
+- [ ] `ClosureReport.IsComplete` is true iff no mandatory FK dangles; failures are actionable.
+- [ ] Fixture-first unit tests cover all of the above with no live DB.
+
+## Migration Path
+
+Additive. Existing whole-model bootstrap/extraction paths are untouched; the
+selector is a new entry point gated on a `data-portability.json` being supplied.

--- a/docs/implementation-specs/M5.1-capture-and-remap-loader.md
+++ b/docs/implementation-specs/M5.1-capture-and-remap-loader.md
@@ -1,0 +1,244 @@
+# M5.1: Data Portability — Capture-and-Remap Loader (DML-only, no IDENTITY_INSERT)
+
+**Date**: 2026-06-18
+**Status**: Specification (design)
+**Priority**: 🔴 Critical Path
+
+> Part of Milestone 5 (Data Portability). Depends on
+> [M5.0](./M5.0-data-portability-closure-selector.md) (the selected dataset) and
+> [M5.2](./M5.2-natural-key-resolution.md) (natural keys). See the
+> [design overview](../design-data-portability-subsetting.md).
+
+---
+
+## Executive Summary
+
+### The Specific Problem
+
+The target environment is **on-prem and DML-only**: the operator has no
+`IDENTITY_INSERT` rights, and identity columns auto-number on insert. The existing
+dynamic loader violates this directly — `PhasedDynamicEntityInsertGenerator`
+brackets its MERGE with `SET IDENTITY_INSERT ON/OFF` whenever a table has an
+identity column (`src/Osm.Emission/PhasedDynamicEntityInsertGenerator.cs:216-223`,
+`:245-250`), preserving source PKs. The non-phased
+`DynamicEntityInsertGenerator` does the same (`:115-121`).
+
+Because the server assigns the surrogate key at insert time, child rows cannot
+reference a parent by its *source* PK — that key no longer exists in the target.
+The loader must insert the parent, **capture the server-assigned key**, and
+**remap** the child's FK to it before inserting the child.
+
+### Recommended Solution
+
+A new emission path — `CaptureRemapLoadGenerator` — that, per identity entity:
+
+1. Stages source rows (including the **source PK** and **natural key**, but *not*
+   inserting the PK into the identity column) in a `#Stage_<Entity>` temp table.
+2. Reuses pre-existing target rows by **natural key** into a `#Map_<Entity>` temp
+   table (`SourceId → TargetId`).
+3. Inserts the genuinely-new rows, capturing the auto-numbered key via
+   `OUTPUT inserted.<pk>` into `#Map_<Entity>`.
+4. Resolves every child FK by **joining** its staged source FK value against the
+   parent `#Map_*` tables, in topological order.
+
+Pure DML. No `IDENTITY_INSERT`. This generalizes the existing **User-only**
+`#UserRemap` + `OUTPUT … INTO #Changes` idiom (`UatUsers/SqlScriptEmitter.cs`) to
+every identity entity, with the map populated **at insert time** rather than from
+a precomputed inventory.
+
+### MVP Scope
+
+- Single-column integer identity entities.
+- Insert order from the existing `EntityDependencySorter`.
+- FK cycles via the existing two-phase insert-then-update.
+- Emit a self-contained T-SQL artifact (the LoadHarness driver is M5.3).
+
+Deferred: composite/non-integer identities (M5.2 §"Composite"), cross-batch
+streaming.
+
+---
+
+## Data Models
+
+### Per-entity temp tables (emitted)
+
+```sql
+-- Staging carries the SOURCE pk + natural key + payload; the identity column is NOT in the insert list.
+CREATE TABLE #Stage_Customer (
+    SourceId      INT          NOT NULL,   -- source surrogate (join handle only)
+    ExternalRef   NVARCHAR(50) NULL,       -- natural key (M5.2)
+    [Name]        NVARCHAR(200) NULL       -- ... non-identity payload columns
+);
+
+-- Map relates source surrogate -> target server-assigned surrogate.
+CREATE TABLE #Map_Customer (
+    SourceId INT NOT NULL PRIMARY KEY,
+    TargetId INT NULL
+);
+```
+
+### Emitted load sequence (per entity, topological order)
+
+```sql
+-- 1) Reuse: match staged rows to existing target rows by natural key
+INSERT INTO #Map_Customer (SourceId, TargetId)
+SELECT s.SourceId, t.[Id]
+FROM #Stage_Customer s
+JOIN [dbo].[Customer] t ON t.[ExternalRef] = s.ExternalRef;
+
+-- 2) Insert-new: capture the auto-numbered key for rows not already mapped.
+--    OUTPUT cannot read non-inserted source columns, so correlate via the natural key.
+INSERT INTO [dbo].[Customer] ([ExternalRef], [Name])
+OUTPUT inserted.[Id], inserted.[ExternalRef] INTO #MapStage_Customer (TargetId, ExternalRef)
+SELECT s.[ExternalRef], s.[Name]
+FROM #Stage_Customer s
+WHERE NOT EXISTS (SELECT 1 FROM #Map_Customer m WHERE m.SourceId = s.SourceId);
+
+INSERT INTO #Map_Customer (SourceId, TargetId)
+SELECT s.SourceId, ms.TargetId
+FROM #Stage_Customer s
+JOIN #MapStage_Customer ms ON ms.ExternalRef = s.ExternalRef
+WHERE NOT EXISTS (SELECT 1 FROM #Map_Customer m WHERE m.SourceId = s.SourceId);
+
+-- 3) Child: resolve the CustomerId FK through the parent map (parents already loaded).
+INSERT INTO [dbo].[Order] ([CustomerId], [Status])
+OUTPUT inserted.[Id], inserted.[ExternalRef] INTO #MapStage_Order (TargetId, ExternalRef)
+SELECT mc.TargetId, s.[Status]
+FROM #Stage_Order s
+JOIN #Map_Customer mc ON mc.SourceId = s.[CustomerId];
+```
+
+> **The `OUTPUT … INTO` correlation problem.** `OUTPUT` can reference only
+> `inserted.*`/`deleted.*` columns, not arbitrary source columns. The chosen
+> mechanism is to **correlate on the natural key**: `OUTPUT` the new identity *and*
+> the natural key into a small `#MapStage_<Entity>`, then join back to
+> `#Stage_<Entity>` on the natural key to recover `SourceId`. This is why M5.2
+> (natural keys) is a hard dependency — every identity entity in a slice must have
+> a natural key that is unique within the staged set. The alternative
+> (`MERGE … OUTPUT`, which *can* expose source columns) is an acceptable fallback
+> and is captured in §Alternatives.
+
+### FK cycles — reuse existing two-phase
+
+For an entity inside an SCC, a cyclic (nullable) FK is inserted as `NULL`, then
+`UPDATE`d once the partner is mapped — exactly the existing
+`PhasedDynamicEntityInsertGenerator` Phase-1/Phase-2 split (`:88-148`,
+`GenerateUpdateForNullableFKs` `:255`). The only change is that the Phase-2
+`UPDATE` resolves the FK through the partner `#Map_*` table instead of a literal
+source key. Cycle membership comes from the existing `BuildCycleTableSet`
+(`:325`) over `EntityDependencyOrderingResult.StronglyConnectedComponents`.
+
+---
+
+## Implementation Scope
+
+### Change 1 — New `CaptureRemapLoadGenerator`
+
+In `src/Osm.Emission/`, a sibling to `PhasedDynamicEntityInsertGenerator`. Given a
+selected `DynamicEntityDataset` (M5.0), the `OsmModel`, the natural-key map (M5.2),
+and `CircularDependencyOptions`:
+
+- Order entities with `EntityDependencySorter.SortByForeignKeys` (reused as-is).
+- For each entity emit: `#Stage_*` create + populate (VALUES, reusing
+  `SqlLiteralFormatter` / `AppendValuesClause` from the phased generator), the
+  reuse-by-natural-key step, the insert-new + capture step, and FK resolution.
+- For SCC members, split into Phase 1 (NULL cyclic FK) and Phase 2 (`UPDATE` via
+  partner map).
+
+### Change 2 — Retire `IDENTITY_INSERT` on the portability path
+
+The portability loader must **never** emit `SET IDENTITY_INSERT`. Identity columns
+are excluded from the insert column list (they auto-number). This is the explicit
+divergence from `PhasedDynamicEntityInsertGenerator.cs:216`; the existing bootstrap
+path keeps its behavior (it targets greenfield first-deploy with IDENTITY_INSERT
+rights). A guard asserts no `IDENTITY_INSERT` token in portability output (mirrors
+the M1.0 assertion `DoesNotContain("SET IDENTITY_INSERT")`).
+
+### Change 3 — Identity-column discovery
+
+Reuse `StaticEntitySeedColumn.IsIdentity`
+(`attribute.OnDisk.IsIdentity ?? attribute.IsAutoNumber`) to decide which column is
+the captured surrogate and to drive `OUTPUT inserted.<pk>`. Non-identity PKs (rare)
+take the literal-insert path with no capture.
+
+### Change 4 — Script assembly + observability
+
+Emit `GO`-separated phases with `PRINT` progress (matching existing generators):
+temp-table setup → per-entity loads in topo order → Phase-2 cyclic updates →
+temp-table cleanup. Carry the slice name and a per-entity inserted/reused count.
+
+---
+
+## Codebase Integration Guide
+
+### Existing infrastructure (leverage these)
+
+| Concern | Reuse | Location |
+| --- | --- | --- |
+| Topological order + SCC + feedback-arc-set | `EntityDependencySorter` | `Osm.Emission/Seeds/EntityDependencySorter.cs` |
+| Two-phase cyclic insert/update | `PhasedDynamicEntityInsertGenerator` (Phase 1/2 shape, `GenerateUpdateForNullableFKs`) | `Osm.Emission/PhasedDynamicEntityInsertGenerator.cs:88,255,325` |
+| `OUTPUT … INTO #temp` capture idiom | `SqlScriptEmitter` (`#UserRemap`, `#Changes`, `OUTPUT … INTO`) | `Osm.Pipeline/UatUsers/SqlScriptEmitter.cs:104-128,215-241` |
+| Natural-key match (reuse step) | `StaticSeedSqlBuilder` MERGE-on-key shape | `Osm.Emission/Seeds/StaticSeedSqlBuilder.cs:229` |
+| Literal/VALUES formatting | `SqlLiteralFormatter`, `AppendValuesClause` | `Osm.Emission/Formatting/`, phased generator `:368` |
+| Identity flag | `StaticEntitySeedColumn.IsIdentity` | `StaticEntitySeedScriptGenerator.cs:218` |
+
+### Required changes
+
+1. New `CaptureRemapLoadGenerator` (+ a `CaptureRemapLoadScript` result record
+   analogous to `PhasedInsertScript`).
+2. No `IDENTITY_INSERT`; identity columns excluded from insert lists.
+3. Wire the natural-key map (M5.2) and slice dataset (M5.0) into the generator.
+
+### Implementation order
+
+1. Acyclic, single-PK, capture-and-remap for a two-table parent→child fixture.
+2. Natural-key reuse step (existing-target merge).
+3. Multi-level closure (grandparent → parent → child) FK chaining.
+4. Cyclic entities via Phase-2 `UPDATE` through partner maps.
+
+---
+
+## Alternatives Considered
+
+- **`MERGE … OUTPUT` exposing source columns.** `MERGE` can `OUTPUT` source-side
+  columns, removing the natural-key correlation dance. Rejected as the *default*
+  because the reuse-vs-insert split is clearer as separate statements and MERGE on
+  large sets has known plan/locking pitfalls — but retained as a documented
+  fallback for entities whose natural key is not unique within the staged set.
+- **Pre-allocating key ranges + `IDENTITY_INSERT`.** Impossible: no
+  `IDENTITY_INSERT` rights (the whole premise).
+- **Client-side key map in the app.** Viable (and is the LoadHarness driver in
+  M5.3), but the portable **artifact** must be self-contained T-SQL, so the
+  temp-table form is primary.
+
+---
+
+## Test Scenarios
+
+**Unit (fixture-first):**
+- Two-table parent→child: assert emitted SQL has no `IDENTITY_INSERT`, creates
+  `#Map_*`, captures via `OUTPUT`, and the child's FK select joins `#Map_parent`.
+- Reuse step present and matches on the configured natural key.
+- Cyclic pair: Phase 1 inserts NULL cyclic FK, Phase 2 `UPDATE`s via partner map.
+- Identity column excluded from the insert column list; non-identity payload included.
+
+**Integration (live SQL, opt-in):**
+- Load a M5.0 slice into a populated target; assert: zero PK collisions, all child
+  FKs resolve to mapped parents, reused parents not duplicated, row counts match
+  the `ClosureReport`.
+
+---
+
+## Success Criteria
+
+- [ ] Portability load emits **no** `SET IDENTITY_INSERT`.
+- [ ] Server-assigned keys captured into `#Map_*` via `OUTPUT`.
+- [ ] Child FKs resolved by join against parent maps, in topological order.
+- [ ] Pre-existing target rows reused by natural key (no duplicates).
+- [ ] FK cycles handled by the existing two-phase split, resolving via partner maps.
+- [ ] Fixture-first unit tests assert the SQL shape; opt-in integration proves a real load.
+
+## Migration Path
+
+Additive and isolated to the new portability path. The bootstrap and UAT-users
+paths are unchanged; this generator is selected only for data-portability slices.

--- a/docs/implementation-specs/M5.2-natural-key-resolution.md
+++ b/docs/implementation-specs/M5.2-natural-key-resolution.md
@@ -1,0 +1,174 @@
+# M5.2: Data Portability — Natural-Key Resolution (reuse-vs-insert)
+
+**Date**: 2026-06-18
+**Status**: Specification (design)
+**Priority**: 🔴 Critical Path (hard dependency of M5.1)
+
+> Part of Milestone 5 (Data Portability). Consumed by
+> [M5.1](./M5.1-capture-and-remap-loader.md). See the
+> [design overview](../design-data-portability-subsetting.md) and
+> [glossary](../data-portability-glossary.md).
+
+---
+
+## Executive Summary
+
+### The Specific Problem
+
+When a sliced row lands in a **populated** target, the loader must decide: is this
+the *same* entity as an existing target row (reuse its server key) or a *new* one
+(insert and capture a new key)? The surrogate PK cannot answer this — it is
+source-local and gets reassigned on the target. We need a target-independent
+**natural (business) key** per identity entity.
+
+Today only the surrogate/PK is used: static seeds MERGE on `IsPrimaryKey` columns
+(`StaticSeedSqlBuilder.cs:147`), and dynamic entities have no natural-key concept.
+
+### Recommended Solution
+
+Two complementary sources, per the locked decision (*declared* + *profile-inferred,
+operator-confirmed*):
+
+1. **Declared** — `naturalKeys` in `data-portability.json` (parsed in M5.0): an
+   explicit column list per entity. Authoritative.
+2. **Profile-inferred proposals** — derive candidate keys from existing profiling
+   (`UniqueCandidateProfile` / `CompositeUniqueCandidateProfile` where
+   `HasDuplicate == false`) and surface them for the operator to confirm into the
+   config. Lowers authoring burden; never auto-applied silently.
+
+The resolved natural key feeds M5.1's reuse step and `OUTPUT`-correlation.
+
+### MVP Scope
+
+- Resolve a single declared natural key (single- or multi-column) per entity.
+- Profile-inferred *proposal* report (single-column first), operator confirms.
+- Validation that declared keys exist on the entity and are non-nullable enough to
+  be a reliable match.
+
+Deferred: automatic confidence ranking across many candidates; fuzzy matching.
+
+---
+
+## Data Models
+
+### Resolved natural-key map (new)
+
+```csharp
+public sealed record NaturalKeyMap(
+    ImmutableDictionary<string, NaturalKey> ByEntity);   // key: logical entity name
+
+public sealed record NaturalKey(
+    string Entity,
+    ImmutableArray<string> Columns,        // logical attribute names
+    NaturalKeySource Source);              // Declared | ProfileConfirmed
+
+public enum NaturalKeySource { Declared, ProfileConfirmed }
+```
+
+### Profile-inferred proposal (new)
+
+```csharp
+public sealed record NaturalKeyProposal(
+    string Entity,
+    ImmutableArray<NaturalKeyCandidate> Candidates);
+
+public sealed record NaturalKeyCandidate(
+    ImmutableArray<string> Columns,
+    bool FromCompositeProfile,
+    ProfilingProbeStatus ProbeStatus);     // carried through from the profile
+```
+
+A candidate is proposable iff its `UniqueCandidateProfile.HasDuplicate == false`
+(single-column) or `CompositeUniqueCandidateProfile.HasDuplicate == false`
+(multi-column), and the probe status is conclusive (not sampled-inconclusive).
+
+---
+
+## Implementation Scope
+
+### Change 1 — `NaturalKeyResolver`
+
+In `src/Osm.Pipeline/DataPortability/`. Inputs: `DataSliceOptions.NaturalKeys`
+(declared), the `OsmModel` (validate columns exist), and an optional
+`ProfileSnapshot` (for proposals). Outputs: a `Result<NaturalKeyMap>` covering
+every **identity entity** present in the slice.
+
+Resolution rules:
+- A declared key wins; validate each column resolves to an `AttributeModel` on the
+  entity and is suitable (prefer mandatory + unique-candidate columns; warn if a
+  declared key column is nullable).
+- An entity with no declared key but a conclusive single unique candidate →
+  surface as a **proposal**, do **not** auto-apply. Loading such an entity into a
+  populated target without a confirmed key is an error (would risk duplicates);
+  loading into an empty target may proceed insert-only (see M5.1 reuse step short-
+  circuit).
+- Missing key for an identity entity that must merge → actionable failure naming
+  the entity and listing proposals.
+
+### Change 2 — Proposal report
+
+Emit `NaturalKeyProposal[]` (e.g. `natural-key-proposals.json`) listing, per
+identity entity lacking a declared key, the profile-derived candidates with their
+probe status. This mirrors the UAT-users "operator confirms a CSV/template"
+ergonomics (`00_user_map.template.csv`) — here the operator pastes confirmed keys
+into `data-portability.json`.
+
+### Change 3 — Wire into M5.1
+
+The `NaturalKeyMap` drives:
+- the reuse step's `JOIN … ON t.<key> = s.<key>`,
+- the `OUTPUT … INTO #MapStage_<Entity>` correlation columns,
+- the `#Stage_<Entity>` column list (must include the key columns).
+
+---
+
+## Codebase Integration Guide
+
+### Existing infrastructure (leverage these)
+
+| Concern | Reuse | Location |
+| --- | --- | --- |
+| Single-column unique candidates | `UniqueCandidateProfile` (`HasDuplicate`, `ProbeStatus`) | `Osm.Domain/Profiling/UniqueCandidateProfile.cs` |
+| Multi-column unique candidates | `CompositeUniqueCandidateProfile` | `Osm.Domain/Profiling/CompositeUniqueCandidateProfile.cs` |
+| Profile container | `ProfileSnapshot.UniqueCandidates` / `.CompositeUniqueCandidates` | `Osm.Domain/Profiling/ProfileSnapshot.cs` |
+| Attribute/identity metadata | `AttributeModel` (`IsMandatory`, `IsIdentifier`), `StaticEntitySeedColumn.IsIdentity` | `Osm.Domain/Model/`, `Seeds/...` |
+| Result/validation | `Result<T>`, `ValidationError.Create` | `Osm.Domain/Abstractions/Result.cs` |
+| Operator-confirm ergonomics | UAT-users template/confirm flow | `Osm.Pipeline/UatUsers/` |
+
+### Required changes
+
+1. `NaturalKey*` records + `NaturalKeyResolver`.
+2. Proposal report emission from profiling.
+3. Consumption wiring in `CaptureRemapLoadGenerator` (M5.1).
+
+### Implementation order
+
+1. Declared-key resolution + column validation (no profiling needed).
+2. Profile-inferred proposals (single-column).
+3. Composite proposals + composite reuse joins.
+
+---
+
+## Test Scenarios
+
+**Unit (fixture-first):**
+- Declared single-column key resolves; unknown column → coded failure.
+- Declared multi-column key resolves; reuse join uses all columns.
+- Profiling with one zero-duplicate column → proposal emitted; not auto-applied.
+- Identity entity with no key + populated-target merge → actionable failure listing proposals.
+- Nullable declared key column → warning surfaced.
+
+---
+
+## Success Criteria
+
+- [ ] Every identity entity in a slice has a resolved natural key or an explicit, actionable gap.
+- [ ] Declared keys validated against the model; nullable columns warned.
+- [ ] Profile-inferred candidates proposed (never silently applied) with probe status.
+- [ ] Resolved keys consumed by M5.1's reuse + `OUTPUT` correlation.
+- [ ] Fixture-first unit coverage for declared, composite, inferred, and gap cases.
+
+## Migration Path
+
+Additive. Natural keys are only required on the portability path; absence is a
+clear, actionable error rather than a silent fallback.

--- a/docs/implementation-specs/M5.3-golden-transfer-verification.md
+++ b/docs/implementation-specs/M5.3-golden-transfer-verification.md
@@ -1,0 +1,173 @@
+# M5.3: Data Portability — Golden/Transfer Duality & Post-Load Verification
+
+**Date**: 2026-06-18
+**Status**: Specification (design)
+**Priority**: 🟡 Basic (ships after the M5.0–M5.2 core)
+
+> Part of Milestone 5 (Data Portability). Depends on
+> [M5.0](./M5.0-data-portability-closure-selector.md),
+> [M5.1](./M5.1-capture-and-remap-loader.md),
+> [M5.2](./M5.2-natural-key-resolution.md). See the
+> [design overview](../design-data-portability-subsetting.md).
+
+---
+
+## Executive Summary
+
+### The Specific Problem
+
+The locked decision for the artifact is **both**: the slice *definition*
+(`data-portability.json`) is versioned/committed, and *running* it produces either
+(a) an on-demand **transfer** between live environments, or (b) a committed
+**golden dataset** an environment can be reset to. A transfer can be **promoted**
+to a golden dataset. Separately, every load needs **verification** that the slice
+landed as a valid, referentially-complete fragment (the "axiom-satisfying"
+guarantee, checked on the *target*).
+
+### Recommended Solution
+
+1. **Materialization modes** over the same engine:
+   - *Transfer* — emit the capture-and-remap T-SQL artifact (M5.1) for immediate
+     application; transient.
+   - *Golden* — additionally persist a deterministic, committed dataset
+     (stable row order, stable selection) that diffs cleanly in version control.
+2. **Post-load verification** reusing the profiler: compare expected
+   (`ClosureReport`) vs actual target state — row counts per entity, zero **new**
+   orphans introduced by the load, and natural-key uniqueness preserved.
+3. **LoadHarness driver** — the existing harness orchestrates apply + verify for
+   the self-contained artifact (the "both" answer to the load-vehicle question).
+
+### MVP Scope
+
+- Transfer artifact + golden materialization (deterministic ordering).
+- Post-load row-count + new-orphan verification via the profiler.
+- Promote-transfer-to-golden command path.
+
+Deferred: full checksum equivalence (defer to the M1.8 data-integrity machinery),
+incremental/delta golden updates.
+
+---
+
+## Data Models
+
+### Golden dataset (committed)
+
+A deterministic, reviewable representation of a materialized slice. Format options
+(decide at build time; default JSON for diffability):
+
+```
+golden/<slice-name>/
+  manifest.json          # slice name, source env id, generated-at, per-entity row counts, closure summary
+  data/<Entity>.jsonl    # stable-ordered rows (one JSON object per line)
+```
+
+Determinism rules: entities in topological order; rows ordered by natural key then
+source PK; values normalized exactly as `StaticEntityRow`/`SqlLiteralFormatter`
+already normalize them, so re-materializing the same source yields a byte-identical
+golden (clean diffs).
+
+### Post-load verification report (new)
+
+```csharp
+public sealed record SliceVerificationReport(
+    string SliceName,
+    ImmutableArray<EntityRowCountCheck> RowCounts,   // expected (ClosureReport) vs actual (profiler)
+    ImmutableArray<NewOrphanFinding> NewOrphans,     // FK reality regressions vs pre-load baseline
+    bool NaturalKeysUnique,
+    bool Passed);
+```
+
+`NewOrphans` is computed by differencing `ForeignKeyReality` (orphan counts) from a
+pre-load profile baseline against a post-load profile of the same target — a load
+that introduces an orphan fails.
+
+---
+
+## Implementation Scope
+
+### Change 1 — Materialization modes
+
+A `DataSliceMaterializer` selecting between *transfer* and *golden*. Both call the
+M5.0 selector and M5.1 generator; *golden* additionally writes the committed
+dataset with deterministic ordering and a manifest.
+
+### Change 2 — Promote transfer → golden
+
+A path that takes an already-extracted transfer dataset and writes it as a golden
+dataset without re-querying the source (so a verified transfer becomes the
+baseline verbatim).
+
+### Change 3 — Post-load verification
+
+Reuse `MultiTargetSqlDataProfiler` to profile the target before and after load;
+diff against `ClosureReport`:
+- per-entity expected vs actual inserted/reused counts;
+- new-orphan detection via `ForeignKeyReality` delta;
+- natural-key uniqueness on the loaded entities (reuse `UniqueCandidateProfile`).
+
+### Change 4 — LoadHarness driver
+
+Extend the existing load harness (analogous to the UAT-users
+`M3.2-load-harness-extension`) to: apply the self-contained artifact, then run
+verification, then emit `SliceVerificationReport`. The T-SQL artifact remains the
+durable deliverable; the harness is the orchestrator/verifier.
+
+---
+
+## Codebase Integration Guide
+
+### Existing infrastructure (leverage these)
+
+| Concern | Reuse | Location |
+| --- | --- | --- |
+| Cross-environment profiling | `MultiTargetSqlDataProfiler`, `ProfileSnapshot` | `Osm.Pipeline/Profiling/` |
+| FK reality / orphan deltas | `ForeignKeyReality` (`HasOrphan`, `OrphanCount`) | `Osm.Domain/Profiling/` |
+| Deterministic ordering/normalization | `EntitySeedDeterminizer`, `SqlLiteralFormatter`, `StaticEntityRow` | `Osm.Emission/...` |
+| Load harness orchestration | `Osm.LoadHarness`, `tools/FullExportLoadHarness` | `src/Osm.LoadHarness/` |
+| Manifest pattern | `FullExportRunManifest` and the artifact contract | `docs/full-export-artifact-contract.md` |
+| Expected closure | `ClosureReport` (M5.0) | M5.0 |
+
+### Required changes
+
+1. `DataSliceMaterializer` (transfer/golden) + golden writer + manifest.
+2. Promote path (transfer → golden).
+3. `SliceVerificationReport` + profiler-diff verifier.
+4. LoadHarness apply+verify extension.
+
+### Implementation order
+
+1. Transfer artifact end-to-end (selector → generator → file).
+2. Golden materialization (deterministic) + manifest.
+3. Post-load profiler verification.
+4. Promote + LoadHarness driver.
+
+---
+
+## Test Scenarios
+
+**Unit / fixture-first:**
+- Golden materialization is deterministic: same fixture source → byte-identical output.
+- Verification report: expected vs actual mismatch → `Passed == false`.
+- New-orphan delta detection flags a load that breaks an FK.
+- Promote writes golden from an in-memory transfer without re-query.
+
+**Integration (live SQL, opt-in):**
+- Apply a slice to a populated target via the harness; assert `SliceVerificationReport`
+  passes (counts match, zero new orphans, natural keys unique).
+- Reset an environment from a committed golden dataset; re-verify idempotence
+  (second apply is a no-op on counts).
+
+---
+
+## Success Criteria
+
+- [ ] Same engine yields both a transient transfer and a committed golden dataset.
+- [ ] Golden output is deterministic and diffs cleanly.
+- [ ] A transfer can be promoted to golden without re-querying the source.
+- [ ] Post-load verification proves counts, zero new orphans, natural-key uniqueness.
+- [ ] LoadHarness applies the self-contained artifact and emits the verification report.
+
+## Migration Path
+
+Additive. Verification reuses existing profiling; golden datasets are new
+committed artifacts that do not affect existing export outputs.

--- a/docs/implementation-specs/README.md
+++ b/docs/implementation-specs/README.md
@@ -70,6 +70,22 @@ Each specification follows a consistent format:
 - [M4.1-performance-benchmarking.md](./M4.1-performance-benchmarking.md) - Scale testing framework
 - [M4.2-security-validation.md](./M4.2-security-validation.md) - Permission and compliance validation
 
+### Milestone 5: Data Portability — Scoped Referential Subsetting & Transfer
+
+Lift a use-case-scoped, referentially-complete subset of rows between environments,
+with collision-safe surrogate remapping for DML-only on-prem targets. See the design
+overview [`design-data-portability-subsetting.md`](../design-data-portability-subsetting.md),
+the [glossary](../data-portability-glossary.md), and the
+[`data-slice` verb](../verbs/data-slice.md).
+
+- [M5.0-data-portability-closure-selector.md](./M5.0-data-portability-closure-selector.md) - **🔴 Critical Path**: `data-portability.json` config + the scoped closure selector (root predicates, per-edge up/down/stop, key-scoped parent pull, completeness invariant)
+- [M5.1-capture-and-remap-loader.md](./M5.1-capture-and-remap-loader.md) - **🔴 Critical Path**: capture-and-remap load that replaces `SET IDENTITY_INSERT` (`#Map_*` temp tables, `OUTPUT` key capture, FK resolution by join, two-phase cycles)
+- [M5.2-natural-key-resolution.md](./M5.2-natural-key-resolution.md) - **🔴 Critical Path**: declared + profile-inferred natural keys driving reuse-vs-insert (hard dependency of M5.1)
+- [M5.3-golden-transfer-verification.md](./M5.3-golden-transfer-verification.md) - **🟡 Basic**: golden/transfer duality + post-load verification (counts, new-orphan delta, natural-key uniqueness)
+
+**Recommended order**: M5.0 → M5.2 → M5.1 → M5.3 (selector and natural keys before
+the loader that consumes both).
+
 ### Additional Sections
 - [Section-1-policy-telemetry.md](./Section-1-policy-telemetry.md) - Policy matrix and decision telemetry
 - [Section-2-smo-emission.md](./Section-2-smo-emission.md) - SMO validation and edge cases

--- a/docs/verbs/data-slice.md
+++ b/docs/verbs/data-slice.md
@@ -1,0 +1,148 @@
+# data-slice Verb
+
+`data-slice` lifts a **use-case-scoped, referentially-complete subset** of rows out
+of one OutSystems-backed SQL Server environment and lands it in another — preserving
+not just the chosen rows but everything they reference (parents, enums, lookups), and
+remapping surrogate keys for **DML-only** on-prem targets that lack `IDENTITY_INSERT`.
+The slice definition is versioned config; running it produces either an on-demand
+transfer or a committed golden dataset.
+
+> Design: [`design-data-portability-subsetting.md`](../design-data-portability-subsetting.md).
+> Specs: [M5.0](../implementation-specs/M5.0-data-portability-closure-selector.md),
+> [M5.1](../implementation-specs/M5.1-capture-and-remap-loader.md),
+> [M5.2](../implementation-specs/M5.2-natural-key-resolution.md),
+> [M5.3](../implementation-specs/M5.3-golden-transfer-verification.md).
+> Glossary: [`data-portability-glossary.md`](../data-portability-glossary.md).
+> Status: planned (specification stage).
+
+---
+
+## ✅ Recommended Approach: scoped transfer between live environments
+
+Extract a slice from a source connection and emit a self-contained, DML-only T-SQL
+load artifact (capture-and-remap) plus a closure report.
+
+```bash
+dotnet run --project src/Osm.Cli -- data-slice \
+  --model ./out/model.json \
+  --config ./config/data-portability.json \
+  --slice order-fulfillment-golden \
+  --source-connection-string "Server=qa;Database=App;..." \
+  --out ./out/slices
+```
+
+**Outcome**: `order-fulfillment-golden/` containing the load artifact, the closure
+report, and (if natural keys are incomplete) a natural-key proposal file.
+
+**Benefits**:
+- Referentially complete by construction (closure-completeness invariant).
+- No `IDENTITY_INSERT` required on the target; surrogate keys remapped at load time.
+- Reuses existing target rows by natural key (no duplicates on a populated target).
+
+---
+
+## Alternative Mode: golden baseline (commit & reset)
+
+Materialize the slice as a deterministic, version-controlled golden dataset that an
+environment can be reset to.
+
+```bash
+dotnet run --project src/Osm.Cli -- data-slice \
+  --model ./out/model.json \
+  --config ./config/data-portability.json \
+  --slice order-fulfillment-golden \
+  --source-connection-string "Server=qa;Database=App;..." \
+  --golden ./golden \
+  --out ./out/slices
+```
+
+Or promote an already-extracted transfer to golden without re-querying the source:
+
+```bash
+dotnet run --project src/Osm.Cli -- data-slice \
+  --promote ./out/slices/order-fulfillment-golden \
+  --golden ./golden
+```
+
+---
+
+## Key Behaviors
+
+* **Scoped closure** – BFS from the slice roots, following per-relationship
+  directives (`up` / `down` / `stop`); pulls only referenced parent rows, not whole
+  tables; terminates at a referential fixed point.
+* **Capture-and-remap load** – inserts without the PK, captures the server-assigned
+  key via `OUTPUT`, and resolves child FKs by join against per-entity `#Map_*` tables.
+* **Natural-key reuse** – matches sliced rows to existing target rows by declared (or
+  profile-inferred, operator-confirmed) natural keys.
+* **Cycle-safe** – FK cycles handled by the existing two-phase insert-then-update.
+* **Verified** – optional post-load verification proves row counts, zero new orphans,
+  and natural-key uniqueness on the target.
+
+---
+
+## CLI Contract
+
+```
+data-slice
+  --model <path>                     # extracted OsmModel JSON
+  --config <path>                    # data-portability.json (slice definitions)
+  --slice <name>                     # which slice to materialize
+  --source-connection-string <conn>  # source environment (read-only)
+  [--out <dir>]                      # artifact output (default ./out/slices)
+  [--golden <dir>]                   # also write a committed golden dataset
+  [--promote <slice-dir>]            # promote an existing transfer to golden (no source query)
+  [--profile <path>]                 # profile snapshot, for natural-key proposals
+  [--verify-connection-string <conn>]# target, for post-load verification
+  [--sampling-threshold <rows>]      # inherits dynamic-extraction sampling knobs
+```
+
+---
+
+## Required Inputs
+
+1. **Model** – an extracted `OsmModel` JSON (`extract-model` output).
+2. **Config** – `data-portability.json` declaring `slices[]` (roots + edges +
+   natural keys). See M5.0 for the schema.
+3. **Source connection** – read-only access to the source environment.
+4. *(Optional)* **Profile snapshot** – enables natural-key proposals from existing
+   `UniqueCandidateProfile` data.
+
+---
+
+## Primary Artifacts (written to `<out>/<slice-name>/`)
+
+| File | Description |
+| --- | --- |
+| `load.capture-remap.sql` | Self-contained DML-only load artifact (`#Stage_*`/`#Map_*`, `OUTPUT` capture, FK resolution, two-phase cycles). No `IDENTITY_INSERT`. |
+| `closure-report.json` | Per-entity row counts, pull provenance (root/up/down), and any dangling-FK findings. |
+| `natural-key-proposals.json` | Profile-inferred candidate keys for entities lacking a declared key (operator confirms into config). |
+| `manifest.json` | Slice name, source env id, generated-at, counts, closure summary. |
+| `verification-report.json` | *(with `--verify-connection-string`)* expected-vs-actual counts, new-orphan findings, natural-key uniqueness. |
+
+Golden mode additionally writes `golden/<slice-name>/` with `manifest.json` and
+deterministic `data/<Entity>.jsonl`.
+
+---
+
+## Workflow
+
+1. **Define the slice** in `data-portability.json` (roots, edges, natural keys).
+2. **Extract + emit**
+   ```bash
+   dotnet run --project src/Osm.Cli -- data-slice --model ... --config ... --slice ... --source-connection-string ...
+   ```
+   Review `closure-report.json`; resolve any dangling-FK or natural-key gaps.
+3. **Apply** `load.capture-remap.sql` to the target (operator, or via the load harness).
+4. **Verify** (optional) with `--verify-connection-string`; inspect `verification-report.json`.
+5. **Promote** to golden once satisfied, if this slice is a baseline.
+
+---
+
+## Acceptance Checklist
+
+* Closure report shows zero dangling mandatory FKs.
+* Load artifact contains no `SET IDENTITY_INSERT`.
+* Re-applying the artifact is idempotent on row counts (natural-key reuse).
+* Post-load verification passes (counts match, zero new orphans, natural keys unique).
+* Golden dataset (if produced) re-materializes byte-identically from the same source.


### PR DESCRIPTION
## What

A complete, convention-matching **documentation set** for the data-portability feature: lifting a *use-case-scoped, referentially-complete subset* of rows between environments with collision-safe identity remapping for **DML-only** on-prem targets. Docs only — no code changes.

## Documents

- **Design overview** — `docs/design-data-portability-subsetting.md` (intent, locked decisions, grounded gap analysis, decision tree, per-milestone checklist).
- **Glossary** — `docs/data-portability-glossary.md` (maps the abstract vocabulary to concrete code anchors; ✅/🟡/❌ status per term).
- **Verb doc** — `docs/verbs/data-slice.md` (operator-facing CLI contract, artifacts, workflow).
- **Implementation specs (Milestone 5)** — M3/M4 were taken, so this is M5:
  - `M5.0` closure selector — `data-portability.json` config + scoped referential closure (root predicates, per-edge up/down/stop, key-scoped parent pull, completeness invariant).
  - `M5.1` capture-and-remap loader — replaces `SET IDENTITY_INSERT` with `#Map_*` temp tables, `OUTPUT` key capture, FK resolution by join, two-phase cycles.
  - `M5.2` natural-key resolution — declared + profile-inferred keys driving reuse-vs-insert.
  - `M5.3` golden/transfer duality + post-load verification.
- Index/roadmap wiring — `docs/implementation-specs/README.md` and `docs/architecture/concerns/ROADMAP.md`.

## Grounding (the surprise)

The specs are written against the real codebase: the hard primitives already ship — Kahn topo sort + Tarjan SCC + feedback-arc-set + **two-phase insert-then-update** (`EntityDependencySorter`, `PhasedDynamicEntityInsertGenerator`); an embryonic closure BFS and live batched extraction (`SqlDynamicEntityDataProvider`); the `#UserRemap`/`OUTPUT … INTO` idiom (`SqlScriptEmitter`); profile-derived uniqueness candidates. The genuinely-new work is isolated to: the closure config/selector, the capture-and-remap swap (the `IDENTITY_INSERT` at `PhasedDynamicEntityInsertGenerator.cs:216` is the load-bearing conflict), and natural keys.

**Recommended build order:** M5.0 → M5.2 → M5.1 → M5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
