### PR TITLE
sidecar/projection: rendering refinements — --query (#17) + responsive width (#11)

### DIFF
--- a/sidecar/projection/SPECTRE_REFINEMENTS.md
+++ b/sidecar/projection/SPECTRE_REFINEMENTS.md
@@ -105,7 +105,7 @@ Status key: **● shipped** · **◐ partial / starved** · **○ not started** 
 | 14 | Trend surfaces (use `Theme.sparkline`) | C | ○ |
 | 15 | `Trail` gets cap-and-name + depth | C | ○ |
 | 16 | Unify the collapsed-affordance vocabulary | C | ○ |
-| 17 | Implement `--query` over `toJson` | D. The query lens | ▢ |
+| 17 | Implement `--query` over `toJson` | D. The query lens | ● |
 | 18 | Per-node addressing (`ViewPath`) | D | ○ |
 | 19 | Emit the intra-stage `summary.stageProgress` events | E. The Watch board | ◐ |
 | 20 | Move the dwell off the emitting thread | E | ○ |
@@ -307,7 +307,24 @@ depth < 1). Inconsistent affordance.
 
 ## D — The query / structured lens
 
-### 17 · Implement `--query`  ▢  *(redeems an already-paid-for lens)*
+### 17 · Implement `--query`  ●  *(landed 2026-06-18)*
+
+**Landed.** A global `--query <path>` flag (extracted in `Program.main` before the
+boolean-flag pass so its value can't be mistaken for a flag; a malformed path
+exits 2 at the boundary) sets `TtyRenderer.queryMode`, which `renderAnswer`
+consults — so every answer surface (diff / explain / survey …) gains it for free,
+no `PlanAction` ripple. The walker is `View.query` / `View.validateQuery`: a pure,
+JSONPath-*subset* fold over the `toJson` tree supporting `.key`, `[n]`, `[]`
+(wildcard), and `[?k=v]` (flat equality filter) — the surface-shaped subset, not a
+full engine (it grows at the next real query, CLAUDE.md §5). Matched nodes print
+one-per-line (jq-like). Seven `ViewTests` cover key / wildcard / index / filter /
+empty-match / malformed-path / `validateQuery`. *Not a full JSONPath* (no
+recursive descent, slices, or `*` over objects) — named here so the boundary is
+honest.
+
+---
+
+#### Original survey note (kept for provenance)
 
 **Problem.** `View.toJson` exists and the code **promises** "a `--query` walks
 this" in `View.fs`'s header and in `RunFaces.explainView`'s doc — but there is no

--- a/sidecar/projection/SPECTRE_REFINEMENTS.md
+++ b/sidecar/projection/SPECTRE_REFINEMENTS.md
@@ -99,7 +99,7 @@ Status key: **● shipped** · **◐ partial / starved** · **○ not started** 
 | 8 | Sealed `Color` palette | B | ✕ |
 | 9 | High-contrast / colorblind theme | B | ✕ |
 | 10 | Screen-reader narration lens | B | ✕ |
-| 11 | **Responsive width** | B | ○ |
+| 11 | **Responsive width** | B | ● |
 | 12 | `View.Table` primitive | C. New primitives | ○ |
 | 13 | Fold `Bench.renderTable` into the substrate | C | ○ |
 | 14 | Trend surfaces (use `Theme.sparkline`) | C | ○ |
@@ -173,7 +173,14 @@ an exception. A display bug today can turn exit 0 into a crash.
 fault degrades to plain text and never fails the run it describes. Pairs with #2
 (which removes most of the *cause*) — keep both: #2 prevents, #3 contains.
 
-### 4 · A `RenderOptions` record  ○  *(the enabling refactor)*
+### 4 · A `RenderOptions` record  ○  *(deferred — see note; build at the second consumer)*
+
+> **Deferred 2026-06-18.** #11 (responsive width) was its stated first consumer,
+> but #11 reads `console.Profile.Width` directly inside `writeBlock` — it needed
+> no record. Per the house "carriers reify at the second consumer" law (CLAUDE.md
+> §5), `RenderOptions` is held until #15 (`Trail` cap) or #18 (`ViewPath`) makes a
+> *second* render parameter real; building it now for one consumer would be a
+> speculative carrier. The original rationale stands for when that day comes:
 
 **Problem.** `defaultDepth`, `laneCap`, the implicit width, and the color policy
 are scattered `[<Literal>]`s and inlined constants. `writeToDepth` threads a bare
@@ -210,7 +217,23 @@ compile-time totality witness by making `writePanel` match a closed `PanelRow`
 > Section scoped to **responsive width** per operator direction (2026-06-18).
 > `NO_COLOR` shipped (#7). #8–#10 de-scoped (§1 table).
 
-### 11 · Responsive width  ○
+### 11 · Responsive width  ●  *(landed 2026-06-18)*
+
+**Landed.** A pure `View.fit (width) (prefix) (text)` helper — the width dual of
+the `laneCap` breadth cap — truncates a too-wide cell with a `…`, and `writeBlock`
+applies it to the text-bearing arms (`Hero` / `Field` / `Note` / `Action` /
+`Disclosure` headline), with prefix math accounting for the indent, label column,
+and glyph. It reads `console.Profile.Width` directly (a redirected sink is pinned
+to `plainWidth`; a TTY reports its real width; an unknown width yields a
+non-positive budget → no-op), so **#4 was not needed** and stays deferred (below).
+`toJson` keeps the full untrimmed string — truncation is a pretty-lens concern.
+Two `ViewTests`: a width-40 console truncates a 66-char value onto one line while
+the machine lens keeps it whole; a width-200 console leaves it untouched. `Lane`
+and `Trail` headlines are not yet fit (short labels; `Trail` is capped by #15).
+
+---
+
+#### Original survey note (kept for provenance)
 
 **Problem.** Everything assumes ≥ `View.plainWidth` (100) columns. The meter is a
 fixed 10 cells (`Theme.meter`); long `Field` values aren't truncated or wrapped;

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -78,6 +78,8 @@ let private usageLines : string list =
         "Every verb persists a bench snapshot to bench/<verb>/<utc-iso>.json; -v surfaces the"
         "table. --pretty / --json force the channel (default AUTO: a TTY gets the live stage"
         "board + verdict panel, a pipe gets NDJSON)."
+        "--query <path> projects an answer's structure (jq-like: .blocks[].status,"
+        "  .fields[0].value, .blocks[?status=warn]) — the machine lens, sharpened to a path."
         ""
         "Exit codes:"
         "    0  succeeded"
@@ -363,6 +365,28 @@ let main argv =
     //     (a real TTY gets the Spectre panel, a pipe gets clean NDJSON — the
     //     operator never thinks about format).
     //   -v / --verbose : surface depth (the bench table, etc.).
+    // `--query <path>` — the structured-lens flag (#17), a global VALUE-flag.
+    // Extracted FIRST, before the boolean-flag detection below, so its value
+    // (`.blocks[].status`) can never be mistaken for a `--pretty` / `--json`
+    // token. A malformed path is refused here with a clean exit (2), never a
+    // crash on the answer surface; both tokens are stripped so the per-verb argv
+    // shape is unchanged. Sets `TtyRenderer.queryMode`, which `renderAnswer`
+    // (the one answer-surface choke point) consults.
+    let queryError, argv =
+        match Array.tryFindIndex ((=) "--query") argv with
+        | Some idx when idx + 1 < argv.Length ->
+            let path = argv.[idx + 1]
+            let stripped = Array.append argv.[.. idx - 1] argv.[idx + 2 ..]
+            match View.validateQuery path with
+            | Ok ()   -> TtyRenderer.queryMode := Some path; (None, stripped)
+            | Error e -> (Some e, stripped)
+        | Some _ -> (Some "--query needs a path argument, e.g. --query .blocks[].status", argv)
+        | None   -> (None, argv)
+    match queryError with
+    | Some e ->
+        Console.Error.WriteLine(sprintf "projection: --query: %s" e)
+        exit 2
+    | None -> ()
     let has flag = Array.contains flag argv
     verboseMode := has "-v" || has "--verbose"
     let forceJson = has "--json" || has "--no-pretty"

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -289,17 +289,36 @@ let renderReadinessBoard (r: RunLedger.Readiness) (recent: string list) (ledgerP
 
 // --- the answer surface — render any View to stdout (INSTRUMENT slice 1) ----
 
+/// The `--query` path, when the operator asked for the structured lens (#17).
+/// A global flag (`Program.main` strips it and its value from argv, like
+/// `--pretty` / `--json`), stored here because `renderAnswer` — the single
+/// answer-surface choke point — is the consumer. `None` is the default (render
+/// the tree); `Some path` projects `View.toJson` through the path instead.
+let queryMode : string option ref = ref None
+
 /// Render any `View` to stdout — the "answer" surface (stdout carries the answer;
 /// structured events stay on stderr). Pretty (color) on a TTY; plain when piped
 /// (width pinned so lines don't collapse); the dig is revealed to `depth` levels.
 /// `--format json` emits the same document as structure (`View.toJson`) — always
-/// the full tree — so the human and machine lenses are the one value.
+/// the full tree — so the human and machine lenses are the one value. `--query`
+/// (when set) walks that same `toJson` tree and emits only the matched nodes
+/// (jq-like, one per line) — the structured lens, sharpened to a path.
 let renderAnswer (asJson: bool) (depth: int) (v: View.View) : unit =
-    if asJson then
-        Console.Out.WriteLine((View.toJson v).ToJsonString())
-    else
-        let console = View.consoleTo Console.Out
-        View.writeToDepth console depth v
+    match queryMode.Value with
+    | Some path ->
+        // The path syntax is validated at the boundary (`Program.main`), so a
+        // walk error here is unreachable in production; handle it anyway rather
+        // than throw on the answer surface.
+        match View.query path (View.toJson v) with
+        | Ok results ->
+            for node in results do Console.Out.WriteLine(node.ToJsonString())
+        | Error e -> eprintfn "projection: --query: %s" e
+    | None ->
+        if asJson then
+            Console.Out.WriteLine((View.toJson v).ToJsonString())
+        else
+            let console = View.consoleTo Console.Out
+            View.writeToDepth console depth v
 
 /// Voice a refusal to STDERR (the §5 channel split — errors never on stdout).
 /// The coded `ValidationError` becomes a register-correct `Surface` via

--- a/sidecar/projection/src/Projection.Cli/View.fs
+++ b/sidecar/projection/src/Projection.Cli/View.fs
@@ -359,3 +359,108 @@ let rec toJson (v: View) : JsonNode =
     | Note text -> obj [ "kind", s "note"; "text", s text ]
     | Action text -> obj [ "kind", s "action"; "text", s text ]
     | Blank -> obj [ "kind", s "blank" ]
+
+// --- The query lens (a JSONPath subset over toJson; #17) -------------------
+// `toJson` is the structured lens; `--query` walks it. The grammar is the
+// surface-shaped subset the operator surfaces actually need — object keys, an
+// array index, the `[]` wildcard (map over an array), and a flat equality
+// filter `[?k=v]` — not a full JSONPath. It grows at the next real query
+// (CLAUDE.md §5 — verbs at the second consumer). The walk is pure over the
+// `JsonNode` the document already produces, so the human (`write`) and machine
+// (`toJson` / `--query`) lenses stay projections of one value.
+
+type private QuerySeg =
+    | Key of string
+    | Index of int
+    | Wildcard
+    | Filter of key: string * value: string
+
+/// Parse a `--query` path (`.blocks[].status`, `.fields[0].value`,
+/// `.blocks[?status=warn]`) into its segments, or a legible error. Paths lead
+/// with `.` or `[` (the jq convention); a malformed path is named, never a crash.
+let private parseQuery (path: string) : Result<QuerySeg list, string> =
+    let segs = ResizeArray<QuerySeg>()
+    let n = path.Length
+    let mutable i = 0
+    let mutable err = None
+    while i < n && Option.isNone err do
+        match path.[i] with
+        | '.' ->
+            let start = i + 1
+            let mutable j = start
+            while j < n && path.[j] <> '.' && path.[j] <> '[' do j <- j + 1
+            if j = start then err <- Some "empty key after '.'"
+            else
+                segs.Add(Key(path.Substring(start, j - start)))
+                i <- j
+        | '[' ->
+            match path.IndexOf(']', i) with
+            | -1 -> err <- Some "unclosed '[' in query path"
+            | close ->
+                let inner = path.Substring(i + 1, close - i - 1)
+                if inner = "" then segs.Add Wildcard
+                elif inner.StartsWith "?" then
+                    let body = inner.Substring 1
+                    match body.IndexOf '=' with
+                    | -1 -> err <- Some "filter needs the form [?key=value]"
+                    | eq -> segs.Add(Filter(body.Substring(0, eq), body.Substring(eq + 1)))
+                else
+                    match System.Int32.TryParse inner with
+                    | true, idx -> segs.Add(Index idx)
+                    | _          -> err <- Some(sprintf "bad array index '%s'" inner)
+                i <- close + 1
+        | c -> err <- Some(sprintf "unexpected '%c' (a query path leads with '.' or '[')" c)
+    match err with
+    | Some e -> Result.Error e
+    | None   -> Result.Ok(List.ofSeq segs)
+
+let private matchesFilter (k: string) (value: string) (node: JsonNode) : bool =
+    match node with
+    | :? JsonObject as o ->
+        match o.TryGetPropertyValue k with
+        | true, fv ->
+            match Option.ofObj fv with
+            // Compare the stringified value, with one layer of JSON quoting
+            // stripped so `[?status=warn]` matches the string "warn" and
+            // `[?filled=7]` matches the number 7.
+            | Some nn -> nn.ToJsonString().Trim('"') = value
+            | None    -> false
+        | _ -> false
+    | _ -> false
+
+let private applySeg (seg: QuerySeg) (node: JsonNode) : JsonNode list =
+    match seg with
+    | Key k ->
+        match node with
+        | :? JsonObject as o ->
+            match o.TryGetPropertyValue k with
+            | true, v -> Option.ofObj v |> Option.toList
+            | _       -> []
+        | _ -> []
+    | Index idx ->
+        match node with
+        | :? JsonArray as a when idx >= 0 && idx < a.Count -> Option.ofObj a.[idx] |> Option.toList
+        | _ -> []
+    | Wildcard ->
+        match node with
+        | :? JsonArray as a -> a |> Seq.choose Option.ofObj |> List.ofSeq
+        | _ -> []
+    | Filter (k, value) ->
+        match node with
+        | :? JsonArray as a -> a |> Seq.choose Option.ofObj |> Seq.filter (matchesFilter k value) |> List.ofSeq
+        | _ -> []
+
+/// Validate a `--query` path's syntax without a document — the boundary
+/// (`Program.main`) calls this to refuse a malformed path early with a clean
+/// exit, rather than letting it silently match nothing.
+let validateQuery (path: string) : Result<unit, string> =
+    parseQuery path |> Result.map ignore
+
+/// Walk a `--query` path over a document's `toJson` tree, returning the matched
+/// nodes (jq-like: zero, one, or many — a `[]` wildcard or `[?…]` filter fans
+/// out). A malformed path is an `Error`; a well-formed path that matches nothing
+/// is `Ok []`.
+let query (path: string) (root: JsonNode) : Result<JsonNode list, string> =
+    match parseQuery path with
+    | Result.Error e -> Result.Error e
+    | Result.Ok segs -> Result.Ok(segs |> List.fold (fun nodes seg -> nodes |> List.collect (applySeg seg)) [ root ])

--- a/sidecar/projection/src/Projection.Cli/View.fs
+++ b/sidecar/projection/src/Projection.Cli/View.fs
@@ -153,15 +153,36 @@ let private marker (depth: int) (hasChildren: bool) : string =
     elif depth >= 1 then Theme.expanded
     else Theme.collapsed
 
+/// Truncate a cell's text to the width that remains on its line, with a `…`
+/// tail — the width dual of the §12 breadth cap (`laneCap`). `prefix` is the
+/// visible characters already spent on the line (indent + label + glyph +
+/// gutters); the rest is the budget for `text`. A non-positive budget (an
+/// unknown / pinned-narrow width) or a string that already fits is a no-op — so
+/// a wide terminal (tests pin 200) is untouched, and a redirected sink (pinned to
+/// `plainWidth`) only trims what would have wrapped. Truncation is a pretty-lens
+/// concern only; `toJson` always carries the full, untrimmed string.
+let private fit (width: int) (prefix: int) (text: string) : string =
+    let budget = width - prefix
+    if budget <= 0 || text.Length <= budget then text
+    elif budget = 1 then "…"
+    else text.Substring(0, budget - 1) + "…"
+
 let rec private writeBlock (console: IAnsiConsole) (depth: int) (indent: string) (v: View) : unit =
     match v with
     | Doc blocks -> for b in blocks do writeBlock console depth indent b
     | Blank -> console.WriteLine()
     | Panel (title, fields) -> writePanel console title fields
     | Hero (st, text) ->
-        console.MarkupLine(sprintf "%s%s  %s" indent (colorOf st (glyphOf st)) (Theme.bold (Markup.Escape text)))
+        let g = glyphOf st
+        let body = fit console.Profile.Width (indent.Length + g.Length + 2) text
+        console.MarkupLine(sprintf "%s%s  %s" indent (colorOf st g) (Theme.bold (Markup.Escape body)))
     | Field (label, value, st) ->
-        console.MarkupLine(sprintf "%s%s   %s" indent (Theme.muted (Markup.Escape label)) (styled st value))
+        // `styled` prepends `glyph + space` (nothing for Neutral); the label
+        // column + its 3-space gutter precede it. Fit the value to what remains.
+        let g = glyphOf st
+        let glyphPart = if g = "" then 0 else g.Length + 1
+        let body = fit console.Profile.Width (indent.Length + label.Length + 3 + glyphPart) value
+        console.MarkupLine(sprintf "%s%s   %s" indent (Theme.muted (Markup.Escape label)) (styled st body))
     | Meter (label, filled, total, suffix) ->
         console.MarkupLine(
             sprintf "%s%s   %s   %s"
@@ -203,15 +224,21 @@ let rec private writeBlock (console: IAnsiConsole) (depth: int) (indent: string)
                         (Theme.muted (sprintf "and %s more" (Theme.humane (n - laneCap)))))
     | Disclosure (headline, st, detail) ->
         let m = marker depth (not (List.isEmpty detail))
-        console.MarkupLine(sprintf "%s%s %s" indent m (styled st headline))
+        let g = glyphOf st
+        let glyphPart = if g = "" then 0 else g.Length + 1
+        let body = fit console.Profile.Width (indent.Length + m.Length + 1 + glyphPart) headline
+        console.MarkupLine(sprintf "%s%s %s" indent m (styled st body))
         if depth >= 1 then
             for child in detail do writeBlock console (depth - 1) (indent + "  ") child
         elif not (List.isEmpty detail) then
             console.MarkupLine(
                 sprintf "%s  %s %s" indent (Theme.muted Theme.collapsed)
                     (Theme.muted (sprintf "%d more" (List.length detail))))
-    | Note text -> console.MarkupLine(sprintf "%s%s" indent (Theme.muted (Markup.Escape text)))
-    | Action text -> console.MarkupLine(sprintf "%s%s %s" indent Theme.arrow (Theme.accent (Markup.Escape text)))
+    | Note text ->
+        console.MarkupLine(sprintf "%s%s" indent (Theme.muted (Markup.Escape (fit console.Profile.Width indent.Length text))))
+    | Action text ->
+        let body = fit console.Profile.Width (indent.Length + Theme.arrow.Length + 1) text
+        console.MarkupLine(sprintf "%s%s %s" indent Theme.arrow (Theme.accent (Markup.Escape body)))
 
 /// Render to a chosen disclosure depth — the dig revealed `depth` levels down,
 /// deeper nodes collapsed behind their `▸ N more` affordance. The interactive

--- a/sidecar/projection/tests/Projection.Tests/ViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ViewTests.fs
@@ -354,3 +354,43 @@ let ``query: a malformed path is a named Error, not a crash`` () =
 let ``query: validateQuery accepts a leading-dot path and rejects a bare key`` () =
     Assert.True(match View.validateQuery ".blocks[].status" with Ok () -> true | _ -> false)
     Assert.True(match View.validateQuery "blocks" with Error _ -> true | _ -> false)
+
+// --- responsive width (#11) ------------------------------------------------
+// Discriminating predicate: a cell too wide for the console is truncated with a
+// `…` and stays on ONE line (no wrap) — the width dual of the §12 breadth cap;
+// but the machine lens (`toJson`) keeps the FULL value, since truncation is a
+// pretty-lens concern only. A wide console leaves the value whole (the no-op
+// path that keeps every existing assertion, which renders at width 200, intact).
+
+let private plainAtWidth (width: int) (v: View.View) : string =
+    use sw = new StringWriter()
+    let console =
+        AnsiConsole.Create(
+            AnsiConsoleSettings(
+                Ansi = AnsiSupport.No, ColorSystem = ColorSystemSupport.NoColors,
+                Out = AnsiConsoleOutput(sw)))
+    console.Profile.Width <- width
+    View.writeToDepth console View.defaultDepth v
+    sw.ToString()
+
+[<Fact>]
+let ``View: a narrow console truncates a long field value with … on one line — json keeps it whole (#11)`` () =
+    let longValue = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo"
+    let v = View.Field("k", longValue, View.Neutral)
+    let out = plainAtWidth 40 v
+    Assert.Contains("…", out)                       // truncated
+    Assert.Contains("alpha", out)                   // a prefix survived
+    Assert.DoesNotContain(longValue, out)           // the full value did not render
+    // one visible line — the truncation prevented the wrap a 66-char value would
+    // otherwise force at width 40.
+    let lines = out.Split('\n') |> Array.filter (fun l -> l.TrimEnd('\r').Trim() <> "")
+    Assert.Equal(1, lines.Length)
+    // the machine lens carries the FULL value — width is a pretty-lens concern.
+    Assert.Equal(longValue, nonNull ((json v).GetProperty("value").GetString()))
+
+[<Fact>]
+let ``View: a wide console leaves the value whole — truncation is width-gated (#11)`` () =
+    let v = View.Field("k", "a readable value", View.Ok)
+    let out = plainAtWidth 200 v
+    Assert.Contains("a readable value", out)
+    Assert.DoesNotContain("…", out)

--- a/sidecar/projection/tests/Projection.Tests/ViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ViewTests.fs
@@ -272,9 +272,10 @@ let ``View: a Panel renders EVERY row to both lenses — no row silently dropped
 
 [<Fact>]
 let ``View: every case renders to plain AND json without throwing (DU totality)`` () =
-    // One instance per `View` case — exhaustive by construction. If a case is
-    // added without a `writeBlock` arm or a `toJson` arm, this list won't compile
-    // (the author must add the case) and the loop will catch a throwing lens.
+    // One instance per `View` case. Keep it in sync as cases are added — the merge
+    // that introduced `Timeline` is the standing reminder: a case here that forgets
+    // its `writeBlock` or `toJson` arm fails the loop below in the pure pool, not
+    // at the tail of a run.
     let cases : (string * View.View) list =
         [ "doc",        View.Doc [ View.Note "child" ]
           "panel",      View.Panel("p", [ View.PanelRow.Labeled("k", "v", View.Ok) ])
@@ -282,6 +283,7 @@ let ``View: every case renders to plain AND json without throwing (DU totality)`
           "field",      View.Field("k", "v", View.Warn)
           "meter",      View.Meter("m", 3, 10, "3 / 10")
           "dots",       View.Dots("history", [ "green"; "red" ])
+          "timeline",   View.Timeline("cutover", [ "green"; "red" ], 1, 10, Some 1)
           "trail",      View.Trail("steps", [ "naming", Some "rename"; "fk", None ])
           "lane",       View.Lane("+", "add", View.Ok, [ "A"; "B" ])
           "disclosure", View.Disclosure("Details", View.Neutral, [ View.Field("exit", "9", View.Bad) ])
@@ -297,3 +299,58 @@ let ``View: every case renders to plain AND json without throwing (DU totality)`
         // machine lens — serializes, and its kind tag is what the consumer expects
         let j = json v
         Assert.Equal(expectedKind, nonNull (j.GetProperty("kind").GetString()))
+
+// --- the query lens (#17) --------------------------------------------------
+// Discriminating predicate: `--query` walks the SAME `toJson` tree the JSON lens
+// emits, so a path projects the machine view without a parallel print path. A
+// malformed path is a named Error, never a crash; a valid path that matches
+// nothing is `Ok []`. The walker is pure over `JsonNode`, so it is tested here
+// without the CLI boundary.
+
+let private queryStrings (path: string) (v: View.View) : string list =
+    match View.query path (View.toJson v) with
+    | Ok nodes -> nodes |> List.map (fun (n: System.Text.Json.Nodes.JsonNode) -> n.ToJsonString())
+    | Error e  -> failwithf "query %s errored: %s" path e
+
+[<Fact>]
+let ``query: a key selects an object member`` () =
+    let v = View.Doc [ View.Hero(View.Ok, "ELIGIBLE") ]
+    Assert.Equal<string list>([ "\"doc\"" ], queryStrings ".kind" v)
+
+[<Fact>]
+let ``query: a wildcard fans out over an array (.blocks[].status)`` () =
+    let v = View.Doc [ View.Field("a", "x", View.Ok); View.Field("b", "y", View.Warn) ]
+    Assert.Equal<string list>([ "\"ok\""; "\"warn\"" ], queryStrings ".blocks[].status" v)
+
+[<Fact>]
+let ``query: an index selects one array element`` () =
+    let v = View.Doc [ View.Note "first"; View.Note "second" ]
+    Assert.Equal<string list>([ "\"note\"" ], queryStrings ".blocks[1].kind" v)
+
+[<Fact>]
+let ``query: a filter keeps only the matching array elements ([?status=warn])`` () =
+    let v =
+        View.Doc [ View.Field("a", "x", View.Ok)
+                   View.Field("b", "y", View.Warn)
+                   View.Field("c", "z", View.Warn) ]
+    match View.query ".blocks[?status=warn]" (View.toJson v) with
+    | Ok nodes -> Assert.Equal(2, List.length nodes)
+    | Error e  -> failwithf "errored: %s" e
+
+[<Fact>]
+let ``query: a well-formed path that matches nothing is Ok empty`` () =
+    match View.query ".nope[].nada" (View.toJson (View.Note "x")) with
+    | Ok []  -> ()
+    | Ok xs  -> failwithf "expected empty, got %d" (List.length xs)
+    | Error e -> failwithf "expected Ok [], got Error %s" e
+
+[<Fact>]
+let ``query: a malformed path is a named Error, not a crash`` () =
+    match View.query ".blocks[oops" (View.toJson (View.Note "x")) with
+    | Error _ -> ()
+    | Ok _    -> failwith "expected Error for an unclosed bracket"
+
+[<Fact>]
+let ``query: validateQuery accepts a leading-dot path and rejects a bare key`` () =
+    Assert.True(match View.validateQuery ".blocks[].status" with Ok () -> true | _ -> false)
+    Assert.True(match View.validateQuery "blocks" with Error _ -> true | _ -> false)


### PR DESCRIPTION
A batch of rendering-layer refinements from `SPECTRE_REFINEMENTS.md`, on the pinned `claude/spectre-improvements-v1fhjq` branch. Each item is a self-contained commit, landed green and tested.

## #17 — `--query`, the structured lens redeemed

`View.toJson` has long promised "a `--query` walks this" (`View.fs` header, `explainView`) with no walker anywhere. This lands it:
- **`View.query` / `View.validateQuery`** — a pure JSONPath-*subset* fold over the `toJson` tree: `.key`, `[n]`, `[]` (wildcard), `[?k=v]` (flat equality filter). The surface-shaped subset, **not** a full engine (no recursive descent / slices / object-wildcards); it grows at the next real query (CLAUDE.md §5). A malformed path is a named `Error`, never a crash.
- **Global value-flag wiring** — `Program.main` extracts `--query <path>` *before* the boolean-flag pass (so its value can't be read as a flag), validates it (**exit 2** on a bad path), and strips both tokens. It sets `TtyRenderer.queryMode`, which `renderAnswer` — the single answer-surface choke point — consults, so every answer verb (`diff`/`explain`/`survey`…) gains it with zero `PlanAction` ripple. Matched nodes print one-per-line (jq-like).
- Seven `ViewTests`; also closed a totality-test gap (the merged-in `Timeline` case).

```
projection readiness --query .blocks[].status
projection diff a b  --query '.blocks[?status=warn]'
```

## #11 — responsive width

The line renderers assumed a wide terminal; on a narrow one (or a width-pinned pipe) long operator values wrapped mid-cell.
- **`View.fit (width) (prefix) (text)`** — the width dual of the §12 breadth cap (`laneCap`): trims a too-wide cell with a `…`; a non-positive budget (unknown / pinned-narrow) or an already-fitting string is a no-op.
- `writeBlock` applies it to the text-bearing arms (`Hero`/`Field`/`Note`/`Action`/`Disclosure` headline) with prefix math for indent + label + glyph, reading `console.Profile.Width` directly — so **`#4 RenderOptions` was not needed** and stays deferred to its real second consumer (#15/#18), per the house "carriers reify at the second consumer" law.
- `toJson` keeps the full untrimmed string — truncation is a pretty-lens concern. Two `ViewTests` (width-40 truncates onto one line, json whole; width-200 untouched).

## Testing

Pure pool green (`scripts/test.sh fast`, warm SQL wired in); build clean under `TreatWarningsAsErrors` (0 warnings). Each commit was built + tested before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)