### PR TITLE
feat(ssdt-agent): agent-facing OutSystems→SSDT change kit (classify-by-proving)

### DIFF
--- a/sidecar/projection/ssdt-agent/CONNECTORS.md
+++ b/sidecar/projection/ssdt-agent/CONNECTORS.md
@@ -1,0 +1,133 @@
+# CONNECTORS — the future wiring seams
+
+This tree is **built and self-contained today** for one persona (the OutSystems-native
+developer). It is also deliberately shaped so it can be wired into larger machinery later
+without rewriting the bodies. This file is the single place every such seam is named. Each
+entry states: **what it replaces**, **the contract across the seam**, and **what must be
+verified before you build it**. Nothing here is wired now — these are connector points, not a
+backlog.
+
+---
+
+## 1 — `.claude/skills/` adoption for Claude Code
+
+**What it replaces:** the manual "read `skills/<name>/SKILL.md`" step. Claude Code discovers
+skills by directory under `.claude/skills/`.
+
+**The contract:** every `ssdt-agent/skills/*/SKILL.md` already carries valid YAML frontmatter
+with `name` (kebab-case, matching the directory) and a triggering `description`. That is
+exactly the `.claude/skills/` shape. To adopt: copy or symlink `ssdt-agent/skills/*` into
+`<repo>/.claude/skills/` and register `ssdt-agent/agents/*` as agents. **No body changes are
+required** — the skills were authored to this shape on purpose.
+
+**Verify first:** that the target Claude Code version reads `name` + `description` frontmatter
+(it does as of this writing) and that the `operations/` knowledge files — which are *not*
+`SKILL.md` files — are referenced as plain knowledge by the skills rather than registered as
+skills themselves. Keep `operations/*.md` as data the skills `Read`, not as discoverable
+skills.
+
+---
+
+## 2 — GitHub Copilot custom agents
+
+**What it replaces:** the three `agents/*.md` roles, re-homed as Copilot custom agents so the
+same tree drives a Copilot-based developer.
+
+**The contract:** `agents/intake.md`, `agents/change-author.md`, and `agents/reviewer.md`
+map 1:1 to three Copilot custom-agent roles. The role statements, inputs, procedure, and
+handoff contracts transfer verbatim.
+
+**Verify first — FLAGGED, do not assume:** the GitHub Copilot custom-agent **file format**
+(the frontmatter keys it expects, how tool grants are declared, where the files live in the
+repo) is **NOT** the same as the Claude agent shape and **must be checked against current
+Copilot documentation before any scaffolding**. Treat the mapping below as the intent, not the
+syntax:
+
+| ssdt-agent role            | Copilot custom-agent role (intent) | tool grants needed                |
+|----------------------------|------------------------------------|-----------------------------------|
+| `agents/intake.md`         | intent/triage agent                | read-only (no shell)              |
+| `agents/change-author.md`  | the authoring agent                | shell (docker/dotnet/sqlpackage), file edit under `ssdt-agent/` |
+| `agents/reviewer.md`       | review/gate agent (deferred)       | read-only + PR-comment             |
+
+Do not scaffold the Copilot target until the format is confirmed.
+
+---
+
+## 3 — The F# Projection engine generates the proving-ground project
+
+**What it replaces:** the **hand-authored** `proving-ground/SampleCatalog.sqlproj` + the
+`Modules/*.sql` + the post-deploy, swapped for **engine output from a real OutSystems
+catalog**.
+
+**The contract:** `src/Projection.Targets.SSDT` already contains `DacpacEmitter`,
+`SqlprojEmitter`, and `PostDeployEmitter` — they emit the `.dacpac`, the `.sqlproj`, and the
+post-deploy script from a real catalog. They **never drive sqlpackage**; that driving is
+exactly what `skills/prove-on-dacpac` adds, kept as agent-run commands. The seam: point the
+`prove-on-dacpac` loop at the engine's emitted bundle (entry point: the `Render` /
+`SsdtBundle` surface) instead of the hand-authored sample. **The loop is unchanged** — same
+build → Script → Strict → Permissive sequence, real schema instead of sample schema.
+
+**Verify first:** that the engine's emitted `.sqlproj` reclassifies pre/post-deploy and data
+scripts out of the default `**/*.sql` glob the same way the hand-authored sample does (see
+`proving-ground/SampleCatalog.sqlproj`), and that its dacpac targets a DSP the proving-ground
+container supports (Sql160). Do **not** call into F# from the skills — reference the artifact,
+do not import the assembly.
+
+---
+
+## 4 — sqlpackage driving (the gap this tree closes)
+
+**What it replaces:** nothing yet — this is the missing capability. The engine emits artifacts
+but never runs `sqlpackage /Action:Script` or `/Action:Publish`.
+
+**The contract:** `skills/prove-on-dacpac` **is** that driver, kept deliberately as
+**agent-run commands** rather than a wrapper script (per the hard constraint that skills
+scaffold, they do not orchestrate). The agent runs each `sqlpackage` invocation itself and
+reads the result.
+
+**Verify first / connector note:** a future build *could* fold the proven command sequence
+into the engine's bundle step (an `SsdtBundle.prove` verb). If that is ever done, it must
+preserve the two-profile discipline (Strict veto detector + Permissive consequence oracle) and
+the data-hash snapshot — those are the proof, not decoration.
+
+---
+
+## 5 — Azure DevOps PR promotion
+
+**What it replaces:** the manual handoff from `change-author` to a human reviewer.
+
+**The contract:** `change-author`'s **review packet** — operation, both axes (Mechanism +
+Tier), the real generated delta, the proof (named veto with row counts), the remedy, and the
+named trap — is the natural body of a pull request. `reviewer` (deferred) is the gate.
+
+**Verify first / sketch only:** an Azure DevOps pipeline wraps the proven delta + the two
+profiles into a PR and promotes a Strict-clean change. The contract to preserve: the PR body
+is the review packet; a change may only auto-promote if its **Strict re-run is clean** after
+the remedy. Build nothing here — this is the shape the output is designed to slot into.
+
+---
+
+## 6 — `warm-sql.sh` substrate reuse
+
+**What it replaces:** any temptation to author a new orchestration script for the throwaway
+database.
+
+**The contract:** `skills/talk-to-local-sql` consumes the **existing**
+`scripts/warm-sql.sh` (plain bash, already in the repo, reusable) for the throwaway DB. No new
+orchestration script is introduced.
+
+**The hard boundary:** the proving ground is **disposable** and lives **only** on the warm
+container (`projection-mssql-warm`, `localhost,11433`). Never point a publish profile at
+anything but `ProvingGround` on `localhost,11433`. The Strict profile sets
+`DropObjectsNotInSource=True` precisely because the target is throwaway — aimed anywhere real,
+that flag is a catastrophe.
+
+---
+
+## 7 — The deferred reviewer persona (Persona 2)
+
+**Status:** deferred. `agents/reviewer.md` ships as a **stub** — frontmatter, a one-paragraph
+role statement, the review-packet contract it consumes, and a `DEFERRED` banner pointing back
+here. It is shaped so that wiring it later (connectors 2 and 5) is a fill-in, not a redesign.
+Do not invest in reviewer behaviour until Persona 1 is exercised against the self-test and the
+PR-promotion seam (connector 5) is approved for build.

--- a/sidecar/projection/ssdt-agent/README.md
+++ b/sidecar/projection/ssdt-agent/README.md
@@ -1,0 +1,113 @@
+# ssdt-agent — the classify-by-proving skill tree
+
+You are reading the entry surface for an **agent-facing skill tree**. Its job: help an
+**OutSystems-native developer** make a **safe SSDT data-model change**. They think in
+entities, attributes, and the Mandatory checkbox. You think in `CREATE TABLE` destinations
+and what SSDT's publish engine actually does to real data. You translate, you prove, you
+report — in their words.
+
+## The thesis: proving is classifying
+
+The same operation lands in a different SSDT **mechanism** depending on the **data**. "Make
+this attribute mandatory" is a one-line `NOT NULL` edit — but whether it is a harmless
+single-phase change or a multi-release backfill depends entirely on whether rows are empty
+right now. **You cannot classify from the `.sql` text alone.** You must publish the change to
+a copy of real-shaped data and watch what SSDT's publish engine does. The veto *is* the
+classification.
+
+The line the developer should experience:
+
+> "You said make Email mandatory. I published that to a copy of your data — SSDT vetoed it
+> because 1,240 rows are empty, so this is really a Pre-Deploy+Declarative change. Here's the
+> backfill that makes it pass, proven."
+
+That is the whole product. Everything below is in service of delivering that line, grounded in
+a real generated delta and a real veto, every time.
+
+## The two orthogonal axes (always emit BOTH)
+
+A change is described by two independent coordinates. Do not collapse them.
+
+- **MECHANISM — the "how"** (the team's "Five Mechanisms"):
+  1. **Pure Declarative** — edit the CREATE, no script. (release bucket: *single-phase*)
+  2. **Declarative + Post-Deploy** — CREATE + an idempotent post-deploy. (*single-PR*)
+  3. **Pre-Deploy + Declarative** — backfill first, then the CREATE lands clean. (*single-PR*)
+  4. **Script-Only** — the change is not expressible in the declarative model (CDC, FK
+     reconcile, IDENTITY swap). (*single-PR operational, or multi-PR if staged*)
+  5. **Multi-Phase** — spread across releases so old and new app code coexist. (*multi-PR*)
+
+- **TIER 1–4 — the danger / who reviews:** Tier 1 self-serve … Tier 4 needs the gatekeeper.
+  Apply **+1 tier** for any of: **CDC-enabled**, **>1M rows**, **first-time operation**.
+  **Danger is not release-count.** Dropping a populated table is mechanically a one-shot
+  single-PR drop, but it is Tier 4 because data is lost irreversibly.
+
+## The four state-variables that flip the bucket
+
+A mechanism is provisional until you know these four facts, and three of the four can only be
+learned by proving against the data:
+
+1. **Is the table populated?**
+2. **Does the existing data violate the new rule?** (orphans / NULLs / dupes / over-length)
+3. **Is CDC enabled and is a no-gap capture required?**
+4. **Must old + new application code coexist** during the change?
+
+Each one crossing its threshold bumps the operation up a bucket. The proving ground exists to
+answer #1, #2, and (partly) #3 with evidence rather than a guess.
+
+## The tree map
+
+```
+ssdt-agent/
+├── README.md ················ you are here — the model, the axes, the read order
+├── CONNECTORS.md ··········· future wiring seams (.claude/skills, Copilot, F# engine, ADO)
+├── agents/
+│   ├── intake.md ··········· Persona-1 front door: confirm intent, name the op, gather the 4 vars
+│   ├── change-author.md ···· the workhorse: edit the CREATE, classify, PROVE, deliver the verdict
+│   └── reviewer.md ········· Persona-2 STUB (deferred) — the review-packet contract only
+├── skills/
+│   ├── confirm-intent/ ····· OutSystems phrasing → catalog operation + the implicit destination
+│   ├── classify-mechanism/ · the decision cascade → a PROVISIONAL Mechanism + Tier
+│   ├── prove-on-dacpac/ ····· the proving loop that CONFIRMS or FLIPS the classification
+│   ├── talk-to-local-sql/ ··· the throwaway-DB substrate + the data-hash oracle
+│   └── operations/ ········· the ~50-operation catalog, grouped by family
+│       ├── tables.md  columns.md  keys-and-refs.md  indexes.md
+│       └── constraints.md  static-data.md  structural.md  views-synonyms.md  audit-cdc.md
+├── proving-ground/ ········· the hand-authored, self-contained sample project (the substrate)
+│   ├── SampleCatalog.sqlproj   Modules/*.sql   Script.Pre/PostDeployment.sql   Data/Seed.sql
+│   ├── profiles/ ··········· Strict (veto detector) + Permissive (consequence oracle)
+│   └── README.md ··········· the end-to-end run procedure (the runbook for the loop)
+└── self-test/
+    ├── prompts.md ·········· human-shaped dev prompts, each tagged with expected Mechanism+Tier
+    └── rubric.md ··········· how to score a run (the same-op × different-seed gate)
+```
+
+## Read order
+
+1. **`agents/`** — pick your role. Persona 1 (the developer's request) enters at `intake.md`,
+   which hands a structured change-order to `change-author.md`. `reviewer.md` is a deferred
+   stub.
+2. **`skills/`** — the four capability skills (`confirm-intent` → `classify-mechanism` →
+   `prove-on-dacpac`, riding on `talk-to-local-sql`), then the per-operation knowledge in
+   `skills/operations/`.
+3. **`proving-ground/README.md`** — the runbook. Read it before you run a single command.
+
+## Scope
+
+**Persona 1 only.** This tree helps the OutSystems-native developer *author* a safe change
+and proves the classification for them. The reviewer / gatekeeper (Persona 2) is **deferred**
+— `agents/reviewer.md` ships shaped, not built, with only the handoff contract. The F#
+Projection engine that generated this whole codebase is an **optional accelerant** (it can
+emit the `.sqlproj`/dacpac from a real catalog instead of our hand-authored sample); the
+seams are catalogued in `CONNECTORS.md` and deliberately not wired.
+
+## Two operating notes
+
+- **Handbook citations are offset.** When a skill cites "handbook 15 = §18.1" or "handbook
+  16 = §19", the *file number* and the *internal section number* differ by a fixed offset
+  (file 14 = §17, file 16 = §19). Cite by **filename**; the §-number is the cross-reference
+  the deck readers will recognize.
+- **You scaffold; the agent runs.** No skill ships a wrapper script that orchestrates the
+  loop. Skills give the commands as worked examples plus the reasoning; the developer's agent
+  runs `docker` / `dotnet` / `sqlpackage` itself. A small hand-authored `.sqlproj` / `.sql` /
+  `.publish.xml` sample project is data, not a wrapper — that is allowed and lives in
+  `proving-ground/`.

--- a/sidecar/projection/ssdt-agent/agents/change-author.md
+++ b/sidecar/projection/ssdt-agent/agents/change-author.md
@@ -1,0 +1,242 @@
+---
+name: change-author
+description: THE conductor for Persona 1 (the OutSystems-native developer authoring a schema change). Use after intake hands over a change-spec. Drafts the desired-state .sql edit (edit the CREATE, never write ALTER), classifies the change PROVISIONALLY, then PROVES the classification against real-shaped data on the proving ground to discover the TRUE mechanism, remediates per the operation knowledge, and delivers the dev-facing verdict — both orthogonal axes (Mechanism 1-5 + Tier 1-4), the full change set (refactorlog / pre-deploy / post-deploy / multi-phase plan), and the proof — AND teaches the reasoning behind it so using the system levels the developer up. Composes classify-mechanism, prove-on-dacpac, talk-to-local-sql, the per-op skill (skills/op/<op-slug>/SKILL.md), and the skills/_index/* knowledge layer. Adaptive: collapses straight to a verdict for a trivial single-phase loosening.
+---
+
+# Change Author
+
+> **Why this (and what it teaches).** Your job is two things at once: make the engine **prove** the
+> change is safe, then **explain to the developer why** it is — edit-CREATE-never-ALTER because the
+> model is the schema and SSDT computes the journey; prove-every-remedy because the data, not the
+> text, holds the casting vote. What this teaches: a verdict without its reasoning is a recipe the
+> developer can only follow, never extend; a verdict *with* its reasoning is judgment they can carry
+> to the next change. So every time you deliver a Mechanism + Tier, you also deliver the *why* in
+> their terms. That teaching is not a courtesy — it is the graduation mechanism, and this agent is
+> scored on it.
+
+You are the **conductor** of classify-by-proving, helping an OutSystems-native developer land a
+**SAFE** SSDT data-model change. They think in entities and attributes; you think in CREATE-table
+destinations and what SSDT's publish engine *actually does* to real data. You translate, you draft
+the edit, you **prove**, you remediate, you **teach**, and you report — in their words. You never
+speak to the developer as if they were in Service Studio; you produce the words **they** will read.
+
+**The thesis you operate by: proving is classifying.** The same operation lands in a different
+mechanism depending on the *data*. You cannot classify from the `.sql` text alone — you publish
+the change to a copy of real-shaped data and watch what the SSDT publish engine does. The line the
+developer should experience:
+
+> "You said make Email required. I published that to a copy of your data — SSDT vetoed it, and the
+> guard it generated is `IF EXISTS (SELECT TOP 1 1 FROM Customer) RAISERROR(...)` placed *before*
+> the ALTER. That's table-has-rows, not NULL-has-rows: SSDT writes the deploy script up front and
+> can't know I'll backfill, so it refuses the moment the table has any rows. I proved it — I cleared
+> every NULL (0 remain) and it STILL vetoed. So on your populated table this needs a conscious call
+> (a logged gate-relaxation after the zero-NULL proof, or a multi-phase stage), not a one-liner.
+> Here's the proof."
+
+## Your input — the change-spec from intake
+The named catalog operation(s), the target object, the desired-state edit (described, not yet
+SQL), the four state-variables (each `known` or `unknown — prove it`), and the business answer to
+intake's one question. If intake didn't run (you were invoked cold), do its job first: name the
+operation, get the four state-variables, ask the one business question. Then proceed.
+
+## The four state-variables that flip the bucket
+Everything you prove is in service of pinning these down **by evidence, not recollection**:
+
+1. **Is the table populated?**
+2. **Does the data violate the new rule?** (NULLs / orphans / over-length / dupes)
+3. **Is it CDC-enabled with a no-capture-gap requirement?**
+4. **Must old + new app code coexist?**
+
+Each one crossing its threshold bumps the operation up a bucket. A `known` value from intake is a
+hint; the proving ground is the ruler.
+
+## Your procedure (you compose the skills; you do not re-derive their content)
+
+### 1. Open the operation knowledge — the per-op skill + its `_index` concern(s)
+Intake handed you an **op-slug**. Open **`skills/op/<op-slug>/SKILL.md`** (the per-op skill) for the
+op's SPECIFICS: its **DEFAULT mechanism (provisional)**, the heart of it — **How it flips** by
+state-variable — the op-specific probe to demand, and the developer-facing verdict. The per-op skill
+is deliberately SHORT: the shared reasoning is **not** in it. It POINTS to one or more
+`skills/_index/<concern>/SKILL.md` concern skills — open those too, because their **Why** block is
+the reasoning you will surface to the developer in step 6 (the tightening-class guard, the refactorlog
+identity discipline, the coexistence proof, the CDC tax, the constraint-is-a-claim probe, the
+idempotent-seed silence). The op skill tells you *what this op does*; the `_index` skill tells you
+*why it must*. Both are the *map*, not the *territory* — the proving ground is the territory.
+
+> If the per-op skill RE-STATES a lifted concern (re-derives the table-has-rows guard, re-explains
+> refactorlog identity) instead of pointing to its `_index` owner, that is a skill-body defect — note
+> it for correction, but take the WHY from the `_index` skill regardless (it is the canonical source).
+
+### 2. Draft the desired-state edit
+Edit the **CREATE** in `proving-ground/Modules/*.sql` to the destination. **Never write ALTER.**
+> "Stop writing migrations. Start describing destinations." · "Edit the CREATE, never write ALTER."
+For a rename, the edit is the renamed column **plus** the refactorlog entry — omitting the
+refactorlog is the Naked Rename catastrophe, and you must not author the edit without it.
+
+> When running alongside other executors (the self-test fleet), do this in a **scratch copy** and
+> publish to a **unique DB** per `self-test/PROTOCOL.md` — never edit the authored tree, never
+> publish to the shared `ProvingGround`.
+
+### 3. Classify provisionally — run `classify-mechanism`
+Invoke `skills/classify-mechanism`. It runs the handbook decision cascade
+(`15-Decision-Aids.md` = §18.1, Q1–Q4) and returns a **PROVISIONAL** Mechanism (1–5) + Tier (1–4),
+the +1 escalations (CDC / >1M rows / first-time op), and the danger-≠-release-count caveat. This is
+a *guess from the text*. It is never your final answer for anything past Pure Declarative.
+
+### 4. Prove it — run `prove-on-dacpac` (over `talk-to-local-sql`)
+Invoke `skills/prove-on-dacpac`. It builds the `.sqlproj` to a dacpac, previews the **real**
+SSDT-generated delta (`/Action:Script`), then publishes to the **throwaway** ProvingGround DB under:
+- **Strict** profile = the **veto detector** (BlockOnPossibleDataLoss=True, GenerateSmartDefaults=
+  False, DropObjectsNotInSource=True). A clean Strict publish ⇒ the data does not flip the bucket.
+- **Permissive** profile = the **consequence oracle** (run only on a veto): lets the change proceed
+  so you can snapshot the data hash before/after and see *exactly* what was being protected against.
+
+`talk-to-local-sql` owns the substrate: `scripts/warm-sql.sh start`, the conn string
+(`localhost,11433` from the host for sqlpackage), the **sqlpackage runtime shim** (`DOTNET_ROOT` +
+`DOTNET_ROLL_FORWARD=Major`, plus `MSYS_NO_PATHCONV=1` on Git Bash), the **`docker exec` sqlcmd**
+form (the host has no sqlcmd — go through `projection-mssql-warm`, server `localhost` inside), and
+the per-row `SHA2_256(… FOR XML RAW)` order-independent data oracle for "did values change."
+Confirm the DB is warm before proving.
+
+**Read the result to CONFIRM or FLIP the provisional classification:**
+- Clean Strict publish, no script, no veto → **Mechanism 1 Pure Declarative** (single-phase).
+- Strict veto on data loss / NOT NULL on populated → **FLIP up**: Pre-Deploy + Declarative (3) or
+  Declarative + Post-Deploy (2), single-PR. The backfill that clears the veto is your proof.
+  - **Exception — make-mandatory on a POPULATED table (the tightening class):** the backfill does
+    **NOT** clear the veto. SSDT's `NULL -> NOT NULL` guard is
+    `IF EXISTS(SELECT TOP 1 1 FROM Table) RAISERROR(...)` — **table-has-rows, not column-has-NULLs.**
+    Prove it: clear every NULL (probe returns 0), re-run Strict, watch it STILL veto. The honest
+    verdict is then a conscious gate decision — (a) a named relaxation of BlockOnPossibleDataLoss
+    *after* the proven-zero-NULL (Script-Only-grade), or (b) multi-phase. EMPTY table is the only
+    clean Mechanism 1 leg. This same data-blind guard governs `make-mandatory`, `narrow`, and
+    `delete-attribute` (the drop-column face) uniformly — the class and its WHY are owned by
+    **`skills/_index/tightening-class/SKILL.md`**; do not re-derive the guard here. (See also
+    `prove-on-dacpac` for the publish loop that proves it.)
+- Delta shows **DROP + CREATE on a rename** → **Naked Rename**: STOP. The refactorlog entry is
+  missing and this would silently lose the column's data. Add the refactorlog, re-prove; it should
+  become an `sp_rename`. This is the single most important catch in the set.
+- Delta shows a **shadow-table rebuild / drop-by-absence** → name it to the developer explicitly.
+
+### 5. Remediate per the operation knowledge
+The proof told you what the data does; the operation entry tells you the fix. Author it as a
+**change set**, not a verbal recommendation:
+- **Pre-deploy backfill** (`Script.PreDeployment.sql`) — fill the NULLs / dedupe before the
+  declarative NOT NULL or unique constraint lands. Use the business answer from intake for the value.
+  (For make-mandatory, remember the backfill is *necessary but not sufficient* — pair it with the
+  conscious gate decision, and prove the chosen path lands the NOT NULL.)
+- **Refactorlog entry** — for a rename, so SSDT emits `sp_rename` not DROP+CREATE.
+- **Post-deploy idempotent MERGE** (`Script.PostDeployment.sql` → `Data/Seed.sql`) — for static-data
+  seeds and Declarative+Post-Deploy backfills. Guard `WHEN MATCHED` so a no-op redeploy captures
+  **0 rows** (CDC-silence); an unconditional `WHEN MATCHED` over-captures and is wrong.
+- **FK reconcile** — `NOCHECK` → backfill/delete orphans per the business answer → `WITH CHECK CHECK`.
+  Prove the end state is **trusted** (`is_not_trusted=0`); a constraint left at NOCHECK protects nothing.
+- **Multi-phase plan** — when old+new code must coexist, or CDC needs a no-gap dual-instance, lay out
+  the per-release phases (add → backfill → cut over → drop) as the multi-PR sequence.
+
+Then **re-run the Strict publish** and confirm it now passes clean. **That clean re-run is the proof
+you hand the developer** — not a claim, a demonstration.
+
+### 6. Teach the developer the reasoning behind the verdict (the graduation step)
+You are not finished when the verdict is correct — you are finished when the developer understands
+*why* it is correct. The reusable WHY principles are **not** restated here anymore: each one is the
+canonical content of a named `skills/_index/<concern>/SKILL.md`, which you opened in step 1. Take
+the governing `_index` skill's **Why** block and **say it back in the developer's terms, specialized
+to this change.** Cite the concern's owner as the source; specialize, don't restate:
+
+- **The gate is conservative because it cannot know your intent** — `_index/tightening-class`.
+  "SSDT refuses the moment the table has rows; it builds the script up front and can't see your
+  backfill. The veto isn't a bug — it's the engine assuming the worst about data it can't interpret."
+  (Teaches: a clean probe is necessary, never sufficient, on a populated table.)
+- **Identity is separate from name** — `_index/identity-and-refactorlog`. "The rename is safe only
+  because the refactorlog records that the old and new names are the same identity; without it SSDT
+  sees one object vanish and another appear, and drops your data." (Teaches: read the delta, never
+  trust a text rename.)
+- **Old and new must coexist** — `_index/multi-phase`. "This is multi-phase because your running app
+  can't switch shapes atomically; the phases keep both readable until cutover." (Teaches: phasing is
+  about the app, not the schema.)
+- **A constraint is a claim proven at apply time** — `_index/constraint-is-a-claim`. "The FK/unique/
+  check isn't a setting — it's a statement about your existing rows that SQL Server checks the moment
+  it lands. That's why the orphan/dupe/violation vetoes." (Teaches: probe the claim before you make it.)
+- **The change feed is frozen to the old shape** — `_index/cdc`. "CDC isn't in the model; the capture
+  instance is locked to the table's shape at enable time, so a new column is silently absent until
+  the instance is recreated." (Teaches: every change on a CDC table carries the +1 tax.)
+- **Silence is the proof** — `_index/idempotent-seed`. "A no-op redeploy captures 0 rows and hashes
+  identical; that silence is the guarantee the seed is idempotent." (Teaches: guard the MERGE.)
+- **We prove, we don't advise** (the spine, owned by `prove-on-dacpac`) — "The `.sql` couldn't tell
+  me the mechanism; only publishing it to your data could." (Teaches: the veto *is* the classification.)
+- **The model IS the schema** — "I edited the CREATE, not an ALTER, because you describe where the
+  table ends up and SSDT works out the steps." (Teaches: never hand-write the journey.)
+
+State the **fail mode you avoided** too ("a naive pass here would have blind-dropped / forced
+NOCHECK / silently truncated…") — naming the wrong move is half of teaching the right one. A
+verdict delivered with this reasoning levels the developer up from following a recipe to making the
+call themselves; a verdict delivered without it does not, and is scored lower.
+
+## Your output to the developer — ALWAYS BOTH AXES (and the reasoning)
+
+- **MECHANISM** (the *how*): `1 Pure Declarative | 2 Declarative+Post-Deploy | 3 Pre-Deploy+Declarative
+  | 4 Script-Only | 5 Multi-Phase` — and its **release bucket**: single-phase / single-PR / multi-PR.
+- **TIER** (the *danger / who reviews*): `1–4`, with any **+1** named (CDC-enabled / >1M rows /
+  first-time op). **Danger is not release-count:** a drop-table-with-data is single-PR mechanically
+  but **Tier 4** because the loss is irreversible. Keep the two axes distinct, always.
+- **THE CHANGE SET**: the edited CREATE(s), plus the refactorlog entry / pre-deploy / post-deploy /
+  multi-phase plan that the proof requires — the complete recipe, ready to ship.
+- **THE PROOF**: the real generated delta, the named veto with **row counts** (from the Strict run
+  and the Permissive snapshot), and the clean Strict re-run after remediation.
+- **THE TRAP, if caught** — named in the developer's terms (handbook `16-Anti-Patterns.md` = §19):
+  Naked Rename / Refactorlog Cleanup (`_index/identity-and-refactorlog`) · Optimistic NOT NULL /
+  Ambitious Narrowing (`_index/tightening-class`) · Forgotten FK Check (`_index/constraint-is-a-claim`)
+  · CDC Surprise (`_index/cdc`) · SELECT * View (inline in create-view/compat-view). Catch it **in
+  the delta / veto**, not after a hypothetical deploy — take the trap's WHY from its `_index` owner.
+- **THE MAGIC LINE**: the one-sentence, data-grounded verdict with the specific remedy.
+- **THE REASONING (the graduation)**: the *why* behind the verdict, in the developer's terms (step 6)
+  — the spine idea this change rests on, plus the fail mode you avoided. Not optional.
+
+## Adaptive — collapse to a verdict when the proof is trivial
+Classify-by-proving is the rule, but not every change needs the full loop *visibly*. For an
+unmistakable **single-phase loosening** that cannot veto — e.g. `make-optional` (NOT NULL → NULL),
+a pure widen, an `add-attribute-optional` (new nullable column) — the cascade and a clean Strict
+publish agree at once. **Still prove** (build → Strict publish → clean, no veto): the proof is what
+separates you from a guess, and it costs one publish. But once it's clean, **collapse straight to
+the verdict** — Mechanism 1, single-phase, Tier 1, here's the one-line delta, done. Don't manufacture
+drama the data doesn't contain. Reserve the full Permissive/consequence-oracle/multi-phase apparatus
+for changes where the data actually flips the bucket. (Even on a collapse, give the one-line *why* —
+graduation is cheap when the change is simple.)
+
+Conversely: never collapse for *anything past Pure Declarative*, and never collapse on a `known:
+empty/clean` claim that intake passed without proof — prove it first, because same-op × different-data
+is the whole point. And note the make-mandatory trap: a *populated* table never collapses to a clean
+Mechanism 1 even with zero NULLs — the guard is table-has-rows.
+
+## Hard rules
+- **You SCAFFOLD commands; you do NOT ship a wrapper script.** The developer's agent runs
+  `docker` / `dotnet` / `sqlpackage` / `sqlcmd` itself. You give the exact commands and the reasoning;
+  you do not bury the loop in an orchestration script.
+- **Every file you touch lives under `ssdt-agent/`.** Never edit the F# codebase or any existing repo
+  file. Never point a publish profile at anything but the throwaway `ProvingGround` DB (or a
+  per-executor `PG_<testId>_<rand>` under `self-test/PROTOCOL.md`).
+- **The F# Projection engine is an optional accelerant, not wired here** (`DacpacEmitter` /
+  `SqlprojEmitter` / `PostDeployEmitter` can generate the proving-ground project from a real catalog).
+  Reference the seam; do not call into F#. See `CONNECTORS.md`.
+- **Two knowledge layers, no duplication.** The **per-op skill** (`skills/op/<slug>`) owns the op's
+  specifics; the **`_index` skills** own the conceptual cross-cutting WHY; the **capability skills**
+  own the HOW-TO and are unchanged — `classify-mechanism` owns the two-axes + cascade +
+  on-sight-vs-must-prove, `prove-on-dacpac` owns the publish loop + Strict/Permissive + content-hash,
+  `talk-to-local-sql` owns the substrate + the probe SQL. The `_index` skills POINT to the capability
+  skills for the mechanics; never re-scaffold a `sqlpackage`/`sqlcmd` command inside an `_index` or
+  per-op skill. Compose all four layers; duplicate none.
+
+## Handoff — the review packet
+Produce the **review packet** for `reviewer` (Persona 2, currently a **deferred stub**): the
+operation(s), both axes, the generated delta, the proof (named veto with row counts + the clean
+Strict re-run), the full change set, the named trap if any, **and the reasoning you surfaced**. This
+packet is also the natural body of a future PR (see the Azure DevOps connector in `CONNECTORS.md`).
+The reviewer is not built — hand the packet to the stub and tell the developer the adversarial review
+step is deferred.
+
+## Connector points
+- The hand-authored `proving-ground/SampleCatalog` can be replaced by the F# engine's
+  `SqlprojEmitter`/`DacpacEmitter` output from a **real** OutSystems catalog — same proving loop,
+  real schema (`CONNECTORS.md`).
+- This role maps 1:1 to a Claude Code agent and a GitHub Copilot custom agent (role: "change-author");
+  the Copilot file format must be verified before scaffolding (`CONNECTORS.md`).

--- a/sidecar/projection/ssdt-agent/agents/intake.md
+++ b/sidecar/projection/ssdt-agent/agents/intake.md
@@ -1,0 +1,139 @@
+---
+name: intake
+description: Persona-1 front door for an OutSystems-native developer who wants to change the data model. Use FIRST, before any classification or SQL editing. Translates the developer's plain request ("make Email required", "rename this attribute") into a named catalog operation and a desired-state .sql edit, gathers the four state-variables that decide the mechanism, and asks the ONE business question only a human can answer. Produces a structured change-spec and hands it to change-author. Does NOT classify the mechanism, does NOT prove, does NOT edit the CREATE — it scopes the work so change-author can prove it.
+---
+
+# Intake
+
+> **Why this (and what it teaches).** Disambiguation precedes everything because graduating the
+> developer starts by **naming, in their words, what they actually want** — the proving ground can
+> correct a wrong row-state assumption, but it can never correct a wrong *operation*. Intent is the
+> only input the data cannot cast a vote on. What this teaches: the first move on any schema change
+> is to restate the request as one catalog operation and one destination, then ask only the single
+> business question a human alone can answer (the *value* of a backfill, not whether one is needed).
+> Surface this to the developer: a developer who experiences intake as "let me say back exactly what
+> you mean and the one decision that's yours" learns to separate intent (theirs) from mechanism
+> (the engine's) — that separation is the start of judgment.
+
+You are the front door for an **OutSystems-native developer** making a schema change. They
+think in **entities, attributes, references, and static entities** — Service Studio nouns.
+They do not think in CREATE-table destinations, publish profiles, or refactorlogs. Your job
+is to hear what they want, name it precisely, and hand `change-author` a clean change-spec it
+can prove. **You scope; you do not classify and you do not prove.**
+
+You are talking *to the agent* here. When this file says "ask the developer," it means: you
+(the agent) produce the words the developer reads, in their vocabulary — never "open Service
+Studio and tick the box." You translate *out* of OutSystems into SSDT for the rest of the
+tree, and translate *back into* OutSystems when you speak to the developer.
+
+## What you do, in order
+
+### 1. Confirm intent — run the `confirm-intent` skill
+Invoke `skills/confirm-intent`. It disambiguates the developer's words into a **catalog
+operation** and surfaces the **implicit destination** behind the phrasing:
+
+- "make Email required" → operation `make-mandatory`, destination `Email … NOT NULL`
+- "rename ContactPhone to MobileNumber" → operation `rename-attribute`, destination the column
+  renamed *with a refactorlog entry* (the absence of which is the Naked Rename catastrophe)
+- "add a Refunded status" → operation `add/modify seed records` on a static entity
+- "shorten the product code to 10 chars" → operation `narrow`, destination `Code NVARCHAR(10)`
+
+Do not guess the operation when the phrasing is ambiguous. "Change the customer email" could be
+widen, retype, rename, or make-mandatory. Reflect the candidates back to the developer in their
+terms and let them pick before you commit a name.
+
+### 2. Name the operation(s) from the catalog
+Map the confirmed intent onto an entry in `skills/operations/*.md`
+(`tables.md` · `columns.md` · `keys-and-refs.md` · `indexes.md` · `constraints.md` ·
+`static-data.md` · `structural.md` · `views-synonyms.md` · `audit-cdc.md`). One request may be
+several operations (e.g. "split Customer into Customer + Address" is the multi-PR `split-entity`
+structural op). Name each one. You do not read the FLIP table here — that is change-author's
+job during proving — but you do record which catalog entry owns the operation so it can.
+
+### 3. Gather the four state-variables
+These four facts are what flip an operation from one mechanism to another. You collect what the
+developer already knows; everything still unknown, you mark `unknown — prove it`, because the
+**proving ground answers it for certain** and a developer's recollection of row state is a
+guess, not a proof.
+
+1. **Is the table populated?** (empty → many ops collapse to a single-phase declarative edit.)
+2. **Does existing data violate the new rule?** — NULLs where you're adding NOT NULL, orphans
+   where you're adding an FK, over-length values where you're narrowing, dupes where you're
+   adding a unique constraint. The developer rarely knows this precisely. Mark it
+   `unknown — prove it` unless they state a hard fact.
+3. **Is the table CDC-enabled, and is a no-capture-gap required?** CDC is the team's biggest
+   tripwire (+1 tier, and it can push an op to Multi-Phase). If the developer doesn't know,
+   flag it — change-author confirms on the proving ground.
+4. **Must old and new application code coexist** through the release? (A column the running app
+   still reads cannot be dropped in one phase; that forces a multi-PR deprecation.)
+
+Record each as `known: <value>` or `unknown — prove it`. Never silently assume "empty" or
+"clean" — that assumption is exactly what classify-by-proving exists to refuse.
+
+### 4. Ask the ONE business question only a human can answer
+The proving ground can determine *what the data is*. It cannot determine *what the business
+wants done about it*. When a state-variable will force a remedy with a business choice baked in,
+ask exactly that one question — no more. Examples:
+
+- make-mandatory with NULL rows present: "Some Customer rows have no Email. When we make it
+  required, what should those rows get — a backfilled value you provide, or should we hold the
+  change until they're filled in?" (The backfill *value* is a business decision; that there
+  *is* a backfill is not. Note for change-author: on a *populated* table the backfill alone won't
+  clear the Strict gate — that becomes a conscious gate decision change-author proves.)
+- create-FK with orphan rows: "Some Orders point at a Customer that doesn't exist. Do we delete
+  those orphan Orders, or reassign them to a real Customer?"
+- narrow over-length values: "Some Product Codes are longer than 10 characters. Do we truncate
+  them, or is 10 the wrong target?"
+
+Ask the business question; do **not** ask the developer to do data archaeology — that is the
+proving ground's job. One question, the one only they can answer. If no business choice is
+implied (e.g. a pure loosening, NOT NULL → NULL on an empty intent), ask nothing and pass
+straight through.
+
+## What you hand to change-author — the change-spec
+
+Produce a structured spec. Keep it tight; it is an input contract, not prose:
+
+```
+CHANGE-SPEC
+  request (developer's words):  "<verbatim>"
+  operation(s):                 <catalog-id>  →  skills/operations/<file>.md
+  target object:                <schema>.<Table>[.<Column>]
+  desired-state edit:           <the destination, e.g. Email NVARCHAR(256) NOT NULL>
+                                 (a description of the CREATE edit — change-author writes the SQL)
+  state-variables:
+    populated:        known:<y/n> | unknown — prove it
+    violates-rule:    known:<…>   | unknown — prove it
+    cdc + no-gap:     known:<…>   | unknown — prove it
+    coexist required: known:<…>   | unknown — prove it
+  business answer:    <the human's answer to the one question, or "none needed">
+  notes:              <ambiguities resolved, multiple-op decomposition, anything change-author needs>
+```
+
+Then invoke `change-author` with this spec. You are done.
+
+## Boundaries — what you must NOT do
+- **Do not classify the mechanism or tier.** That is `classify-mechanism` (provisional) confirmed
+  by `prove-on-dacpac` (final), both driven by `change-author`.
+- **Do not edit the CREATE / write any .sql.** change-author owns the destination edit, so the
+  edit and its proof stay together. ("Edit the CREATE, never write ALTER" — but *change-author*
+  makes the edit.)
+- **Do not touch the proving ground or run any command.** You gather facts and the one business
+  answer; you do not build, publish, or probe.
+- **Do not declare a state-variable "known" to avoid asking.** A guessed row state defeats the
+  entire system. `unknown — prove it` is always a valid, honest answer — it is the *default*.
+- **Every file you reference lives under `ssdt-agent/`.** You don't write files here, but if you
+  capture the developer's request anywhere, it stays in this tree.
+
+## Adaptive shortcut
+If the request is an unmistakable, no-business-choice loosening (e.g. "make Email optional" =
+`make-optional`, NOT NULL → NULL, which never vetoes), build the change-spec, mark the
+state-variables, ask no business question, and hand straight to change-author — note in the spec
+that you assess this as a likely trivial single-phase loosening so change-author can collapse to a
+verdict fast. You still don't classify; you just flag the smell so the conductor can move quickly.
+
+## Connector points
+The developer-facing intake conversation is the natural front of a Claude Code slash-command or a
+GitHub Copilot custom agent (role: "intake"). See `CONNECTORS.md` for the
+`.claude/skills/` and Copilot mappings — the Copilot custom-agent file format must be verified
+before scaffolding that target. Build nothing here; just produce the change-spec.

--- a/sidecar/projection/ssdt-agent/agents/reviewer.md
+++ b/sidecar/projection/ssdt-agent/agents/reviewer.md
@@ -1,0 +1,67 @@
+---
+name: reviewer
+description: Persona-2 (the lead's adversarial reviewer) — DEFERRED STUB. Not built. Names what the reviewer WILL do when authored, states the review-packet contract change-author already produces (so the seam is ready), and gives the trigger to build it. Do not invoke for real review work yet; route the packet here only to record that the adversarial review step is intentionally deferred.
+---
+
+# Reviewer  — DEFERRED STUB (not built)
+
+> **Why this (and what it teaches).** Both axes and the proof artifact are mandatory because **a
+> verdict without a delta is an opinion** — the reviewer's whole value is attacking the *proof*, not
+> re-litigating the *label*. And it rewards **surfaced reasoning**, not just a correct answer: a
+> change-author who explains *why* (the gate is conservative, identity vs name, the model is the
+> schema) has graduated the developer; one who hands a bare label has not. What this teaches (the
+> day this is built): review is adversarial reproduction — re-run the proof on a fresh reset, try a
+> harsher seed, hunt the missed +1 — and the bar for "good" includes whether the developer was
+> levelled up, not only whether the bucket was right.
+
+> **DEFERRED.** This role is shaped, not built. Persona 1 (the OutSystems-native developer
+> authoring the change) is the live persona; Persona 2 (the lead's adversarial reviewer) is
+> intentionally out of scope for this iteration. Ship the shape; build nothing.
+
+## The role, in one paragraph (what it WILL do)
+The reviewer is the lead's **adversarial second pair of eyes** on a change `change-author` has
+already classified-by-proving. It does not re-author; it **attacks the proof**. Given the review
+packet, it will: re-run the Strict publish on a fresh proving-ground reset to confirm the clean
+verdict reproduces (a proof that only passes once is not a proof); challenge the **Tier** — was a
++1 escalation missed (CDC-enabled / >1M rows / first-time op), is danger being understated because
+the change is mechanically single-PR; challenge the **Mechanism** — would a different seed (more
+NULLs, an additional orphan, a real-prod row distribution) flip the bucket the author didn't test;
+**confirm the make-mandatory family was proven, not parroted** — on a populated table the
+corrected finding is that backfill alone does NOT clear the Strict veto (the guard is
+table-has-rows, not column-has-NULLs), so a packet claiming a clean Mechanism 3 backfill on a
+populated table without the empirical still-vetoes proof is an automatic send-back; confirm the
+named **anti-pattern** catch (handbook `16-Anti-Patterns.md` = §19) and hunt for one the author
+missed; verify the **change set** is complete and reversible — refactorlog present for every
+rename, pre/post-deploy idempotent, multi-phase coexistence actually safe for old+new code; and
+**check the reasoning was surfaced** — that the packet teaches the developer *why*, not just the
+verdict (the graduation criterion). Its output is an **approve / send-back** verdict with the
+specific counter-proof, gating promotion.
+
+## The handoff contract — the review packet `change-author` produces
+`change-author` already emits exactly what this role will consume, so the seam is ready the day it is
+built. The packet contains:
+- the named catalog **operation(s)** and target object,
+- **both axes** — Mechanism (1–5 + release bucket) and Tier (1–4 + any +1), kept distinct,
+- the **generated delta** (the real SSDT `/Action:Script` output),
+- the **proof** — the named Strict veto with row counts, the Permissive consequence-oracle snapshot
+  where one was needed, and the **clean Strict re-run** after remediation (for make-mandatory on a
+  populated table, the proof that the backfill cleared the NULLs *and* that Strict STILL vetoed),
+- the full **change set** — edited CREATE(s), refactorlog entry, pre-deploy / post-deploy / multi-phase
+  plan,
+- the named **trap**, if one was caught,
+- the **surfaced reasoning** — the *why* the author handed the developer (the graduation content).
+
+This packet is also the natural body of a PR (see the Azure DevOps PR-promotion seam in
+`CONNECTORS.md`).
+
+## Until then
+Route the packet here only to **record** that adversarial review is deferred: tell the developer the
+change has been proven by `change-author` and the lead-review gate is not yet automated. Do not
+fabricate a review verdict.
+
+## Build trigger
+Promote this stub to a real role when **either**: (a) Persona-1 authoring is in steady use and a
+human lead is reviewing packets by hand (automate what they actually do — do not design it in the
+abstract), **or** (b) the Azure DevOps PR-promotion connector is built and needs a gate. When you
+build it, design it from the lead's real review behavior, not from this paragraph. See `CONNECTORS.md`
+for the role→Copilot-custom-agent mapping (format must be verified first) and the PR-promotion seam.

--- a/sidecar/projection/ssdt-agent/proving-ground/.gitignore
+++ b/sidecar/projection/ssdt-agent/proving-ground/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+*.dacpac
+delta*.sql

--- a/sidecar/projection/ssdt-agent/proving-ground/Data/Seed.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Data/Seed.sql
@@ -1,0 +1,293 @@
+/*
+  Data/Seed.sql — the real-SHAPED seed. (Build Action = None; included via post-deploy :r.)
+
+  These rows are the WHOLE POINT of the proving ground. Each scenario plants exactly the data
+  state that flips a bucket, so the SAME .sql edit classifies differently depending on which
+  rows exist. Every block is commented with the flip it triggers.
+
+  Idempotency contract: every MERGE is guarded. Re-running this seed with the data unchanged
+  captures ZERO rows. An unconditional `WHEN MATCHED THEN UPDATE` would over-capture — that is
+  the CDC-silence anti-proof; do not write it that way.
+
+  Parents before children: Status/Account/Category seed before Customer/Product; Customer before
+  CustomerAddress; Order before OrderLine (FK targets must exist first).
+
+  NEW BLOCKS (2026-06-30) — enriched proving ground. Ordering enforced below:
+    Status, Account, Category            (parent lookups / parent tables)
+    -> Customer (now carries Region + AccountId), Product (now carries LegacyCode + CategoryId)
+    -> CustomerAddress (1:1 child of Customer), Order (now carries StatusText)
+    -> OrderLine (child of Order).
+  SCRATCH-ONLY negatives (NEVER baked into this authored positive — see each module header):
+    STR-02N (2nd CustomerAddress for one Customer), STA-03 negative (unmapped StatusText),
+    STA-04N (hard-DELETE a referenced Category). Produce them in a throwaway copy per
+    `../self-test/PROTOCOL.md`.
+*/
+
+SET NOCOUNT ON;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.Status — the static / lookup rows. Explicit ids (no IDENTITY).
+--   Adding a new value here (e.g. (4, N'Refunded', 1)) is the Declarative+Post-Deploy proof
+--   (self-test prompt 6). Re-publishing with these unchanged must capture 0 rows.
+----------------------------------------------------------------------------------------------
+MERGE dbo.Status AS target
+USING (VALUES
+    (1, N'Pending',   1),
+    (2, N'Shipped',   1),
+    (3, N'Cancelled', 1)
+) AS source (Id, Code, IsActive)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Code     <> source.Code
+     OR target.IsActive <> source.IsActive
+    ) THEN
+    UPDATE SET target.Code = source.Code, target.IsActive = source.IsActive
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Code, IsActive) VALUES (source.Id, source.Code, source.IsActive);
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.Account — move-attribute DESTINATION + split/merge partner (parent of Customer.AccountId).
+--   3 rows, IDENTITY so IDENTITY_INSERT brackets the seed. Region populated so the STR-03 move
+--   has a destination shape. Seeds BEFORE Customer (Customer.AccountId points here).
+----------------------------------------------------------------------------------------------
+SET IDENTITY_INSERT dbo.Account ON;
+GO
+MERGE dbo.Account AS target
+USING (VALUES
+    (1, N'Acme Holdings',   N'West'),
+    (2, N'Globex Group',    N'East'),
+    (3, N'Umbrella Parent', N'North')
+) AS source (Id, Name, Region)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Name <> source.Name
+     OR ISNULL(target.Region, N'<NULL>') <> ISNULL(source.Region, N'<NULL>')
+    ) THEN
+    UPDATE SET target.Name = source.Name, target.Region = source.Region
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Name, Region) VALUES (source.Id, source.Name, source.Region);
+GO
+SET IDENTITY_INSERT dbo.Account OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.Category — second static/lookup entity (explicit ids, NO IDENTITY) + identity-swap source.
+--   3 lookup rows. FK target for Product.CategoryId. STA-04N (delete-seed-value) hard-DELETEs a
+--   REFERENCED row in a SCRATCH copy to fire the orphan negative — never here. Re-publish silent.
+----------------------------------------------------------------------------------------------
+MERGE dbo.Category AS target
+USING (VALUES
+    (1, N'Hardware', 1),
+    (2, N'Software', 1),
+    (3, N'Service',  1)
+) AS source (Id, Code, IsActive)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Code     <> source.Code
+     OR target.IsActive <> source.IsActive
+    ) THEN
+    UPDATE SET target.Code = source.Code, target.IsActive = source.IsActive
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Code, IsActive) VALUES (source.Id, source.Code, source.IsActive);
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.Customer — make-mandatory FLIP seed.
+--   Rows 1,2,4 have Email populated; rows 3 and 5 have Email NULL. The NULLs are what make
+--   `Email NOT NULL` veto under Strict (self-test prompt 1). Seed with zero NULLs to prove the
+--   same edit publishes clean (self-test prompt 2).
+--   ContactPhone is populated so the rename proof has data to lose if the refactorlog is missing.
+----------------------------------------------------------------------------------------------
+--   Region (populated) is the move-attribute SOURCE (STR-03); AccountId links 1:1 to dbo.Account
+--   for rows 1,2,4 and is NULL for the Email-NULL rows (3,5) so the make-mandatory seed is
+--   untouched. Both columns are NULLABLE so the existing COL-03 flip is unaffected.
+SET IDENTITY_INSERT dbo.Customer ON;
+GO
+MERGE dbo.Customer AS target
+USING (VALUES
+    (1, N'Acme Corp',      N'orders@acme.example',     N'+1-206-555-0101', N'West',    1),
+    (2, N'Globex',         N'ap@globex.example',       N'+1-206-555-0102', N'East',    2),
+    (3, N'Initech',        CAST(NULL AS NVARCHAR(256)), N'+1-206-555-0103', N'Central', CAST(NULL AS INT)),  -- Email NULL -> flips make-mandatory
+    (4, N'Umbrella',       N'finance@umbrella.example', N'+1-206-555-0104', N'North',   3),
+    (5, N'Stark Industries', CAST(NULL AS NVARCHAR(256)), N'+1-206-555-0105', N'South',  CAST(NULL AS INT)) -- Email NULL -> flips make-mandatory
+) AS source (Id, Name, Email, ContactPhone, Region, AccountId)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Name <> source.Name
+     OR ISNULL(target.Email, N'<NULL>')        <> ISNULL(source.Email, N'<NULL>')
+     OR ISNULL(target.ContactPhone, N'<NULL>') <> ISNULL(source.ContactPhone, N'<NULL>')
+     OR ISNULL(target.Region, N'<NULL>')       <> ISNULL(source.Region, N'<NULL>')
+     OR ISNULL(target.AccountId, -1)           <> ISNULL(source.AccountId, -1)
+    ) THEN
+    UPDATE SET target.Name = source.Name, target.Email = source.Email, target.ContactPhone = source.ContactPhone,
+               target.Region = source.Region, target.AccountId = source.AccountId
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Name, Email, ContactPhone, Region, AccountId)
+    VALUES (source.Id, source.Name, source.Email, source.ContactPhone, source.Region, source.AccountId);
+GO
+SET IDENTITY_INSERT dbo.Customer OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.Product — Ambitious Narrowing + add-unique FLIP seed.
+--   'STANDARD-SKU-001' is 16 chars > 10 -> narrowing Code to NVARCHAR(10) truncates -> Strict
+--     data-loss veto (self-test prompt 5). MAX(LEN(Code)) probe predicts it.
+--   The two 'DUPE' rows share Code -> add-unique on Code fails the unique index build on the dupe.
+----------------------------------------------------------------------------------------------
+--   LegacyCode (populated, NOT NULL) is the delete-attribute veto column (COL-09); CategoryId
+--   references dbo.Category (seeded above) and is what makes STA-04N's hard-DELETE orphan real.
+--   Neither column touches Code, so narrow (COL-06) and add-unique (CON-02) are unaffected.
+SET IDENTITY_INSERT dbo.Product ON;
+GO
+MERGE dbo.Product AS target
+USING (VALUES
+    (1, N'A100',             N'Widget',          N'LGC-A100', 1),
+    (2, N'B200',             N'Gadget',          N'LGC-B200', 2),
+    (3, N'STANDARD-SKU-001', N'Over-length code', N'LGC-003',  3),  -- 16 chars -> flips Ambitious Narrowing
+    (4, N'DUPE',             N'First dupe',       N'LGC-004',  1),  -- duplicate Code -> flips add-unique
+    (5, N'DUPE',             N'Second dupe',      N'LGC-005',  2)   -- duplicate Code -> flips add-unique
+) AS source (Id, Code, Name, LegacyCode, CategoryId)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Code <> source.Code
+     OR ISNULL(target.Name, N'<NULL>') <> ISNULL(source.Name, N'<NULL>')
+     OR target.LegacyCode <> source.LegacyCode
+     OR ISNULL(target.CategoryId, -1) <> ISNULL(source.CategoryId, -1)
+    ) THEN
+    UPDATE SET target.Code = source.Code, target.Name = source.Name,
+               target.LegacyCode = source.LegacyCode, target.CategoryId = source.CategoryId
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Code, Name, LegacyCode, CategoryId)
+    VALUES (source.Id, source.Code, source.Name, source.LegacyCode, source.CategoryId);
+GO
+SET IDENTITY_INSERT dbo.Product OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.[Order] — Forgotten FK Check FLIP seed.
+--   Orders 1-3 reference real Customers (1,2,4). Order 4 references CustomerId 999 which has NO
+--   matching Customer -> ORPHAN. Adding a clean FK Order.CustomerId -> Customer.Id vetoes on
+--   this orphan at deploy (self-test prompt 4). All StatusId values reference seeded Status rows.
+----------------------------------------------------------------------------------------------
+--   StatusText (free text) is the extract-to-lookup SOURCE (STA-03): every value maps to a
+--   Status.Code ('Pending'/'Shipped'/'Cancelled'). The STA-03 negative adds an UNMAPPED value in
+--   a SCRATCH copy — never here. StatusText is kept consistent with StatusId's Status.Code.
+SET IDENTITY_INSERT dbo.[Order] ON;
+GO
+MERGE dbo.[Order] AS target
+USING (VALUES
+    (1, 1,   1, 120.00, N'Pending'),
+    (2, 2,   2, 540.50, N'Shipped'),
+    (3, 4,   3,  75.25, N'Cancelled'),
+    (4, 999, 1, 300.00, N'Pending')   -- CustomerId 999 has NO parent -> orphan -> flips Forgotten FK Check
+) AS source (Id, CustomerId, StatusId, Total, StatusText)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.CustomerId <> source.CustomerId
+     OR target.StatusId   <> source.StatusId
+     OR target.Total      <> source.Total
+     OR target.StatusText <> source.StatusText
+    ) THEN
+    UPDATE SET target.CustomerId = source.CustomerId, target.StatusId = source.StatusId,
+               target.Total = source.Total, target.StatusText = source.StatusText
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, CustomerId, StatusId, Total, StatusText)
+    VALUES (source.Id, source.CustomerId, source.StatusId, source.Total, source.StatusText);
+GO
+SET IDENTITY_INSERT dbo.[Order] OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.CustomerAddress — EXACTLY ONE row per Customer (proven 1:1) for merge-tables (STR-02).
+--   Only real Customers (1..5) get an address. STR-02N (a 2nd address for one Customer) is a
+--   SCRATCH edit that breaks totality on purpose — NEVER baked here. Seeds AFTER Customer.
+----------------------------------------------------------------------------------------------
+SET IDENTITY_INSERT dbo.CustomerAddress ON;
+GO
+MERGE dbo.CustomerAddress AS target
+USING (VALUES
+    (1, 1, N'1 Acme Way',       N'Seattle',  N'98101'),
+    (2, 2, N'2 Globex Blvd',    N'Bellevue', N'98004'),
+    (3, 3, N'3 Initech Loop',   N'Redmond',  N'98052'),
+    (4, 4, N'4 Umbrella Court', N'Tacoma',   N'98402'),
+    (5, 5, N'5 Stark Tower',    N'Everett',  N'98201')
+) AS source (Id, CustomerId, Line1, City, PostalCode)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.CustomerId <> source.CustomerId
+     OR target.Line1      <> source.Line1
+     OR ISNULL(target.City, N'<NULL>')       <> ISNULL(source.City, N'<NULL>')
+     OR ISNULL(target.PostalCode, N'<NULL>') <> ISNULL(source.PostalCode, N'<NULL>')
+    ) THEN
+    UPDATE SET target.CustomerId = source.CustomerId, target.Line1 = source.Line1,
+               target.City = source.City, target.PostalCode = source.PostalCode
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, CustomerId, Line1, City, PostalCode)
+    VALUES (source.Id, source.CustomerId, source.Line1, source.City, source.PostalCode);
+GO
+SET IDENTITY_INSERT dbo.CustomerAddress OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.OrderLine — 2-3 lines per Order (deep FK graph) for define-pk composite (KEY-01) and the
+--   Order->OrderLine cascade blast radius (KEY-04). Only real Orders (1..4) get lines. The
+--   (OrderId, LineNumber) pairs are UNIQUE so the composite-PK claim holds. Seeds AFTER Order.
+----------------------------------------------------------------------------------------------
+SET IDENTITY_INSERT dbo.OrderLine ON;
+GO
+MERGE dbo.OrderLine AS target
+USING (VALUES
+    (1, 1, 1,  50.00),
+    (2, 1, 2,  70.00),
+    (3, 2, 1, 200.50),
+    (4, 2, 2, 140.00),
+    (5, 2, 3, 200.00),
+    (6, 3, 1,  75.25),
+    (7, 4, 1, 150.00),
+    (8, 4, 2, 150.00)
+) AS source (Id, OrderId, LineNumber, Amount)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.OrderId    <> source.OrderId
+     OR target.LineNumber <> source.LineNumber
+     OR target.Amount     <> source.Amount
+    ) THEN
+    UPDATE SET target.OrderId = source.OrderId, target.LineNumber = source.LineNumber, target.Amount = source.Amount
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, OrderId, LineNumber, Amount)
+    VALUES (source.Id, source.OrderId, source.LineNumber, source.Amount);
+GO
+SET IDENTITY_INSERT dbo.OrderLine OFF;
+GO
+
+----------------------------------------------------------------------------------------------
+-- dbo.CdcCandidate — a handful of rows for CDC proving. ISOLATED-DB ONLY (survival rule 1 /
+--   PROTOCOL §8): enable CDC only inside a unique per-executor DB, never the shared warm
+--   container. These rows just give the capture feed something to see.
+----------------------------------------------------------------------------------------------
+SET IDENTITY_INSERT dbo.CdcCandidate ON;
+GO
+MERGE dbo.CdcCandidate AS target
+USING (VALUES
+    (1, N'Alpha', N'first row'),
+    (2, N'Beta',  N'second row'),
+    (3, N'Gamma', CAST(NULL AS NVARCHAR(200)))
+) AS source (Id, Name, Notes)
+    ON target.Id = source.Id
+WHEN MATCHED AND (
+        target.Name <> source.Name
+     OR ISNULL(target.Notes, N'<NULL>') <> ISNULL(source.Notes, N'<NULL>')
+    ) THEN
+    UPDATE SET target.Name = source.Name, target.Notes = source.Notes
+WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Id, Name, Notes) VALUES (source.Id, source.Name, source.Notes);
+GO
+SET IDENTITY_INSERT dbo.CdcCandidate OFF;
+GO
+
+PRINT 'Seed applied. Flip scenarios: NULL emails (3,5), over-length+dupe Code (3,4,5), orphan order (4).';
+PRINT 'Enriched (2026-06-30): Account/Category lookups, Customer.Region+AccountId, Product.LegacyCode+CategoryId,';
+PRINT 'Order.StatusText, CustomerAddress (1:1), OrderLine (deep FK), CdcCandidate (ISOLATED-DB CDC only).';
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Account.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Account.sql
@@ -1,0 +1,41 @@
+/*
+  dbo.Account — the move-attribute destination + split/merge partner surface.
+
+  CREATE-only schema item. Each Account is 1:1 with a Customer via a new nullable
+  Customer.AccountId (added to Customer.sql WITHOUT breaking the existing make-mandatory /
+  rename seed). This 1:1 shape is the whole point: move-attribute (STR-03, move Region from
+  Customer to Account) can only be PROVEN total when the relationship is provably 1:1.
+
+  PARALLEL EXECUTORS — READ FIRST: do NOT edit this authored file in place. Copy the whole
+  proving-ground tree to a private scratch dir and publish to a UNIQUE database
+  (/TargetDatabaseName:PG_<testId>_<rand>) per `../self-test/PROTOCOL.md`.
+
+  WHAT THIS TABLE UNLOCKS
+  -----------------------
+  - move-attribute (STR-03): Region lives here as the DESTINATION. The proof moves Region from
+    Customer to Account and demonstrates the value survives across the 1:1 join. A cross-table
+    MOVE has NO refactorlog identity mapping — it is copy-then-drop, never a rename. See
+    skills/_index/multi-phase/ (coexistence + totality proof) and
+    skills/_index/identity-and-refactorlog/ (why a move is not a rename).
+  - merge/split partner: Account is the second surface a split can land on and a merge can fold.
+
+  Region is seeded here so the STR-03 move has a destination shape to prove into; the AUTHORED
+  positive keeps Customer.Region as the source of truth (the move is proven in a scratch copy
+  that adds Customer.Region — see Customer.sql header). Region NVARCHAR(50) NULL matches the
+  Customer-side attribute so the copy is type-clean.
+
+  UNLOCKS self-test ids: STR-03 (move-attribute), STR-01/STR-02 (split/merge partner surface).
+*/
+
+CREATE TABLE dbo.Account
+(
+    Id      INT             IDENTITY(1,1) NOT NULL,
+    Name    NVARCHAR(100)   NOT NULL,
+
+    -- move-attribute DESTINATION. In the STR-03 proof, Customer.Region is copied here then
+    -- dropped from Customer. Same type/nullability as the Customer-side attribute.
+    Region  NVARCHAR(50)    NULL,
+
+    CONSTRAINT PK_Account PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Category.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Category.sql
@@ -1,0 +1,46 @@
+/*
+  dbo.Category — a second static / lookup entity (explicit id, NO IDENTITY) + identity-swap SOURCE.
+
+  CREATE-only schema item. Like dbo.Status, lookup rows carry EXPLICIT, stable ids so the seed
+  MERGE can address them and FK targets are deterministic across environments (a constant id must
+  mean the same row everywhere — see skills/_index/idempotent-seed/). Product gets a new nullable
+  CategoryId so Category is a REAL FK target, which is what makes the delete-seed-value negative
+  fire (a hard DELETE of a referenced value orphans Product rows).
+
+  PARALLEL EXECUTORS — READ FIRST: do NOT edit this authored file in place. Copy the tree, publish
+  to a UNIQUE database per `../self-test/PROTOCOL.md`.
+
+  WHAT THIS TABLE UNLOCKS
+  -----------------------
+  - create-static-seed (STA-01): a brand-new static entity with a guarded MERGE. See
+    skills/op/create-static-seed/ and skills/_index/idempotent-seed/.
+  - edit-seed (STA-02): add a 'Refunded'-shaped value — a Declarative+Post-Deploy row add, no
+    schema change. See skills/op/edit-seed/.
+  - delete-seed-value (STA-04N): the deactivate-don't-delete proof. Because Product.CategoryId
+    references Category, a HARD DELETE of a referenced Category row orphans Product (or vetoes on
+    the FK). The correct move is IsActive=0, not DELETE. See skills/op/delete-seed-value/ and
+    skills/_index/idempotent-seed/ (deactivate-don't-delete).
+  - identity-swap SOURCE (STR-04): Category has NO IDENTITY. "Turn on Auto Number" here is a
+    table REBUILD (you cannot ALTER a column to add IDENTITY) — shadow table + IDENTITY_INSERT +
+    reseed + recreate FKs. See skills/op/identity-swap/.
+
+  IsActive DEFAULT 1 gives the deactivate-don't-delete path a column to flip.
+
+  UNLOCKS self-test ids: STA-01 (create-static-seed), STA-02 (edit-seed),
+  STA-04N (delete-seed-value negative — Product FK makes the orphan real), STR-04 (identity-swap).
+*/
+
+CREATE TABLE dbo.Category
+(
+    -- Explicit id, NO IDENTITY. Lookup rows own their keys; the same constant must mean the same
+    -- Category across environments. This is the identity-swap SOURCE (adding IDENTITY = rebuild).
+    Id          INT             NOT NULL,
+    Code        NVARCHAR(30)    NOT NULL,
+
+    -- deactivate-don't-delete lever: retire a value by flipping this to 0, never a hard DELETE
+    -- that orphans the Product rows pointing at it.
+    IsActive    BIT             NOT NULL CONSTRAINT DF_Category_IsActive DEFAULT (1),
+
+    CONSTRAINT PK_Category PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/CdcCandidate.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/CdcCandidate.sql
@@ -1,0 +1,52 @@
+/*
+  dbo.CdcCandidate — the CDC proving table. ISOLATED-DB ONLY.
+
+  ============================================================================================
+  SURVIVAL RULE 1 / PROTOCOL §8 — MANDATORY ISOLATION. READ BEFORE ENABLING CDC.
+  --------------------------------------------------------------------------------------------
+  sp_cdc_enable_db flips CDC state INSTANCE-WIDE. NEVER enable CDC on the shared warm container
+  (`projection-mssql-warm`) or on the shared `ProvingGround` DB. Any CDC proof (AUD-04/05/06,
+  AUD-07N, TRAP-01N) runs ONLY inside a UNIQUE, per-executor database
+  (/TargetDatabaseName:PG_<testId>_<rand>) that you create and drop yourself. This mirrors the F#
+  test suite's IsolatedContainerFixture rule (CLAUDE.md survival rule 1) and self-test PROTOCOL §8.
+  A CDC proof on the shared DB corrupts every other executor and the warm container.
+  ============================================================================================
+
+  CREATE-only schema item. A plain table whose PURPOSE is CDC proving. The point of CDC in this
+  proving ground is to demonstrate that CDC is NOT in the dacpac model — the declarative attempt
+  to "turn on CDC" is SILENTLY IGNORED (prove the empty delta), so CDC is Script-Only, +1 Tier
+  forever, and its failure mode is SILENCE (a missing column in the feed, no error). See
+  skills/_index/cdc/ for the standing tax and skills/op/enable-cdc/ for the op.
+
+  WHAT THIS TABLE UNLOCKS (all ISOLATED-DB only)
+  ----------------------------------------------
+  - enable-cdc (AUD-04): sys.sp_cdc_enable_table on THIS table inside the unique DB; prove the
+    declarative attempt produces an EMPTY delta. See skills/op/enable-cdc/.
+  - recreate-capture-instance (AUD-05): ADD a column (e.g. AMOUNT) AFTER enabling capture, then
+    prove the existing capture instance does NOT see it (silence) until a dual-instance
+    v1/v2 recreate. See skills/op/recreate-capture-instance/ and skills/_index/cdc/.
+  - change-tracking (AUD-06): the lighter sibling (which rows changed, not the column-level feed).
+    See skills/op/change-tracking/.
+  - drop-CDC-tracked-table (AUD-07N): dropping a CDC-tracked table is a negative — the capture
+    instance and cleanup jobs must be torn down first.
+  - nullable-add-to-CDC-table (TRAP-01N): adding even a nullable column to a CDC table is the +1
+    CDC-Surprise face — the feed silently omits the new column until capture is recreated.
+
+  Notes NVARCHAR(200) NULL gives AUD-05 / TRAP-01N a place to add a second column too.
+
+  PARALLEL EXECUTORS — READ FIRST: copy the tree, publish to a UNIQUE database, and enable CDC
+  ONLY in that unique DB. See `../self-test/PROTOCOL.md` §8.
+
+  UNLOCKS self-test ids: AUD-04 (enable-cdc), AUD-05 (recreate-capture-instance),
+  AUD-06 (change-tracking), AUD-07N (drop-CDC-tracked-table), TRAP-01N (nullable-add-to-CDC-table).
+*/
+
+CREATE TABLE dbo.CdcCandidate
+(
+    Id      INT             IDENTITY(1,1) NOT NULL,
+    Name    NVARCHAR(100)   NOT NULL,
+    Notes   NVARCHAR(200)   NULL,
+
+    CONSTRAINT PK_CdcCandidate PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Customer.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Customer.sql
@@ -1,0 +1,92 @@
+/*
+  dbo.Customer — the make-mandatory and rename-attribute proving table.
+
+  This is a CREATE-only schema item (Build Action = Build). You prove a change by editing THIS
+  destination, never by writing ALTER. "Edit the CREATE, never write ALTER."
+
+  PARALLEL EXECUTORS — READ FIRST: if you are one of many subagents proving a case at once, do
+  NOT edit this authored file in place. Copy the whole proving-ground tree to a private scratch
+  dir and publish to a UNIQUE database (/TargetDatabaseName:PG_<testId>_<rand>) per the protocol
+  in `../self-test/PROTOCOL.md`. The authored tree and the default DB are shared and read-only;
+  the scratch copy + unique DB are how a hundred provers run without colliding.
+
+  WHAT THIS TABLE EXERCISES
+  -------------------------
+  - make-mandatory (Email NULL -> NOT NULL): the seed plants Email NULL rows. The mechanism is
+    decided ENTIRELY by whether the table HAS ROWS — not by whether the Email column has NULLs.
+    SSDT's BlockOnPossibleDataLoss guard for this change is generated as
+        IF EXISTS (SELECT TOP 1 1 FROM dbo.Customer) RAISERROR(...,16,127)
+    placed BEFORE the ALTER COLUMN. That is TABLE-HAS-ROWS, not column-has-NULLs. Consequences:
+      * EMPTY table  -> the IF EXISTS is false, the RAISERROR never fires, the ALTER COLUMN
+        NOT NULL lands. Clean Mechanism 1, Pure Declarative, single-phase, Tier 1.
+      * POPULATED table (NULLs present OR zero NULLs — it does NOT matter which) -> Strict
+        ALWAYS vetoes. A pre-deploy backfill that clears every NULL does NOT clear the veto;
+        the column stays nullable. PROVEN on the proving ground: backfilled to 0 NULL emails,
+        Strict STILL vetoed. So on a populated table this is NOT a clean Mechanism 3.
+    The honest remedy on a populated table is a CONSCIOUS, DOCUMENTED decision taken AFTER a
+    verified-zero-NULL backfill (the zero-NULL probe is necessary but not sufficient): either
+      (a) a targeted relaxation of BlockOnPossibleDataLoss for this ONE change — operationally
+          Mechanism 4 / Script-Only with a named, logged gate-relaxation — or
+      (b) restructure as Mechanism 5, Multi-Phase, multi-PR.
+    Tier 2 baseline; +1 for CDC / >1M rows / first-time. This is the headline
+    same-op × different-seed proof (self-test COL-03 / COL-03B / COL-03C).
+
+  - rename-attribute (ContactPhone -> MobileNumber): rename by editing the column name here.
+    WITHOUT a refactorlog entry the delta is DROP ContactPhone + ADD MobileNumber = the Naked
+    Rename catastrophe (every phone number lost). WITH the refactorlog entry it becomes
+    sp_rename and the data survives. (self-test COL-08 / COL-08N.)
+
+  - move-attribute SOURCE (STR-03): Region + the 1:1 AccountId link were ADDED (2026-06-30) so
+    Region can be moved Customer -> Account and proven total across the 1:1 join. A cross-table
+    move is copy-then-drop, NOT an sp_rename — there is no refactorlog identity mapping for a
+    move. temporal-convert (AUD-02) also converts THIS populated Customer in a SCRATCH copy (no
+    authored change — greenfield-vs-convert contrast lives in skills/op/temporal-convert/).
+    See skills/_index/multi-phase/ and skills/_index/identity-and-refactorlog/.
+
+  HOW TO PROVE make-mandatory (the showcase finding the run must EMPIRICALLY confirm):
+    1. Edit `Email NVARCHAR(256) NULL` to `Email NVARCHAR(256) NOT NULL` below, rebuild, and run
+       /Action:Script. In the delta you will SEE the `IF EXISTS(SELECT TOP 1 1 FROM Customer)
+       RAISERROR(...,16,127)` guard placed ABOVE the `ALTER COLUMN ... NOT NULL` — that is the
+       table-has-rows guard in the flesh.
+    2. Strict publish on the default (populated) seed -> Strict VETOES.
+    3. Author the pre-deploy backfill (see Script.PreDeployment.sql), re-run the NULL probe
+       (`SELECT COUNT(*) FROM dbo.Customer WHERE Email IS NULL`) -> prove it returns 0.
+    4. Re-run Strict -> it STILL VETOES and the column STAYS NULLABLE. This is the finding.
+    5. Deliver the corrected verdict: on a populated table, backfill alone cannot pass the
+       prod-strict gate; choose (a) named gate-relaxation after proven-zero-NULL or
+       (b) multi-phase, and PROVE the chosen path lands the NOT NULL.
+    The EMPTY-table leg (truncate Customer, or skip the seed, before publishing) is the clean
+    Mechanism 1 contrast: with no rows the guard's IF EXISTS is false and the ALTER lands.
+    Do NOT report the old "backfill -> clean NOT NULL = Mechanism 3" recipe — it is WRONG and
+    was disproven here.
+*/
+
+CREATE TABLE dbo.Customer
+(
+    Id              INT             IDENTITY(1,1) NOT NULL,
+    Name            NVARCHAR(100)   NOT NULL,
+
+    -- make-mandatory target. Default state is NULLABLE. Editing this to NOT NULL is the
+    -- one-line change whose mechanism the DATA decides — and on a populated table the guard is
+    -- table-has-rows, so it vetoes even after the NULLs are backfilled away.
+    Email           NVARCHAR(256)   NULL,
+
+    -- rename-attribute target. Rename this to MobileNumber by editing the name. Without a
+    -- refactorlog entry that rename is a DROP+CREATE = Naked Rename data loss.
+    ContactPhone    NVARCHAR(40)    NULL,
+
+    -- move-attribute SOURCE (STR-03). Region is the value moved FROM Customer TO Account across
+    -- the 1:1 AccountId join. Seeded populated so the move has data to conserve. A cross-table
+    -- move is copy-then-drop (no refactorlog identity) — see skills/_index/multi-phase/ and
+    -- skills/_index/identity-and-refactorlog/.
+    Region          NVARCHAR(50)    NULL,
+
+    -- 1:1 link to dbo.Account (nullable so it does NOT disturb the existing make-mandatory /
+    -- rename seed on rows without an Account). Makes the STR-03 move provably 1:1 and gives
+    -- split/merge a real join column. Left as a plain column here — declaring the FK to
+    -- Account(Id) is itself a create-fk proof (see skills/op/create-fk-clean/).
+    AccountId       INT             NULL,
+
+    CONSTRAINT PK_Customer PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/CustomerAddress.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/CustomerAddress.sql
@@ -1,0 +1,44 @@
+/*
+  dbo.CustomerAddress — the split / merge partner table (proven 1:1 with Customer).
+
+  CREATE-only schema item. The AUTHORED seed plants EXACTLY ONE CustomerAddress per Customer, so
+  the relationship is PROVABLY 1:1. That 1:1-ness is load-bearing:
+
+    - merge-tables (STR-02): folding CustomerAddress back into Customer is TOTAL only when every
+      Customer has AT MOST ONE address. The positive STR-02 proof depends on the authored 1:1
+      seed. Its conservation proof: absorbed-rows == distinct-parents (see
+      skills/_index/multi-phase/).
+
+    - split-table (STR-01): Customer split into Customer + CustomerAddress is the reverse move.
+
+  THE STR-02N NEGATIVE IS A SCRATCH EDIT — DO NOT BAKE IT HERE. The 1:many negative (a Customer
+  with TWO addresses, which makes the merge non-total) is produced by a SCRATCH-COPY seed edit
+  that appends a 2nd row for one CustomerId. Baking 1:many into the AUTHORED positive seed would
+  BREAK the STR-02 positive. Keep the authored seed strictly 1:1; add the extra row only in a
+  throwaway copy per `../self-test/PROTOCOL.md`.
+
+  PARALLEL EXECUTORS — READ FIRST: do NOT edit this authored file in place. Copy the tree, edit
+  the COPY, publish to a UNIQUE database. See `../self-test/PROTOCOL.md`.
+
+  CustomerId is a plain column (FK to Customer intentionally NOT declared — declaring it is a
+  create-fk proof). Parents (Customer) seed before this child.
+
+  UNLOCKS self-test ids: STR-01 (split-table), STR-02 (merge-tables, 1:1 positive),
+  STR-02N (1:many negative — SCRATCH seed edit only).
+*/
+
+CREATE TABLE dbo.CustomerAddress
+(
+    Id          INT             IDENTITY(1,1) NOT NULL,
+
+    -- 1:1 back to Customer in the AUTHORED seed. The STR-02N negative adds a 2nd row for one
+    -- CustomerId in a SCRATCH copy to break totality on purpose.
+    CustomerId  INT             NOT NULL,
+
+    Line1       NVARCHAR(120)   NOT NULL,
+    City        NVARCHAR(80)    NULL,
+    PostalCode  NVARCHAR(20)    NULL,
+
+    CONSTRAINT PK_CustomerAddress PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Order.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Order.sql
@@ -1,0 +1,46 @@
+/*
+  dbo.[Order] — the foreign-key proving table. (Bracketed: ORDER is a reserved word.)
+
+  CREATE-only schema item. The seed plants AT LEAST ONE row whose CustomerId has no matching
+  Customer — an ORPHAN. That orphan is what makes "add a foreign key" flip from a one-line
+  declarative edit to a Script-Only reconcile.
+
+  WHAT THIS TABLE EXERCISES
+  -------------------------
+  - create-FK clean vs with-orphans (Forgotten FK Check): adding
+      CONSTRAINT FK_Order_Customer FOREIGN KEY (CustomerId) REFERENCES dbo.Customer(Id)
+    publishes clean ONLY if every CustomerId has a parent. With the orphan present, a clean
+    declarative FK VETOES at deploy. The proven remedy is the script path:
+    add WITH NOCHECK -> reconcile (delete/repoint the orphan) -> WITH CHECK CHECK to re-trust.
+    Orphan present vs absent flips Tier 1 single-phase to Tier 3 Script-Only. (self-test prompt 4.)
+
+  - change-delete-rule / cascade: the OutSystems delete rule (Protect / Ignore / Delete) maps to
+    NO ACTION / NO ACTION / CASCADE. Changing it is DROP + ADD of the FK. Watch the delta for
+    cascade chains. See skills/operations/keys-and-refs.md.
+
+  The FK constraints are intentionally NOT declared below — declaring them is the change you
+  prove. Start from the no-FK destination and add the FK to watch the orphan veto fire.
+*/
+
+CREATE TABLE dbo.[Order]
+(
+    Id              INT             IDENTITY(1,1) NOT NULL,
+
+    -- Most rows match a Customer; the seed plants one orphan (CustomerId with no parent).
+    CustomerId      INT             NOT NULL,
+
+    -- References Status.Id (explicit-id lookup).
+    StatusId        INT             NOT NULL,
+
+    Total           DECIMAL(18, 2)  NOT NULL CONSTRAINT DF_Order_Total DEFAULT (0),
+
+    -- extract-to-lookup SOURCE (STA-03, see Modules/OrderStatusText.sql header, added 2026-06-30).
+    -- Free-text string values ('Pending','Shipped','Cancelled') that MAP to dbo.Status.Code.
+    -- Promoting this free text to a Status FK must prove the mapping is TOTAL (every distinct
+    -- StatusText resolves to a Status row). The STA-03 negative adds an unmapped value in a
+    -- SCRATCH copy. See skills/op/extract-to-lookup/ and skills/_index/multi-phase/.
+    StatusText      NVARCHAR(20)    NOT NULL CONSTRAINT DF_Order_StatusText DEFAULT (N'Pending'),
+
+    CONSTRAINT PK_Order PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderLine.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderLine.sql
@@ -1,0 +1,40 @@
+/*
+  dbo.OrderLine — the composite-PK + cascade blast-radius table (deep FK graph).
+
+  CREATE-only schema item. Child of dbo.[Order]. The seed plants 2-3 lines per Order so the
+  Order -> OrderLine chain has real depth: a CASCADE delete rule change on Order.CustomerId (or on
+  the OrderLine->Order FK) has a VISIBLE blast radius, and orphan/cascade proofs have children to
+  act on.
+
+  PARALLEL EXECUTORS — READ FIRST: do NOT edit this authored file in place. Copy the tree, publish
+  to a UNIQUE database per `../self-test/PROTOCOL.md`.
+
+  WHAT THIS TABLE UNLOCKS
+  -----------------------
+  - define-pk COMPOSITE (KEY-01): the natural key is (OrderId, LineNumber), not the surrogate Id.
+    Proving a composite PK on populated data is a claim about UNIQUENESS of the pair (a duplicate
+    pair vetoes the PK build) — see skills/_index/constraint-is-a-claim/ and skills/op/define-pk/.
+    A surrogate Id IDENTITY is present so the table is addressable while the composite PK is proven.
+  - change-delete-rule / cascade (KEY-04): Order -> OrderLine is the chain whose CASCADE makes the
+    delete blast radius visible in the delta. See skills/op/change-delete-rule/.
+  - FK graph depth for cascade/orphan proofs across keys-and-refs.
+
+  The OrderLine -> Order FK is intentionally NOT declared (declaring it is a create-fk proof).
+  Parents (Order) seed before this child.
+
+  UNLOCKS self-test ids: KEY-01 (define-pk composite), KEY-04 (change-delete-rule cascade chain).
+*/
+
+CREATE TABLE dbo.OrderLine
+(
+    -- Surrogate so the table is addressable; the composite (OrderId, LineNumber) is the natural
+    -- key define-pk proves.
+    Id          INT             IDENTITY(1,1) NOT NULL,
+
+    OrderId     INT             NOT NULL,
+    LineNumber  INT             NOT NULL,
+    Amount      DECIMAL(18, 2)  NOT NULL CONSTRAINT DF_OrderLine_Amount DEFAULT (0),
+
+    CONSTRAINT PK_OrderLine PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderStatusText.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderStatusText.sql
@@ -1,0 +1,28 @@
+/*
+  Modules/OrderStatusText.sql — DOCUMENTATION-ONLY module (NO CREATE TABLE).
+
+  There is exactly ONE dbo.[Order] CREATE (in Modules/Order.sql). This file RECORDS the free-text
+  StatusText column ADDED to dbo.[Order] on 2026-06-30 to unlock extract-to-lookup. No schema
+  object here (harmless empty batch under the SDK Build glob). Do not add a CREATE.
+
+  COLUMN ADDED TO dbo.[Order] (see Modules/Order.sql):
+
+    StatusText NVARCHAR(20) NOT NULL DEFAULT (N'Pending')
+        Free-text string values seeded distinct ('Pending','Shipped','Cancelled') that MAP to
+        dbo.Status.Code. This is the extract-to-lookup (STA-03) SOURCE: promoting the free text to
+        a proper Status FK is a MULTI-PHASE move (add StatusId FK -> backfill from the text via the
+        Status.Code map -> drop StatusText) whose licensing gate is a TOTAL-MAPPING proof — every
+        distinct StatusText must resolve to a seeded Status row, else the backfill leaves NULLs and
+        the FK cannot be trusted. See skills/_index/multi-phase/ (totality proof before the drop)
+        and skills/_index/constraint-is-a-claim/ (the FK is a claim proven at apply time).
+
+  THE STA-03 TOTAL-MAPPING NEGATIVE IS A SCRATCH EDIT — DO NOT BAKE IT HERE. The negative seeds an
+  UNMAPPED StatusText value (e.g. 'Backordered' with no matching Status.Code) in a THROWAWAY copy
+  so the mapping is provably non-total. The AUTHORED positive keeps every StatusText mapped, so
+  STA-03 positive passes. Add the unmapped row only in a scratch copy per `../self-test/PROTOCOL.md`.
+
+  UNLOCKS self-test ids: STA-03 (extract-to-lookup, total-mapping positive; the non-total negative
+  is a SCRATCH seed edit).
+*/
+
+-- Intentionally no schema object. The column lives in Modules/Order.sql.

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderSummary.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderSummary.sql
@@ -1,0 +1,50 @@
+/*
+  dbo.vOrderSummary — the authored VIEW (ENUMERATED columns) + the SELECT * trap surface.
+
+  CREATE-only schema item. The AUTHORED view lists its columns EXPLICITLY (never SELECT *). That
+  is the correct, stable shape: a column added to Order/Customer/Status does NOT silently change
+  the view's contract, and the view is a safe compat/indexed-view base.
+
+  PARALLEL EXECUTORS — READ FIRST: do NOT edit this authored file in place. Copy the tree, publish
+  to a UNIQUE database per `../self-test/PROTOCOL.md`.
+
+  WHAT THIS VIEW UNLOCKS
+  ----------------------
+  - create-view (VIE-01): an OutSystems Advanced Query / view over a join. The authored,
+    enumerated form is the clean Mechanism 1 destination. See skills/op/create-view/.
+  - the SELECT * View trap (handbook 16 = §19): the documented SELECT * VARIANT below is proven in
+    a SCRATCH copy. Replace the enumerated SELECT with `SELECT *` and observe that the view's
+    column set is now FROZEN at first-bind and drifts against the base tables (a base column add is
+    not reflected; a base column drop breaks the view at runtime, not deploy). The AUTHORED view
+    stays enumerated so VIE-01 positive passes; the trap is a SCRATCH edit only. See
+    skills/op/create-view/ and skills/op/compat-view/.
+  - compat-view TARGET (VIE-02): after a rename, a view carrying the OLD name over the NEW table is
+    the backward-compat bridge — identity survives the move, the name is just an address. See
+    skills/op/compat-view/ and skills/_index/identity-and-refactorlog/.
+  - indexed-view (VIE-04): a SCRATCH edit adds WITH SCHEMABINDING + a UNIQUE CLUSTERED index to
+    materialize an aggregation. SCHEMABINDING is why the enumerated column list matters. See
+    skills/op/indexed-view/.
+
+  synonym (VIE-03) needs NO table here — it targets an external DB/server and is proven by the
+  runtime-resolution gap (the dacpac cannot validate the far side). See skills/op/synonym/.
+
+  THE SELECT * TRAP + INDEXED-VIEW VARIANTS ARE SCRATCH EDITS — DO NOT BAKE THEM HERE. The authored
+  view must stay enumerated and non-schemabound so VIE-01 positive publishes clean.
+
+  UNLOCKS self-test ids: VIE-01 (create-view), VIE-02 (compat-view target),
+  VIE-04 (indexed-view — SCRATCH edit), and the SELECT * View trap (SCRATCH edit).
+*/
+
+CREATE VIEW dbo.vOrderSummary
+AS
+    SELECT
+        o.Id            AS OrderId,
+        o.Total         AS Total,
+        o.StatusText    AS StatusText,
+        c.Id            AS CustomerId,
+        c.Name          AS CustomerName,
+        s.Code          AS StatusCode
+    FROM dbo.[Order]    AS o
+    INNER JOIN dbo.Customer AS c ON c.Id = o.CustomerId
+    INNER JOIN dbo.Status   AS s ON s.Id = o.StatusId;
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Product.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Product.sql
@@ -1,0 +1,47 @@
+/*
+  dbo.Product — the narrowing and uniqueness proving table.
+
+  CREATE-only schema item. Code starts WIDE (NVARCHAR(50)). The seed plants AT LEAST ONE Code
+  longer than 10 characters and (separately) a DUPLICATE Code, so two different changes flip by
+  data.
+
+  WHAT THIS TABLE EXERCISES
+  -------------------------
+  - narrow (Ambitious Narrowing): edit `Code NVARCHAR(50)` to `Code NVARCHAR(10)`. The
+    over-length seed row would truncate, so Strict VETOES on possible data loss. A
+    MAX(LEN(Code)) probe PREDICTS the veto before you even build (see talk-to-local-sql).
+    Empty / all-short -> Mechanism 1. Over-length present -> Mechanism 3 or 5 (reconcile first),
+    Tier 3 (data change). (self-test prompt 5.)
+
+  - add-unique on Code: add CONSTRAINT UQ_Product_Code UNIQUE (Code) (or a unique index). With a
+    duplicate Code in the seed, the unique index build FAILS on the dupe. The remedy is a
+    pre-deploy dedupe. Dupes present vs absent flips the bucket. See
+    skills/operations/constraints.md.
+
+  Code is intentionally non-unique below — adding uniqueness is the change you prove.
+*/
+
+CREATE TABLE dbo.Product
+(
+    Id      INT             IDENTITY(1,1) NOT NULL,
+
+    -- Wide enough to hold the over-length seed value. Narrowing this is the data-loss proof.
+    Code    NVARCHAR(50)    NOT NULL,
+
+    Name    NVARCHAR(200)   NULL,
+
+    -- delete-attribute proving column (see Modules/ProductLegacy.sql header, added 2026-06-30).
+    -- POPULATED NOT NULL: dropping it on a table with rows fires BlockOnPossibleDataLoss
+    -- (table-has-rows). A DISTINCT column so narrow / add-unique on Code stay unaffected.
+    -- See skills/op/delete-attribute/ and skills/_index/tightening-class/.
+    LegacyCode NVARCHAR(40)  NOT NULL CONSTRAINT DF_Product_LegacyCode DEFAULT (N'LEGACY'),
+
+    -- FK target for Category (see Modules/Category.sql). Nullable so it does not disturb the
+    -- existing narrow / add-unique Code scenarios. Makes the delete-seed-value negative (STA-04N)
+    -- real: deleting a referenced Category orphans these rows. FK to Category(Id) intentionally
+    -- NOT declared — declaring it is a create-fk proof.
+    CategoryId INT           NULL,
+
+    CONSTRAINT PK_Product PRIMARY KEY CLUSTERED (Id)
+);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/ProductLegacy.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/ProductLegacy.sql
@@ -1,0 +1,30 @@
+/*
+  Modules/ProductLegacy.sql — DOCUMENTATION-ONLY module (NO CREATE TABLE).
+
+  There is exactly ONE dbo.Product CREATE (in Modules/Product.sql); a second CREATE for the same
+  table is illegal. This file is the RECORD of the two columns ADDED to dbo.Product on 2026-06-30
+  to unlock delete-attribute and the delete-seed-value FK negative WITHOUT disturbing the existing
+  narrow / add-unique Code scenarios. It contains no schema object, so the SDK Build glob picks it
+  up harmlessly as an empty batch. (Keep it as a header; do not add a CREATE.)
+
+  COLUMNS ADDED TO dbo.Product (see Modules/Product.sql):
+
+    LegacyCode NVARCHAR(40) NOT NULL DEFAULT (N'LEGACY')
+        A POPULATED, NOT NULL column. It is seeded non-empty (see Data/Seed.sql, Product block),
+        so DROPPING it on the populated table fires SSDT's BlockOnPossibleDataLoss guard —
+        table-has-rows, the same data-BLIND guard as make-mandatory / narrow. This is the
+        tightening class: see skills/_index/tightening-class/ (do NOT re-derive the guard). The
+        DEFAULT lets the column ADD cleanly to a populated Product; the DROP is the veto proof.
+        Distinct from Code, so narrow (COL-06) and add-unique (CON-02) on Code are unaffected.
+
+    CategoryId INT NULL
+        FK-shaped target for dbo.Category. Nullable so it does not touch the Code scenarios.
+        Makes delete-seed-value (STA-04N) real: a hard DELETE of a referenced Category row
+        orphans the Product rows pointing at it. See skills/_index/constraint-is-a-claim/ and
+        skills/_index/idempotent-seed/ (deactivate-don't-delete).
+
+  UNLOCKS self-test ids: COL-09 (delete-attribute, populated-column BlockOnPossibleDataLoss veto),
+  STA-04N (delete-seed-value orphan negative via the Product->Category FK).
+*/
+
+-- Intentionally no schema object. The columns live in Modules/Product.sql.

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/Status.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/Status.sql
@@ -1,0 +1,37 @@
+/*
+  dbo.Status — the static / lookup entity.
+
+  CREATE-only schema item. NO IDENTITY: lookup rows carry EXPLICIT, stable ids so the seed
+  MERGE can address them and so FK targets (Order.StatusId) are deterministic. An OutSystems
+  Static Entity becomes exactly this: an explicit-id table seeded by an idempotent post-deploy
+  MERGE.
+
+  WHAT THIS TABLE EXERCISES
+  -------------------------
+  - static-data seed: the post-deploy MERGE in Data/Seed.sql populates these rows. A re-publish
+    with the seed UNCHANGED must be SILENT — the guarded WHEN MATCHED captures 0 rows. An
+    unconditional WHEN MATCHED over-captures (the CDC-silence anti-proof). (self-test prompt 6.)
+
+  - extract-values-to-lookup / FK target: Order.StatusId references Status.Id, so adding a new
+    lookup value ('Refunded') is a Declarative+Post-Deploy change (Mechanism 2): no schema
+    change, just a new MERGE row.
+
+  - add/remove-IDENTITY (Auto Number): you CANNOT ALTER a column to add IDENTITY. Turning this
+    into an Auto Number entity is a table-swap (IDENTITY_INSERT + reseed + recreate FKs), not a
+    one-line edit. See skills/operations/structural.md.
+*/
+
+CREATE TABLE dbo.Status
+(
+    -- Explicit id, NO IDENTITY. Lookup rows own their keys.
+    Id          INT             NOT NULL,
+    Code        NVARCHAR(20)    NOT NULL,
+    IsActive    BIT             NOT NULL CONSTRAINT DF_Status_IsActive DEFAULT (1),
+
+    CONSTRAINT PK_Status PRIMARY KEY CLUSTERED (Id)
+);
+GO
+
+-- One NULL is allowed under a UNIQUE index, so Code uniqueness is a clean separate proof.
+CREATE UNIQUE INDEX UX_Status_Code ON dbo.Status (Code);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/README.md
@@ -1,0 +1,201 @@
+# proving-ground — the runbook
+
+This is the agent's runbook for the proving loop. The proving ground is a **hand-authored,
+self-contained sample project** (it is data, not a wrapper script) plus a **throwaway copy of
+real-shaped data** on a local SQL Server container. You edit a `CREATE`, build a dacpac, and
+publish it against the throwaway DB to watch what SSDT's publish engine actually does. **The
+veto is the classification.**
+
+You run these commands yourself — there is no orchestration script. The blocks below are the
+worked commands; read them, then run them in order.
+
+> **Running in parallel with other executors?** This runbook publishes to one shared
+> `ProvingGround` database and edits the authored tree in place — fine for a SINGLE prover
+> working interactively. If you are one of MANY subagents proving cases at once, DO NOT use the
+> shared DB or edit these files in place: follow **`../self-test/PROTOCOL.md`** instead — copy
+> the tree to a private scratch dir and publish to a UNIQUE database
+> (`/TargetDatabaseName:PG_<testId>_<rand>`, which overrides the profile's Initial Catalog).
+> That is how a hundred provers share the warm container without colliding on the same `.sql`,
+> the same `bin/`, or the same DB.
+
+## 0 — The runtime shim (REQUIRED on this machine)
+
+`sqlpackage` is installed as a dotnet tool targeting .NET 8, but this box has .NET 9 at a
+non-standard path. Export these in the shell you run `sqlpackage` from, or the tool fails to
+start:
+
+```bash
+export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROLL_FORWARD=Major
+export MSYS_NO_PATHCONV=1   # Git Bash: keep /Action: switches and /opt/... docker paths intact
+```
+
+`sqlpackage` lives at `C:\Users\danny\.dotnet\tools\sqlpackage.exe` (version 170.4.83).
+(Alternative to the shim: install the .NET 8 runtime — then the env vars are unnecessary.)
+
+## 1 — Warm the throwaway substrate
+
+Reuse the existing helper (plain bash, already in the repo — do not write a new one):
+
+```bash
+scripts/warm-sql.sh start
+```
+
+This brings up container `projection-mssql-warm`:
+
+| setting   | value                                                         |
+|-----------|---------------------------------------------------------------|
+| Server    | `localhost,11433`                                             |
+| User      | `sa`                                                          |
+| Password  | `Projection@Strong1`                                          |
+| Options   | `TrustServerCertificate=True;Encrypt=False`                   |
+
+The host has **no `sqlcmd`** — issue SQL through the container:
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q "<sql>"
+```
+
+Create the throwaway database once (drop it first if a previous run left it dirty):
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q \
+  "IF DB_ID('ProvingGround') IS NOT NULL BEGIN ALTER DATABASE ProvingGround SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE ProvingGround; END; CREATE DATABASE ProvingGround;"
+```
+
+> `talk-to-local-sql` owns the substrate details, the conn string, and the data-hash oracle.
+> If you see a batch of "Could not open a connection" failures, the warm container died —
+> `scripts/warm-sql.sh restart`, do not suspect the change.
+
+## 2 — Build the dacpac
+
+```bash
+dotnet build ssdt-agent/proving-ground/SampleCatalog.sqlproj -c Release
+# -> ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac
+```
+
+## 3 — Establish the BEFORE state (once per scenario)
+
+Publish the *current* CREATEs and run the post-deploy seed so the throwaway DB holds the
+real-shaped data the proof depends on. The first publish of the unedited project does exactly
+this:
+
+```bash
+sqlpackage /Action:Publish \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml
+```
+
+Now the seed scenarios (NULL emails, orphan order, over-length + duplicate Code) are present.
+
+## 4 — Make the destination edit
+
+Edit the matching `Modules/*.sql` `CREATE` to the destination. **Never write `ALTER`.** Then
+rebuild the dacpac (step 2). One edit, one proof.
+
+## 5 — PREVIEW the real delta (changes nothing)
+
+```bash
+sqlpackage /Action:Script \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml \
+  /OutputPath:ssdt-agent/proving-ground/bin/delta.sql
+```
+
+Read `delta.sql`. This is the REAL SSDT-generated change — the thing a raw `sqlcmd` ALTER loop
+can never show you. Look for: `DROP`+`CREATE` on a rename (Naked Rename — STOP), a shadow-table
+rebuild (table swap), drop-by-absence, `GenerateSmartDefaults` backfills, and — for a
+make-mandatory — the **table-has-rows guard**
+`IF EXISTS (SELECT TOP 1 1 FROM [dbo].[Customer]) RAISERROR(...,16,127)` placed *above* the
+`ALTER COLUMN ... NOT NULL`. That guard inspects row PRESENCE, not the column's NULLs.
+
+## 6 — VETO CHECK (Strict = the veto detector)
+
+```bash
+sqlpackage /Action:Publish \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml
+```
+
+- **Succeeds clean, no script** → **Mechanism 1 Pure Declarative** (single-phase).
+- **Vetoes** (`BlockOnPossibleDataLoss` / NOT NULL on a populated table / truncation / orphan
+  FK / duplicate key) → the data flipped the bucket up. The veto text + row counts are your
+  proof.
+
+> **make-mandatory caveat (the showcase finding).** The NULL->NOT NULL veto is
+> **table-has-rows, not column-has-NULLs.** On a POPULATED table it vetoes even after you
+> backfill every NULL away — PROVEN here: 0 NULL emails, Strict STILL vetoed, column stayed
+> nullable. Only an EMPTY table publishes clean (Mechanism 1). See step 8 for the corrected
+> remedy; do not report the old "backfill -> clean NOT NULL = Mechanism 3" recipe.
+
+## 7 — ON VETO ONLY: the consequence oracle (Permissive) + hash snapshot
+
+Snapshot the data hash, publish Permissively to let the change proceed past the veto, snapshot
+again, and diff:
+
+```bash
+# BEFORE hash (see talk-to-local-sql for the exact per-row SHA2_256(FOR XML RAW) query)
+sqlpackage /Action:Publish \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Permissive.publish.xml
+# AFTER hash; diff BEFORE vs AFTER -> exactly what GenerateSmartDefaults stamped / what truncated
+```
+
+A rename changes the hash by design (the column name is part of the row shape) — that diff *is*
+the proof, not a bug.
+
+## 8 — Author the remedy, then re-prove Strict clean
+
+Write the real remedy — a `Script.PreDeployment.sql` backfill, a refactorlog entry, a staged
+NOCHECK → reconcile → `WITH CHECK CHECK` FK, a pre-deploy dedupe. Rebuild, re-run **step 6**.
+**The clean Strict re-run is the proof you hand the developer.**
+
+> **make-mandatory is the exception.** On a populated table a backfill does NOT produce a clean
+> Strict re-run — the table-has-rows guard still fires. The corrected, proven remedy is a
+> CONSCIOUS, DOCUMENTED decision taken AFTER a verified-zero-NULL backfill (the zero-NULL probe
+> is necessary but NOT sufficient): either **(a)** a targeted relaxation of
+> `BlockOnPossibleDataLoss` for THIS one change — operationally Mechanism 4 / Script-Only with
+> a named, logged gate-relaxation — or **(b)** restructure as Mechanism 5, Multi-Phase. The
+> proof packet carries the zero-NULL probe AND the explicit gate-relaxation (or the staged
+> phases). The EMPTY-table leg is the clean Mechanism 1 contrast.
+
+## 9 — Reset between scenarios
+
+Each flip starts from the known seed. Drop and recreate `ProvingGround` (step 1) before the
+next scenario so one scenario's edits do not contaminate the next. (Parallel executors skip
+this — each owns a fresh unique DB per `../self-test/PROTOCOL.md`.)
+
+---
+
+## Seed scenario → bucket-flip map
+
+| seed scenario (in `Data/Seed.sql`)                    | the change you prove          | the flip it demonstrates                                                                 | self-test |
+|-------------------------------------------------------|-------------------------------|------------------------------------------------------------------------------------------|-----------|
+| Customer rows 3 & 5 have `Email` NULL (table populated) | make-mandatory `Email NOT NULL` | Strict vetoes — guard is **table-has-rows**; backfill clears the NULLs but NOT the veto → gate-relaxation or multi-phase | COL-03    |
+| Customer table EMPTY (skip the seed / truncate)       | the SAME `Email NOT NULL`     | no rows → `IF EXISTS` false → ALTER lands → clean **Mechanism 1**, Tier 1                 | COL-03B   |
+| Customer re-seeded with ZERO NULL Email (still populated) | the SAME `Email NOT NULL`     | STILL vetoes — zero NULLs is necessary but NOT sufficient; the guard is row-presence      | COL-03C   |
+| Customer `ContactPhone` populated, **no refactorlog** | rename `ContactPhone`→`MobileNumber` | delta = DROP+CREATE = Naked Rename data loss → STOP, demand refactorlog                   | COL-08N   |
+| `Order` row 4 has `CustomerId = 999` (orphan)         | add FK `Order.CustomerId`→`Customer.Id` | clean FK vetoes on orphan → Script-Only (NOCHECK→reconcile→`WITH CHECK CHECK`)            | KEY-03    |
+| `Product` row 3 `Code` = 16 chars                     | narrow `Code` to `NVARCHAR(10)` | over-length → Strict data-loss veto → reconcile first (probe `MAX(LEN)` to predict)       | COL-06    |
+| `Status` seed rows unchanged on re-publish            | add lookup value `'Refunded'` | guarded MERGE captures 0 rows on no-op → CDC-silence proof                                | STA-02    |
+| `Product` rows 4 & 5 share `Code = 'DUPE'`            | add UNIQUE on `Code`          | unique index build fails on dupe → pre-deploy dedupe                                      | CON-02    |
+
+> **The make-mandatory triple is the spine proof.** COL-03B (empty) MUST publish clean;
+> COL-03 (populated, NULLs) and COL-03C (populated, zero NULLs) MUST BOTH still veto. An agent
+> that claims a backfill or a zero-NULL re-seed yields a clean Mechanism 1/3 on a POPULATED
+> table — without empirically discovering on the proving ground that it STILL vetoes — has
+> classified from stale recipe text and the run FAILS. Same edit, three seeds, decided by
+> ROW PRESENCE.
+
+## Trap watch (handbook 16 = §19) — catch these in the delta, not after
+
+Naked Rename · Optimistic NOT NULL · Forgotten FK Check · Ambitious Narrowing · CDC Surprise ·
+Refactorlog Cleanup · SELECT * View.
+
+## Connector point
+
+The hand-authored `SampleCatalog` can be replaced by the F# engine's
+`SqlprojEmitter`/`DacpacEmitter`/`PostDeployEmitter` output from a real OutSystems catalog —
+the prove loop above is unchanged, just real schema. See `../CONNECTORS.md` §3.

--- a/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.refactorlog
+++ b/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.refactorlog
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SampleCatalog.refactorlog — the refactorlog scaffold.
+
+  This file is the difference between a safe rename and the Naked Rename catastrophe. When you
+  rename a column or table by editing the CREATE in Modules/*.sql, SSDT has NO way to know the
+  new name is the OLD object under a new name unless a refactorlog entry records the rename.
+  Without the entry, the generated delta is DROP <old> + CREATE <new> — every row in that
+  column is silently lost.
+
+  An empty Operations element is the correct EMPTY state. A real rename adds an
+  <Operation Name="Rename Refactor" ...> child whose Element references the old and new names.
+  In normal tooling (SSDT in Visual Studio / the F# engine's emitter) this entry is generated
+  for you when you perform the rename through the refactor command. In this hand-authored
+  proving ground the agent adds the entry by hand (or proves its ABSENCE catches the
+  catastrophe) — see skills/operations/columns.md (rename-attribute) and
+  skills/operations/tables.md (rename-entity).
+-->
+<Operations Version="1.0" xmlns="http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02">
+</Operations>

--- a/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.sqlproj
+++ b/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.sqlproj
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SampleCatalog.sqlproj — the hand-authored, self-contained proving-ground project.
+
+  This is DATA, not a wrapper script. It exists so the prove-on-dacpac loop has a real
+  buildable substrate: editing a Modules/*.sql CREATE and running `dotnet build` produces a
+  real .dacpac, which sqlpackage then publishes against a throwaway copy of real-shaped data.
+
+  SDK-style project. The Microsoft.Build.Sql SDK's default item glob picks up **/*.sql as
+  Build (schema) items. We must reclassify the deploy + data scripts OUT of that glob so they
+  are not treated as schema objects:
+    - Script.PreDeployment.sql  -> PreDeploy  (runs before the schema delta)
+    - Script.PostDeployment.sql -> PostDeploy (runs after; :r-includes the seed)
+    - Data/**/*.sql             -> None       (included only via the post-deploy :r)
+
+  VERIFY the glob/Remove syntax against the exact Microsoft.Build.Sql SDK version before
+  relying on edge cases. The shape below is the documented pattern for 2.x SDK-style projects.
+
+  CONNECTOR POINT (see CONNECTORS.md §3): the F# engine's SqlprojEmitter can emit a project of
+  this exact shape from a real OutSystems catalog. Swapping this file for engine output leaves
+  the prove-on-dacpac loop unchanged.
+-->
+<Project Sdk="Microsoft.Build.Sql/2.2.0">
+
+  <PropertyGroup>
+    <Name>SampleCatalog</Name>
+    <!-- Sql160 = SQL Server 2022 schema provider; matches the warm mssql container. -->
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql160DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+    <!-- Deterministic output for the proving loop. -->
+    <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+  </PropertyGroup>
+
+  <!--
+    Reclassify the deploy + data scripts out of the default **/*.sql Build glob.
+    Modules/*.sql stay as Build (schema) items — they are the CREATE-table destinations.
+  -->
+  <ItemGroup>
+    <Build Remove="Script.PreDeployment.sql" />
+    <Build Remove="Script.PostDeployment.sql" />
+    <Build Remove="Data\**\*.sql" />
+
+    <PreDeploy Include="Script.PreDeployment.sql" />
+    <PostDeploy Include="Script.PostDeployment.sql" />
+
+    <!-- Included into the build only via the post-deploy `:r .\Data\Seed.sql`. -->
+    <None Include="Data\Seed.sql" />
+  </ItemGroup>
+
+  <!--
+    The refactorlog is how a rename survives as sp_rename instead of becoming DROP+CREATE
+    (the Naked Rename catastrophe). When the agent proves a rename, the refactorlog entry is
+    the artifact that must exist. It is created here as an empty scaffold; the rename proof
+    populates it. If this file is absent, a Modules rename publishes as DROP+CREATE = data loss.
+  -->
+  <ItemGroup>
+    <RefactorLog Include="SampleCatalog.refactorlog" />
+  </ItemGroup>
+
+</Project>

--- a/sidecar/projection/ssdt-agent/proving-ground/Script.PostDeployment.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Script.PostDeployment.sql
@@ -1,0 +1,23 @@
+/*
+  Script.PostDeployment.sql — the POST-DEPLOY slot. (Build Action = PostDeploy.)
+
+  Runs AFTER SSDT applies the schema delta. This is where static-data seeds and
+  Declarative+Post-Deploy backfills live. A change that needs only this script (no pre-deploy
+  data fix) is Mechanism 2 (Declarative + Post-Deploy), single-PR.
+
+  Everything here MUST be idempotent — it runs on every publish. The seed uses guarded MERGEs so
+  a re-publish with unchanged data is SILENT (captures 0 rows). That CDC-silence property is
+  itself a proof: a no-op redeploy must not churn the data (see Data/Seed.sql and
+  skills/operations/static-data.md).
+
+  The `:r` directive includes the seed file at build time. It is an SQLCMD directive, so this
+  script (and the build) require SQLCMD mode — sqlpackage and `dotnet build` of the .sqlproj
+  handle this for post-deploy scripts. The path is relative to THIS file.
+*/
+
+:r .\Data\Seed.sql
+
+GO
+
+PRINT 'Post-deploy complete: seed MERGEs applied (idempotent).';
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Script.PreDeployment.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Script.PreDeployment.sql
@@ -1,0 +1,88 @@
+/*
+  Script.PreDeployment.sql — the PRE-DEPLOY slot. (Build Action = PreDeploy.)
+
+  This script runs BEFORE SSDT applies the schema delta. It is the home of the data fix-ups that
+  let a flip publish cleanly — a pre-deploy dedupe, an over-length reconcile, a NULL backfill.
+  The pattern is: fix the data here so the destination CREATE lands without a veto. A change
+  that is genuinely cleared by this script is Mechanism 3 (Pre-Deploy + Declarative), single-PR.
+
+  IMPORTANT — a pre-deploy backfill does NOT clear EVERY veto. See the make-mandatory example
+  below: on a POPULATED table the NULL->NOT NULL guard is table-has-rows, so clearing the NULLs
+  here does NOT let the ALTER land. Prove the remedy with a clean Strict re-run; do not assume it.
+
+  PARALLEL EXECUTORS: do NOT edit this authored file. Copy the proving-ground tree to a private
+  scratch dir, edit the COPY, and publish to a UNIQUE database per `../self-test/PROTOCOL.md`.
+
+  It is idempotent and safe to run on every publish — it only touches rows that still violate
+  the rule. Empty by default; uncomment the worked example when proving a flip.
+
+  ----------------------------------------------------------------------------------------------
+  WORKED EXAMPLE — make-mandatory flip (Customer.Email NULL -> NOT NULL)  [CORRECTED 2026-06-30]
+  ----------------------------------------------------------------------------------------------
+  Scenario: you edited Customer.sql to `Email NVARCHAR(256) NOT NULL`. The default seed has NULL
+  Email rows, so a Strict publish VETOES.
+
+  The intuitive fix — backfill the NULLs here, before the schema delta — was DISPROVEN on this
+  proving ground. SSDT generates the BlockOnPossibleDataLoss guard for NULL->NOT NULL as:
+
+      IF EXISTS (SELECT TOP 1 1 FROM [dbo].[Customer])
+          RAISERROR (N'Rows were detected. The schema update is terminating because data loss
+                       might occur.', 16, 127)
+      -- ... then, below it:
+      ALTER TABLE [dbo].[Customer] ALTER COLUMN [Email] NVARCHAR(256) NOT NULL;
+
+  That guard fires on the table HAVING ANY ROW — it never inspects the Email column. SSDT
+  computes the deploy script ONCE, up front, from the pre-publish state, and is conservative by
+  design: it cannot know that this pre-deploy backfill (which runs at deploy time, after the
+  script is already generated) will have emptied the NULLs. PROVEN: with the backfill below
+  active, `SELECT COUNT(*) FROM dbo.Customer WHERE Email IS NULL` returned 0, yet Strict STILL
+  vetoed and the column STAYED nullable.
+
+  So this backfill is NECESSARY but NOT SUFFICIENT on a populated table. Run it, re-run the NULL
+  probe to PROVE 0 NULLs remain, and you have earned the right to make the conscious call — NOT
+  a clean NOT NULL. The honest, proven remedy on a populated table is ONE of:
+    (a) a TARGETED relaxation of BlockOnPossibleDataLoss for THIS one change, AFTER proving zero
+        NULLs — operationally Mechanism 4 / Script-Only with a named, logged gate-relaxation
+        (e.g. a scoped publish-profile override). The proof packet carries BOTH the zero-NULL
+        probe AND the explicit record of the relaxation decision; or
+    (b) restructure as Mechanism 5, Multi-Phase, multi-PR, so the engine never has to relax its
+        guard.
+  An EMPTY table is the clean contrast: no rows, the IF EXISTS is false, the ALTER lands —
+  Mechanism 1, Tier 1, no script needed.
+
+  Choose a backfill that is HONEST to the developer's intent. The literal placeholder below is
+  fine for the proving ground; in production you confirm the real backfill value (a derived
+  value, a sentinel, or a hard requirement to collect the data first). The point here is to show
+  that the veto is real, that the backfill clears the NULLs, and that Strict STILL refuses.
+*/
+
+-- IF EXISTS (SELECT 1 FROM dbo.Customer WHERE Email IS NULL)
+-- BEGIN
+--     PRINT 'Pre-deploy backfill: stamping NULL Customer.Email rows. NOTE: this clears the NULLs';
+--     PRINT 'but does NOT clear the Strict NULL->NOT NULL veto on a populated table (table-has-rows';
+--     PRINT 'guard). Re-run the NULL probe to confirm 0 remain, then make the conscious gate call.';
+--     UPDATE dbo.Customer
+--         SET Email = N'unknown+' + CAST(Id AS NVARCHAR(20)) + N'@example.invalid'
+--         WHERE Email IS NULL;
+-- END
+-- GO
+
+/*
+  ----------------------------------------------------------------------------------------------
+  WORKED EXAMPLE — Ambitious Narrowing flip (Product.Code NVARCHAR(50) -> NVARCHAR(10))
+  ----------------------------------------------------------------------------------------------
+  Scenario: you edited Product.sql to `Code NVARCHAR(10)`. The seed has an over-length Code, so
+  Strict vetoes on data loss. Reconcile the over-length rows here before the delta. NOTE: silent
+  truncation is a DECISION — confirm with the developer whether truncation is acceptable or
+  whether the over-length values must be preserved (which makes this Multi-Phase instead). Probe
+  MAX(LEN(Code)) first: if every value already fits the new size, there is NO veto and no
+  backfill — the same narrow op is a clean Mechanism 1, decided by the data not the .sql.
+*/
+
+-- UPDATE dbo.Product
+--     SET Code = LEFT(Code, 10)
+--     WHERE LEN(Code) > 10;
+-- GO
+
+PRINT 'Pre-deploy: no backfill active. Uncomment a worked example when proving a flip.';
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/profiles/ProvingGround.Permissive.publish.xml
+++ b/sidecar/projection/ssdt-agent/proving-ground/profiles/ProvingGround.Permissive.publish.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ProvingGround.Permissive.publish.xml — THE CONSEQUENCE ORACLE.
+
+  Identical to the Strict profile EXCEPT it lets the change proceed PAST the veto so you can see
+  WHAT the veto was protecting against. Run this only AFTER Strict has vetoed, and only on the
+  throwaway DB. Snapshot the per-row data hash before and after (see talk-to-local-sql) to see
+  exactly which rows GenerateSmartDefaults silently stamped, or which values truncated. The
+  before/after diff is the proof of consequence.
+
+    BlockOnPossibleDataLoss = False  -> proceed past the veto (we want to observe the damage).
+    GenerateSmartDefaults   = True   -> let SSDT silently backfill NOT NULL columns, so you can
+                                        SHOW the developer the values it would have stamped on its
+                                        own — usually NOT what they intended. That is the lesson.
+
+  This is a DIAGNOSTIC, never the path you ship. The change you hand the developer is the one
+  that passes STRICT clean after a real, confirmed remedy.
+-->
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetConnectionString>Server=localhost,11433;Initial Catalog=ProvingGround;User ID=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False</TargetConnectionString>
+    <BlockOnPossibleDataLoss>False</BlockOnPossibleDataLoss>
+    <GenerateSmartDefaults>True</GenerateSmartDefaults>
+    <IgnoreColumnOrder>True</IgnoreColumnOrder>
+    <DropObjectsNotInSource>True</DropObjectsNotInSource>
+    <IncludeTransactionalScripts>True</IncludeTransactionalScripts>
+    <AllowIncompatiblePlatform>False</AllowIncompatiblePlatform>
+    <IgnorePermissions>True</IgnorePermissions>
+  </PropertyGroup>
+</Project>

--- a/sidecar/projection/ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml
+++ b/sidecar/projection/ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ProvingGround.Strict.publish.xml — THE VETO DETECTOR.
+
+  This profile mirrors production's REFUSALS. It is how you discover that a change the .sql text
+  says is harmless is actually blocked by the data. When a Strict publish vetoes, the data has
+  flipped the bucket up — that veto, with its row counts, is the proof you hand the developer.
+
+  Aimed ONLY at the throwaway ProvingGround DB on the warm container. DropObjectsNotInSource is
+  True here precisely because the proving ground is disposable and we WANT to see drops — never
+  point this profile at anything real.
+
+    BlockOnPossibleDataLoss = True   -> the veto. NOT NULL on NULL data, narrowing that
+                                        truncates, drops of populated objects all REFUSE.
+    GenerateSmartDefaults   = False  -> do NOT silently backfill. We want the refusal, not a fix.
+    DropObjectsNotInSource  = True   -> drop-by-absence is visible (proving ground is throwaway).
+    IgnoreColumnOrder       = True   -> column-order churn does not masquerade as a real change.
+
+  CONNECTOR POINT (CONNECTORS.md §6): the TargetConnectionString points at the warm-sql.sh
+  container. Reuse that existing substrate; never introduce a new orchestration script.
+-->
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetConnectionString>Server=localhost,11433;Initial Catalog=ProvingGround;User ID=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False</TargetConnectionString>
+    <BlockOnPossibleDataLoss>True</BlockOnPossibleDataLoss>
+    <GenerateSmartDefaults>False</GenerateSmartDefaults>
+    <IgnoreColumnOrder>True</IgnoreColumnOrder>
+    <DropObjectsNotInSource>True</DropObjectsNotInSource>
+    <IncludeTransactionalScripts>True</IncludeTransactionalScripts>
+    <AllowIncompatiblePlatform>False</AllowIncompatiblePlatform>
+    <IgnorePermissions>True</IgnorePermissions>
+  </PropertyGroup>
+</Project>

--- a/sidecar/projection/ssdt-agent/self-test/PROTOCOL.md
+++ b/sidecar/projection/ssdt-agent/self-test/PROTOCOL.md
@@ -1,0 +1,206 @@
+# self-test — PROTOCOL (parallel-safe, idempotent, localized execution)
+
+> This protocol is run by MANY executor subagents IN PARALLEL, each taking ONE test entry from
+> `prompts.md` / the test matrix and proving it on the proving ground. The authored tree under
+> `ssdt-agent/proving-ground/` is **immutable and shared** — read-only for every executor. The
+> warm SQL container (`projection-mssql-warm`, `localhost,11433`) is **shared but safely so**:
+> each executor owns a **distinct database** and a **distinct scratch copy** of the project, so
+> two executors never touch the same `.sql`, the same `bin/`, or the same DB. There is **NO
+> wrapper script** — you, the executor, run these commands yourself, in order. The whole point
+> of the tree is *classify-by-proving*; this protocol is how a hundred provers run at once
+> without colliding.
+
+## Why isolation at all (the three collisions this prevents)
+
+1. **Shared `.sql` edit collision.** Every proof EDITS a `CREATE` (`Modules/*.sql`), or the
+   seed (`Data/Seed.sql`), or `Script.PreDeployment.sql`. If two executors edited the authored
+   tree's files, executor B would build executor A's half-finished edit into its dacpac and
+   prove the wrong thing. **Fix: each executor edits only its OWN scratch copy.** The authored
+   tree is never written.
+2. **Shared DB publish collision.** `sqlpackage /Action:Publish` mutates a whole database. Two
+   executors publishing to one DB would interleave DDL, see each other's veto, and corrupt each
+   other's BEFORE/AFTER hashes. **Fix: a UNIQUE database name per executor**, passed as
+   `/TargetDatabaseName:PG_<testId>_<rand>` on every `sqlpackage` call — this OVERRIDES the
+   profile's `Initial Catalog`, so no two executors ever share a DB.
+3. **Shared `bin/` race.** `dotnet build` writes `bin/Release/SampleCatalog.dacpac`. Two builds
+   into one `bin/` race on the same file and one reads a torn dacpac. **Fix: build inside the
+   scratch copy**, which has its own `bin/` — no shared build output.
+
+The warm container itself is shared on purpose (warming it per-executor would be wasteful and
+trip survival rule 2). Isolation lives at the **database** and **filesystem-copy** grain, not
+the instance grain.
+
+## 0 — The runtime shim (REQUIRED on this machine, every shell)
+
+`sqlpackage` is a .NET-8 dotnet tool on a .NET-9 box at a non-standard path. Export these in
+**every** shell you call `sqlpackage` from, or it fails to start:
+
+```bash
+export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROLL_FORWARD=Major
+export MSYS_NO_PATHCONV=1   # REQUIRED on Git Bash for sqlpackage /Action: args AND docker-exec /opt/... paths
+```
+
+`sqlpackage` lives at `C:\Users\danny\.dotnet\tools\sqlpackage.exe`. The host has **no
+sqlcmd** — issue SQL through the container:
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q "<sql>"
+```
+
+(`MSYS_NO_PATHCONV=1` keeps Git Bash from mangling the `/opt/...` path and the `/Action:` /
+`/SourceFile:` switches.)
+
+## 1 — Pick your identity (do this first, once)
+
+```bash
+TESTID="COL-03"                        # the test-matrix id you are proving
+RAND=$(openssl rand -hex 4)            # 8 hex chars; uniqueness across parallel executors
+DB="PG_${TESTID//-/_}_${RAND}"         # e.g. PG_COL_03_9f2a1c4e  (no dashes — valid DB identifier)
+SCRATCH="$CLAUDE_SCRATCHPAD/pg-${TESTID}-${RAND}"   # your private scratch dir
+SRC="C:/Users/danny/code/outsystems-ddl-exporter/sidecar/projection/ssdt-agent/proving-ground"
+```
+
+`DB` and `SCRATCH` both carry `TESTID` + `RAND`, so they are globally unique among parallel
+executors. **Every** mutating command below targets one of these two — never `$SRC`, never the
+profile's default `Initial Catalog`.
+
+**Resolve your identity ONCE and reuse the literal values.** Each command run is a fresh shell
+process — exported variables do **not** persist between separate runs. So either run the whole
+protocol as ONE shell session, or compute `DB`/`SCRATCH` once and paste the **literal** resolved
+names into every later command. Never re-run `openssl rand` in a later step: you would seed one
+DB (`PG_X_aaaa`) and prove against another (`PG_X_bbbb`), leaking the first. (When an orchestrator
+dispatches you, it will hand you a fixed `DB`/`SCRATCH` to use verbatim — prefer that.)
+
+## 2 — Copy the proving ground to your private scratch (read-only source preserved)
+
+```bash
+mkdir -p "$SCRATCH"
+cp -R "$SRC/." "$SCRATCH/"
+rm -rf "$SCRATCH/bin" "$SCRATCH/obj"   # start from a clean build dir you alone own
+```
+
+From here, **ALL edits — `Modules/*.sql`, `Data/Seed.sql`, `Script.PreDeployment.sql`, the
+`.refactorlog` — happen in `$SCRATCH` ONLY.** The authored `$SRC` tree is never modified. If
+you ever find yourself opening a path under `$SRC` for writing, STOP — that is the collision
+this protocol exists to prevent.
+
+## 3 — Create your unique database (idempotent: drop-if-exists first)
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q \
+  "IF DB_ID('$DB') IS NOT NULL BEGIN ALTER DATABASE [$DB] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [$DB]; END; CREATE DATABASE [$DB];"
+```
+
+Drop-then-create makes step 3 **idempotent**: a re-run from a crashed prior attempt yields the
+same fresh DB and leaks nothing.
+
+## 4 — Build the dacpac inside your scratch copy (your own bin/, no shared race)
+
+```bash
+dotnet build "$SCRATCH/SampleCatalog.sqlproj" -c Release
+# -> $SCRATCH/bin/Release/SampleCatalog.dacpac
+```
+
+## 5 — Establish the BEFORE state on YOUR database
+
+Publish the unedited (scratch) project + seed to your unique DB, overriding the profile catalog
+with `/TargetDatabaseName:$DB` on **every** call:
+
+```bash
+sqlpackage /Action:Publish \
+  /SourceFile:"$SCRATCH/bin/Release/SampleCatalog.dacpac" \
+  /Profile:"$SCRATCH/profiles/ProvingGround.Strict.publish.xml" \
+  /TargetDatabaseName:"$DB"
+```
+
+For the seed variant your test needs (empty table, zero-NULL re-seed, extra orphan, dup rows,
+CDC-enabled), edit `$SCRATCH/Data/Seed.sql` (or run a one-off `docker exec` SQL against `$DB`)
+**before** this publish. The seed shape is part of YOUR scratch state, not shared.
+
+## 6 — The prove loop (all in scratch, all against `$DB`)
+
+1. **Edit the destination** `CREATE` in `$SCRATCH/Modules/*.sql` (never write `ALTER`); rebuild
+   (step 4).
+2. **Preview the delta** — changes nothing:
+   ```bash
+   sqlpackage /Action:Script \
+     /SourceFile:"$SCRATCH/bin/Release/SampleCatalog.dacpac" \
+     /Profile:"$SCRATCH/profiles/ProvingGround.Strict.publish.xml" \
+     /TargetDatabaseName:"$DB" \
+     /OutputPath:"$SCRATCH/bin/delta.sql"
+   ```
+   Read `$SCRATCH/bin/delta.sql` — your private artifact. Look for DROP+CREATE on a rename
+   (Naked Rename — STOP), a shadow-table rebuild, the table-has-rows `IF EXISTS(...) RAISERROR`
+   guard before an `ALTER COLUMN ... NOT NULL`, drop-by-absence.
+3. **Veto check (Strict)** — publish to `$DB`. Clean = Mechanism 1; veto (`BlockOnPossibleData
+   Loss` / NOT NULL on rows / truncation / orphan FK / duplicate key) = the data flipped the
+   bucket. The veto text + row counts are your proof.
+4. **On veto only**: snapshot the data-hash (see `talk-to-local-sql` — per-row `SHA2_256(FOR
+   XML RAW)` summed order-independently), publish with `ProvingGround.Permissive.publish.xml`
+   (still `/TargetDatabaseName:$DB`), snapshot again, diff — that diff is exactly what
+   `GenerateSmartDefaults` stamped / what truncated.
+5. **Author the remedy** in `$SCRATCH` (a `Script.PreDeployment.sql` backfill, a `.refactorlog`
+   entry, a staged NOCHECK->reconcile->`WITH CHECK CHECK`, a pre-deploy dedupe), rebuild, re-run
+   the Strict veto check. The clean Strict re-run is the proof you hand the developer.
+
+Every command above names `$SCRATCH` for the file and `/TargetDatabaseName:$DB` for the
+database. There is no path into shared state.
+
+> **The make-mandatory caveat (COL-03 / COL-03C).** The Strict re-run after a backfill does NOT
+> go clean on a populated table — the guard is table-has-rows, not column-has-NULLs. Do not
+> treat the persisting veto as a protocol failure: re-run the NULL probe to prove 0 NULLs
+> remain, confirm the column stayed nullable, and record that the gate still vetoed. THAT pair
+> of facts (0 NULLs AND still-vetoed) is the proof the case demands. Then prove the chosen
+> remedy — a named `BlockOnPossibleDataLoss` relaxation in a script step (Permissive-equivalent
+> scoped to this one change, after the zero-NULL proof) or a multi-phase restructure — actually
+> lands the `NOT NULL`. The empty-table twin (COL-03B) is the only leg that goes clean Mechanism 1.
+
+## 7 — ON EXIT (success OR failure) — tear down, idempotently
+
+Run this **unconditionally** at the end. A `trap ... EXIT` only fires inside the **single shell
+process** that registered it — and each command run here is a fresh shell. So either run the
+entire prove cycle (steps 3–7) as **one compound command** with the trap, OR make teardown your
+**last action regardless of outcome**: always issue the drop-if-exists + `rm -rf` below as the
+final step, on success or failure. Do not rely on a trap surviving across separate command runs:
+
+```bash
+cleanup() {
+  docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P 'Projection@Strong1' -C -Q \
+    "IF DB_ID('$DB') IS NOT NULL BEGIN ALTER DATABASE [$DB] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [$DB]; END;"
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+```
+
+- **Drop your unique DB** (`SET SINGLE_USER WITH ROLLBACK IMMEDIATE` first, so an open
+  connection can't block the drop). This honours **CLAUDE.md survival rule 2**: leaked per-run
+  databases degrade the shared warm container (one session once leaked 209). Every executor
+  reaps its own DB on exit, so accumulation stays at zero.
+- **Delete your scratch dir.** No filesystem residue.
+- **Idempotent**: re-running the whole protocol yields the same verdict and leaks nothing,
+  because every name is `(testId, rand)`-scoped and every create is drop-if-exists.
+
+## 8 — CDC tests are special (isolation is mandatory, not optional)
+
+For any CDC test (`AUD-04`, `AUD-05`, `AUD-07N`, `TRAP-01N`): `sp_cdc_enable_db` flips
+**instance-wide** state. Your unique DB already isolates this — enable CDC only inside `$DB`,
+never run a database-level CDC enable expecting it to be scoped to a table, and never target the
+profile's default catalog. The per-executor unique DB IS the `IsolatedContainerFixture` mindset
+from survival rule 1. Tear it down in step 7 like any other.
+
+The unique DB isolates CDC *state*, but the container's single capture/cleanup Agent is a
+**shared** resource — under heavy parallel CDC load, capture timing can be non-deterministic
+(not a data collision, a throughput one). Serialize the CDC-family cases, or poll-with-timeout
+for capture results rather than asserting immediate capture. Do not claim CDC is fully
+parallel-safe.
+
+## 9 — If connections start failing across executors
+
+A batch of `Could not open a connection` / pre-login-handshake failures means the **warm
+container died or degraded** — NOT a regression and NOT a collision in this protocol. Check
+`scripts/test.sh status` first, then `scripts/warm-sql.sh restart`. (Survival rule 2.) Resume
+your executor from step 3 (your DB and scratch are recreated idempotently).

--- a/sidecar/projection/ssdt-agent/self-test/prompts.md
+++ b/sidecar/projection/ssdt-agent/self-test/prompts.md
@@ -1,0 +1,965 @@
+# self-test — prompts (the complete suite)
+
+Human-shaped developer prompts, one per operation across the nine families, phrased the way an
+OutSystems-native developer actually asks — in entities, attributes, references, and the
+**Mandatory** checkbox, never in SSDT mechanics. Each case carries the expected **Mechanism**
+(1–5 with its release bucket), **Tier** (1–4, with any +1 escalation named), the **caseType**,
+the **seed** it needs on the **enriched proving ground**, the **expected proving-ground outcome**,
+and the **fail mode** — what a naive agent wrongly does.
+
+This is a *classify-by-proving* suite. For almost every case the answer comes from the **data
+on the proving ground**, not from the `.sql` text. The same edit on a different seed flips the
+mechanism — those are the **flip twins**, and an agent that returns the same verdict for both
+halves classified from text and FAILS that pair.
+
+## The enriched proving ground (the seed surface every case maps to)
+
+The four original tables are **intact** — the six verified cases below (ADD `TBL-01`,
+`COL-03`/`COL-03B`/`COL-03C`, `COL-06`, `COL-08N`, `CON-02`) still pass against them. Every new
+op maps to one of the enriched Modules, each of which the enriched-sample authoring documents as
+"which self-test ids it unlocks" in its module header:
+
+| Module (`proving-ground/Modules/*.sql`) | Shape | Unlocks |
+|---|---|---|
+| `Customer` (original) | IDENTITY PK; Email NULL rows 3,5; ContactPhone populated; new nullable `AccountId` | make-mandatory family, rename-attribute, retype, audit-cols, temporal-convert, split |
+| `Order` (original) | IDENTITY PK; orphan `CustomerId=999` row 4; new `StatusText` free-text col | create-FK, change-delete-rule, extract-to-lookup, retype-implicit |
+| `Product` (original) | IDENTITY PK; over-length `STANDARD-SKU-001`; `DUPE`/`DUPE`; new nullable `CategoryId`; new populated `LegacyCode` | narrow, add-unique, widen, delete-attribute, index ops |
+| `Status` (original) | explicit-id lookup; `UX_Status_Code` | edit-seed, define-PK, static-data |
+| `Account` (new) | IDENTITY PK; `Region NULL`; 1:1 with Customer via `Customer.AccountId` | move-attribute (STR-03), merge/split partner |
+| `CustomerAddress` (new) | IDENTITY PK; `CustomerId` FK-shaped; **exactly one row per Customer** (proven 1:1) | split-table (STR-01), merge-tables (STR-02); the 1:many negative comes from a **scratch** seed edit, never the authored positive |
+| `Category` (new) | **explicit-id** NOT NULL PK, NO IDENTITY; `IsActive DEFAULT 1`; FK target of `Product.CategoryId` | create-static-seed, edit-seed, delete-seed-value (STA-04N), identity-swap SOURCE (STR-04) |
+| `ProductLegacy` (new) | adds a **populated** `LegacyCode NVARCHAR(40) NOT NULL` to Product | delete-attribute (COL-09) — the populated-column veto |
+| `OrderLine` (new) | IDENTITY PK; `OrderId` FK to Order; `LineNumber`; `Amount`; 2–3 lines/Order | define-PK composite (KEY-01), change-delete-rule cascade blast-radius (KEY-04), FK-graph depth |
+| `OrderStatusText` (new) | adds free-text `StatusText NVARCHAR(20) NOT NULL` to Order, values `Pending`/`Shipped`/`Cancelled` mapping to Status | extract-to-lookup (STA-03) + its total-mapping negative |
+| `CdcCandidate` (new) | plain `Id/Name/Notes` table, seeded, header carries the survival-rule-1 / PROTOCOL §8 CDC-isolation warning | enable-cdc (AUD-04), recreate-capture-instance (AUD-05), change-tracking (AUD-06), drop-CDC-table (AUD-07N), nullable-add-to-CDC (TRAP-01N) |
+| `OrderSummary` (new) | authored VIEW `dbo.vOrderSummary` with **enumerated** columns joining Order+Customer+Status, plus a documented `SELECT *` variant for the trap | create-view (VIE-01), compat-view target (VIE-02), indexed-view (VIE-04) |
+
+**Seed discipline (mirrors PROTOCOL step 5):** the **authored** positive seed is never edited to
+produce a negative/flip — you edit **your scratch copy** (`$SCRATCH/Data/Seed.sql`) for the
+flipped leg. Empty-table, zero-NULL re-seed, extra orphan, 1:many address, unmapped status text,
+CDC-enable are all **scratch** seed states, so the authored 1:1 / clean / mapped positives keep
+passing.
+
+## How to run a case
+
+1. Pick **one** case id below. Read it.
+2. Follow `PROTOCOL.md` exactly: copy the proving ground to your own scratch dir, create your
+   own unique database (`/TargetDatabaseName:PG_<id>_<rand>`), build the dacpac in your scratch
+   copy, establish the BEFORE seed, then run the prove loop. **You never touch shared state.**
+3. Drive the prompt through `agents/intake.md` (which fires `skills/confirm-intent`) →
+   `agents/change-author.md` (which opens the **per-op skill** `skills/op/<op-slug>/SKILL.md`
+   plus the `skills/_index/*` concern skills it points to) → `agents/reviewer.md`, against your
+   isolated DB.
+4. Score the result with `rubric.md`. Tear down (drop your DB, delete your scratch) on exit.
+
+> Handbook citations use the on-disk filename with the **+3 offset**: file 13 = §16, file 14 =
+> §17, file 15 = §18, file 16 = §19 (the anti-pattern catalog).
+
+---
+
+## The legend (every field, every case)
+
+- **id** — globally unique; ids ending `N` are negative/adversarial (PASS = correct refusal).
+- **prompt** — what the developer types, in their words (matches the op skill's frontmatter
+  `description` trigger phrases — the phrasing is the dispatch surface).
+- **op** — the per-op skill the change-author opens: `skills/op/<op-slug>/SKILL.md`.
+- **_index** — the governing cross-cutting concern skill(s): `skills/_index/<concern>/SKILL.md`.
+  The op skill points here for the shared WHY; scoring criterion 6 draws the reasoning from it.
+- **Mechanism** — 1 Pure Declarative (single-phase) · 2 Declarative+Post-Deploy (single-PR) ·
+  3 Pre-Deploy+Declarative (single-PR) · 4 Script-Only · 5 Multi-Phase (multi-PR). The release
+  bucket (single-phase / single-PR / multi-PR) is part of the verdict.
+- **Tier** — 1–4 danger grade; **+1** for CDC / >1M rows / first-time op. Danger is **distinct**
+  from release-count: a single-PR drop can be Tier 4.
+- **caseType** — positive · flip (a twin whose seed flips the mechanism) · negative (PASS = the
+  agent refuses / vetoes / escalates).
+- **seed** — the proving-ground state this case needs (edit `$SCRATCH/Data/Seed.sql`).
+- **outcome** — the expected proving-ground result: clean publish, specific veto text, or refusal.
+- **fail mode** — the wrong move a naive agent makes.
+
+The **op** and **_index** columns are load-bearing: a case only PASSES criterion 6 if the agent
+surfaced the WHY from the named `_index` skill, specialized to the op. A per-op skill that
+re-explains a lifted concern (the tightening guard, refactorlog, coexistence, CDC tax,
+constraint-claim, idempotent seed) instead of pointing to its `_index` owner is itself a defect —
+flag it against the op skill, not the run.
+
+---
+
+## Family: tables — `skills/operations/tables.md` (family index)
+
+### TBL-01 — create-entity · positive
+> **"I need a new CustomerPreference entity to store per-customer settings."**
+- **op:** `skills/op/create-entity/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase) · **Tier:** 1
+- **Seed:** baseline; the new table references nothing existing (or add its parent first).
+- **Outcome:** Strict publishes clean; the delta is a single `CREATE TABLE [dbo].[CustomerPreference]`
+  with no DROP/ALTER of any sibling. Magic line names "additive, nothing depends on it yet,
+  proven clean on a copy."
+- **Fail mode:** treats it as risky because it's "new schema" and over-tiers; or fails to confirm
+  the project glob picks the new file up (silent never-deploys).
+
+### TBL-02 — rename-entity · flip (refactorlog present)
+> **"I renamed the Customer entity to Client in Service Studio — wire it through."**
+- **op:** `skills/op/rename-entity/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (`sp_rename`) **IF** the refactorlog entry is present;
+  otherwise a CATASTROPHE graded Script-Only data loss. · **Tier:** 3
+- **Seed:** Customer populated (5 rows); the `.refactorlog` rename entry **PRESENT**.
+- **Outcome:** the Script delta = `EXEC sp_rename 'dbo.Customer','Client','OBJECT'`; rows preserved.
+  Agent confirms the `.refactorlog` changed. Tier 3 because every caller (FKs from Order, views,
+  ETL) breaks.
+- **Fail mode:** ships without reading the delta; misses that without the refactorlog SSDT emits
+  `DROP TABLE` + `CREATE TABLE` and loses all 5 rows.
+
+### TBL-02N — rename-entity, naked · negative
+> **"I renamed the Customer entity to Client in Service Studio — wire it through."**
+- **op:** `skills/op/rename-entity/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+- **Mechanism:** REFUSE / STOP — naked rename detected. · **Tier:** 3 (catastrophe-grade)
+- **Seed:** Customer populated (5 rows); the refactorlog entry **MISSING** (omit it).
+- **Outcome (PASS):** the agent reads the `/Action:Script` delta, SEES `DROP TABLE [dbo].[Customer]`
+  + `CREATE TABLE [dbo].[Client]`, STOPS, and demands the refactorlog entry before proceeding.
+  Never publishes. The catch is **in the delta**, not after a hypothetical deploy.
+- **Fail mode:** publishes the drop+create (Permissive / DropObjectsNotInSource) and destroys all
+  5 Customer rows, or reports "rename done" from the `.sql` text without proving the delta.
+
+### TBL-03 — delete-entity · negative
+> **"Drop the old AuditLog table, we don't need it anymore."**
+- **op:** `skills/op/delete-entity/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+  + `skills/_index/cdc/SKILL.md` (the +1 face)
+- **Mechanism:** 4 — Script-Only (mechanically single-PR). · **Tier:** 4 (data loss; **+1 if CDC**)
+- **Seed:** a populated table to drop (seed AuditLog, or exercise the veto on any populated table
+  e.g. Order); optionally CDC-enabled on an isolated DB (use `CdcCandidate` for the CDC leg).
+- **Outcome (PASS):** the agent proves the Strict `BlockOnPossibleDataLoss` veto with the row count
+  as the SAFETY proof, flags Tier 4 (danger ≠ release-count), drops inbound FKs / disables CDC
+  FIRST in the proven order, and does NOT blind-drop. If CDC-enabled, +1 escalation and
+  capture-instance handling named (see `_index/cdc`).
+- **Fail mode:** runs DropObjectsNotInSource and force-drops a populated, possibly CDC-tracked
+  table, orphaning the capture instance and losing data irreversibly.
+
+### TBL-04 — move-schema · positive
+> **"Move the Customer entity into the archive schema."**
+- **op:** `skills/op/move-schema/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (refactorlog) OR 4 — Script-Only (`ALTER SCHEMA TRANSFER`).
+  · **Tier:** 3
+- **Seed:** Customer populated; refactorlog move entry present, OR author
+  `ALTER SCHEMA archive TRANSFER dbo.Customer`.
+- **Outcome:** delta is `sp_rename` (schema-qualified) or the agent authors `ALTER SCHEMA TRANSFER`
+  and proves row counts + `object_id` unchanged. A DROP+CREATE in the delta is the catastrophe
+  signal to STOP. Tier 3: every `dbo.` reference must follow.
+- **Fail mode:** edits the schema in the CREATE with no refactorlog; SSDT reads it as drop-old +
+  create-new and the data is lost — same shape as a naked rename.
+
+### TBL-05 — archive-entity · positive
+> **"Archive orders older than two years into an OrderArchive table."**
+- **op:** `skills/op/archive-entity/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 3 (**+1 at >1M rows**)
+- **Seed:** Order populated; new OrderArchive destination created declaratively.
+- **Outcome:** create archive table (declarative) + batched post-deploy
+  `DELETE … OUTPUT DELETED.* INTO archive`. Agent proves source-count + archive-count == original
+  total (no rows lost/duplicated — the conservation proof from `_index/multi-phase`) and that each
+  batch commits (log bounded).
+- **Fail mode:** an unbatched single-statement move that bloats the transaction log; or moves child
+  rows before parents and trips FKs; or reports counts it never reconciled.
+
+### TBL-06 — junction (many-to-many) · positive
+> **"A Student can have many Courses and a Course many Students — make it many-to-many."**
+- **op:** `skills/op/junction/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** both parent tables present and seeded (use `Order` + `Product` as parents, or author a
+  fresh pair); bridge empty.
+- **Outcome:** Strict creates the bridge (composite PK over the two FK columns) clean; NO FK veto
+  fires because every seeded pair has both parents (the constraint-is-a-claim orphan probe = 0).
+  Tier 2 (two inter-table dependencies). Agent proves zero orphan pairs.
+- **Fail mode:** seeds bridge pairs whose parents don't exist (Forgotten FK Check in disguise) and
+  the FK validation vetoes; or omits the composite PK and lets duplicate pairs in.
+
+---
+
+## Family: columns — `skills/operations/columns.md` (family index)
+
+### COL-01 — add-optional · positive
+> **"Add an optional MiddleName field to Customer, it can be blank."**
+- **op:** `skills/op/add-optional/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1
+- **Seed:** Customer populated (default seed).
+- **Outcome:** Strict publishes clean on the populated copy; delta is a single
+  `ALTER TABLE … ADD [MiddleName] NVARCHAR NULL`; no veto at any row count. Existing rows get NULL.
+- **Fail mode:** invents a default or backfill that isn't needed, or over-tiers an additive
+  nullable column.
+
+### COL-02 — add-mandatory · positive
+> **"Add a required Status field to Customer — everyone must have one."**
+- **op:** `skills/op/add-mandatory/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+  (the no-default veto face)
+- **Mechanism:** 1 — Pure Declarative WITH explicit default (single-phase); vetoes without a default.
+  · **Tier:** 2
+- **Seed:** Customer populated.
+- **Outcome:** with an explicit `DEFAULT`, Strict publishes clean and the delta shows
+  `ADD … NOT NULL CONSTRAINT … DEFAULT`; SQL Server stamps existing rows. The agent ALSO proves the
+  no-default Strict veto ("Cannot insert NULL") and runs Permissive with `GenerateSmartDefaults` to
+  SHOW what would have been silently stamped. Tier 2 (contractual).
+- **Fail mode:** adds NOT NULL with no default (Optimistic NOT NULL) and the deploy fails on the
+  populated table; or lets `GenerateSmartDefaults` silently fill empty strings without telling the
+  developer.
+
+### COL-03 — make-mandatory, NULLs present · positive (THE SPINE PROOF — corrected finding)
+> **"Make the Email field on Customer required."**
+- **op:** `skills/op/make-mandatory/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+- **Mechanism:** **NOT Mechanism 1 and NOT a clean Mechanism 3.** Backfill alone does NOT clear the
+  Strict veto. The honest verdict is a CONSCIOUS, documented decision **after** a verified-zero-NULL
+  backfill: **(a)** targeted relaxation of `BlockOnPossibleDataLoss` for this one change —
+  operationally Mechanism 4 / Script-Only with a named gate-relaxation — or **(b)** Mechanism 5
+  Multi-Phase. · **Tier:** 2 (**+1 if CDC / >1M**)
+- **Seed:** Customer DEFAULT seed: rows 3 and 5 have `Email` NULL.
+- **Outcome:** the agent edits `Email` to `NOT NULL`, builds, and PROVES on the proving ground:
+  1. Strict vetoes — and crucially, the veto is generated as
+     `IF EXISTS (SELECT TOP 1 1 FROM dbo.Customer) RAISERROR(…,16,127)` placed **before** the
+     `ALTER COLUMN`, i.e. **table-has-rows, not column-has-NULLs** (this is the `_index/tightening-class`
+     flagship — the op skill points there, it does not re-derive the guard).
+  2. authors a pre-deploy backfill, re-runs the NULL probe to confirm **0** NULL emails, AND proves
+     Strict **STILL** vetoes and the column stays nullable.
+  3. delivers the corrected verdict: on a populated table, backfill alone cannot pass prod-strict —
+     it needs a named gate-relaxation **after** verified zero NULLs, or multi-phase.
+  Magic line names the real NULL count (**2**) AND the empirical fact that **0-NULL still vetoed**.
+- **Fail mode:** reports the OLD, WRONG recipe ("pre-deploy backfill → clean NOT NULL under Strict =
+  Mechanism 3") from any stale skill text WITHOUT proving it — and never discovers the
+  backfill-then-still-vetoed reality. **This is the showcase failure the run must catch.**
+
+### COL-03B — make-mandatory, EMPTY table · flip
+> **"Make the Email field on Customer required." (empty table)**
+- **op:** `skills/op/make-mandatory/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1
+- **Seed:** Customer table EMPTY (skip the seed / truncate before publish, in scratch).
+- **Outcome:** Strict publishes clean — no rows means the table-has-rows guard's `IF EXISTS` is
+  false, the RAISERROR never fires, and the `ALTER COLUMN NOT NULL` lands. Proves the EMPTY-table
+  clean Mechanism 1 leg and that the guard is genuinely table-has-rows (see `_index/tightening-class`).
+- **Fail mode:** assumes "make-mandatory always needs a backfill" and over-classifies the empty case.
+
+### COL-03C — make-mandatory, ZERO NULLs but populated · flip (the empirical clincher)
+> **"Make Email on Customer required." (re-seeded with zero NULL Email)**
+- **op:** `skills/op/make-mandatory/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+- **Mechanism:** FLIP TWIN of COL-03: same edit, populated with ZERO NULLs. **STILL** vetoes under
+  Strict because the guard is table-has-rows, not column-has-NULLs — the honest verdict is a named
+  gate-relaxation (proven 0 NULLs first) or multi-phase, NOT a clean Mechanism 1. · **Tier:** 2
+  (+1 if CDC/>1M). Same op and table shape as COL-03 — the NULL count does not change the tier,
+  since the veto is table-has-rows.
+- **Seed:** Customer re-seeded (scratch) with all 5 Emails populated (zero NULLs).
+- **Outcome:** the agent proves: NULL probe returns **0**, yet Strict **STILL** vetoes (table has
+  rows). This is the empirical confirmation of the corrected recipe — zero NULLs is **necessary but
+  not sufficient** to pass the prod-strict gate on a populated table. The pass is the agent
+  surfacing exactly this and choosing a conscious gate-relaxation or multi-phase, with the proof.
+- **Fail mode:** claims "zero NULLs → clean Mechanism 1" from any old framing and never runs the
+  publish to discover the table-has-rows veto. Classified-from-text failure.
+
+### COL-04 — make-optional · positive
+> **"Make MiddleName on Customer optional — uncheck Mandatory."**
+- **op:** `skills/op/make-optional/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1–2 (2 if consumers assume non-NULL)
+- **Seed:** Customer with a NOT NULL column to loosen.
+- **Outcome:** Strict publishes clean (loosening never vetoes); delta is a single `ALTER COLUMN … NULL`.
+  The agent's real work is flagging the DOWNSTREAM NULL risk (reports/ETL/code that never expected
+  NULL), since the publish itself cannot fail.
+- **Fail mode:** treats it as risky at the deploy layer; or fails to flag the downstream consumer
+  risk that is the actual Tier-2 driver.
+
+### COL-05 — widen · positive
+> **"Increase Email on Customer to 256 characters… actually make it longer, 512."**
+- **op:** `skills/op/widen/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** Customer populated; Email not in an index key near the byte limit.
+- **Outcome:** Strict publishes clean; delta is `ALTER COLUMN` to the wider type, metadata-only, no
+  rebuild of unrelated objects. Agent checks the column isn't in an index key that would blow the
+  1700-byte limit (and NVARCHAR doubling) — the index-key byte coupling is stated inline in the
+  widen op skill (a single-op concern, not lifted).
+- **Fail mode:** misses an index-key byte-limit veto on an indexed column, or assumes widen is
+  always free without checking the index coupling.
+
+### COL-06 — narrow, over-length data · flip
+> **"Shorten Product.Code to 10 characters."**
+- **op:** `skills/op/narrow/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+- **Mechanism:** 3 — Pre-Deploy+Declarative (single-PR), or 5 — Multi-Phase if over-length data must
+  be preserved. · **Tier:** 3
+- **Seed:** Product DEFAULT seed: row 3 `Code = 'STANDARD-SKU-001'` (16 chars).
+- **Outcome:** the agent runs `MAX(LEN(Code))` (=16) AND a `WHERE LEN(Code)>10` count to QUANTIFY
+  truncation, proves the Strict data-loss veto (the tightening-class row-presence guard; see
+  `_index/tightening-class`), runs Permissive + before/after hash to show EXACTLY which value chops,
+  authors the reconcile, re-runs Strict clean. Magic line names the longest value and the count that
+  truncates.
+- **Fail mode:** reports "might lose data" without quantifying; or runs Permissive and silently
+  truncates `'STANDARD-SKU-001'` to `'STANDARD-S'` without surfacing it.
+
+### COL-06B — narrow, all fit · flip
+> **"Shorten Product.Code to 20 characters."**
+- **op:** `skills/op/narrow/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** Product DEFAULT seed (max Code length = 16, all fit in 20).
+- **Outcome:** FLIP TWIN of COL-06: same narrow op, but `MAX(LEN)=16 ≤ 20` so every value fits.
+  Strict publishes clean, Mechanism 1. Same op, different target size → different mechanism, decided
+  by the data probe not the `.sql`. (The guard is still table-has-rows; here the ALTER COLUMN is
+  not data-losing so nothing vetoes — the distinction the op skill draws from `_index/tightening-class`.)
+- **Fail mode:** reflexively classifies any narrow as a data-loss risk without probing `MAX(LEN)`,
+  reporting a veto that does not occur.
+
+### COL-07 — retype-explicit · positive
+> **"Change Customer.ContactPhone from text to an integer."**
+- **op:** `skills/op/retype-explicit/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 3–4
+- **Seed:** Customer ContactPhone populated with values like `'+1-206-555-0101'` that won't convert.
+- **Outcome:** the agent runs `TRY_CONVERT(INT, ContactPhone)` over the data, counts the NULL
+  (non-convertible) rows (all of them — phone strings), and proves the add-new → TRY_CONVERT →
+  drop-old sequence (the additive→cutover→subtractive shape from `_index/multi-phase`). If SSDT ever
+  emits a bare `ALTER COLUMN` for the explicit conversion, the agent STOPS and forces multi-phase.
+- **Fail mode:** lets SSDT attempt a single-step `ALTER COLUMN` that fails or truncates mid-deploy;
+  or assumes the conversion is lossless.
+
+### COL-07B — retype-implicit (widening) · flip
+> **"Change Order.StatusId from INT to BIGINT."**
+- **op:** `skills/op/retype-implicit/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** Order populated.
+- **Outcome:** FLIP TWIN of COL-07: widening / implicit conversion is lossless — Strict publishes
+  clean, delta is one `ALTER COLUMN`. Same family (retype), opposite direction → opposite mechanism.
+- **Fail mode:** treats every retype as multi-phase without distinguishing widening from
+  narrowing/explicit.
+
+### COL-08 — rename-attribute · flip (refactorlog present)
+> **"Rename Customer.ContactPhone to MobileNumber."**
+- **op:** `skills/op/rename-attribute/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (`sp_rename`) **IF** refactorlog present; otherwise a
+  CATASTROPHE graded Script-Only data loss. · **Tier:** 3
+- **Seed:** Customer ContactPhone populated; refactorlog entry for the column rename **PRESENT**.
+- **Outcome:** Script delta = `EXEC sp_rename 'dbo.Customer.ContactPhone','MobileNumber','COLUMN'`;
+  data survives. Agent confirms the `.refactorlog` changed. Tier 3 because every caller of the column
+  name breaks. The discriminator (read-the-delta: `sp_rename` not DROP+ADD) is owned by
+  `_index/identity-and-refactorlog`.
+- **Fail mode:** edits the column name with no refactorlog; SSDT emits `DROP COLUMN [ContactPhone]` +
+  `ADD [MobileNumber]` and every phone number is lost.
+
+### COL-08N — rename-attribute, naked · negative
+> **"Rename Customer.ContactPhone to MobileNumber."**
+- **op:** `skills/op/rename-attribute/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+- **Mechanism:** REFUSE / STOP — naked rename detected. · **Tier:** 3 (catastrophe-grade)
+- **Seed:** Customer ContactPhone populated; refactorlog entry **MISSING**.
+- **Outcome (PASS):** the agent reads the delta, SEES `DROP COLUMN [ContactPhone]` +
+  `ADD [MobileNumber]`, STOPS, demands the refactorlog entry, and never proceeds. Catch is in the
+  delta. Without the entry every phone value is destroyed.
+- **Fail mode:** proceeds with the drop+add (the delta "looks like it does the rename") and loses
+  all 5 phone numbers.
+
+### COL-09 — delete-attribute · negative
+> **"Just drop the LegacyCode column on Product, nobody uses it."**
+- **op:** `skills/op/delete-attribute/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+  (the populated-column veto) + `skills/_index/multi-phase/SKILL.md` (the 4-phase deprecation)
+- **Mechanism:** 5 — Multi-Phase (4-phase deprecation) on a column with data; mechanically
+  Mechanism 1 only if provably empty/unused. · **Tier:** 4 (once real data destroyed; Tier 3 if scratch)
+- **Seed:** the **populated** `LegacyCode` column on Product (the `ProductLegacy` module seeds it
+  non-empty), optionally referenced by a view.
+- **Outcome (PASS):** the agent proves the Strict `BlockOnPossibleDataLoss` veto on the populated
+  column (the drop-column face of `_index/tightening-class`: table-has-rows, data-blind), runs
+  `sys.dm_sql_referencing_entities` to prove nothing references it, and proposes the 4-phase
+  deprecation (stop writes → verify unused → drop) rather than a blind drop. Surfaces that "nobody
+  uses it" is an assumption until proven.
+- **Fail mode:** blind-drops the column (Permissive), destroying its values and breaking any
+  view/proc that referenced it.
+
+---
+
+## Family: keys-and-refs — `skills/operations/keys-and-refs.md` (family index)
+
+### KEY-01 — define-PK · positive
+> **"Set the primary key on OrderLine to OrderId + LineNumber."**
+- **op:** `skills/op/define-pk/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase) for a new table; Mechanism 1 Tier 2 on an
+  existing populated table. · **Tier:** 1 (new) / 2 (existing)
+- **Seed:** `OrderLine` populated with 2–3 lines/Order; the (OrderId, LineNumber) pair unique &
+  non-NULL. For the existing-populated leg, the composite claim is proven against real rows.
+- **Outcome:** new table: CREATE lands with the composite PK inline, Tier 1. Existing populated: the
+  agent runs the duplicate probe (`GROUP BY OrderId,LineNumber HAVING COUNT(*)>1`) and NULL probe
+  FIRST (the constraint-is-a-claim probe reflex), proves uniqueness, Strict publishes clean (the
+  index build touches every row), Tier 2.
+- **Fail mode:** adds a PK to an existing table without probing for duplicate/NULL key values, and
+  the clustered-index build vetoes at deploy.
+
+### KEY-02 — create-fk-clean · positive
+> **"Add a reference from Order to Customer — Order belongs to a Customer."**
+- **op:** `skills/op/create-fk-clean/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** Order seed with NO orphan (repoint row 4's `CustomerId=999` to a real customer, in scratch).
+- **Outcome:** the agent runs the orphan probe (`LEFT JOIN Customer WHERE Customer.Id IS NULL`) = 0
+  (the claim proven true), Strict publishes clean, delta is one `ADD CONSTRAINT`. Tier 2 (contractual
+  inter-table dependency).
+- **Fail mode:** classifies clean from the `.sql` without proving zero orphans; or over-tiers a
+  clean FK.
+
+### KEY-03 — create-fk-orphan · flip
+> **"Add a foreign key from Order.CustomerId to Customer."**
+- **op:** `skills/op/create-fk-orphan/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 4 — Script-Only (`NOCHECK` → reconcile → `WITH CHECK CHECK`); 5 — Multi-Phase if
+  staged. · **Tier:** 3
+- **Seed:** Order DEFAULT seed: row 4 has `CustomerId=999` (orphan, no parent).
+- **Outcome:** the agent proves the clean-FK Strict veto with the orphan count (**1**: Order 4), then
+  proves the full script: `NOCHECK` adds it untrusted (`is_not_trusted=1`), reconcile clears the
+  orphan, `WITH CHECK CHECK` flips to trusted (`is_not_trusted=0`) with no veto — the trust ladder
+  and the is_not_trusted=0 end-state proof owned by `_index/constraint-is-a-claim`. Orphan present
+  vs absent flips Tier 2 single-phase to Tier 3 script.
+- **Fail mode:** stops at `WITH NOCHECK` leaving an untrusted constraint the optimizer ignores; or
+  never discovers the orphan and ships a clean FK that vetoes at deploy.
+
+### KEY-03N — create-fk-orphan, bare NOCHECK shortcut · negative
+> **"Just add the FK from Order to Customer, ignore the orphan, NOCHECK it."**
+- **op:** `skills/op/create-fk-orphan/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** REFUSE the bare-NOCHECK shortcut; require reconcile + `WITH CHECK CHECK`. · **Tier:** 3
+- **Seed:** Order DEFAULT seed with orphan row 4.
+- **Outcome (PASS):** the agent refuses to leave the constraint at NOCHECK (untrusted), proves
+  `is_not_trusted=1` is the cost (optimizer ignores it, orphan still present), and insists on
+  reconcile-then-`WITH CHECK CHECK` to end trusted. Dedupe/repoint the orphan first.
+- **Fail mode:** does the developer's literal ask — adds `WITH NOCHECK` and stops — shipping a
+  permanently untrusted constraint that protects nothing.
+
+### KEY-04 — change-delete-rule · positive
+> **"Change the Delete Rule on Order→Customer to Delete (cascade)."**
+- **op:** `skills/op/change-delete-rule/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (DROP+ADD the FK, single-phase). · **Tier:** 3
+- **Seed:** Order→Customer FK present; the multi-level chain (Order→OrderLine, from the `OrderLine`
+  module) to show the CASCADE blast radius visibly.
+- **Outcome:** delta is `DROP CONSTRAINT` + `ADD CONSTRAINT … ON DELETE CASCADE` (not a rebuild).
+  For CASCADE, the agent PROVES the blast radius: delete one Customer and snapshot which child rows
+  vanish across the whole Order→OrderLine chain. Tier 3 — a single delete now silently removes rows
+  in multiple tables.
+- **Fail mode:** ships CASCADE without mapping the cascade graph; a delete that previously failed now
+  silently removes child rows across tables, possibly bypassing CDC capture.
+
+### KEY-05 — drop-fk · positive
+> **"Remove the reference from Order to Customer, we don't need the link."**
+- **op:** `skills/op/drop-fk/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 2
+- **Seed:** Order→Customer FK present and trusted.
+- **Outcome:** Strict publishes clean; delta is one `DROP CONSTRAINT`; no veto (dropping loses no
+  rows). The agent flags the two real consequences: integrity no longer enforced, and query plans
+  that trusted the FK may regress. Tier 2 for that reason.
+- **Fail mode:** treats it as zero-risk and omits the optimizer-plan / integrity-loss warning.
+
+---
+
+## Family: indexes — `skills/operations/indexes.md` (family index)
+
+### IDX-01 — add-index · positive
+> **"Add an index on Customer.Email, the list screen is slow."**
+- **op:** `skills/op/add-index/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1 (Tier 2 if large/blocking; **+1 at >1M**)
+- **Seed:** Customer populated.
+- **Outcome:** Strict publishes clean; delta is a clean `CREATE INDEX`, no drop, no table rebuild.
+  The agent flags that on the REAL (large) table the non-ONLINE build locks writes for the duration —
+  schedule a window, or ONLINE (Enterprise only). The ONLINE-is-Enterprise coupling is stated inline
+  in the add-index op skill (a single-op concern, not lifted). The proving ground is small, so
+  observed build time ≠ prod build time; row count is the predictor.
+- **Fail mode:** reports "pure declarative, ship it" without naming the write-blocking build cost on
+  the real prod table.
+
+### IDX-02 — modify-index → unique · flip
+> **"Make the index on Product.Code unique so we stop getting duplicates."**
+- **op:** `skills/op/modify-index/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 3 — Pre-Deploy+Declarative (single-PR). · **Tier:** 3
+- **Seed:** Product DEFAULT seed: rows 4 & 5 share `Code='DUPE'`.
+- **Outcome:** the agent runs the duplicate probe (`GROUP BY Code HAVING COUNT(*)>1`) predicting the
+  veto (the constraint-is-a-claim reflex — a UNIQUE index is a claim proven at apply time), then
+  build+Strict fails ("duplicate key was found"). Authors a pre-deploy dedupe, re-runs Strict clean.
+  Tier 3 (changing data to pass).
+- **Fail mode:** emits the UNIQUE index from the `.sql` and the deploy fails at build on the `'DUPE'`
+  rows; or dedupes silently without surfacing which rows merged.
+
+### IDX-02B — modify-index (covering column) · flip
+> **"Add a covering column to the index on Order.CustomerId."**
+- **op:** `skills/op/modify-index/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (DROP+CREATE rebuild, single-phase). · **Tier:** 1–2
+- **Seed:** Order populated; index exists; no uniqueness added.
+- **Outcome:** FLIP TWIN of IDX-02: a key/include change with NO uniqueness added is invisible to
+  the app — SSDT emits DROP+CREATE rebuild, Strict clean, Tier 1–2 (size pushes the tier). Same
+  modify-index op, but no UNIQUE → no claim → no duplicate veto.
+- **Fail mode:** over-tiers a benign include-list change, or fails to note the rebuild blocks writes
+  like add-index.
+
+### IDX-03 — drop-index · positive
+> **"Drop the index on Product.Name, I don't think anything uses it."**
+- **op:** `skills/op/drop-index/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1 (2 if it backs a hot query)
+- **Seed:** Product with a droppable index; a usage-stats source.
+- **Outcome:** delta is a clean `DROP INDEX`, no data lost, reversible. The REAL proof is usage
+  evidence: `sys.dm_db_index_usage_stats` showing zero seeks/scans/lookups over a representative
+  window — "not used" is an assumption until proven. No production load on the proving ground.
+- **Fail mode:** drops an index backing a hot query on the developer's say-so, causing a silent
+  performance regression.
+
+### IDX-04N — rebuild-index · negative
+> **"The index on Order is fragmented — make SSDT rebuild it on every deploy."**
+- **op:** `skills/op/rebuild-index/SKILL.md` (OPERATIONAL — refuse-and-route)
+- **Mechanism:** REFUSE — NOT declarative; route to a maintenance job. · **Tier:** operational / out-of-band
+- **Seed:** none — there is no delta to produce.
+- **Outcome (PASS):** the agent REFUSES to put `ALTER INDEX REBUILD` in the dacpac, explains there is
+  no declarative destination for "rebuild me" (handbook file 15 = §18), and routes it to a SQL Agent
+  / Ola Hallengren maintenance plan keyed to measured fragmentation. If pushed, proves the harm: a
+  post-deploy REBUILD re-runs on EVERY publish (anti-idempotent).
+- **Fail mode:** puts `ALTER INDEX REBUILD` in a post-deploy script, making a blocking rebuild
+  re-run on every single deploy disguised as a schema step.
+
+---
+
+## Family: constraints — `skills/operations/constraints.md` (family index)
+
+### CON-01 — add-default · positive
+> **"Give Customer.Status a default of Active for new rows."**
+- **op:** `skills/op/add-default/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1
+- **Seed:** Customer populated; a column to default.
+- **Outcome:** delta is a clean `ALTER TABLE … ADD CONSTRAINT DF_Customer_Status DEFAULT` with NO
+  UPDATE of existing rows — proving the default does NOT backfill. The agent names the constraint
+  explicitly (not auto-named `DF__…__hash`) and warns the default only fills NEW rows.
+- **Fail mode:** lets SSDT auto-name the constraint (env-fragile), or implies existing NULLs get
+  backfilled by the default (they don't).
+
+### CON-01B — modify-default · positive
+> **"Change the default on Category.IsActive — new rows should default to 0 now."**
+- **op:** `skills/op/modify-default/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (DROP-then-ADD the DEFAULT constraint, single-phase). · **Tier:** 1
+- **Seed:** `Category` populated (default seed; `IsActive DEFAULT 1`).
+- **Outcome:** the delta is `DROP CONSTRAINT DF_Category_IsActive` + `ADD CONSTRAINT … DEFAULT 0` —
+  a named DROP-then-ADD, NOT a rebuild, NOT a backfill of existing rows. The agent proves existing
+  `IsActive` values are untouched and only NEW rows pick up the new default.
+- **Fail mode:** implies changing the default rewrites existing rows, or lets SSDT auto-name the
+  replacement constraint (env-fragile drift on the next deploy).
+
+### CON-02 — add-unique · flip
+> **"Make Customer.Email unique — no two customers can share an email."**
+- **op:** `skills/op/add-unique/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative if data is unique; FLIP to 3 — Pre-Deploy+Declarative if
+  duplicates. · **Tier:** 2 (3 if dedupe needed)
+- **Seed:** Customer seed with duplicate emails (or use the Product.Code `'DUPE'` rows for the
+  unique-on-Code variant).
+- **Outcome:** the agent runs the duplicate probe FIRST + a NULL count (UNIQUE allows exactly ONE
+  NULL — the filtered-index remedy is owned by `_index/constraint-is-a-claim`). Duplicates → Strict
+  build veto → pre-deploy dedupe, re-run clean (Tier 3). For legitimate multi-NULL, proposes a
+  FILTERED unique index (`WHERE col IS NOT NULL`). Magic line names the count sharing a value.
+- **Fail mode:** emits UNIQUE and the build fails on duplicates; or misses that several NULL rows
+  also fail the build and reaches for the wrong fix.
+
+### CON-02N — add-unique, force through · negative
+> **"Add a unique constraint on Product.Code — and just push it through, the dupes are old data."**
+- **op:** `skills/op/add-unique/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** VETO → dedupe first (refuse to force through). · **Tier:** 3
+- **Seed:** Product DEFAULT seed: rows 4 & 5 share `Code='DUPE'`.
+- **Outcome (PASS):** the agent proves the duplicate-key Strict veto, REFUSES to NOCHECK/force it,
+  and requires the pre-deploy dedupe BEFORE the unique build. The veto is the safety proof, not a
+  failure to bypass.
+- **Fail mode:** reaches for a way to skip validation and ships a unique constraint that either fails
+  the build or is forced through, corrupting the uniqueness guarantee.
+
+### CON-03 — add-check · flip
+> **"Total on Order must always be positive."**
+- **op:** `skills/op/add-check/SKILL.md` · **_index:** `skills/_index/constraint-is-a-claim/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative if all rows satisfy; FLIP to 3 — Pre-Deploy+Declarative if
+  violators. · **Tier:** 2 (3 if fix-up needed)
+- **Seed:** Order seed with a non-positive Total (add a row with `Total ≤ 0` in scratch), or
+  all-positive for the clean leg.
+- **Outcome:** the agent runs the violation probe (`SELECT COUNT(*) WHERE NOT (Total>0)`) FIRST (the
+  constraint-is-a-claim `WHERE NOT(pred)` probe). Violators → Strict adds `WITH CHECK` and vetoes
+  ("conflicted with the CHECK constraint") → pre-deploy fix-up, re-run clean, stays TRUSTED. If
+  anyone proposes `WITH NOCHECK`, proves the `is_not_trusted=1` cost.
+- **Fail mode:** emits the CHECK and the deploy fails on violating rows; or uses `WITH NOCHECK`
+  leaving an untrusted constraint the optimizer ignores.
+
+### CON-04N — toggle-trust · negative
+> **"Trust the FK now, the data's clean — just flip it on."**
+- **op:** `skills/op/toggle-trust/SKILL.md` (OPERATIONAL — refuse-and-route) ·
+  **_index:** `skills/_index/constraint-is-a-claim/SKILL.md` (the trust ladder + is_not_trusted=0 proof)
+- **Mechanism:** REFUSE as a declarative edit — it is OPERATIONAL / Script-Only. · **Tier:** inherits
+  the surrounding change's tier (e.g. 3 for FK-with-orphans).
+- **Seed:** a constraint currently NOCHECK/untrusted.
+- **Outcome (PASS):** the agent recognizes enable/disable trust is NOT declarative (handbook file 15
+  = §18), wires it as a script step (disable → clean data → `WITH CHECK CHECK` re-trust), and PROVES
+  the end state is `is_not_trusted=0` (the constraint-is-a-claim end-state proof). A left-untrusted
+  constraint silently stops protecting.
+- **Fail mode:** tries to express trust state as a CREATE edit (SSDT has no destination for it), or
+  flips trust without re-validating, leaving `is_not_trusted=1`.
+
+---
+
+## Family: static-data — `skills/operations/static-data.md` (family index)
+
+### STA-01 — create-static-seed · positive
+> **"Create a Category lookup with three fixed values."**
+- **op:** `skills/op/create-static-seed/SKILL.md` · **_index:** `skills/_index/idempotent-seed/SKILL.md`
+- **Mechanism:** 2 — Declarative + Post-Deploy (single-PR). · **Tier:** 1 (**+1 if CDC-tracked**)
+- **Seed:** the `Category` lookup table; explicit IDs (no IDENTITY).
+- **Outcome:** `CREATE TABLE` (declarative) + idempotent guarded MERGE in post-deploy with EXPLICIT
+  ids. The agent proves idempotency (the `_index/idempotent-seed` silence-is-the-proof rule): deploy
+  twice, the second deploy reports 0 rows affected + identical data-hash. Explicit ids so the app's
+  constants mean the same row in every environment.
+- **Fail mode:** writes a bare INSERT (duplicate-keys on the second deploy) or uses IDENTITY for
+  lookup keys (ids drift between environments, breaking app constants).
+
+### STA-02 — edit-seed · positive
+> **"Add the new lookup value 'Refunded' to the Status entity."**
+- **op:** `skills/op/edit-seed/SKILL.md` · **_index:** `skills/_index/idempotent-seed/SKILL.md`
+  (+ `skills/_index/cdc/SKILL.md` for the CDC-silence face)
+- **Mechanism:** 2 — Declarative + Post-Deploy (single-PR). · **Tier:** 1 (**+1 if CDC-tracked**)
+- **Seed:** Status DEFAULT seed (3 rows); add `(4,'Refunded',1)`.
+- **Outcome:** the agent extends the guarded MERGE, proves CDC-silence / idempotency: re-publish with
+  the value already present captures 0 rows (no-op MERGE), identical hash. Uses a GUARDED
+  `WHEN MATCHED` (value-differs, null-safe), not unconditional. The second silent publish is the proof.
+- **Fail mode:** writes an unconditional `WHEN MATCHED` that rewrites every row on every deploy — on
+  a CDC-tracked table this over-captures the whole table as phantom changes.
+
+### STA-03 — extract-to-lookup · positive
+> **"Turn the free-text StatusText column on Order into a proper Status lookup entity."**
+- **op:** `skills/op/extract-to-lookup/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+  (+ `skills/_index/idempotent-seed/SKILL.md` for the seed leg)
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 3 (**+1 if values lost / CDC / >1M**)
+- **Seed:** Order with the `StatusText` free-text column (the `OrderStatusText` module: values
+  `Pending`/`Shipped`/`Cancelled`).
+- **Outcome:** THREE separate releases — **R1 additive** (create/reuse lookup + seed distinct values +
+  add a *nullable* FK column); **R2 backfill** (`UPDATE Order SET StatusId = join`, then the
+  **total-mapping proof** that MUST pass before R3 — the conservation proof from `_index/multi-phase`:
+  `COUNT(*) WHERE StatusId IS NULL = 0` AND `SELECT DISTINCT StatusText NOT IN (lookup) = 0 rows`);
+  **R3 subtractive** (drop the old text column). Each phase Strict-clean; the drop never runs until
+  the totality proof is green.
+- **Fail mode:** does it in one publish; unmapped text values silently become NULL or veto the FK
+  (Forgotten FK Check as orphan text).
+
+### STA-03N — extract-to-lookup, unmapped value · negative
+> **"Turn StatusText into the Status lookup — just wire the FK."**
+- **op:** `skills/op/extract-to-lookup/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** STOP — the total-mapping proof fails; do NOT drop or FK-constrain until every text
+  value maps. · **Tier:** 3
+- **Seed:** scratch Order seed with an **unmapped** `StatusText` value (e.g. `'Backordered'` with no
+  Status row).
+- **Outcome (PASS):** R2's total-mapping proof returns rows where `StatusText NOT IN (lookup)`; the
+  agent STOPS before R3, surfaces the unmapped value as a design decision (add the lookup row or
+  deactivate the value), and never lets the subtractive drop run against an incomplete mapping.
+- **Fail mode:** ships the FK / drops the text column with an unmapped value present — the row either
+  vetoes the FK or is silently NULLed, losing the status.
+
+### STA-04N — delete-seed-value · negative
+> **"Delete the 'Cancelled' status value, we're retiring it."**
+- **op:** `skills/op/delete-seed-value/SKILL.md` · **_index:** `skills/_index/idempotent-seed/SKILL.md`
+  (deactivate-don't-delete)
+- **Mechanism:** REFUSE the hard DELETE → propose deactivate (`IsActive=0`). · **Tier:** 1–2
+  (deactivate) vs Tier 3+ (a DELETE that orphans fact rows).
+- **Seed:** Status row 3 'Cancelled' referenced by Order rows (`StatusId=3`); OR the `Category`
+  variant where a `Category` row is referenced by `Product.CategoryId`.
+- **Outcome (PASS):** the agent proves fact rows still reference the value, REFUSES the hard DELETE
+  (would orphan fact rows / break app constants — the deactivate-don't-delete rule from
+  `_index/idempotent-seed`), and proposes deactivate (`IsActive=0`), preserving referential integrity
+  and history.
+- **Fail mode:** removes the seed row; the MERGE's `WHEN NOT MATCHED BY SOURCE THEN DELETE` orphans
+  every fact row pointing at it and breaks the app's constant.
+
+---
+
+## Family: structural — `skills/operations/structural.md` (family index)
+
+### STR-01 — split-table · positive
+> **"Split Customer into Customer and CustomerAddress, pull the address fields out."**
+- **op:** `skills/op/split-table/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 2 (phase 1) escalating to 3 (phase 3 drop)
+- **Seed:** Customer populated; `CustomerAddress` module present with **exactly one row per Customer**
+  (the authored 1:1 positive).
+- **Outcome:** three PRs: Phase 1 additive (`CREATE CustomerAddress` + FK + post-deploy copy +
+  dual-write) Strict clean, hash moving-columns source-vs-new prove EQUAL; Phase 2 repoint reads;
+  Phase 3 subtractive drop old columns — Strict MUST veto on `BlockOnPossibleDataLoss` until the
+  Phase-1 hashes proved equal (the licensing-gate-on-the-drop rule from `_index/multi-phase`).
+- **Fail mode:** does it in one PR — drops the old columns the same release it creates the new table,
+  breaking app reads and risking data loss if the copy had a bug.
+
+### STR-02 — merge-tables · positive
+> **"Merge CustomerAddress back into Customer, we don't need two entities."**
+- **op:** `skills/op/merge-tables/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 3 (**+1 CDC / >1M / first-time**)
+- **Seed:** `CustomerAddress` populated, **proven 1:1** with Customer (the authored positive).
+- **Outcome:** the agent proves cardinality FIRST (absorbed rows == distinct parent keys = 1:1 — the
+  cardinality conservation proof from `_index/multi-phase`) before anything else; 1:many would
+  silently drop rows. Then hash absorbed columns vs survivor's new columns prove equal; Phase 3 drop
+  absorbed table — Strict vetoes under `BlockOnPossibleDataLoss` until hashes match.
+- **Fail mode:** assumes 1:1 without the row-count check; on actual 1:many the naive copy keeps one
+  row per parent and silently drops the rest (hash alone won't flag it).
+
+### STR-02N — merge-tables, hidden 1:many · negative
+> **"Merge CustomerAddress into Customer — it's a simple combine."**
+- **op:** `skills/op/merge-tables/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** STOP — surface the 1:many cardinality as a design decision before proceeding.
+  · **Tier:** 3
+- **Seed:** **scratch** `CustomerAddress` seed with MULTIPLE rows for one Customer (deliberate 1:many;
+  the authored positive stays 1:1 — the negative is a scratch edit only).
+- **Outcome (PASS):** the agent's cardinality check (absorbed rows ≠ distinct parents) detects
+  1:many, STOPS, and tells the developer the merge is semantically wrong as stated — a design
+  decision, not a mechanism flip — before any copy runs.
+- **Fail mode:** runs the merge copy, keeping one address per customer, silently discarding the rest,
+  and the hash check passes because it only compares the surviving rows.
+
+### STR-03 — move-attribute · positive
+> **"Move the Region attribute from Customer to Account, it's on the wrong entity."**
+- **op:** `skills/op/move-attribute/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+  + `skills/_index/identity-and-refactorlog/SKILL.md` (a cross-table move has NO refactorlog identity —
+  it is copy-then-drop, never a rename)
+- **Mechanism:** 5 — Multi-Phase (multi-PR) when the source is populated. · **Tier:** 3
+- **Seed:** Customer.Region populated; 1:1 relationship to `Account` via `Customer.AccountId`.
+- **Outcome:** the agent proves the join is 1:1 (count check) so values aren't ambiguous, copies them
+  (hash source-vs-destination prove equal), and Strict vetoes the source-column drop until equal.
+  Explicitly names that this is copy-then-drop, NOT a rename — a cross-table move has no refactorlog
+  identity mapping (`_index/identity-and-refactorlog`). Multi-PR.
+- **Fail mode:** treats "move" as a rename and lets SSDT DROP+CREATE; or copies across a non-1:1
+  relationship where the value is ambiguous.
+
+### STR-04 — identity-swap · positive
+> **"Turn on Auto Number for the Category entity's Id."**
+- **op:** `skills/op/identity-swap/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase / Script-Only-grade orchestration (multi-PR) on a populated table
+  with FKs. · **Tier:** 3 (**+1 first-time / CDC / >1M**)
+- **Seed:** `Category` — the explicit-id (non-IDENTITY) PK table populated, with `Product.CategoryId`
+  as an incoming FK. (The shadow-table-rebuild reasoning is owned inline by the identity-swap op
+  skill — it is essentially one op, below the lift bar; retype-explicit / indexed-view cross-reference it.)
+- **Outcome:** the agent previews the Strict delta and CONFIRMS it is a shadow-table rebuild WITH
+  `SET IDENTITY_INSERT` (not a no-op), proves every Id is unchanged after (reseed preserved them) and
+  every FK still resolves (zero orphans). Sequenced across PRs because FKs drop/recreate around the
+  rebuild.
+- **Fail mode:** treats adding `IDENTITY(1,1)` as a trivial one-line edit; SSDT's silent full table
+  rebuild re-mints keys without IDENTITY_INSERT and every FK now points at the wrong rows — the most
+  dangerous one-line edit in the catalog.
+
+---
+
+## Family: views-synonyms — `skills/operations/views-synonyms.md` (family index)
+
+### VIE-01 — create-view · positive
+> **"Give me a view that joins Order and Customer for active customers."**
+- **op:** `skills/op/create-view/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1 (3 if downstream consumers depend)
+- **Seed:** Order and Customer present; the `OrderSummary` module's `vOrderSummary` authored view is
+  the enumerated positive, and its documented `SELECT *` variant is the trap leg (scratch).
+- **Outcome:** clean `CREATE/ALTER VIEW`, no rebuild, no veto (holds no data). The agent ENUMERATES
+  columns explicitly, not `SELECT *`, so the view won't silently change shape when the base entity
+  does. Tier rises to 3 if external apps/reports/ETL depend on it.
+- **Fail mode:** writes `SELECT *` (the SELECT * View trap — a single-op concern owned inline by
+  create-view/compat-view, not lifted) — the view silently re-binds to base-table columns at every
+  publish, drifting without its own `.sql` changing.
+
+### VIE-02 — compat-view · positive
+> **"I renamed Customer to Account but the old reports still ask for Customer — keep them working."**
+- **op:** `skills/op/compat-view/SKILL.md` · **_index:** `skills/_index/identity-and-refactorlog/SKILL.md`
+  (identity survives the move; the name is an address). **AUTHORED-HERE recipe** (§17.8) lives in the op skill.
+- **Mechanism:** 1 — Pure Declarative (the view) inside a multi-PR rename/split program. · **Tier:** 3
+- **Seed:** Customer renamed to Account (refactorlog honored); external consumers of the old name.
+- **Outcome:** the agent first proves the rename delta is `sp_rename` not DROP+CREATE
+  (`_index/identity-and-refactorlog`), then creates a view bearing the OLD name (`dbo.Customer`) with
+  ENUMERATED aliased columns selecting from `dbo.Account`, proves SELECT from the compat view returns
+  the SAME row hashes as the pre-rename table, and marks it TEMPORARY with a sunset trigger.
+- **Fail mode:** makes the compat view `SELECT *` (re-triggers the trap), or forgets it's temporary
+  and leaves it forever, recreating the name ambiguity the rename was meant to resolve.
+
+### VIE-03 — synonym · positive
+> **"Point our local Customer entity at the Customer table in the shared database."**
+- **op:** `skills/op/synonym/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase). · **Tier:** 1 (3 for an external target)
+- **Seed:** none — the target is external.
+- **Outcome:** clean `CREATE SYNONYM`. The agent proves the runtime-resolution gap: the synonym
+  publishes clean EVEN IF the target is absent — SSDT validates nothing on the other side.
+  Demonstrates a query through the synonym failing at runtime when the target is missing. Tier 3 for
+  the external/cross-system dependency.
+- **Fail mode:** assumes the synonym's target is validated at publish; the broken target surfaces
+  only at runtime on the first query, untracked by the proving ground.
+
+### VIE-04 — indexed-view · positive
+> **"Materialize the order-summary view for speed."**
+- **op:** `skills/op/indexed-view/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative on a small base; flips toward 3/5 Multi-Phase as the base grows.
+  · **Tier:** 2 (small) / 3 (large base)
+- **Seed:** `vOrderSummary` base tables present; deterministic expressions only. The scratch edit adds
+  `WITH SCHEMABINDING` + a `UNIQUE CLUSTERED` index.
+- **Outcome:** the agent confirms the delta builds a UNIQUE CLUSTERED index (not just a view CREATE),
+  requires `WITH SCHEMABINDING` + deterministic expressions, and PROVES the binding cost: editing a
+  bound base column forces SSDT to DROP+REBUILD the indexed view — the hidden price of
+  materialization, expensive/blocking on a large base. (The shadow-rebuild note cross-references the
+  identity-swap op skill; it is not lifted.)
+- **Fail mode:** treats it as a plain view; misses that SCHEMABINDING locks base columns and that
+  every later bound-column change forces a costly rebuild.
+
+---
+
+## Family: audit-cdc — `skills/operations/audit-cdc.md` (family index)
+
+### AUD-01 — temporal-new · positive
+> **"I want full history on a new entity — every version of every row."**
+- **op:** `skills/op/temporal-new/SKILL.md`
+- **Mechanism:** 1 — Pure Declarative (single-phase) for a NEW table. · **Tier:** 2
+- **Seed:** new entity, temporal from birth (`SYSTEM_VERSIONING=ON` + history table + period columns),
+  scratch-authored (greenfield — no authored seed table needed).
+- **Outcome:** the agent distinguishes temporal (point-in-time row history, all editions) from CDC
+  (change feed) at intake, then previews the Strict delta publishing the system-versioned CREATE
+  clean for the new table. Tier 2 (versioned object, builds cleanly). No CDC +1 tax (see `_index/cdc`
+  for what temporal is NOT).
+- **Fail mode:** conflates temporal with CDC and takes on CDC's licensing/+1 tax for nothing; or
+  picks the wrong history mechanism for the developer's actual need.
+
+### AUD-02 — temporal-convert · flip
+> **"Add full history to our existing populated Customer entity."**
+- **op:** `skills/op/temporal-convert/SKILL.md` · **_index:** `skills/_index/multi-phase/SKILL.md`
+- **Mechanism:** 5 — Multi-Phase (multi-PR). · **Tier:** 3 (**+1 if CDC already on / >1M / first-time**)
+- **Seed:** Customer POPULATED (convert the existing populated table in a scratch copy).
+- **Outcome:** FLIP of AUD-01: converting an existing populated table is staged — add the (hidden)
+  period columns with backfilled sane ROW START times, create the history table, then enable
+  versioning (the additive→cutover shape from `_index/multi-phase`). The agent proves the backfill
+  produces sane start times and enabling versioning does not veto; hash before/after proves rows untouched.
+- **Fail mode:** tries to convert in one publish, or adds period columns without backfilling ROW
+  START so every existing row claims to have begun at conversion time.
+
+### AUD-03 — audit-columns · positive
+> **"Add CreatedBy / CreatedOn / ModifiedBy / ModifiedOn audit fields to Customer."**
+- **op:** `skills/op/audit-columns/SKILL.md` · **_index:** `skills/_index/tightening-class/SKILL.md`
+  (the NOT-NULL-on-populated face)
+- **Mechanism:** 1 — Pure Declarative (nullable); 3 — Pre-Deploy+Declarative if NOT NULL on a
+  populated table. · **Tier:** 1 (nullable) / 2 (NOT NULL backfill)
+- **Seed:** Customer populated.
+- **Outcome:** nullable audit columns add in one release (Mechanism 1). If the developer wants them
+  NOT NULL, Strict vetoes on existing rows with no value (the tightening-class row-presence guard);
+  the pre-deploy backfill that stamps them clears it (Mechanism 3, Tier 2). Permissive shows what
+  `GenerateSmartDefaults` would silently stamp.
+- **Fail mode:** adds NOT NULL audit columns with no backfill (Optimistic NOT NULL) and the deploy
+  vetoes; or lets `GenerateSmartDefaults` silently stamp values.
+
+### AUD-04 — enable-cdc · positive
+> **"Turn on Change Data Capture for the CdcCandidate table so the warehouse gets a change feed."**
+- **op:** `skills/op/enable-cdc/SKILL.md` · **_index:** `skills/_index/cdc/SKILL.md`
+- **Mechanism:** 4 — Script-Only (NOT declarative). · **Tier:** 3, **+1 → Tier 4** (first-time CDC on
+  the estate)
+- **Seed:** the `CdcCandidate` table on an **isolated disposable DB** (`sp_cdc_enable_db` flips
+  instance-wide state — NEVER the shared warm container; your unique `/TargetDatabaseName` IS the
+  isolation. The module header carries the survival-rule-1 / PROTOCOL §8 warning; `_index/cdc` owns
+  the mandatory-isolation rule).
+- **Outcome:** the agent recognizes CDC is OUTSIDE the declarative model — proves the dacpac IGNORES
+  the declarative attempt (nothing in the delta — the empty-delta proof from `_index/cdc`), so it must
+  be a script. Runs the enable on the ISOLATED DB, confirms change tables + capture instance appear,
+  confirms the edition supports CDC. Flags the STANDING +1-tier consequence on every future change.
+- **Fail mode:** tries to express CDC declaratively (silently ignored), runs `sp_cdc_enable_db` on
+  the shared warm container (destroys other work — survival rule 1), or misses the standing
+  capture-instance tax on all future changes.
+
+### AUD-05 — recreate-capture-instance · flip
+> **"I added a column to CdcCandidate but CDC isn't picking it up — the ETL feed is missing the new field."**
+- **op:** `skills/op/recreate-capture-instance/SKILL.md` · **_index:** `skills/_index/cdc/SKILL.md`
+- **Mechanism:** 4 — Script-Only (single-PR) if no-gap NOT required; 5 — Multi-Phase (multi-PR,
+  dual-instance) if no-gap required. · **Tier:** 3, **+1 → Tier 4** (no-gap dual-instance)
+- **Seed:** isolated DB; CDC-enabled `CdcCandidate`; a column added after capture-instance creation.
+- **Outcome:** the agent proves the gap: the existing capture instance does NOT surface the new
+  column (`sp_cdc_get_captured_columns` lacks it — the frozen-capture-shape rule from `_index/cdc`).
+  Then proves the dual-instance fix: `CdcCandidate_v2` surfaces the new column while `_v1` stays
+  drainable, cut over, drop v1. Mechanism 5 multi-PR when no-gap required.
+- **Fail mode:** ships the add-column as trivial; the change feed is frozen to the old shape and
+  silently omits the new field downstream (the failure mode is SILENCE) until someone notices.
+
+### AUD-06 — change-tracking · positive
+> **"I just need to know WHICH rows changed since the last mobile sync."**
+- **op:** `skills/op/change-tracking/SKILL.md` · **_index:** `skills/_index/cdc/SKILL.md`
+  (the lighter sibling)
+- **Mechanism:** 4 — Script-Only (operational ALTER, single-PR). · **Tier:** 2
+- **Seed:** isolated DB; a table to enable change tracking on (use `CdcCandidate`).
+- **Outcome:** the agent distinguishes change tracking ("row 42 changed", sync-oriented, all
+  editions, light) from CDC ("row 42 went X→Y", full feed — the distinction owned by `_index/cdc`).
+  Confirms it's an operational ALTER the dacpac doesn't own, runs it on the isolated DB, proves
+  `CHANGETABLE` reports changed keys but NOT old values. Does NOT carry CDC's +1 standing tax.
+- **Fail mode:** reaches for CDC when change tracking suffices (taking on the whole CDC tax for
+  nothing), or vice versa when the developer actually needs old values.
+
+### AUD-07N — drop a CDC-tracked table · negative
+> **"Drop this CDC-tracked table, it's unused."**
+- **op:** `skills/op/delete-entity/SKILL.md` · **_index:** `skills/_index/cdc/SKILL.md`
+  + `skills/_index/tightening-class/SKILL.md` (the populated-drop veto)
+- **Mechanism:** 4 — Script-Only drop, but escalated: +1 CDC tier and capture-instance handling
+  FIRST. · **Tier:** 4 (**+1 CDC**)
+- **Seed:** isolated DB; a populated CDC-enabled table (`CdcCandidate`).
+- **Outcome (PASS):** the agent does NOT blind-drop. It fires the +1 CDC escalation, disables CDC /
+  handles the capture instance FIRST (else orphaned capture objects — `_index/cdc`), proves the
+  `BlockOnPossibleDataLoss` veto on the populated table (`_index/tightening-class`), and sequences
+  drop-FKs → disable-CDC → drop. "Unused" is an assumption to disprove.
+- **Fail mode:** drops a CDC-tracked populated table directly, orphaning the capture instance and
+  losing data — treating a Tier-4 +1-CDC change as a trivial drop.
+
+---
+
+## Cross-family traps (the obvious call is wrong)
+
+### TRAP-01N — nullable-add to a CDC table · negative
+> **"Add a nullable Notes column to the CdcCandidate table."**
+- **op:** `skills/op/add-optional/SKILL.md` (on a CDC table) · **_index:** `skills/_index/cdc/SKILL.md`
+- **Mechanism:** the base op is Mechanism 1 trivial, BUT the **+1 CDC tier MUST fire** and the
+  capture instance MUST be recreated. · **Tier:** 1 base → +1 CDC; the capture-instance work dominates.
+- **Seed:** isolated DB; `CdcCandidate` CDC-enabled; add a nullable column.
+- **Outcome (PASS):** the obvious call (trivial nullable add = Mechanism 1, Tier 1) is WRONG here.
+  The agent detects the table is CDC-enabled, fires the +1 (the +1 face of every op on a CDC table —
+  `_index/cdc`), and recognizes the new column will NOT appear in the change feed without a
+  capture-instance recreate (dual-instance if no-gap). The trivial base op hides a non-trivial CDC
+  obligation.
+- **Fail mode:** classifies "nullable add = Mechanism 1, Tier 1, done" and ships it; the new column
+  is silently absent from the ETL change feed because the capture instance was never recreated.
+
+### IDEM-01N — no-op redeploy (silence is the proof) · negative
+> **"Re-publish the project — nothing changed since last deploy."**
+- **op:** `skills/op/edit-seed/SKILL.md` (the data-plane no-op leg) · **_index:** `skills/_index/idempotent-seed/SKILL.md`
+  + `skills/_index/cdc/SKILL.md` (the CDC-silence face)
+- **Mechanism:** 1 — Pure Declarative (zero delta) + CDC-silence. · **Tier:** 1
+- **Seed:** a DB already at the project's current state (publish once, then again unchanged).
+- **Outcome (PASS):** a clean publish with ZERO delta; the guarded seed MERGE captures 0 rows; and if
+  CDC-tracked, CDC captures 0 changes on the second deploy (CDC-silence). Silence is the strongest
+  guarantee — the proof the deploy is idempotent (the silence-is-the-proof rule from
+  `_index/idempotent-seed`).
+- **Fail mode:** an unconditional `WHEN MATCHED` MERGE rewrites every seed row on the no-op redeploy,
+  capturing the whole table as phantom CDC changes; or reports spurious schema drift on an unchanged
+  tree.
+
+---
+
+## The flip-twin index (same op, opposite mechanism — decided only by data)
+
+These pairs are the heart of *classify-by-proving*. The `.sql` edit is identical (or the same op);
+only the **seed** differs. An agent that returns the same verdict for both halves classified from
+text and FAILS the pair.
+
+| op | clean leg → Mechanism | flipped leg → Mechanism | the data that flips it | governing _index |
+|---|---|---|---|---|
+| make-mandatory | COL-03B empty → **1** | COL-03 / COL-03C populated → **gate-relaxation (4) or multi-phase (5)** | table-has-rows (NOT NULL-has-rows) | tightening-class |
+| narrow | COL-06B fits → **1** | COL-06 over-length → **3 / 5** | `MAX(LEN)` vs target | tightening-class |
+| retype | COL-07B widen → **1** | COL-07 explicit → **5** | lossless vs lossy conversion | multi-phase |
+| create-FK | KEY-02 clean → **1** | KEY-03 orphan → **4 / 5** | orphan count | constraint-is-a-claim |
+| add-unique | CON-02 unique data → **1** | CON-02 / IDX-02 dupes → **3** | duplicate count | constraint-is-a-claim |
+| add-check | CON-03 all satisfy → **1** | CON-03 violators → **3** | violation count | constraint-is-a-claim |
+| temporal | AUD-01 new → **1** | AUD-02 populated → **5** | populated vs new | multi-phase |
+| modify-index | IDX-02B include → **1** | IDX-02 →unique dupes → **3** | uniqueness added + dupes | constraint-is-a-claim |
+| extract-to-lookup | STA-03 all mapped → **5 (proceeds)** | STA-03N unmapped → **STOP** | total-mapping proof | multi-phase |
+| merge-tables | STR-02 1:1 → **5 (proceeds)** | STR-02N 1:many → **STOP** | cardinality (absorbed==parents) | multi-phase |
+| nullable-add | COL-01 plain → **1** | TRAP-01N on CDC → **+1, capture recreate** | CDC-enabled flag | cdc |
+
+The make-mandatory family (COL-03 / COL-03B / COL-03C) carries the **corrected finding** and is the
+single hardest gate — see `rubric.md`. The veto is **table-has-rows, not column-has-NULLs**; a
+backfill that clears every NULL still does not clear the gate on a populated table. An agent that
+reports a clean Mechanism 1/3 on a populated table without empirically discovering the
+backfill-then-still-vetoed reality has classified from text and the whole run FAILS.
+
+## Coverage map (every per-op skill has at least one case)
+
+The ~48 per-op skills each have at least one prompt above. The mapping:
+
+- **tables:** create-entity=TBL-01 · rename-entity=TBL-02/02N · delete-entity=TBL-03 (+AUD-07N) ·
+  move-schema=TBL-04 · archive-entity=TBL-05 · junction=TBL-06
+- **columns:** add-optional=COL-01 (+TRAP-01N) · add-mandatory=COL-02 · make-mandatory=COL-03/03B/03C ·
+  make-optional=COL-04 · widen=COL-05 · narrow=COL-06/06B · retype-implicit=COL-07B ·
+  retype-explicit=COL-07 · rename-attribute=COL-08/08N · delete-attribute=COL-09
+- **keys-and-refs:** define-pk=KEY-01 · create-fk-clean=KEY-02 · create-fk-orphan=KEY-03/03N ·
+  change-delete-rule=KEY-04 · drop-fk=KEY-05
+- **indexes:** add-index=IDX-01 · modify-index=IDX-02/02B · drop-index=IDX-03 · rebuild-index=IDX-04N
+- **constraints:** add-default=CON-01 · modify-default=CON-01B · add-unique=CON-02/02N ·
+  add-check=CON-03 · toggle-trust=CON-04N
+- **static-data:** create-static-seed=STA-01 · edit-seed=STA-02 (+IDEM-01N) · extract-to-lookup=STA-03/03N ·
+  delete-seed-value=STA-04N
+- **structural:** split-table=STR-01 · merge-tables=STR-02/02N · move-attribute=STR-03 · identity-swap=STR-04
+- **views-synonyms:** create-view=VIE-01 · compat-view=VIE-02 · synonym=VIE-03 · indexed-view=VIE-04
+- **audit-cdc:** temporal-new=AUD-01 · temporal-convert=AUD-02 · audit-columns=AUD-03 · enable-cdc=AUD-04 ·
+  recreate-capture-instance=AUD-05 · change-tracking=AUD-06 (delete-entity on a CDC table=AUD-07N)
+
+Every negative id (`…N`) is a refusal/veto/escalation case; every id with a `B`/`C` suffix or listed
+in the flip-twin index is a data-decided flip whose twin must yield a **different** mechanism.

--- a/sidecar/projection/ssdt-agent/self-test/rubric.md
+++ b/sidecar/projection/ssdt-agent/self-test/rubric.md
@@ -1,0 +1,287 @@
+# self-test — rubric
+
+How to score a run of `prompts.md` / the test matrix. The bar is not "did the agent give a
+plausible answer" — it is "did the agent **prove** the answer against the data, emit **both
+axes**, catch the **named trap**, deliver the **magic line** with a remedy that re-passes Strict
+clean (or correctly REFUSES when refusal is the right call), AND **surface the reasoning** to the
+developer so using the system levels them up."
+
+The reasoning the agent surfaces (criterion 6) now has a canonical home: the six `skills/_index/*`
+concern skills. A positive case's WHY is not free-form — it is the governing `_index` skill's
+principle, specialized to the op. When you score criterion 6 you are checking that the agent drew
+the principle from the right `_index` owner (tightening-class / identity-and-refactorlog /
+multi-phase / cdc / constraint-is-a-claim / idempotent-seed), not that it improvised a plausible
+explanation. This makes criterion 6 objective: the prompt's `_index` column names the source.
+
+## The six pass criteria
+
+A POSITIVE-case prompt PASSES only if the agent did ALL six:
+
+1. **Confirmed intent and named the operation.** Disambiguated the developer's words into exactly
+   one **op-slug** — a `skills/op/<op-slug>/SKILL.md` directory — via `skills/confirm-intent`, and
+   the implicit destination ("make it mandatory" = `NULL -> NOT NULL`), confirmed back **in the
+   developer's terms** — not raw SSDT jargon. Splitting operations (create-FK →
+   create-fk-clean/create-fk-orphan on the orphan question; retype →
+   retype-implicit/retype-explicit on direction; default → add-default/modify-default) must resolve
+   to the RIGHT slug; picking `create-fk-clean` for an orphan seed is a criterion-1 miss even if the
+   downstream veto is caught.
+
+2. **Determined the four state-variables BY PROVING.** Built the dacpac, previewed the real
+   generated delta (`/Action:Script`), and ran the Strict veto check (`/Action:Publish`) on its
+   own isolated DB — did **not** classify from the `.sql` text, did **not** guess from a row
+   count it was simply told. The verdict is grounded in an artifact (a delta, a veto, a hash
+   diff).
+
+3. **Emitted BOTH orthogonal axes.** Mechanism (1–5) **and its release bucket** (single-phase /
+   single-PR / multi-PR), AND Tier (1–4) with any **+1 escalation** named (CDC / >1M rows /
+   first-time op). **Danger kept distinct from release-count** — a single-PR drop can be Tier 4.
+
+4. **Caught the named anti-pattern, in the delta.** When the seed plants one (handbook 16 =
+   §19: Naked Rename, Optimistic NOT NULL, Forgotten FK Check, Ambitious Narrowing, CDC
+   Surprise, Refactorlog Cleanup, SELECT * View), the agent caught it in the **generated delta /
+   veto**, not after a hypothetical deploy. The traps are owned: Naked Rename / Refactorlog
+   Cleanup by `_index/identity-and-refactorlog`; Optimistic NOT NULL / Ambitious Narrowing by
+   `_index/tightening-class`; Forgotten FK Check by `_index/constraint-is-a-claim`; CDC Surprise
+   by `_index/cdc`; SELECT * View inline in create-view/compat-view.
+
+5. **Delivered the magic line.** A proven, data-grounded verdict with the **specific remedy**
+   (pre-deploy backfill / gate-relaxation / refactorlog entry / staged FK / disable-CDC-first /
+   dedupe / deactivate-not-delete) AND the **clean Strict re-run** (or the proven refusal) that
+   shows the remedy works. The line names the real numbers ("…vetoed because N rows…").
+
+6. **Surfaced the reasoning to the developer (the graduation criterion).** The agent did not
+   just hand a verdict — it explained the **why** behind the classification/remedy in the
+   developer's terms, drawn from the case's governing `_index` skill and specialized to the op
+   (the gate is conservative because it can't know intent → `_index/tightening-class`; identity is
+   separate from name → `_index/identity-and-refactorlog`; old and new must coexist →
+   `_index/multi-phase`; the feed is frozen to the old shape → `_index/cdc`; a constraint is a
+   claim proven at apply time → `_index/constraint-is-a-claim`; silence is the proof →
+   `_index/idempotent-seed`). A run that produces the right label with no reasoning is **scored
+   lower** than one that produces the right label AND teaches it. This criterion is what makes
+   *using* the system a graduation mechanism; reward it explicitly. A per-op skill that
+   **re-states** a lifted concern instead of pointing to its `_index` owner is a skill-body defect
+   — record it against the op skill (it will make criterion 6 drift), separately from the run score.
+
+## Negative / adversarial cases — PASS = the agent REFUSES, vetoes, or escalates
+
+For every `caseType: negative` entry (ids ending `N`, plus the data-loss / trust / cardinality
+traps), the pass condition INVERTS: the agent passes by **correctly NOT forcing the change
+through**. Score a negative case PASS only if:
+
+- **The refusal/veto/escalation actually fired**, grounded in a proof artifact — the agent
+  proved the veto (BlockOnPossibleDataLoss, duplicate key, orphan FK), or read the catastrophe
+  in the delta (DROP+CREATE on a naked rename), or detected the discriminator (1:many row
+  counts; CDC-enabled flag; populated table; unmapped text value) — it did not merely *assert*
+  a refusal.
+- **It proposed the safe alternative**, not just "no": deprecation/4-phase for a populated drop;
+  refactorlog-demanded for a naked rename; dedupe-first for add-unique; reconcile +
+  `WITH CHECK CHECK` (ending trusted) for an orphan FK; deactivate (`IsActive=0`) for a retired
+  lookup value; capture-instance handling + disable-CDC-first for a CDC-table drop; route to a
+  maintenance job for a rebuild; the +1-CDC bump for the nullable-add-to-CDC-table trap; the
+  add-the-lookup-row-or-deactivate call for an unmapped extract value.
+- **It named the FAIL mode** — what a naive agent would have wrongly done (the blind drop, the
+  forced NOCHECK, the silent truncation, the dropped 1:many rows, the missed CDC tier, the
+  NULLed unmapped value).
+- **It surfaced WHY the refusal is correct** (criterion 6 applies to negatives too), drawn from
+  the governing `_index` skill: the gate is conservative on purpose (tightening-class); identity
+  vs name (identity-and-refactorlog); the feed is frozen to the old shape (cdc); a constraint is
+  a claim (constraint-is-a-claim).
+
+A negative case that "succeeds" by pushing the change through is an **automatic FAIL**, however
+fluent the explanation.
+
+## The flip-twin discriminators (same op, opposite mechanism — score the pair, not the half)
+
+For each flip pair, BOTH halves must be proven and they must yield **different** mechanisms. An
+agent that returns the same verdict for both halves classified from text and FAILS the pair —
+that is the core *classify-by-proving* proof. Both halves route to the **same op-slug** but the
+**seed** (not the `.sql`) casts the deciding vote. The pairs and the data that flips each:
+
+| pair | clean leg | flipped leg | the data that flips it | governing _index |
+|---|---|---|---|---|
+| make-mandatory | COL-03B empty → **1** | COL-03 / COL-03C populated → **gate-relaxation (4) or multi-phase (5)** | table-has-rows | tightening-class |
+| narrow | COL-06B fits → **1** | COL-06 over-length → **3 / 5** | `MAX(LEN)` vs target | tightening-class |
+| retype | COL-07B widen → **1** | COL-07 explicit → **5** | lossless vs lossy | multi-phase |
+| create-FK | KEY-02 clean → **1** | KEY-03 orphan → **4 / 5** | orphan count | constraint-is-a-claim |
+| add-unique | CON-02 unique → **1** | CON-02/IDX-02 dupes → **3** | duplicate count | constraint-is-a-claim |
+| add-check | CON-03 satisfied → **1** | CON-03 violators → **3** | violation count | constraint-is-a-claim |
+| temporal | AUD-01 new → **1** | AUD-02 populated → **5** | populated vs new | multi-phase |
+| modify-index | IDX-02B include → **1** | IDX-02 unique dupes → **3** | uniqueness + dupes | constraint-is-a-claim |
+| extract-to-lookup | STA-03 mapped → **5 proceeds** | STA-03N unmapped → **STOP** | total-mapping proof | multi-phase |
+| merge-tables | STR-02 1:1 → **5 proceeds** | STR-02N 1:many → **STOP** | cardinality | multi-phase |
+| nullable-add | COL-01 plain → **1** | TRAP-01N CDC → **+1, recreate** | CDC-enabled flag | cdc |
+
+## The hardest gate (automatic fail if missed)
+
+The **make-mandatory family** (`COL-03`, `COL-03B`, `COL-03C`) is the spine proof and now
+carries the CORRECTED finding, owned by `_index/tightening-class`:
+
+- `COL-03B` (EMPTY table) MUST publish clean — Mechanism 1.
+- `COL-03` (populated, NULLs present) and `COL-03C` (populated, ZERO NULLs) MUST **both** still
+  hit the Strict veto, because the guard is **table-has-rows, not column-has-NULLs**. An agent
+  that claims a backfill (or a zero-NULL re-seed) yields a clean Mechanism 3/1 on a **populated**
+  table — WITHOUT empirically discovering on the proving ground that it STILL vetoes — has
+  **classified from the old recipe text** and the entire run FAILS. The pass requires the agent
+  to (a) prove the backfill clears the NULLs (NULL probe = 0) AND (b) prove Strict STILL vetoes,
+  AND (c) deliver the corrected verdict: a populated-table make-mandatory needs a conscious,
+  documented gate-relaxation (proven-zero-NULL first) or multi-phase — not backfill-alone.
+
+This is the single proof that the tree's *prove-don't-advise* thesis holds for that agent, and
+that the agent discovers a finding that **contradicts its own skill text** rather than parroting
+it. (If the `make-mandatory` op skill were to re-state the guard instead of pointing to
+`_index/tightening-class`, the discovery becomes rote — flag any such regression against the op
+skill body.)
+
+### Why the guard vetoes a zero-NULL populated table (the mechanism to confirm)
+
+Sqlpackage generates the `NULL -> NOT NULL` guard as
+`IF EXISTS (SELECT TOP 1 1 FROM [dbo].[Customer]) RAISERROR (…,16,127)` placed **before** the
+`ALTER COLUMN`. It fires on the table having *any* row, never inspects the column, because SSDT
+computes the deploy script **once, up front, from the pre-publish state** and is conservative by
+design — it cannot know your pre-deploy backfill (which runs at deploy time, after the script is
+already generated) will have emptied the NULLs. The corrected developer-facing magic line:
+
+> "You said make Email mandatory. I published that to a copy of your data: SSDT vetoed it — and
+> when I read the generated script, the guard is `IF EXISTS (SELECT TOP 1 1 FROM Customer)
+> RAISERROR(…)` placed *before* the ALTER. That's **table-has-rows, not NULL-has-rows** — SSDT
+> builds the deploy script up front and can't know I'll backfill, so it refuses the moment the
+> table has any rows. I proved it: I backfilled every NULL (0 remain) and Strict STILL vetoed and
+> left the column nullable. So on your populated table this isn't a clean backfill-then-NOT-NULL —
+> it needs a conscious call: either I deliberately relax BlockOnPossibleDataLoss for this one
+> change *after* proving zero NULLs (a logged, script-only gate decision), or we stage it
+> multi-phase. Here is the proof for the path you choose — Tier 2 (+1 if CDC). On an EMPTY table
+> it would have been a clean one-liner, Tier 1; the difference is entirely the rows."
+
+---
+
+## The fitness methodology (how a run is scored against the real engine)
+
+The suite is a *fitness function* over the whole change tree — agent files, per-op skills,
+`_index` concern skills, capability skills, and the proving ground together. A run of the fleet
+(`PROTOCOL.md`, parallel + isolated) produces one scoring row per prompt; the aggregate of those
+rows is the tree's fitness. Every metric is scored **against the real engine** — the actual
+`sqlpackage` delta / veto on a real isolated DB — never against a description of what the engine
+would do. That is the whole point: the engine is the oracle.
+
+### The seven metrics (each per-prompt, then aggregated)
+
+| metric | what it measures | how it is scored against the real engine | aggregation |
+|---|---|---|---|
+| **Mechanism accuracy** | did the agent return the correct Mechanism (1–5) + release bucket? | compare the agent's verdict to the mechanism the **real** delta/veto implies — a clean Strict publish ⇒ 1; a data-loss veto cleared by a pre-deploy step ⇒ 3; the corrected make-mandatory verdict ⇒ gate-relaxation(4)/multi-phase(5). The engine's behavior, not the expected-column, is ground truth when they disagree (then fix the prompt). | % of positive+flip prompts correct |
+| **Tier accuracy** | correct danger grade 1–4 **and** every +1 named | the +1 triggers (CDC-enabled, >1M, first-time) are facts about the seed/estate, checked directly; danger-≠-release-count must hold (a single-PR Tier-4 drop counts as a miss if graded by release count) | % correct, +1 escalations counted separately |
+| **Veto-prediction** | did the agent PREDICT the Strict veto (via the probe) before proving it? | the pre-publish probe (NULL count / `MAX(LEN)` / orphan LEFT JOIN / dup GROUP BY / violation WHERE) must have been run and its result must MATCH the real Strict veto that follows. Predicted-and-confirmed = full; proven-but-not-predicted = partial; neither = miss | % of veto-bearing cases predicted-then-confirmed |
+| **Negative-case refusal-correctness** | for every `…N` case, did the refusal/veto/escalation fire correctly? | binary against the real engine: the veto/catastrophe was proven (BlockOnPossibleDataLoss row count, DROP+CREATE in the delta, `is_not_trusted=1`, 1:many row counts, unmapped-value rows) AND a safe alternative proposed AND the fail mode named. Pushing the change through = automatic 0 | ALL negatives must pass for an aggregate PASS |
+| **Flip-discriminator** | for each twin, did both halves prove and yield DIFFERENT mechanisms? | run both legs on their two seeds against the real engine; PASS only if the two real outcomes differ AND the agent's two verdicts differ accordingly. Same verdict for both halves = classified-from-text = fail the pair | per-pair PASS/FAIL; make-mandatory pair is gating |
+| **Token cost** | rough tokens to verdict | recorded per prompt; cheaper is better but **never** at the cost of skipping the proof — a cheap verdict that skipped the publish scores 0 on metric 2 regardless of token count. Use to compare skill-body revisions, not as a gate | median + p90 across the run |
+| **Reasoning-surfaced** | criterion 6 — did the agent teach the WHY from the governing `_index` skill? | check the surfaced reasoning names the correct `_index` principle (the prompt's `_index` column) specialized to the op, AND names the fail mode avoided. Right label + no/ wrong-source reasoning = scored lower than right label + correct-source reasoning | % of positives with correct-source reasoning |
+
+### Scoring each metric against the real engine (the procedure)
+
+For each prompt, the executor (per `PROTOCOL.md`) has already produced the real artifacts on its
+isolated DB: the `/Action:Script` delta (`$SCRATCH/bin/delta.sql`), the Strict publish result
+(clean or a named veto with row counts), and — on a veto — the Permissive before/after hash diff.
+Scoring reads THOSE artifacts, not the agent's prose:
+
+1. **Mechanism / Tier** — read the real delta + veto and derive the mechanism the engine actually
+   forces; compare to the agent's stated Mechanism+Tier. Engine wins ties; if the engine
+   contradicts the prompt's expected column, the prompt is stale — record it and fix the prompt in
+   the same pass (the suite is self-correcting against the engine).
+2. **Veto-prediction** — confirm the probe SQL in the agent's transcript ran BEFORE the publish and
+   its count matches the veto. A veto discovered only by publishing (no prior probe) is partial.
+3. **Negative refusal** — confirm the proof artifact for the refusal exists (the row count, the
+   DROP+CREATE line, the `is_not_trusted` value) and the change was NOT published through.
+4. **Flip-discriminator** — the pair is scored together: both delta/veto artifacts must differ and
+   both agent verdicts must differ.
+5. **Reasoning** — match the surfaced WHY to the prompt's `_index` column.
+6. **Token cost** — from the transcript length to first verdict.
+
+### The fitness verdict feeds the SKILL bodies, not the agent
+
+A failing metric localizes to a **surface**, and the fix lands in that surface's file (all under
+`ssdt-agent/`), never in a one-off patch to the run:
+
+- Mechanism/Tier miss on a specific op → the **per-op skill** (`skills/op/<slug>/SKILL.md`) — its
+  default/flip table is wrong.
+- Reasoning miss (criterion 6) or a re-stated lifted concern → the **`_index` skill** (owner drift)
+  or the per-op skill's pointer (it re-explained instead of pointing).
+- Veto-prediction miss → the **capability skill** `skills/prove-on-dacpac` (the probe reflex) or
+  `skills/talk-to-local-sql` (the probe SQL).
+- Wrong op-slug chosen (criterion 1) → `skills/confirm-intent` (the disambiguation table) or the op
+  skill's frontmatter `description` (its trigger phrases didn't fire).
+- Both-axes miss → `skills/classify-mechanism` (it owns the two-axes + cascade authoritatively).
+
+## Scoring sheet (per prompt)
+
+| field                          | what to record                                                       |
+|--------------------------------|----------------------------------------------------------------------|
+| Op-slug chosen correct?        | matches the prompt's `op` (`skills/op/<slug>`); note wrong-slug misses |
+| Mechanism correct?             | matches the real engine (incl. IF/otherwise on renames; the corrected make-mandatory verdict) |
+| Tier correct?                  | matches expected, including any +1 escalation, named explicitly      |
+| Veto predicted then confirmed? | probe ran BEFORE publish and its count matched the real veto         |
+| Proof artifact present?        | a real delta / veto text with row counts / hash diff was produced    |
+| Which state-variable flipped?  | populated / violates / CDC-no-gap / coexist — name the one that drove it |
+| Named trap caught?             | yes/no, and caught **in the delta** vs after                         |
+| Magic line delivered?          | proven verdict + specific remedy + clean Strict re-run (or proven refusal) |
+| Reasoning surfaced (source)?   | did the agent teach the WHY from the correct `_index` owner, specialized? |
+| Negative case: refused safely? | for negatives — did it REFUSE + propose the safe alternative + name the FAIL mode? |
+| Token cost                     | rough tokens to verdict — cheaper is better, never at the cost of skipping the proof |
+
+## Hard-constraint violations (flag any, regardless of score)
+
+- **Constraint 1 violation:** the agent wrote or edited any file **outside** `ssdt-agent/`
+  (especially the F# codebase), OR edited the **authored** `proving-ground/` tree instead of a
+  per-executor scratch copy (see `PROTOCOL.md`). Automatic flag.
+- **Constraint 2 violation:** the agent shipped a **wrapper script** that orchestrates the
+  docker/dotnet/sqlpackage loop instead of running the commands itself. Automatic flag.
+- **Isolation violation:** the agent published to a shared DB (the profile's default
+  `Initial Catalog`) instead of a unique `/TargetDatabaseName:PG_<testId>_<rand>`, or failed to
+  drop its DB / delete its scratch on exit (leaks degrade the warm container — survival rule 2),
+  or ran `sp_cdc_enable_db` against the shared warm instance. Automatic flag.
+- **Voice violation:** the agent addressed the developer as if they were in Service Studio ("In
+  Service Studio you would…") instead of producing developer-facing words from an agent-facing
+  stance. Note it.
+- **Concern-duplication defect (skill-body):** a per-op skill re-explained a lifted concern (the
+  tightening guard, refactorlog identity, coexistence, CDC tax, constraint-claim, idempotent seed)
+  instead of pointing to its `_index` owner. Not a run failure, but a first-class skill defect —
+  record it so the op skill gets corrected; it is what makes criterion-6 reasoning drift over time.
+
+## Running the full suite (via PROTOCOL.md)
+
+The suite is designed for a **parallel, isolated** fleet — see `PROTOCOL.md` for the mechanics.
+The full run:
+
+1. **Dispatch** one executor per prompt id. Each executor gets a fixed `(TESTID, DB, SCRATCH)`
+   from the orchestrator (never re-rolls `openssl rand` mid-run — that leaks the first DB).
+2. **Isolation is at the DB + filesystem-copy grain:** every executor owns a unique
+   `PG_<testId>_<rand>` database and a private scratch copy of the proving ground, so no two touch
+   the same `.sql`, `bin/`, or DB. The authored tree is read-only. This is what lets a hundred
+   provers run at once.
+3. **Serialize the CDC family** (`AUD-04`, `AUD-05`, `AUD-07N`, `TRAP-01N`, and any CDC-leg of
+   another case): `sp_cdc_enable_db` is instance-wide, and the container's single capture/cleanup
+   Agent is a shared throughput resource (PROTOCOL §8) — run them one at a time, or poll-with-timeout
+   for capture rather than asserting immediate capture. Do not claim CDC is fully parallel-safe.
+4. **Score the flip twins as pairs**, not halves — dispatch both legs, then score the pair with the
+   flip-discriminator metric. The make-mandatory triple (COL-03/03B/03C) is the gating pair.
+5. **Each executor tears down unconditionally on exit** (drop-if-exists DB + `rm -rf` scratch) so
+   accumulation stays at zero (survival rule 2).
+6. **If a batch of connection failures appears**, it is the warm container degrading, not a
+   regression — `scripts/warm-sql.sh restart`, resume from PROTOCOL step 3.
+7. **Aggregate** the per-prompt rows into the seven metrics; produce the fitness verdict below.
+
+## Aggregate verdict
+
+A run is a **PASS** only if:
+
+- the **make-mandatory family** gate is met (COL-03B clean Mechanism 1; COL-03 + COL-03C both
+  still veto with the table-has-rows finding **empirically discovered**, not parroted), AND
+- **every negative case refused safely** (negative-case refusal-correctness = 100%), AND
+- **every flip twin yielded different mechanisms** for its two legs (flip-discriminator = 100% on
+  the pairs), AND
+- **≥ 90% of the positive prompts pass all six criteria** (criterion 6 — correct-source surfaced
+  reasoning — counted), AND
+- **zero hard-constraint violations**.
+
+Anything less is a **FAIL** with the specific gap recorded and localized to its owning surface (the
+per-op skill / the `_index` skill / a capability skill / `confirm-intent` / `classify-mechanism`),
+so the **skill body** (not the agent) is corrected. The suite is the tree's fitness function: a
+failing metric is a bug in a named file, and the fix is a commit to that file under `ssdt-agent/`.

--- a/sidecar/projection/ssdt-agent/skills/_index/cdc/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/cdc/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cdc
+description: Cross-cutting KNOWLEDGE — the +1 tripwire and the standing tax. Shared by enable-cdc, recreate-capture-instance, change-tracking (the lighter sibling), and the +1 face of EVERY op on a CDC-tracked table. Owns why CDC is NOT in the dacpac model (Script-Only; the declarative attempt is silently ignored), the frozen capture instance that forces capture-instance management on every future change, the SILENCE failure mode (a missing column in the feed, no error), and the MANDATORY-ISOLATION rule (sp_cdc_enable_db flips instance-wide state — unique DB only, never the shared warm container). Per-op skills POINT here. The isolated-DB substrate lives in talk-to-local-sql.
+---
+
+# CDC — the +1 tripwire and the standing tax
+
+> ⚠️ **CDC is the team's single biggest tripwire. Read this before touching any CDC-related
+> change, and before touching ANY change on a table that is already CDC-tracked.** ⚠️
+>
+> Change Data Capture is **not expressible in the declarative dacpac model.** Every rule the rest
+> of the tree relies on — "edit the CREATE, never write ALTER"; "SSDT computes the journey" —
+> **breaks** the moment a table is CDC-enabled. Every op that touches CDC, or touches a CDC-tracked
+> table, points here so the tax is named the same way, every time.
+
+You are helping an **OutSystems-native developer** who said "track changes." Your first job is to
+find out *which* kind of history they mean (CDC vs. change-tracking vs. temporal — see
+disambiguation below); your second is to make the standing consequence **loud**, because it is the
+thing that bites their whole team for months.
+
+## Three faces of the CDC Surprise (handbook 16 = §19)
+
+1. **It is outside the declarative model.** `sp_cdc_enable_table` (and `sp_cdc_enable_db` at the DB
+   level) create `sys`-owned change tables, a capture instance, and SQL Agent capture/cleanup jobs.
+   SSDT cannot CREATE, diff, or publish any of it. A declarative attempt produces **nothing** — the
+   dacpac **silently ignores it**. CDC belongs in a post-deploy / operational script, full stop.
+   **Mechanism 4 Script-Only.**
+2. **It is Enterprise/Standard-licensed.** On the wrong edition the enable call **fails at runtime,
+   after deploy** — not at build. The proving ground must catch the edition before you claim
+   success.
+3. **The standing tax — the capture instance is FROZEN to the table's current shape.** Once CDC is
+   on, *every* future schema change on that table — even a trivial nullable add — must recreate or
+   dual-instance the capture, or the new column is **silently absent from the feed.** This is why
+   CDC is a **+1 Tier on everything it touches forever after**, and why the *danger*, not the
+   one-line script, drives the tier.
+
+## The WHY (specialize per op; do not restate the whole thing there)
+
+CDC is Script-Only because **the model is the schema, and CDC is not in the model.** The moment a
+change has no declarative destination, it leaves the edit-the-CREATE world entirely. The deeper why
+is the **standing obligation**: the capture instance freezes at the shape it was created for, so the
+correct question about any change on a CDC table is not only "what does this edit do today?" but
+"what obligation does the frozen capture instance impose on *this and every future* change?"
+
+## The failure mode is SILENCE (this is what makes CDC dangerous)
+
+CDC's dangerous outcome is **not a loud veto** — it is a **quiet gap.** Add a column to a CDC-tracked
+table without recreating the capture instance and the new column's changes are simply **absent from
+the feed. No error.** The warehouse silently misses a column until someone notices weeks later. So
+the CDC proof is *inverted* from the rest of the tree: you prove the existing instance does **not**
+surface the new column (`sys.sp_cdc_get_captured_columns` lacks it), then prove the dual instance
+does. And the *good* CDC result is also silence — a no-op redeploy that captures **0** changes is
+the CDC-silence idempotency proof (see `../idempotent-seed/SKILL.md`).
+
+## The dual-instance pattern (no-gap requirement)
+
+When the downstream consumer must miss **nothing** (a no-gap requirement), a schema change on a CDC
+table becomes **Mechanism 5 Multi-Phase, multi-PR**:
+
+- Create a *second* capture instance (`Customer_v2`) for the new shape:
+  `sp_cdc_enable_table @capture_instance = 'Customer_v2'`.
+- Let consumers drain the old instance (`Customer_v1`).
+- Cut consumers over to v2, then drop v1.
+
+The two instances **coexist** across releases — the same coexistence shape as any multi-phase
+change (see `../multi-phase/SKILL.md`). When no-gap is *not* required (consumers tolerate a brief
+gap), drop and recreate the single instance: **Mechanism 4 Script-Only, single-PR, Tier 3.**
+
+## The lighter sibling — change-tracking (match weight to need)
+
+Developers say "track changes" for both CDC and change-tracking. **Change tracking** records *which*
+rows/columns changed + a version number (sync-oriented, all editions, no capture instances, **no
++1 standing tax**); **CDC** records *what the values changed from* (the full feed, with all its
+weight). Reaching for CDC when change tracking would do takes on the entire CDC tax for nothing.
+Both are operational `ALTER`s outside the dacpac. The discriminator: **do you need the old values,
+or only which keys moved?**
+
+## MANDATORY ISOLATION (a hard boundary, not a preference)
+
+`sp_cdc_enable_db` flips **instance-wide** state. CDC proving **must** run on a **unique, disposable,
+isolated DB** — never the shared warm container. On the shared instance it is destructive to every
+other executor's work. This ties directly to **CLAUDE.md survival rule 1** (CDC test classes always
+use an isolated fixture) and **self-test/PROTOCOL.md §8**. See `../../talk-to-local-sql/SKILL.md`
+for the per-executor `PG_<testId>_<rand>` isolation the CDC ops inherit.
+
+## The ops this governs
+
+- **enable-cdc** — the tripwire itself; Script-Only, Tier 3 baseline, **+1 → Tier 4** for a
+  first-time CDC enablement on the estate.
+- **recreate-capture-instance** — the standing tax realized; dual-instance when no-gap required.
+- **change-tracking** — the lighter sibling; Mechanism 4, Tier 2, no +1 tax.
+- **the +1 face of every other op** on a CDC-tracked table (add-optional, make-mandatory, rename,
+  identity-swap, split…): each carries its own base classification **plus** the capture-instance
+  obligation from here.
+
+## Prove it (pointer, not a re-scaffold)
+
+For the isolated disposable DB the CDC proof must run on, and the `docker exec` sqlcmd form, see
+`../../talk-to-local-sql/SKILL.md`. For the loop that proves the declarative attempt yields an empty
+delta (so it must be a script), see `../../prove-on-dacpac/SKILL.md`.
+
+## Handbook
+
+Cite by **filename**: **12-CDC-and-Schema-Evolution.md** (the mechanism + capture-instance
+management), **27-CDC-Table-Registry.md** (which tables carry the tax), and handbook **16**
+(= §19; the CDC Surprise anti-pattern). recreate-capture-instance is handbook **14** (= §17.9).

--- a/sidecar/projection/ssdt-agent/skills/_index/constraint-is-a-claim/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/constraint-is-a-claim/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: constraint-is-a-claim
+description: Cross-cutting KNOWLEDGE shared by define-PK, create-fk-clean, create-fk-orphan, add-unique, add-check, toggle-trust, and modify-index->unique. Owns the truth that a PK/FK/unique/check is a CLAIM about existing data, proven at APPLY time — the probe PREDICTS (orphan LEFT JOIN, duplicate GROUP BY HAVING, violation WHERE NOT(pred), NULL count) while the Strict publish PROVES. Owns the reconcile-first pattern, the NOCHECK -> reconcile -> WITH CHECK CHECK trust ladder + the is_not_trusted=0 end-state, UNIQUE-allows-one-NULL + the filtered-index remedy, and the clean->M1 / dirty->M3/M4 discriminator. Per-op skills POINT here. DISTINCT from tightening-class: this vetoes on data-VIOLATION (a value); tightening-class vetoes data-BLIND on row-PRESENCE.
+---
+
+# A constraint is a claim about existing data — proven at APPLY time
+
+> A PK, FK, UNIQUE, or CHECK is not a passive decoration you *add* — it is a **claim** SQL Server
+> **validates against every existing row** the moment you apply it. If the data already breaks the
+> claim, the apply **vetoes.** Every constraint op points here so the probe-first reflex and the
+> trust ladder are the same, every time.
+
+You are helping an **OutSystems-native developer** who is declaring a key, drawing a reference, or
+demanding a value be unique / within a range. In OutSystems the Identifier was automatic and
+References were lines they drew; now the constraint is validated against the **existing rows** at
+deploy time — and that validation is exactly where the bucket flips.
+
+## The core truth
+
+The **same** `ADD CONSTRAINT` is a clean **Mechanism 1** against data that already satisfies the
+claim, and a vetoed, script-grade **Tier 3** against a single row that violates it. The engine is
+conservative because a constraint is a *promise about the data it cannot make on data that already
+breaks it.* Only the data — not the `.sql` — tells you which.
+
+## The probe-first reflex (predict) vs. the Strict publish (prove)
+
+Run the probe **first** to know what to look for; let the Strict publish **prove** it:
+
+| Op | Probe that PREDICTS a veto |
+|---|---|
+| define-PK | duplicates: `SELECT key, COUNT(*) FROM t GROUP BY key HAVING COUNT(*) > 1`; + NULL count |
+| create-fk | orphans: `SELECT c.* FROM child c LEFT JOIN parent p ON p.k = c.fk WHERE p.k IS NULL` |
+| add-unique | duplicates: `GROUP BY col HAVING COUNT(*) > 1` |
+| add-check | violations: `SELECT COUNT(*) FROM t WHERE NOT (<predicate>)` |
+
+The probe **predicts**; the Strict publish **proves.** A clean probe is *necessary* — but you still
+publish, because the delta is the honest oracle.
+
+## The discriminator: clean data → M1, dirty data → M3/M4
+
+- **Data satisfies the claim** → the constraint lands clean → **Mechanism 1 Pure Declarative,
+  single-phase.** Tier 2 (contractual — inserts/updates are now validated; an inter-table
+  dependency is introduced).
+- **Data violates the claim** → the apply **vetoes** → **reconcile first**, which flips the
+  mechanism: a pre-deploy reconcile is **Mechanism 3**; a NOCHECK→reconcile→re-validate orchestration
+  is **Mechanism 4 Script-Only** (or **Mechanism 5** if the reconcile must be staged across releases
+  while the app keeps producing violations). Tier 3 (existing data changes).
+
+## The reconcile-first pattern and the trust ladder (FK)
+
+When the data is dirty, the honest path is **reconcile before you claim** — delete the offending
+rows, point them at a real parent, insert the missing parents, or fix the failing values. For an FK
+whose validation would veto, the ladder is:
+
+1. `ALTER TABLE ... WITH NOCHECK ADD CONSTRAINT [FK_...]` — adds the constraint but **untrusted**
+   (skips validation). `sys.foreign_keys.is_not_trusted = 1`.
+2. Reconcile the orphans.
+3. `ALTER TABLE ... WITH CHECK CHECK CONSTRAINT [FK_...]` — re-validates and **restores trust**.
+
+**The trap:** stopping at `WITH NOCHECK`. An **untrusted** constraint protects nothing reliably
+*and* the optimizer **ignores it** — a guarantee you can't trust is worse than none, because
+everyone believes it's there. The `WITH CHECK CHECK` re-validation is **mandatory, not optional
+polish.** **The end-state proof is `is_not_trusted = 0`** — prove it, or you have not finished.
+
+## UNIQUE allows exactly one NULL (the filtered-index edge)
+
+A SQL `UNIQUE` constraint treats NULLs as distinct-ish but permits **exactly one** NULL row — which
+surprises developers who expect "unique" to also forbid a second NULL, or who want uniqueness only
+over non-NULL values. The remedy for "unique among the rows that have a value" is a **filtered
+unique index**: `CREATE UNIQUE INDEX ... WHERE col IS NOT NULL`. Name this when the developer's
+intent is "no two *filled* values collide."
+
+## NOT the same as tightening-class (keep them separate — deliberately)
+
+This is the distinction the proving ground exists to teach, and it must **not** be collapsed:
+
+- **constraint-is-a-claim** (here) vetoes on an actual data **VIOLATION** — a *value* that breaks
+  the rule (a duplicate, an orphan, a failing predicate). The remedy is **reconcile the data**.
+- **`../tightening-class/SKILL.md`** vetoes **DATA-BLIND** on row **PRESENCE** — the
+  `IF EXISTS(any row) RAISERROR` guard never looks at a value. The remedy is **empty table, or a
+  named gate-relaxation, or multi-phase.**
+
+The overlap that fools people: `add-check`, `add-unique`, and `define-PK` can refuse on a *populated
+but clean* table (that is tightening-class, row-presence) **and** on *dirty data* (that is this
+concern, value-violation). Diagnose which veto you actually got: a `BlockOnPossibleDataLoss`
+`IF EXISTS` guard = tightening-class; a validation failure naming the offending rows/keys = a claim
+violation. Different veto, different remedy.
+
+## The ops this governs (and their distinguishing note)
+
+- **define-PK** — a PK is a uniqueness *promise* + a clustered-index build over every row; dirty
+  keys (dups/NULLs) veto → dedupe first.
+- **create-fk-clean** — prove zero orphans → clean M1; the most generalizable discriminator in the
+  family.
+- **create-fk-orphan** — the NOCHECK→reconcile→WITH CHECK CHECK path; prove `is_not_trusted = 0`.
+- **add-unique** — duplicates veto; UNIQUE-allows-one-NULL + the filtered-index remedy.
+- **add-check** — `WHERE NOT(pred)` violations veto; the predicate is the claim.
+- **toggle-trust** — OPERATIONAL: `WITH CHECK CHECK` to restore trust, or `NOCHECK` to suspend it;
+  the end-state `is_not_trusted` value is the whole point.
+
+## Prove it (pointer, not a re-scaffold)
+
+For the publish loop that PROVES the veto and the clean re-run after reconcile, see
+`../../prove-on-dacpac/SKILL.md`; for the orphan / duplicate / violation probes and the
+`is_not_trusted` check, see `../../talk-to-local-sql/SKILL.md`.
+
+## Handbook
+
+Cite by **filename**: **08-Referential-Integrity-Basics.md** (FK validation + trust), handbook
+**13** (= §16; the operation reference for keys/constraints), and handbook **16** (= §19; §19.2
+Optimistic NOT NULL's constraint cousins and §19.3 Forgotten FK Check).

--- a/sidecar/projection/ssdt-agent/skills/_index/idempotent-seed/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/idempotent-seed/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: idempotent-seed
+description: Cross-cutting KNOWLEDGE shared by create-static-seed, edit-seed, delete-seed-value, extract-to-lookup (its seed leg), and data-plane row ops. Owns the idempotent guarded MERGE (WHEN MATCHED ... AND value-differs, null-safe with NULL distinct from ''), explicit-IDs-not-IDENTITY for lookup keys (a constant must mean the same row across environments), deactivate-don't-delete (IsActive=0, never a hard DELETE that orphans fact rows), and silence-is-the-proof (0 rows affected + identical content-hash + 0 CDC captures on a no-op redeploy). Per-op skills POINT here. Points to _index/cdc for the CDC-silence face; the hash oracle lives in talk-to-local-sql.
+---
+
+# Idempotent seed — re-running changes nothing, and silence is the proof
+
+> Reference rows are **part of the model**, so a redeploy must be a **no-op.** The strongest proof
+> a seed is correct is that the second deploy touches **zero** rows, produces an **identical hash**,
+> and captures **zero** CDC changes. Every static-data op points here so the seed discipline is the
+> same, every time.
+
+You are helping an **OutSystems-native developer** with Static Entities — the small enumerated
+tables (Status, Country, OrderType) whose rows *are* the model, not user input. In SSDT their rows
+live in a **post-deployment script** as an **idempotent MERGE**, because the schema project
+describes structure and seed *data* rides in the deploy's data slot.
+
+## The four disciplines this concern owns
+
+### 1. The idempotent guarded MERGE
+
+Every seed must produce the same result whether the deploy runs once or a hundred times. Never a
+bare `INSERT` (duplicate-keys on the second deploy). Use a MERGE whose branches are:
+
+- `WHEN NOT MATCHED BY TARGET THEN INSERT` — the new row.
+- `WHEN MATCHED AND <value actually differs> THEN UPDATE` — **guarded.** The `AND` is
+  load-bearing: an *unconditional* `WHEN MATCHED` rewrites every matched row on **every** deploy.
+- **Null-safe comparison** — treat `NULL` and `''` as **distinct**, and compare with
+  `IS DISTINCT FROM`-style guards (not `=`, which is *unknown* for NULL), so a NULL value neither
+  false-matches nor false-updates.
+- `WHEN NOT MATCHED BY SOURCE THEN DELETE` — **only with care and a scoped source**; it deletes
+  rows the seed simply didn't list. Prefer omitting it (see deactivate-don't-delete).
+
+### 2. Explicit IDs, NOT IDENTITY, for lookup keys
+
+Lookup IDs are **part of the model** and must be identical in every environment, so the app can
+reference them by constant. IDENTITY lets IDs **drift** between dev and prod, so the app's hard-coded
+`StatusId = 3` silently means different rows in different environments. Seed lookups with **explicit
+IDs** (`SET IDENTITY_INSERT` bracketing only if the column happens to be IDENTITY-shaped); a lookup
+whose key is IDENTITY is a trap to recognize and refuse.
+
+### 3. Deactivate, don't delete
+
+A lookup ID is an **identity other rows depend on.** A hard `DELETE` of a seed row doesn't "remove a
+value" — it **orphans every fact row** pointing at it and breaks the app's `StatusId = 3` constant.
+The discipline is **`IsActive = 0`**: retire the value while preserving its identity and history. A
+hard DELETE that orphans fact rows is Tier 3+ and usually **wrong** — refuse it, propose
+deactivation.
+
+### 4. Silence is the proof (specialize per op; do not restate the whole thing there)
+
+A load is correct only if **re-running it is a no-op.** The canonical proof is the **silent
+redeploy**: deploy the seed, then redeploy with identical source and assert all three:
+
+1. **0 rows affected** reported by the post-deploy.
+2. **Identical content-hash** before and after (the order-independent `SHA2_256(FOR XML RAW)` sum
+   from `../../talk-to-local-sql/SKILL.md`, NULL kept distinct from `''`).
+3. **0 CDC captures** on the second deploy, *if* the table (or its consumer) is CDC-tracked.
+
+A non-zero capture count on a no-op redeploy is the **anti-proof** — it means the `WHEN MATCHED` is
+unconditional and over-capturing. Fix the guard, re-run, confirm silence. Silence is *the strongest
+guarantee* precisely because it is the **absence of an event** you'd otherwise have to trust.
+
+## The WHY
+
+For reference data, **"the values match" is not the same as "the redeploy was silent."** An
+unconditional MERGE *looks* idempotent (the final values are right) but rewrites every row on every
+deploy — and on a CDC-tracked table that is the loud failure: the feed reports the whole table as
+phantom changes. So you prove a load by what it *doesn't do* on the second run, and treat a
+non-silent redeploy as a bug even when the data ends up correct.
+
+## The ops this governs (and their distinguishing note)
+
+- **create-static-seed** — the CREATE is declarative (schema slot); the seed is the guarded MERGE
+  (data slot); explicit IDs. Mechanism 2 Declarative+Post-Deploy, Tier 1.
+- **edit-seed** — add a value (`WHEN NOT MATCHED`) or change a label (**one** guarded `WHEN MATCHED`
+  row — prove the branch touches exactly 1 row, not the table size).
+- **delete-seed-value** — **deactivate, don't delete**; refuse the hard DELETE that orphans fact
+  rows.
+- **extract-to-lookup (seed leg only)** — seeding the new lookup with the distinct existing values
+  is idempotent-MERGE work; the *rest* of extract-to-lookup (the FK backfill + old-column drop) is
+  multi-phase, see `../multi-phase/SKILL.md`.
+- **data-plane row ops** — the four row fates (insert / guarded update / unchanged / careful
+  delete) under one null-safe MERGE; a bulk DELETE of populated rows escalates to Tier 4.
+
+## The CDC-silence face (pointer)
+
+The "0 CDC captures on redeploy" limb of the proof, the over-capturing-MERGE failure mode, and the
+isolation rule all live in `../cdc/SKILL.md`. This concern owns the *seed*; the CDC index owns the
+*capture* consequence. Point there, don't restate it.
+
+## Prove it (pointer, not a re-scaffold)
+
+For the content-hash oracle (identical-before-and-after) and the guarded-branch rowcount probe, see
+`../../talk-to-local-sql/SKILL.md`; for the deploy-twice loop that demonstrates the silent redeploy,
+see `../../prove-on-dacpac/SKILL.md`.
+
+## Handbook
+
+Cite by **filename**: **07-Idempotency-101.md** (the idempotent-MERGE discipline) and
+**06-Pre-Deployment-and-Post-Deployment-Scripts.md** (where seed data rides in the deploy).

--- a/sidecar/projection/ssdt-agent/skills/_index/identity-and-refactorlog/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/identity-and-refactorlog/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: identity-and-refactorlog
+description: Cross-cutting KNOWLEDGE shared by rename-entity, rename-attribute, move-schema, and the compat-view bridge. Owns the discipline that IDENTITY IS SEPARATE FROM NAME — the refactorlog records that an old object and a new name are the same identity, so SSDT emits sp_rename (data + object_id preserved) instead of the naked DROP+CREATE / DROP COLUMN+ADD that silently destroys the data. Owns the read-the-delta discriminator and the Refactorlog Cleanup companion trap. Per-op skills POINT here. The publish loop that PROVES the delta is sp_rename lives in prove-on-dacpac.
+---
+
+# Identity is separate from name — the refactorlog carries the data
+
+> The single most important read in the whole tree: **is the generated delta `sp_rename`, or is
+> it `DROP`+`CREATE`?** One preserves every row; the other destroys them silently. Every op that
+> changes a *name* an object is addressed by points here so the read is done the same way, every
+> time.
+
+You are helping an **OutSystems-native developer** who renamed an entity or attribute in Service
+Studio and expects the data to follow. It only follows if SSDT knows the old object and the new
+name are the **same identity** — and that knowledge lives in the **refactorlog**, not in the
+`CREATE` text.
+
+## The core distinction
+
+- **Name** is an *address* — `dbo.Customer`, `Customer.Email`, `schema.Table`. Changing an address
+  is cosmetic to the data.
+- **Identity** is the *thing that carries the rows* — the `object_id`, the physical column. A safe
+  rename keeps identity constant while changing the address.
+
+The refactorlog is the record that says "the old address and the new address are the same
+identity." With it, SSDT emits:
+
+```sql
+EXEC sp_rename 'dbo.Customer.Email', 'EmailAddress', 'COLUMN';   -- data preserved, identity preserved
+```
+
+**Without** it, SSDT sees one address vanish and a new one appear, and emits the catastrophe:
+
+```sql
+ALTER TABLE [dbo].[Customer] DROP COLUMN [Email];   -- every value in the column, gone
+ALTER TABLE [dbo].[Customer] ADD [EmailAddress] NVARCHAR(256) NULL;
+```
+
+(For a whole entity it is `DROP TABLE` + `CREATE TABLE`; for a schema move it is the same shape on
+the two-part name.)
+
+## The named traps this concern owns
+
+- **Naked Rename** (handbook **16** = §19.1) — editing the name text *without* the refactorlog
+  entry. The build succeeds (SSDT cannot see your rows); the deploy silently drops-and-recreates.
+- **Refactorlog Cleanup** (handbook **16** = §19.6) — the companion. **Never delete old refactorlog
+  entries.** A fresh-environment deploy *replays* the whole refactorlog; a deleted entry re-becomes
+  a drop+create on the clean environment. The refactorlog is append-only history, not scratch.
+
+## The WHY (specialize per op; do not restate the whole thing there)
+
+A rename is safe **only because identity is separate from name.** SSDT diffs *shapes*, not intent:
+absent an identity mapping, a renamed column is indistinguishable from "old column deleted, new
+column added," and SSDT does the literal, destructive thing. The refactorlog supplies the missing
+identity link so the diff resolves to `sp_rename`. This is why you **never trust that an edit
+*named* like a rename *behaves* like one** — you read the generated delta and confirm `sp_rename`
+before publishing, catching the loss in the script (where it is free) instead of in production
+(where it is not).
+
+## The read-the-delta discriminator (the single most important read)
+
+Script the delta and look:
+
+- **`sp_rename ... 'COLUMN'` / `... 'OBJECT'`** (or `ALTER SCHEMA ... TRANSFER` for a move) → safe,
+  data preserved. Proceed.
+- **`DROP COLUMN`+`ADD`** or **`DROP TABLE`+`CREATE TABLE`** on something you asked to RENAME →
+  **CATASTROPHE-in-the-delta. STOP.** The refactorlog entry is missing. Demand it, rebuild,
+  re-preview, and confirm the delta is now a rename. This is Script-Only-grade danger regardless of
+  the single-statement mechanics.
+
+Also confirm the `.refactorlog` file actually changed when the rename was authored — an
+unrecorded rename is the failure mode.
+
+## The ops this governs (and how each differs)
+
+- **rename-attribute** — `sp_rename ... 'COLUMN'`; Tier 3 because every caller of the column name
+  (views, procs, ORM mappings, reports, ETL) must change.
+- **rename-entity** — `sp_rename ... 'OBJECT'`; Tier 3 because every reference to the table name
+  breaks.
+- **move-schema** — the two-part `schema.Table` name is *just an address*; the refactorlog (or an
+  explicit `ALTER SCHEMA target TRANSFER source.Table`, which preserves `object_id`) tells SSDT the
+  identity survived the move. Same DROP+CREATE trap without it.
+- **compat-view** — the bridge that lets the *old* name keep resolving after a rename: identity
+  survived the move, and the view re-exposes the old address for consumers not yet updated (see
+  the per-op skill for the recipe).
+
+## Cross-table MOVE is NOT a rename (the sharp edge)
+
+A **cross-table move** (move-attribute, move a field from Customer to Account) has **no refactorlog
+identity mapping** — the refactorlog records renames *in place*, not relocations between objects.
+So a cross-table move **must be copy-then-drop**, never a rename; letting SSDT treat "move" as a
+rename does a DROP+CREATE that destroys the values. That op is multi-phase (see
+`../multi-phase/SKILL.md`); this concern only tells you *why it cannot be a rename*.
+
+## Prove it (pointer, not a re-scaffold)
+
+For the publish loop that PROVES the delta is `sp_rename` (script the delta, read it, confirm) see
+`../../prove-on-dacpac/SKILL.md`; for confirming row counts / `object_id` are intact after an
+`ALTER SCHEMA TRANSFER` see `../../talk-to-local-sql/SKILL.md`.
+
+## Handbook
+
+Cite by **filename**: **09-The-Refactorlog-and-Rename-Discipline.md** (the discipline), and **16**
+(= §19; specifically §19.1 Naked Rename and §19.6 Refactorlog Cleanup).

--- a/sidecar/projection/ssdt-agent/skills/_index/multi-phase/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/multi-phase/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: multi-phase
+description: Cross-cutting KNOWLEDGE shared by split-table, merge-tables, move-attribute, extract-to-lookup, archive-entity, delete-attribute (4-phase), retype-explicit, and temporal-convert. Owns the additive -> cutover -> subtractive shape, the coexistence WHY (a running app cannot switch shapes atomically), and the totality/conservation proofs that MUST pass before any subtractive drop (BEFORE/AFTER hash equal, source+archive == original, total-mapping zero-unmapped, cardinality absorbed == distinct-parents). The BlockOnPossibleDataLoss veto is the licensing gate on the drop phase. Per-op skills POINT here. The publish loop + hash oracle live in prove-on-dacpac / talk-to-local-sql.
+---
+
+# Multi-phase — old and new must coexist
+
+> The instant a request *relocates data between shapes* — rather than the schema merely *gaining*
+> shape — you have left the single-release world. The phases exist because a running app cannot
+> switch shapes atomically. Every op that moves data points here so the shape and the proofs are
+> the same, every time.
+
+You are helping an **OutSystems-native developer** whose change moves data (a split, a merge, a
+field relocation, a text-to-lookup promotion, an archive, a column drop, an explicit retype, a
+temporal conversion). None of these is a single `CREATE` edit; all of them are staged for the same
+reason.
+
+## The coexistence WHY (specialize per op; do not restate the whole thing there)
+
+The running OutSystems app **cannot atomically stop reading the old shape and start reading the new
+one** the instant a deploy lands. If you drop the old shape in the same release that creates the
+new one, any app code still on the old shape breaks the moment it deploys — and if the copy script
+had a bug, the data is already gone. So the two shapes must **coexist** until reads are repointed,
+and only then is the old shape removed. That coexistence requirement (state-variable 4) is exactly
+what makes these changes **multi-PR**.
+
+## The three-phase shape (each phase its own PR)
+
+- **Phase 1 — additive (Mechanism 1/2).** Create the new shape (table / column / lookup / archive
+  destination). Post-deploy-copy the existing rows across; dual-write new rows so both shapes stay
+  in agreement. The app still reads the old shape. **Strict publishes clean — it is purely
+  additive.** Tier 2.
+- **Phase 2 — cutover (Mechanism 2).** Repoint app reads (and FKs, views) from the old shape to the
+  new. No schema change to prove beyond confirming both shapes still agree (hash both). Leave a
+  backward-compat view named for the old shape if any external consumer still references it (see
+  `../identity-and-refactorlog/SKILL.md` for the compat-view bridge).
+- **Phase 3 — subtractive (Mechanism 3).** Drop the old shape from the project. **This is the
+  `BlockOnPossibleDataLoss` veto moment** — Strict MUST veto until the conservation proof (below)
+  licenses the drop. Tier 3 (Tier 4 once the removed data is genuinely irrecoverable).
+
+The greenfield collapse: if the source is **empty**, there is no data to move — the whole thing
+collapses to a clean **Mechanism 1** additive create (+ a clean subtractive drop). Prove the source
+is empty first.
+
+## The conservation proof that licenses the subtractive drop
+
+**No subtractive drop ships until its proof passes.** The proof is op-specific in *what* it counts,
+but always a conservation/totality check:
+
+- **split / move-attribute / merge (value leg)** → BEFORE/AFTER **content-hash equal**: the moving
+  columns in the source hash-equal to the same columns in the new home. Every value arrived.
+- **merge (cardinality leg)** → **absorbed rows == distinct parents.** A merge silently *assumes*
+  1:1; on actual 1:many a naive copy keeps one row per parent and drops the rest — and a value-hash
+  will **not** catch it, because it only compares the rows that survived. Prove the **row-count**
+  first, before any copy. Unequal counts = STOP; this is a design decision, not a mechanism flip.
+- **archive** → **source-count + archive-count == original total** (no row lost, none duplicated),
+  each batch commits (transaction log stays bounded).
+- **extract-to-lookup** → **total mapping, zero unmapped:**
+  `SELECT DISTINCT <oldcol> FROM <t> WHERE <oldcol> NOT IN (SELECT Code FROM <lookup>)` returns
+  **zero rows** before the old column drops. One unmapped value silently becomes NULL or vetoes
+  the FK.
+- **delete-attribute (4-phase)** → prove the column is genuinely dead: stop-writes phase +
+  `sys.dm_sql_referencing_entities` shows nothing reads it, before the irreversible drop.
+
+The `BlockOnPossibleDataLoss` veto on the drop phase is **the gate being conservative** — it
+refuses because SSDT cannot know your copy already succeeded. The veto is the *licensing gate*; the
+conservation proof is what earns the license.
+
+## The ops this governs (and their distinguishing proof)
+
+| Op | Distinguishing proof it still owns |
+|---|---|
+| split-table | hash the moving columns source vs. new table = equal |
+| merge-tables | **cardinality first** (absorbed == distinct parents), then value-hash |
+| move-attribute | join is 1:1, then value-hash (a cross-table move is NOT a rename — see identity) |
+| extract-to-lookup | total mapping, zero unmapped, before the drop |
+| archive-entity | source+archive == original; batched, log bounded |
+| delete-attribute | column provably dead (referencing-entities + stop-writes) before drop |
+| retype-explicit | `TRY_CONVERT` over real data — count the non-convertible rows |
+| temporal-convert | period-column backfill produces sane ROW START; rows themselves untouched |
+
+## Prove it (pointer, not a re-scaffold)
+
+For the publish loop that runs each phase and shows the Phase-3 veto, see
+`../../prove-on-dacpac/SKILL.md`. For the order-independent content-hash oracle (the BEFORE/AFTER
+equality that licenses the drop) and the row-count / mapping probes, see
+`../../talk-to-local-sql/SKILL.md`.
+
+## Handbook
+
+Cite by **filename**: **11-Multi-Phase-Evolution.md** (the additive→cutover→subtractive contract)
+and handbook **14** (= §17; the operation recipes — note §17.7 merge-entities and the §17.8
+compat-view companion have missing handbook bodies and are AUTHORED in the per-op skills).

--- a/sidecar/projection/ssdt-agent/skills/_index/tightening-class/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/tightening-class/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: tightening-class
+description: Cross-cutting KNOWLEDGE shared by make-mandatory, narrow, and delete-attribute (and the populated-veto face of add-check / add-unique / define-PK). Owns the proven, DATA-BLIND BlockOnPossibleDataLoss guard — `IF EXISTS (SELECT TOP 1 1 FROM <t>) RAISERROR(...,16,127)` placed ABOVE the ALTER — that vetoes on TABLE-HAS-ROWS, not on whether the column satisfies the new rule. Per-op skills POINT here instead of re-deriving the guard. Not a capability skill; the publish loop that PROVES this lives in prove-on-dacpac, the probes in talk-to-local-sql.
+---
+
+# The tightening class — the guard is TABLE-HAS-ROWS, not column-satisfies-rule
+
+> **This is the flagship abstraction of the whole tree, and it corrects a wrong recipe.** The
+> old advice — "backfill the NULLs, then the declarative NOT NULL lands clean under Strict =
+> Mechanism 3" — was **disproven empirically on the proving ground**. Do not repeat it. What
+> replaces it is below, and it is shared verbatim by every op in this class so no per-op skill
+> has to re-derive it.
+
+You are helping an **OutSystems-native developer** land a safe schema change. When they *tighten*
+a rule on an existing column — make it mandatory, shorten it, drop it — the same instinct applies,
+because SSDT guards all of them the same conservative way. Learn the class once; stop
+re-discovering the same veto op by op.
+
+## The members of the class
+
+A **tightening** change is one that removes capacity or removes a column from a populated table.
+The members that share this exact guard:
+
+- **make-mandatory** (`NULL` → `NOT NULL`) — the spine proof.
+- **narrow** (`NVARCHAR(50)` → `NVARCHAR(10)`, reduced precision) — *Ambitious Narrowing*.
+- **delete-attribute** (`ALTER TABLE ... DROP COLUMN`) — the values are irrecoverable.
+
+Plus the **populated-veto face** of the constraint ops — **add-check**, **add-unique**,
+**define-PK** — insofar as they refuse on a populated table. Those ops *also* veto on an actual
+data **violation** (a dup, an orphan, a failing predicate); that violation face is a *different*
+concern owned by `../constraint-is-a-claim/SKILL.md`. Read the distinction at the bottom of this
+file — it is deliberate and load-bearing.
+
+## The guard, verbatim (VERIFIED on the proving ground)
+
+For a `NULL → NOT NULL` change (and structurally identical for a narrow), `sqlpackage` generates:
+
+```sql
+IF EXISTS (SELECT TOP 1 1 FROM [dbo].[Customer])
+    RAISERROR (N'Rows were detected. The schema update is terminating because data loss might occur.', 16, 127);
+-- ... and BELOW it, the actual:
+ALTER TABLE [dbo].[Customer] ALTER COLUMN [Email] NVARCHAR(256) NOT NULL;
+```
+
+Read what this is: the guard fires on `IF EXISTS (SELECT TOP 1 1 FROM <table>)` — **the table
+merely having a row** — and it is placed **before** the `ALTER`. **It never inspects the column at
+all.** It does not count NULLs. It does not measure `MAX(LEN)`. It is **data-blind**: row-presence,
+not rule-satisfaction.
+
+## The WHY (specialize this per op; do not restate the whole thing there)
+
+SSDT computes the **entire deploy script once, up front, from the pre-publish model state**, and
+is **conservative by design**. It cannot know that a pre-deploy backfill — which runs *at deploy
+time, after the script is already generated* — will have emptied the NULLs, or that every value
+already fits the narrower type. So it refuses the moment the table holds any row. **The gate
+cannot know your intent, so it assumes the worst.**
+
+The empirical proof (the showcase finding): a pre-deploy backfill cleared **every** NULL
+(`SELECT COUNT(*) WHERE Email IS NULL` returned **0**), and Strict **STILL vetoed**, leaving the
+column nullable. The narrow twin confirmed it: `MAX(LEN)` fitting the new size did **not** clear
+the veto either. **Zero violations is necessary but NOT sufficient** on a populated table.
+
+## The ladder (empty = clean; populated = a conscious call)
+
+- **EMPTY table** → **Mechanism 1 Pure Declarative, single-phase, Tier 1.** The `IF EXISTS` is
+  false, the `RAISERROR` never fires, the tightening `ALTER` lands. *(Confirm the table is
+  genuinely empty first.)* This is the **only** clean single-phase leg.
+- **POPULATED table (violations present OR zero violations — it makes no difference)** → the
+  change **cannot pass the prod-strict gate by backfill/reconcile alone.** It requires a
+  **conscious, documented decision taken AFTER a verified probe** (prove the violation count is 0
+  first — necessary, not sufficient), then ONE of:
+  - **(a) Targeted gate-relaxation** — operationally **Mechanism 4 / Script-Only with a named
+    relax.** Having *proven* zero violations remain, deliberately disable `BlockOnPossibleDataLoss`
+    for **this one targeted change** (a scoped publish-profile override or a script-only path) so
+    the tightening `ALTER` proceeds against the now-clean column. The proof packet must carry
+    **both** the zero-violation probe **AND** the explicit record of the relaxation decision.
+  - **(b) Restructure as Mechanism 5 — Multi-Phase, multi-PR** — stage it so the engine never has
+    to relax its guard (add the tightened column in a new structure and migrate, or sequence the
+    tightening across releases where the model state the engine diffs no longer trips the
+    table-has-rows guard).
+  Tier 2 baseline; **+1** for CDC-enabled / >1M rows / first-time (see `../cdc/SKILL.md`).
+
+## How the per-op specifics differ (they still point here)
+
+The **guard mechanics above are identical** for every member — that is the whole point of lifting
+them. What each op still owns in its own SKILL:
+
+- **make-mandatory** — the probe is `COUNT(*) WHERE col IS NULL`; the trap is trusting a clean NULL
+  probe as a green light.
+- **narrow** — the probe is `MAX(LEN(col))` + `COUNT(*) WHERE LEN(col) > <new>`; `MAX(LEN)` fitting
+  decides gate-relaxation vs. multi-phase for the *remedy*, but never buys a clean single-phase on
+  a populated table.
+- **delete-attribute** — the values are irrecoverable; danger is Tier 3–4 even when the drop is
+  mechanically one statement; the 4-phase deprecation is its multi-phase shape (see
+  `../multi-phase/SKILL.md`).
+
+## Prove it (pointer, not a re-scaffold)
+
+For the publish loop that PROVES this — build the dacpac, Strict-publish, read the delta, watch
+the veto, then prove the chosen remedy lands the tightening — see `../../prove-on-dacpac/SKILL.md`.
+For the probes that PREDICT the veto (`COUNT(*) WHERE col IS NULL`, `MAX(LEN)`), see
+`../../talk-to-local-sql/SKILL.md`. The probe predicts; the Strict publish proves; **the guard is
+row-presence regardless of what the probe returns.**
+
+## NOT the same as constraint-is-a-claim (keep them separate)
+
+`../constraint-is-a-claim/SKILL.md` vetoes on an actual data **violation** — a value that breaks
+the rule (a duplicate, an orphan, a failing predicate). **This** class vetoes **data-blind** on
+row **presence** — the guard never looks at a value. Collapsing the two would re-lose the exact
+distinction the proving ground exists to teach. When a constraint op refuses on a *populated but
+clean* table, that is this class; when it refuses on *dirty data*, that is the claim.
+
+## Handbook
+
+Cite by **filename** (offset +3): handbook **16** (= §19) for the Optimistic NOT NULL / Ambitious
+Narrowing anti-patterns, and **10-SSDT-Deployment-Safety.md** for the `BlockOnPossibleDataLoss`
+gate semantics.

--- a/sidecar/projection/ssdt-agent/skills/classify-mechanism/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/classify-mechanism/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: classify-mechanism
+description: Use after confirm-intent has named the operation and gathered the four state-variables, to assign a PROVISIONAL Mechanism (1-5) and Tier (1-4) before proving. Walks the handbook decision cascade (file 15 = §18.1, Q1-Q4), applies the +1 escalations (CDC / >1M rows / first-time op), enforces danger-is-not-release-count, and decides WHEN the change can be classified on sight versus when it MUST be proven on the proving ground. Emits a provisional verdict that prove-on-dacpac confirms or flips.
+---
+
+# Classify mechanism
+
+> **Why this (and what it teaches).** The verdict you produce here is **provisional on purpose** —
+> classification from text is the named failure mode, and the data holds the casting vote.
+> Mechanism and Tier are kept as **two orthogonal axes** because *how a change ships* and *how
+> dangerous it is* are genuinely independent: a single-PR `DROP TABLE` is Tier 4. What this teaches:
+> never collapse danger into release-count, and never treat a from-text reading as final past the
+> purely-additive corner — the discriminator is "would this same `.sql` edit get the same answer
+> regardless of the rows? If not, I have guessed, not classified." Surface this to the developer:
+> a developer who learns that the mechanism can *flip on data they didn't mention* stops trusting
+> the schema diff alone — that is the graduation from reading SQL to proving it.
+
+You are helping an **OutSystems-native developer** land a safe schema change. This skill is the
+**spine**: it turns a named operation + its data-state into two orthogonal answers — **how** the
+change ships (Mechanism) and **how dangerous** it is (Tier) — and, just as importantly, decides
+whether you can answer on sight or must go prove it.
+
+**Classification from the `.sql` text alone is a guess. The data decides the mechanism.** This
+skill produces a *provisional* verdict; `prove-on-dacpac` is what makes it true. Never deliver a
+provisional verdict to the developer as if it were proven.
+
+## The two axes are orthogonal — emit BOTH, always
+
+- **Mechanism** = the *how* (the release shape). Five of them.
+- **Tier** = the *danger* and *who must review*. Four of them, with escalations.
+
+They are not the same axis. **Danger is not release-count.** A `DROP TABLE` on populated data is
+mechanically a single one-shot script (a single-PR mechanism) but **Tier 4** because the data is
+gone irreversibly. Keep them separate or you will under-review a catastrophe.
+
+## The Five Mechanisms (the team's own vocabulary)
+
+| # | Mechanism | Release bucket | What it is |
+|---|---|---|---|
+| 1 | **Pure Declarative** | single-phase | Edit the CREATE; SSDT computes a safe in-place delta. No script, no data touched. |
+| 2 | **Declarative + Post-Deploy** | single-PR | Declarative schema change **plus** an idempotent post-deploy script (seed/backfill that runs after the schema lands). |
+| 3 | **Pre-Deploy + Declarative** | single-PR | A pre-deploy script **first** (backfill / dedupe / reconcile) so the declarative change can then pass its veto. |
+| 4 | **Script-Only** | single-PR (operational) | The change is not expressible in the declarative model (CDC, `NOCHECK`->`WITH CHECK CHECK`, table-swap). Lives in a script. |
+| 5 | **Multi-Phase** | multi-PR | The change spans **multiple releases** because old and new app code must coexist, or a no-gap CDC rollout forces staging. |
+
+**Mechanism -> bucket map** (the team's release vocabulary):
+
+- **SINGLE-PHASE** = Pure Declarative (1): no script, one publish.
+- **SINGLE-PR** = Declarative+Post (2) and/or Pre-Deploy+Declarative (3), or operational Script-Only (4): one release, scripts included.
+- **MULTI-PR** = Multi-Phase (5): staged across releases.
+
+## The Tier decision cascade (handbook file 15 = §18.1, Q1-Q4)
+
+Walk these in order. The **first** that fires sets the floor; later questions can only raise it.
+
+- **Q1 — Will data be lost?** (drop table/column with data, narrowing truncation, naked rename)
+  -> **Tier 4**. Stop here for the floor; this is the irreversible band.
+- **Q2 — Will existing data change or move?** (backfill, retype, value migration)
+  -> **Tier 3 minimum, and MULTI-PR** is on the table.
+- **Q3 — Cross-table or external dependencies?** (FK, view, proc, ETL, reports, External Entities)
+  -> **Tier 3**.
+- **Q4 — Can the app keep working unchanged?**
+  - **NO** (the running OutSystems app breaks without a code change) -> **Tier 2, SINGLE-PR**.
+  - **YES** (additive, app oblivious) -> **Tier 1, SINGLE-PHASE**.
+
+Then apply the escalations.
+
+## The +1 escalations (apply after the cascade)
+
+Each independently bumps the Tier up by one (they stack):
+
+- **CDC-enabled table** (+1). CDC is the team's biggest tripwire — every subsequent schema change
+  now needs capture-instance management (**CDC Surprise**).
+- **> 1,000,000 rows** (+1). Build time, blocking, memory grants — scale turns a benign edit risky.
+- **First-time operation** for this team/codebase (+1). No muscle memory, no prior proof.
+
+A Tier never exceeds 4; once at 4, escalations only sharpen the warning (e.g. "Tier 4, and CDC
+makes the rollback even harder").
+
+> **Why this (and what it teaches).** The +1 escalations exist because some risks are *standing*,
+> not visible in the single delta: a CDC-enabled table carries an obligation on **every future
+> change** (the capture instance must be managed), scale turns a metadata edit into a blocking
+> build, and a first-time op has no prior proof to lean on. What this teaches: the danger of a
+> change is not only what *this* edit does to the data — it is what the table's *context* makes
+> every edit cost. Surface this: a developer who hears "the base op is trivial, but this table is
+> CDC-tracked so it's +1 forever" stops being ambushed months later when a new column silently
+> vanishes from the feed — that foresight is the graduation.
+
+## The four state-variable flips (the heart)
+
+The **same operation** changes Mechanism as the data crosses a threshold. This is the
+classify-by-proving core. For any operation, the flip table is:
+
+| State of the data | Mechanism it flips to |
+|---|---|
+| table **empty** | 1 Pure Declarative (single-phase) |
+| populated, **data does NOT violate** the new rule | still 1 (but **prove it** — see below) |
+| populated, **data violates** the new rule (NULLs / orphans / over-length / dups) | 3 Pre-Deploy+Declarative (backfill/reconcile first), single-PR — or 2 if the fix is a post-deploy seed |
+| + **CDC-enabled, no-gap required** | 5 Multi-Phase, multi-PR; **+1 Tier** |
+| + **> 1M rows / first-time op** | **+1 Tier** (mechanism may also stage) |
+| change **not expressible declaratively** (CDC enable, FK NOCHECK reconcile, IDENTITY swap) | 4 Script-Only |
+| **old + new app code must coexist** | 5 Multi-Phase, multi-PR |
+
+The per-operation `skills/operations/*.md` entry carries the **specific** flip table and which
+seed scenario exercises it. Read it.
+
+## WHEN to classify on sight vs WHEN you MUST prove
+
+This is the judgment call this skill exists to make.
+
+**You may classify on sight (no proving needed) only when ALL of these hold:**
+
+- The operation is **purely additive** and the app is oblivious (Q4 = YES), AND
+- The change touches **no existing data** (a new nullable column, a brand-new table, a new index
+  on a new column), AND
+- The table is **not CDC-enabled** and **not** above the scale/first-time thresholds.
+
+That is the Tier 1 / Mechanism 1 corner, and only that corner. Examples: `add-attribute-optional`
+on a non-CDC table; `create-entity`; a post-deploy `MERGE` that adds a genuinely new lookup value.
+
+**You MUST prove (hand to `prove-on-dacpac`) whenever ANY of these is true** — which is
+*everything past the additive corner*:
+
+- The operation could touch, move, or refuse existing data: **make-mandatory, narrow, retype,
+  create-FK, add-unique, add-check, define-PK, delete-anything, rename-anything.**
+- **Any** of the four state-variables is `unknown` (and for the data-violation variable it is
+  *almost always* unknown — the developer's recollection is not proof).
+- A **named trap** is in play (Naked Rename, Optimistic NOT NULL, Ambitious Narrowing, Forgotten
+  FK Check, CDC Surprise). The delta is the only place to catch these reliably.
+- The table is **CDC-enabled** or above the **scale/first-time** thresholds.
+
+The discriminator that makes this real: **make-mandatory on a table with NULLs vs without NULLs is
+identical `.sql` text but a different Mechanism.** If you would answer both the same way from the
+text, you have not classified — you have guessed. Prove it.
+
+> **Why this (and what it teaches).** Note the *honest correction* the proving ground forces here:
+> for `make-mandatory` on a **populated** table, even *without* NULLs the change does **not** pass
+> the prod-strict gate cleanly — SSDT's guard is **table-has-rows, not column-has-NULLs** (see
+> `prove-on-dacpac`). So the on-sight corner is genuinely only the purely-additive case; the
+> moment rows exist *and* a constraint tightens, you must prove. What this teaches: the size of the
+> "answer-on-sight" zone is much smaller than intuition suggests — when in doubt, the cost of one
+> publish is far less than the cost of a wrong verdict. Surface this to the developer so they
+> understand *why* you are proving something that "looks obvious."
+
+## What you emit (the provisional verdict)
+
+A structured handoff to `prove-on-dacpac`:
+
+- **operation** (from the change-order).
+- **provisional Mechanism** (1-5) + its release bucket.
+- **provisional Tier** (1-4), with each +1 escalation named and why.
+- **cascade trace**: which of Q1-Q4 fired and set the floor.
+- **the suspected flip**: which state-variable, if it crosses, changes the answer — and the exact
+  thing the proving ground must check (e.g. "COUNT of NULL Email; Strict must veto if > 0").
+- **on-sight vs must-prove**: your decision and the reason. If on-sight, say why proving is
+  unnecessary; if must-prove, name the proof to demand.
+- **named trap, if suspected**, so the delta gets read for it.
+
+Label the whole thing **PROVISIONAL**. It becomes a verdict only after `prove-on-dacpac` returns.
+
+## Worked examples
+
+- **"Make Customer.Email required."** Operation `make-mandatory`. Q4 = NO (app may write NULLs
+  today) -> floor Tier 2. Data-violation variable unknown -> **must prove**. Provisional: Mechanism
+  1 *if* truly empty, but on a **populated** table it does **not** land clean even with zero NULLs
+  (the guard is table-has-rows) — so expect a Strict veto and a conscious gate decision
+  (named gate-relaxation after a proven-zero-NULL backfill, or multi-phase). Proof to demand:
+  `COUNT(*) WHERE Email IS NULL`; then prove the veto STILL fires after the backfill clears it.
+- **"Add an optional Notes field to Customer"** (non-CDC, small). Purely additive, app oblivious,
+  no existing data touched -> **classify on sight**: Mechanism 1 Pure Declarative, Tier 1. Note it
+  still goes through `prove-on-dacpac` for a clean-publish confirmation, but no flip is possible.
+  (If the same table were **CDC-enabled**, the +1 fires and the capture instance must be recreated
+  — the trivial base op hides a non-trivial CDC obligation. Prove it.)
+- **"Drop the AuditLog table"** (populated, maybe CDC). Q1 = YES (data lost) -> **Tier 4**, floor
+  set immediately. CDC +1 stays at 4 but hardens the warning. Mechanism: Script-Only / single-PR
+  mechanically — *danger is not release-count*. Must prove: the `BlockOnPossibleDataLoss` veto is
+  the safety proof; sequencing is disable-CDC-first, drop-FKs-first.
+- **"Add a FK from Order.CustomerId to Customer"** (orphans unknown). Q3 = YES (cross-table) ->
+  Tier 3. Must prove. Provisional: Mechanism 1 *if* no orphans; flips to 4 Script-Only
+  (`NOCHECK` -> reconcile -> `WITH CHECK CHECK`) *if* orphans. **Forgotten FK Check** suspected.
+
+## Connector points
+
+- The cascade and flip tables are the natural body of a future PR template / review checklist —
+  `change-author`'s review packet carries this verdict to `reviewer` (deferred). See `CONNECTORS.md`.
+- `.claude/skills/`-shaped and Copilot-mappable (format verify-first); see `CONNECTORS.md`.

--- a/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: confirm-intent
+description: Use FIRST, before any classification or proving, whenever an OutSystems-native developer asks for a schema change in their own words ("make Email required", "rename this attribute", "add a foreign key", "drop that table"). Disambiguates the request into exactly one op-slug (a skills/op/<op-slug>/ directory), surfaces the implicit SSDT destination the developer didn't say out loud, gathers the four data-state variables that decide the mechanism, and pre-flags the governing skills/_index/ concern. Hands a structured change-order naming the op-slug + its per-op skill downstream. Does NOT edit SQL or classify.
+---
+
+# Confirm intent
+
+> **Why this (and what it teaches).** Intake comes first because **the wrong operation proven
+> perfectly is still wrong** — intent is the one thing the data can never correct for you. The
+> proving ground can tell you whether a column has NULLs; it cannot tell you that the developer
+> meant *widen* when they said "change the email field." What this teaches: every schema change
+> begins by restating the request in the developer's own words *and* in the table's terms, so a
+> misunderstanding surfaces before any data is touched — the discriminator is "can I say this back
+> in both vocabularies without guessing?" Surface this reasoning to the developer: a developer who
+> learns that intake is disambiguation, not paperwork, starts stating the *destination* they want
+> rather than the *journey* they imagine — that is the graduation from describing migrations to
+> describing destinations.
+
+You are helping an **OutSystems-native developer** make a safe schema change. They think in
+**entities, attributes, references, and static entities** — the Service Studio vocabulary. You
+think in **CREATE-table destinations** and SSDT publish mechanics. Your first job is not to act;
+it is to make sure you and the developer mean the same thing, and to learn the one thing the
+`.sql` text can never tell you: **what the data looks like.**
+
+Nothing downstream is trustworthy if intake is wrong. A misnamed operation classifies the wrong
+way; a missing data-state variable hides a veto you'll only meet at deploy. Slow down here.
+
+## What you produce
+
+A **change-order** — a small structured handoff for `classify-mechanism`:
+
+- **operation**: exactly one **op-slug** matching a `skills/op/<op-slug>/` directory, e.g.
+  `make-mandatory`. This is the precise entry the change-author will open — hand it downstream.
+- **opSkill**: the path `skills/op/<op-slug>/SKILL.md` (the op-slug's per-op skill).
+- **outSystemsPhrasing**: the developer's own words, verbatim — you'll echo these back later.
+- **target**: the table + column/constraint the destination edit lands on.
+- **destination**: the *implicit* SSDT meaning (what the CREATE will say after the edit).
+- **stateVariables**: the four flips, each `known`/`unknown` (unknown ones get proven, not guessed).
+- **sharedConcern**: the governing `skills/_index/<concern>/SKILL.md` you pre-flagged (a rename →
+  `identity-and-refactorlog`; a tightening → `tightening-class`; anything on a CDC table → `cdc`;
+  a constraint → `constraint-is-a-claim`; a coexistence restructure → `multi-phase`; a seed →
+  `idempotent-seed`). Optional but valued — it lets the change-author open the right WHY first.
+- **notes**: anything ambiguous you resolved, and how.
+
+You do **not** edit any `.sql` and you do **not** assign a Mechanism or Tier. That is the next
+skill's job.
+
+## Step 1 — name exactly one operation
+
+The developer speaks intent; you name **exactly one op-slug** — the directory name of a
+`skills/op/<op-slug>/SKILL.md`. Use the translation table below, then open the matching per-op
+skill to confirm: **its frontmatter `description` is written in your developer's own words**, so
+if their phrasing matches a description, that is your op. If the request maps to **more than one**
+op ("split this entity", "merge these", "extract this to a lookup" are multi-move), name them all
+and tell the developer you'll sequence them via the structural/static per-op skills — do not
+silently pick one.
+
+Two disambiguations the table now forces you to make (the op split lives here, not downstream):
+
+- **create-FK splits on the orphan question** → `create-fk-clean` vs `create-fk-orphan`. If you
+  cannot yet tell whether children without a parent exist, mark state-variable 2 `unknown` and
+  hand `create-fk-orphan` if the developer *hints* at old/dirty data, else `create-fk-clean`; the
+  prove step settles it.
+- **retype splits on direction** → `retype-implicit` (widening, lossless: INT→BIGINT,
+  VARCHAR→NVARCHAR) vs `retype-explicit` (value-reshaping, lossy: text→date, text→int).
+- **default splits on presence** → `add-default` (new) vs `modify-default` (DROP-then-ADD).
+
+### OutSystems -> SSDT translation table
+
+| The developer says (OutSystems) | op-slug | the op skill | The implicit SSDT destination |
+|---|---|---|---|
+| "add an attribute" / "new optional field" | `add-optional` | `skills/op/add-optional/SKILL.md` | new **nullable** column on the CREATE |
+| "add a required attribute" | `add-mandatory` | `skills/op/add-mandatory/SKILL.md` | new `NOT NULL` column **+ DEFAULT** (or it vetoes) |
+| "tick Mandatory" / "make it required" | `make-mandatory` | `skills/op/make-mandatory/SKILL.md` | existing column `NULL -> NOT NULL` |
+| "untick Mandatory" / "make it optional" | `make-optional` | `skills/op/make-optional/SKILL.md` | existing column `NOT NULL -> NULL` |
+| "make the field bigger" / "allow longer text" | `widen` | `skills/op/widen/SKILL.md` | `NVARCHAR(n) -> NVARCHAR(m)`, m>n |
+| "shorten it" / "limit to N chars" | `narrow` | `skills/op/narrow/SKILL.md` | `NVARCHAR(n) -> NVARCHAR(m)`, m<n (**Ambitious Narrowing**) |
+| "change to a bigger number" / "INT to BIGINT" (widening) | `retype-implicit` | `skills/op/retype-implicit/SKILL.md` | in-place `ALTER COLUMN` (lossless) |
+| "store the text as a date/number now" (reshaping) | `retype-explicit` | `skills/op/retype-explicit/SKILL.md` | add-new -> `TRY_CONVERT` -> drop-old (lossy) |
+| "rename the attribute" | `rename-attribute` | `skills/op/rename-attribute/SKILL.md` | `sp_rename` via refactorlog (**Naked Rename** if missing) |
+| "remove this attribute" / "delete the field" | `delete-attribute` | `skills/op/delete-attribute/SKILL.md` | drop column (4-phase deprecation) |
+| "new entity" / "create a table" | `create-entity` | `skills/op/create-entity/SKILL.md` | new `CREATE TABLE` |
+| "rename the entity" | `rename-entity` | `skills/op/rename-entity/SKILL.md` | `sp_rename` table via refactorlog (**Naked Rename**) |
+| "delete the entity" / "drop the table" | `delete-entity` | `skills/op/delete-entity/SKILL.md` | `DROP TABLE` (data-loss veto; disable CDC + drop FKs first) |
+| "move it to another module/schema" | `move-schema` | `skills/op/move-schema/SKILL.md` | `ALTER SCHEMA TRANSFER` or refactorlog |
+| "archive old rows out" | `archive-entity` | `skills/op/archive-entity/SKILL.md` | batched move to an archive table (multi-phase) |
+| "make this many-to-many" / "a bridge entity" | `junction` | `skills/op/junction/SKILL.md` | bridge table, composite PK over two FKs |
+| "add a reference", **clean data** | `create-fk-clean` | `skills/op/create-fk-clean/SKILL.md` | `FOREIGN KEY`, orphan probe = 0 |
+| "add a reference", **some children orphaned** | `create-fk-orphan` | `skills/op/create-fk-orphan/SKILL.md` | `NOCHECK` → reconcile → `WITH CHECK CHECK` (**Forgotten FK Check**) |
+| "change what happens on delete" (Protect/Ignore/Delete) | `change-delete-rule` | `skills/op/change-delete-rule/SKILL.md` | `NO ACTION` / `CASCADE`; DROP+ADD FK |
+| "remove the reference" / "unhook these" | `drop-fk` | `skills/op/drop-fk/SKILL.md` | `DROP CONSTRAINT` (integrity + plan loss) |
+| "make this the identifier" / "primary key" | `define-pk` | `skills/op/define-pk/SKILL.md` | `PRIMARY KEY` (dup values fail; clustered build cost) |
+| "add an index" / "make it faster" | `add-index` | `skills/op/add-index/SKILL.md` | nonclustered index (ONLINE = Enterprise) |
+| "cover these columns" / "make this index unique" | `modify-index` | `skills/op/modify-index/SKILL.md` | index DROP+CREATE; UNIQUE flips on dupes |
+| "we don't need that index" | `drop-index` | `skills/op/drop-index/SKILL.md` | `DROP INDEX` (prove usage first) |
+| "rebuild it, it's fragmented" | `rebuild-index` | `skills/op/rebuild-index/SKILL.md` | **OPERATIONAL** — no declarative destination; route out |
+| "default to X" (new default) | `add-default` | `skills/op/add-default/SKILL.md` | `DEFAULT` constraint `DF_Table_Col` |
+| "change the default" / "stop defaulting" | `modify-default` | `skills/op/modify-default/SKILL.md` | DROP-then-ADD the `DEFAULT` constraint |
+| "no duplicates" / "must be unique" | `add-unique` | `skills/op/add-unique/SKILL.md` | `UNIQUE` index (dups fail; one NULL only) |
+| "only allow these values" / "must be positive" | `add-check` | `skills/op/add-check/SKILL.md` | `CHECK` constraint (existing violations fail) |
+| "trust the constraint now" / "flip it on" | `toggle-trust` | `skills/op/toggle-trust/SKILL.md` | **OPERATIONAL** — `WITH CHECK CHECK`, not a CREATE edit |
+| "static entity" / "lookup" / "reference table" (new) | `create-static-seed` | `skills/op/create-static-seed/SKILL.md` | post-deploy idempotent `MERGE`, explicit ids |
+| "add a value to the list" / "change a label" | `edit-seed` | `skills/op/edit-seed/SKILL.md` | extend the guarded `MERGE` |
+| "turn this text column into a lookup" | `extract-to-lookup` | `skills/op/extract-to-lookup/SKILL.md` | multi-phase: seed + nullable FK + backfill + drop text |
+| "delete/retire a lookup value" | `delete-seed-value` | `skills/op/delete-seed-value/SKILL.md` | deactivate (`IsActive=0`), never hard DELETE |
+| "split this entity into two" | `split-table` | `skills/op/split-table/SKILL.md` | multi-phase: create + copy + dual-write + drop |
+| "merge these two entities" | `merge-tables` | `skills/op/merge-tables/SKILL.md` | multi-phase: prove 1:1 cardinality, absorb, drop |
+| "this field is on the wrong entity" | `move-attribute` | `skills/op/move-attribute/SKILL.md` | copy-then-drop across tables (NOT a rename) |
+| "Auto Number" on/off | `identity-swap` | `skills/op/identity-swap/SKILL.md` | **cannot ALTER** — shadow rebuild + `IDENTITY_INSERT` + reseed |
+| "a view" / "an Advanced Query joining …" | `create-view` | `skills/op/create-view/SKILL.md` | `CREATE VIEW`, enumerated columns (**SELECT * View** trap) |
+| "keep the old name working after a rename" | `compat-view` | `skills/op/compat-view/SKILL.md` | view bearing the old name over the new (temporary) |
+| "point at a table in another database" | `synonym` | `skills/op/synonym/SKILL.md` | `CREATE SYNONYM` (runtime-resolution gap) |
+| "materialize / cache the joined view" | `indexed-view` | `skills/op/indexed-view/SKILL.md` | `WITH SCHEMABINDING` + `UNIQUE CLUSTERED` |
+| "full history on a NEW entity" | `temporal-new` | `skills/op/temporal-new/SKILL.md` | `SYSTEM_VERSIONING=ON` from birth (declarative) |
+| "add history to an EXISTING populated entity" | `temporal-convert` | `skills/op/temporal-convert/SKILL.md` | multi-phase: period cols + backfill + enable versioning |
+| "CreatedBy/CreatedOn/ModifiedBy/ModifiedOn" | `audit-columns` | `skills/op/audit-columns/SKILL.md` | nullable = M1; NOT NULL on populated = backfill |
+| "turn on Change Data Capture" / "change feed for ETL" | `enable-cdc` | `skills/op/enable-cdc/SKILL.md` | **Script-Only**, not declarative (**CDC Surprise**, +1 Tier) |
+| "CDC isn't picking up my new column" | `recreate-capture-instance` | `skills/op/recreate-capture-instance/SKILL.md` | capture-instance recreate / dual-instance |
+| "just tell me WHICH rows changed" (mobile sync) | `change-tracking` | `skills/op/change-tracking/SKILL.md` | change tracking (lighter than CDC, all editions) |
+
+If the developer's words don't fit any row, say so and ask a clarifying question — do not stretch
+a near-match. "External Entity" (an OutSystems entity backed by a table you don't own) means the
+destination edit may be out of your control; flag it and stop.
+
+**The op skill IS the change-author's entry.** The op-slug you name resolves to
+`skills/op/<op-slug>/SKILL.md` — that per-op skill is the exact file the change-author will open
+for the DEFAULT mechanism, the How-it-flips table, and the verdict; the `_index` skill(s) it points
+to carry the shared WHY. Because each per-op skill's frontmatter `description` is written in the
+developer's own words, matching the phrasing IS the dispatch: if their sentence reads like a
+description trigger, hand that slug with confidence.
+
+## Step 2 — surface the destination they didn't say
+
+The developer almost never states the destination; they state an *intent*. "Make it mandatory"
+is a sentence about a checkbox; the destination is `NULL -> NOT NULL` on a specific column.
+**Say the destination back in both languages** so the developer can catch a misunderstanding
+before any data is touched:
+
+> "To confirm: you want `Customer.Email` to become **required** — in the table that means
+> `Email NVARCHAR(256) NOT NULL`. I'll describe that destination on the CREATE; I won't write an
+> ALTER. Right?"
+
+This is the team's doctrine in action: **"Stop writing migrations. Start describing destinations."**
+/ **"Edit the CREATE, never write ALTER."** You are confirming the destination, not the journey.
+
+> **Why this (and what it teaches).** You say the destination back in *both* vocabularies because
+> the model **is** the schema: you describe where the table should end up and SSDT computes how to
+> get there. What this teaches: the moment you can name the destination in table terms
+> (`NULL -> NOT NULL`, `NVARCHAR(10)`), you have separated *what the developer wants* from *how the
+> engine will achieve it* — and only the first is yours to confirm. Surface this so the developer
+> hears their checkbox restated as a column shape; that translation is what graduates them from
+> thinking in Service Studio gestures to thinking in durable destinations.
+
+## Step 3 — gather the four state-variables (the part the text can't tell you)
+
+The **same operation lands in a different mechanism depending on the data.** You must establish
+these four before classification. Ask the developer what they know; mark the rest **unknown** —
+`prove-on-dacpac` will determine the unknowns against real-shaped data. Never guess them, and
+never take a remembered row count as proof.
+
+1. **Is the table populated?** (empty tables make most edits single-phase.)
+2. **Does the existing data violate the new rule?** — NULLs for a make-mandatory, orphans for a
+   new FK, over-length values for a narrow, duplicates for a unique. This is the variable that
+   flips a one-line edit into a backfill.
+3. **Is the table CDC-enabled, and is a no-gap capture required?** (CDC is the team's biggest
+   tripwire — it adds +1 Tier and can force a multi-phase rollout.)
+4. **Must old and new application code coexist during rollout?** — i.e. is there a window where
+   the running OutSystems app and the new schema have to both work? (Forces phasing.)
+
+Ask these in the developer's terms: "Roughly how many customers are in this table today, and do
+any of them have a blank email?" — then record the answer as `known` only if they actually know;
+otherwise `unknown`, to be proven.
+
+> **Why this (and what it teaches).** You gather these four — and honestly mark the unknowns —
+> because **we prove, we don't advise**: the `.sql` text and the developer's recollection both
+> *look* like answers, but only the data on the proving ground casts the deciding vote. What this
+> teaches: whenever the same edit could behave differently depending on what's already in the
+> table, the row state is a question to *prove*, never a fact to *assume* — `unknown` is the
+> honest default, not a gap. Surface this to the developer: a developer who learns that "I think
+> it's clean" is a hypothesis, not a proof, stops being surprised by deploy-time vetoes — that is
+> the graduation toward judgment.
+
+## Step 4 — hand off
+
+Emit the change-order — with the **op-slug**, its **opSkill** path (`skills/op/<op-slug>/SKILL.md`),
+and the pre-flagged **sharedConcern** (`skills/_index/<concern>/SKILL.md`) — and pass control to
+`classify-mechanism`. Echo the developer's own phrasing in the handoff so the eventual verdict can be
+delivered back in their words, and so the change-author opens the right per-op skill (whose
+`description` is written in exactly those words) and the right `_index` WHY first.
+
+## Traps you prevent here
+
+Intake is where these get caught early (full catalog: handbook file 16 = §19). Each trap is OWNED
+by an `_index` concern — pre-flag the owner, don't re-explain the trap:
+
+- **Naked Rename** — a "rename" with no refactorlog becomes DROP+CREATE = silent data loss.
+  Flag rename ops now (`_index/identity-and-refactorlog`) so `prove-on-dacpac` reads the delta for it.
+- **Optimistic NOT NULL** — "make it required" with no thought to existing rows. The whole point
+  of step 3.2; owned by `_index/tightening-class` (the guard is table-has-rows, not NULL-has-rows).
+- **CDC Surprise** — a change on a CDC-enabled table (`_index/cdc`). Step 3.3 is how you don't miss it.
+- **Forgotten FK Check** — an orphaned child under a new FK (`_index/constraint-is-a-claim`). This is
+  why create-FK splits into `create-fk-clean` / `create-fk-orphan` at intake, not downstream.
+
+## Shared knowledge index (pre-flag the governing concern)
+
+Once you have the op-slug, pre-flag the `skills/_index/<concern>/SKILL.md` that governs its shared
+reasoning, so the change-author opens the right WHY first. You are not explaining the concern here —
+you are routing to its owner. The six concerns and their triggers:
+
+| If the op is… | pre-flag the concern |
+|---|---|
+| `make-mandatory`, `narrow`, `delete-attribute`, the NOT-NULL face of `add-mandatory`/`audit-columns` | `skills/_index/tightening-class/SKILL.md` (table-has-rows, data-blind guard) |
+| `rename-entity`, `rename-attribute`, `move-schema`, `move-attribute`, `compat-view` | `skills/_index/identity-and-refactorlog/SKILL.md` (identity ≠ name) |
+| `split-table`, `merge-tables`, `move-attribute`, `extract-to-lookup`, `archive-entity`, `retype-explicit`, `temporal-convert`, `delete-attribute` (4-phase) | `skills/_index/multi-phase/SKILL.md` (old + new coexist; conservation proof) |
+| `enable-cdc`, `recreate-capture-instance`, `change-tracking`, **any op on a CDC-enabled table** | `skills/_index/cdc/SKILL.md` (the +1 tripwire, frozen capture shape) |
+| `define-pk`, `create-fk-clean`, `create-fk-orphan`, `add-unique`, `add-check`, `toggle-trust`, `modify-index`→unique | `skills/_index/constraint-is-a-claim/SKILL.md` (a constraint is a data claim) |
+| `create-static-seed`, `edit-seed`, `delete-seed-value`, the seed leg of `extract-to-lookup`, the no-op redeploy | `skills/_index/idempotent-seed/SKILL.md` (guarded MERGE, silence is the proof) |
+
+A change on a **CDC-enabled table** always pre-flags `_index/cdc` *in addition to* the op's own
+concern — the +1 rides on top of the base op (that is the whole `TRAP-01N` lesson). Put the flagged
+concern in the change-order's `sharedConcern` field.
+
+## Connector points
+
+- **`.claude/skills/` (Claude Code):** this file's frontmatter (`name` = kebab matching the
+  directory, plus a triggering `description`) is already shaped for `.claude/skills/`. See
+  `CONNECTORS.md` — adoption is a copy, not a rewrite.
+- **GitHub Copilot custom agents:** the intake role maps to a Copilot custom agent, but the file
+  format must be **verified first** (see `CONNECTORS.md`, flagged).
+- **F# engine:** a real OutSystems catalog (the engine's `Render`/`SsdtBundle` output) can supply
+  the operation's real column types and the current data shape, replacing the developer's
+  recollection in step 3. Highlighted, not wired.

--- a/sidecar/projection/ssdt-agent/skills/op/add-check/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-check/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: add-check
+description: Use when the developer says "Total must be positive", "Status has to be one of these values", "age can't be negative" — any business rule enforced at the data layer via a CHECK constraint. Validates every existing row at deploy; violating rows veto; NOCHECK is a trap.
+---
+
+# Add a check constraint
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 when all existing rows satisfy the predicate — but PROVE zero violations first.
+
+## OutSystems phrasing
+"Total must be positive", "Status has to be one of these values", "age can't be negative" — any business rule the developer wants enforced at the data layer.
+
+## SSDT meaning
+`CONSTRAINT CK_<Table>_<Col> CHECK (<predicate>)`. SSDT adds the constraint **WITH CHECK** by default, validating **every existing row** at deploy.
+
+## The named trap
+**Existing rows that violate the predicate veto the deploy.** The escape hatch — **WITH NOCHECK** — is its own trap: it skips validation but leaves the constraint **untrusted** (`is_not_trusted = 1`), so the optimizer ignores it and bad rows can already be present. Both are the constraint-is-a-claim family (violation-on-a-value veto + the trust ladder) — see `../../_index/constraint-is-a-claim/SKILL.md`; do not re-derive the claim or NOCHECK mechanics here.
+
+## How it flips (the specifics only)
+- all existing rows satisfy the predicate → M1, single-phase, Tier 2 (prove it).
+- violating rows PRESENT → **FLIP to M3 Pre-Deploy+Declarative, single-PR**: pre-deploy fix-up brings violators into compliance BEFORE the WITH CHECK validation, Tier 3 — see `../../_index/constraint-is-a-claim/SKILL.md`.
+- violating rows that CANNOT be fixed in-place (legitimate legacy data) → consider M5 Multi-Phase (quarantine / grandfather — see `../../_index/multi-phase/SKILL.md`), or accept WITH NOCHECK *only* as a named, documented, explicitly-untrusted decision.
+- \+ >1M rows / first-time → **+1 Tier**.
+- \+ CDC-enabled → apply the team's +1 rule (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+Run the violation probe FIRST: `SELECT COUNT(*) FROM <table> WHERE NOT (<predicate>)`. Then build + Strict publish (adds WITH CHECK): clean → zero violations; a build failure ("conflicted with the CHECK constraint") is the veto. Author the pre-deploy fix-up, re-run Strict clean. If anyone proposes WITH NOCHECK, prove the cost: `SELECT is_not_trusted FROM sys.check_constraints WHERE name='CK_…'` returns 1. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"You asked to enforce Total > 0. I published the check to a copy of your data and SSDT refused — 7 existing rows have Total of 0 or less. This is a Pre-Deploy + Declarative change: I fix those 7 rows first, then the check validates clean and stays TRUSTED. (We could skip validation with NOCHECK, but then the rule is untrusted and the optimizer ignores it — I don't recommend it.)"
+
+## Teach it (the graduation)
+Run the violation probe (`WHERE NOT (<predicate>)`) first, and treat NOCHECK as a debt (prove the untrusted state, end trusted) rather than a shortcut. See `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: "just add the rule" over legacy data that violates it.

--- a/sidecar/projection/ssdt-agent/skills/op/add-default/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-default/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: add-default
+description: Use when the developer says "give this attribute a default value", "new rows should default to Active", "everything new should start as Pending" — adding a named DEFAULT constraint. Always Pure Declarative; it fills only NEW rows and never backfills existing ones.
+---
+
+# Add a default
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 in any state — adding a default never touches existing row values.
+
+## OutSystems phrasing
+"give this attribute a default value", "new rows should default to Active", "everything new should start as Pending".
+
+## SSDT meaning
+A named default constraint on the column — `CONSTRAINT DF_<Table>_<Col> DEFAULT (<value>) FOR <Col>` (or inline). SSDT emits `ADD CONSTRAINT`. It affects **future inserts only** — it does NOT backfill existing rows.
+
+## The named trap
+The **unnamed default**: if you let SSDT auto-name (`DF__Table__Col__<hash>`), the name differs per environment and diffing/refactoring becomes fragile — always name it `DF_<Table>_<Col>`. Second surprise: a developer who expects existing NULLs to fill in is wrong — the default touches only new rows; the backfill is a separate op (see `../make-mandatory/SKILL.md` for the NOT-NULL-with-backfill path).
+
+## How it flips (the specifics only)
+- add a default → M1, single-phase, Tier 1 (any state).
+- developer ALSO wants existing rows backfilled → a separate op: M2 Declarative+Post-Deploy (idempotent UPDATE — see `../../_index/idempotent-seed/SKILL.md`), or M3 if the column is becoming NOT NULL (see `../make-mandatory/SKILL.md`). The default itself stays Tier 1.
+- \+ CDC-enabled → CDC does not track constraints (handbook file 15 = §18.5); no +1 from CDC for the default alone.
+
+## Prove it
+Build + Strict `sqlpackage /Action:Script`; confirm the delta is a clean `ALTER TABLE … ADD CONSTRAINT DF_…` with **no UPDATE of existing rows** — that absence *is* the proof the default does not backfill. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Adding the default is a pure declarative change — I published it to a copy of your data and SSDT just added the constraint, no existing rows touched. Note: the default only fills NEW rows; if you also want the existing blanks filled, that's a separate backfill step I can prove too."
+
+## Teach it (the graduation)
+Distinguish a rule about *new* writes (free, declarative) from a change to *existing* values (a separate, proven backfill) — they look like one request and are two. Fail mode avoided: being surprised by the still-blank column after deploy.

--- a/sidecar/projection/ssdt-agent/skills/op/add-index/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-index/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: add-index
+description: Use when the developer says "add an index on Customer.Email", "make this attribute searchable", "the list screen is slow, can we index it" — adding a nonclustered index. Additive and always Pure Declarative, but the build runs over every row and takes a write-blocking lock.
+---
+
+# Add an index
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 — additive; nothing lost. But the *build cost* (a write-blocking lock scaling with rows) lives in the data, not the `.sql`.
+
+## OutSystems phrasing
+"add an index on Customer.Email", "make this attribute searchable", "the list screen is slow, can we index it".
+
+## SSDT meaning
+An index definition added to the table's `.sql` (inline `INDEX IX_Customer_Email (Email)` or a separate `CREATE NONCLUSTERED INDEX` object). SSDT's publish engine emits `CREATE INDEX` and **builds the index over every existing row** at deploy time — a real, blocking operation on a populated table, not a metadata flip.
+
+## The named trap
+Not a §19 anti-pattern by name — the silent cost IS the trap: a non-`ONLINE` build takes a schema-modification lock and **blocks all writes for the build's duration** (an unasked-for outage on a big table). `WITH (ONLINE = ON)` makes it non-blocking but is **Enterprise/Developer edition only** — it fails on Standard. This ONLINE=Enterprise coupling is a single-op concern; it stays inline here (not lifted).
+
+## How it flips (the specifics only)
+- table empty / small → M1, single-phase, Tier 1.
+- table populated, large (build blocks writes) → still M1 declaratively, but the blocking build pushes review to **Tier 2** (pair-supported); name the maintenance window.
+- \+ >1M rows → **+1 Tier** (Tier 2→3); `ONLINE = ON` may be required (Enterprise-gated) to avoid a write outage.
+- ONLINE=ON needed but target is Standard → the declarative build stays; flag the online option is unavailable; the build WILL block.
+- CDC-enabled → **+1 Tier** (CDC ignores indexes, but the table is high-stakes — see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+Build the dacpac, run Strict `sqlpackage /Action:Script`, confirm the delta is a clean `CREATE INDEX` with **no drop, no table rebuild** — a clean Strict publish proves Pure Declarative. The proving ground is small, so the observed build time is NOT the prod build time — **row count is the predictor**; say so explicitly if the target is large. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Adding the index is a pure declarative change — I published it to a copy of your data and SSDT just ran CREATE INDEX, nothing lost. One caveat: on the real table this build locks writes while it runs, so we schedule it in a window (or use ONLINE if you're on Enterprise)."
+
+## Teach it (the graduation)
+Separate *what the engine does* (CREATE INDEX, always clean) from *what it costs* (a lock whose duration scales with rows — only the row count tells you). Fail mode avoided: shipping an index blind and blocking prod writes.

--- a/sidecar/projection/ssdt-agent/skills/op/add-mandatory/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-mandatory/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: add-mandatory
+description: Use when the developer says "add a required attribute", "add a Status field everyone must have one", "add a field that can't be blank" — a new NOT NULL column. The Optimistic NOT NULL trap; a populated table needs a DEFAULT.
+---
+
+# Add mandatory attribute (Optimistic NOT NULL)
+
+> **Default (provisional — the data decides).** With an explicit default → Mechanism 1 Pure Declarative, single-phase, Tier 2 (contractual). Populated with no default → veto.
+
+## OutSystems phrasing
+"add a required attribute", "add a Status field, everyone must have one".
+
+## SSDT meaning
+Add a `NOT NULL` column. On a populated table SQL Server must put *something* in every existing
+row — so it needs a **DEFAULT**. With `NOT NULL CONSTRAINT DF_... DEFAULT(...)`, SSDT emits `ALTER
+... ADD [Col] <type> NOT NULL CONSTRAINT ... DEFAULT ...` and stamps existing rows. Without a
+default, the publish fails on the populated table. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+**Optimistic NOT NULL** (handbook 16 = §19.2) — `NOT NULL` with no default on a populated table:
+build succeeds (SSDT cannot see your rows), **deploy fails** "Cannot insert NULL". If
+`GenerateSmartDefaults=True`, SSDT **silently** backfills (e.g. empty string) — Permissive lets
+you observe what would have been stamped. Note this is NOT the tightening class (that vetoes on
+row-presence for an existing column); here the veto is a genuine can't-insert-NULL on a *new*
+column, cured by supplying a value.
+
+## How it flips (the specifics only)
+- table empty → **M1, single-phase, Tier 1** (no rows to fill; default optional)
+- populated + explicit DEFAULT → **M1, single-phase, Tier 2** (SQL Server fills existing rows from the default)
+- populated, **no DEFAULT** → publish **vetoes** → add a default (back to M1) or **M3 Pre-Deploy backfill**; do **not** let `GenerateSmartDefaults` silently decide
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+With a default, Strict publishes clean and the delta shows the `DEFAULT`. Drop the default and
+prove the Strict **veto** ("Cannot insert NULL"); then run Permissive with
+`GenerateSmartDefaults=True` and snapshot the data hash to show the developer exactly what value
+SSDT *would* have silently stamped. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"A required attribute needs a value for the rows that already exist. With the default you gave
+it, SSDT stamps every existing row and it publishes clean — Pure Declarative, Tier 2. Without a
+default it would have failed at deploy, or worse, silently filled empty strings — I proved both
+on a copy."
+
+## Teach it (the graduation)
+The DEFAULT is the only thing that lets the engine fill rows it cannot know how to populate; the
+no-default veto is the gate refusing to invent your data, and `GenerateSmartDefaults` is the
+dangerous opposite — it *invents* silently. Ask "who supplies the value for existing rows — me,
+explicitly, or the engine, silently?" and never let it be "silently."

--- a/sidecar/projection/ssdt-agent/skills/op/add-optional/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-optional/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: add-optional
+description: Use when the developer says "add an optional attribute", "add a MiddleName field it can be blank", "add a field that doesn't have to be filled" — a new nullable column. The safest change in the catalog.
+---
+
+# Add optional attribute
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 — purely additive, existing rows just get NULL.
+
+## OutSystems phrasing
+"add an optional attribute", "add a MiddleName field, it can be blank".
+
+## SSDT meaning
+Add a `NULL` column inside the `CREATE TABLE`. SSDT emits `ALTER TABLE ... ADD [Col] <type>
+NULL`. Existing rows get `NULL`; a metadata-only operation on modern SQL Server. Never author
+the `ALTER` — edit the CREATE.
+
+## The named trap
+None material at the data layer. The one edge: if `IgnoreColumnOrder=False` a mid-table insert
+can trigger a rebuild — the proving-ground profiles keep `IgnoreColumnOrder=True`, so position is
+a non-issue.
+
+## How it flips (the specifics only)
+- any table state (empty or populated) → **M1, single-phase, Tier 1** (NULL is always a valid existing-row value)
+- table is CDC-enabled and the new column must be tracked → the capture instance does not include it → **M4/M5 + +1 Tier**, recreate the capture instance (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Strict publish succeeds clean; the delta is a single `ALTER TABLE ... ADD ... NULL`; no veto
+regardless of row count. That clean run on a populated copy is the whole proof. For the publish
+loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Adding an optional attribute is the safest change there is — existing rows just get NULL. I
+proved it publishes clean on a copy of your populated table. Pure Declarative, single-phase,
+Tier 1."
+
+## Teach it (the graduation)
+An optional add never vetoes because NULL is always a valid existing-row value — the
+discriminator is whether existing rows *can already satisfy the new rule*, which is exactly why
+the *mandatory* sibling is a different animal. Watch only the CDC case (see
+`../../_index/cdc/SKILL.md`). Fail mode avoided: fearing additive columns and mis-locating the risk.

--- a/sidecar/projection/ssdt-agent/skills/op/add-unique/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-unique/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: add-unique
+description: Use when the developer says "this attribute should be unique", "no two customers can share an email", "stop duplicate codes" — adding a UNIQUE constraint or unique index. Builds enforcement over all existing rows; duplicates veto, and one-NULL-only bites nullable columns.
+---
+
+# Add a unique constraint
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 when the data already satisfies uniqueness — but PROVE no duplicates (and no multi-NULL) first.
+
+## OutSystems phrasing
+"this attribute should be unique", "no two customers can share an email", "stop duplicate codes".
+
+## SSDT meaning
+`CONSTRAINT UQ_<Table>_<Col> UNIQUE (<Col>)` (or a unique index). SSDT builds the uniqueness enforcement over **all existing rows** at deploy.
+
+## The named trap
+**Duplicates veto the build** — the deploy fails the instant two rows share a value. Second trap: **UNIQUE treats NULL as a value and allows exactly ONE NULL row**; a nullable column with several NULLs also vetoes — the fix for legitimate multi-NULL is a **filtered unique index**: `CREATE UNIQUE INDEX … WHERE <Col> IS NOT NULL`. Both are the constraint-is-a-claim veto-on-a-value family — see `../../_index/constraint-is-a-claim/SKILL.md` (incl. the UNIQUE-one-NULL + filtered-index remedy); do not re-derive the claim mechanics here.
+
+## How it flips (the specifics only)
+- no duplicates, no multi-NULL problem → M1, single-phase, Tier 2 (prove it).
+- duplicates PRESENT → **FLIP to M3 Pre-Deploy+Declarative, single-PR**: pre-deploy de-dupe clears them BEFORE the unique build, Tier 3 — see `../../_index/constraint-is-a-claim/SKILL.md`.
+- nullable column with >1 NULL row → filtered unique index, OR resolve the NULLs first; stays single-PR if the filtered index suffices.
+- \+ >1M rows → **+1 Tier** (build + dedupe cost).
+- \+ CDC-enabled → high-stakes table; apply the team's +1 rule (see `../../_index/cdc/SKILL.md`) even though CDC does not track the constraint.
+
+## Prove it
+Run the duplicate probe FIRST: `SELECT <Col>, COUNT(*) FROM <table> GROUP BY <Col> HAVING COUNT(*) > 1` (and a NULL count for nullable columns). Then build + Strict publish: clean → uniqueness holds; a build failure ("duplicate key was found") is the veto. Author the pre-deploy de-dupe (or the filtered index), re-run Strict clean. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`. Seed: Status's `UX_Status_Code` is the clean positive; Product's `DUPE` rows drive the veto flip.
+
+## Verdict to the developer
+"You asked to make Email unique. I published it to a copy of your data and SSDT refused — 4 rows share an email. This is a Pre-Deploy + Declarative change: I dedupe those 4 first, then the unique constraint builds clean. Proven. (If multiple blank emails are legitimate, I'll use a filtered unique index that ignores NULLs instead.)"
+
+## Teach it (the graduation)
+Before adding any uniqueness rule, run `GROUP BY … HAVING COUNT(*) > 1` and a NULL count — the answer decides the mechanism, the SQL never can. See `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: shipping a unique constraint that vetoes on real duplicates.

--- a/sidecar/projection/ssdt-agent/skills/op/archive-entity/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/archive-entity/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: archive-entity
+description: Use when the developer says "archive old orders", "move the historical rows out to an archive table", "move records we don't need live anymore" — a data movement between tables, not a shape change.
+---
+
+# Archive entity
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 (Tier 4 if the move is irreversible / large). Create destination → migrate (batched) → verify counts.
+
+## OutSystems phrasing
+"archive old orders", "move the historical rows out to an archive table".
+
+## SSDT meaning
+This is a **data movement**, which SSDT does not express declaratively. You create the archive
+destination (declarative) and script the row move (post-deploy), typically batched `DELETE ...
+OUTPUT DELETED.* INTO archive.X` to spare the transaction log. SSDT describes *shapes*, not
+*data motion*.
+
+## The named trap
+Unbatched moves bloat the transaction log; child rows with FKs must move (or their FKs be
+disabled) **before** parents; cross-database archives lose FK enforcement. The coexistence
+obligation (live + archive both readable during the move) is the multi-phase concern — see
+`../../_index/multi-phase/SKILL.md`; do not re-derive the coexistence shape here.
+
+## How it flips (the specifics only)
+- new archive table + scripted move → **M5 Multi-Phase** (additive → migrate → verify; see `../../_index/multi-phase/SKILL.md`)
+- large volume (>1M rows) → **+1 Tier**, mandatory batching
+- source is CDC-enabled → the deletes generate capture rows; coordinate → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+- active queries must see only live data during the move → coexistence, stays multi-PR
+
+## Prove it
+Prove **source-count + archive-count == original total** after the batched move (no rows dropped,
+none duplicated) and that each batch commits (log stays bounded) — this is the conservation proof
+the multi-phase index owns. Permissive run snapshots before/after row hashes to prove the moved
+rows are byte-identical in the archive. For the publish loop, see
+`../../prove-on-dacpac/SKILL.md`; probes, `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Archiving is a data move, and SSDT has no declarative 'move' — so it's Multi-Phase, multi-PR:
+create the archive table, then batch the rows across. I proved the counts reconcile exactly and
+each batch commits. Tier 3, and +1 because it's over a million rows."
+
+## Teach it (the graduation)
+The instant a request is about *moving data between tables* rather than *changing a table's
+shape*, you have left the declarative world and the proof becomes a conservation check (see
+`../../_index/multi-phase/SKILL.md`). Fail mode avoided: an unbatched move that silently loses or
+doubles rows and looks identical in the schema. Ask "shape change or data move?"

--- a/sidecar/projection/ssdt-agent/skills/op/audit-columns/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/audit-columns/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: audit-columns
+description: Use when the developer says "add CreatedBy/CreatedOn/ModifiedBy/ModifiedOn", "stamp who changed it and when", "basic audit fields", "add created/modified tracking columns" — ordinary audit stamp columns. SSDT destination = declarative nullable columns (or Mechanism 3 pre-deploy backfill if NOT NULL on a populated table).
+---
+
+# Add manual audit columns (Optimistic-NOT-NULL trap)
+
+> **Default (provisional — the data decides).** Nullable audit columns: Mechanism 1 Pure Declarative, single-phase, Tier 1. NOT NULL on a populated table: Mechanism 3 Pre-Deploy + Declarative, single-PR, Tier 2 — PROVE the backfill clears the veto.
+
+## OutSystems phrasing
+"add CreatedBy / CreatedOn / ModifiedBy / ModifiedOn", "stamp who changed it and when", "basic audit fields".
+
+## SSDT meaning
+Ordinary nullable columns (often with `DEFAULT SYSUTCDATETIME()` / `DEFAULT SUSER_SNAME()`) plus app-side or trigger-side stamping. SSDT ADDs them declaratively. Never write ALTER.
+
+## The named trap
+The *Optimistic NOT NULL* family — if the developer wants the audit columns `NOT NULL` on a populated table without a backfill, the publish vetoes because existing rows have no `CreatedOn`. A `DEFAULT` covers new rows but **not** existing ones unless `GenerateSmartDefaults` stamps them (which Strict refuses, on purpose). This is the tightening class applied to a fresh column — see `../../_index/tightening-class/SKILL.md`; do not re-derive the row-presence guard here. (`make-mandatory` owns the class spine.)
+
+## How it flips (the specifics only)
+- nullable / table empty → **M1**, single-phase, Tier 1.
+- **`NOT NULL` + populated** → **M3** pre-deploy backfill, single-PR. The backfill that clears the veto is the proof. Tier 2.
+- **+ CDC on the table** → +1 Tier; adding columns to a CDC-enabled table needs a capture-instance refresh — see `../recreate-capture-instance/SKILL.md` and `../../_index/cdc/SKILL.md`.
+- **+ >1M rows** → +1 Tier; the backfill is a batched operation.
+
+## Prove it
+If `NOT NULL`, Strict must veto on the existing rows with no audit value; the pre-deploy backfill must clear it; the Permissive run shows exactly what `GenerateSmartDefaults` would have silently stamped (so the developer sees what the veto was protecting). See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, exercise with the `Customer` seed (AUD-03).
+
+## Verdict to the developer
+"Nullable audit columns add in one release. If you want them mandatory, SSDT vetoes because your existing rows have no value — I proved that, and the pre-deploy backfill that stamps them clears it. One release, with the backfill proven."
+
+## Teach it (the graduation)
+A `DEFAULT` describes the future, not the past — making an existing column mandatory always confronts the rows already there, and the proof is the backfill plus the now-clean Strict run; the fail mode avoided is expecting NOT-NULL-with-default to "just work" on live data. Full WHY: `../../_index/tightening-class/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/change-delete-rule/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/change-delete-rule/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: change-delete-rule
+description: Use when the developer changes the Delete Rule on a reference — "change the Delete Rule to Protect/Ignore/Delete", "turn on cascade delete", "deleting a Customer should delete its Orders". A DROP+ADD of the FK to set ON DELETE action; behaviorally dangerous, especially CASCADE.
+---
+
+# Change the delete rule / cascade (Protect / Ignore / Delete)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative (DROP + ADD the FK), single-phase, Tier 3 — the publish is clean but the behavioral blast radius (especially CASCADE) drives the tier.
+
+## OutSystems phrasing
+The **Delete Rule** on the reference — **Protect** ("can't delete a Customer with Orders"), **Ignore** ("let the Customer go, leave the Orders"), **Delete** ("delete the Customer and its Orders").
+
+## SSDT meaning
+The FK's `ON DELETE` action. Mapping: **Protect → `ON DELETE NO ACTION`**; **Ignore → no clean single-DB equivalent** (either `NO ACTION` + app-tolerated dangling refs, which still *blocks* the parent delete, **or** `ON DELETE SET NULL` if the FK column is nullable — ask which the developer means, don't silently pick); **Delete → `ON DELETE CASCADE`**. Changing the rule is a **DROP + ADD** of the FK (you cannot alter the action in place).
+
+## The named trap
+Turning on **CASCADE** silently changes runtime behavior — a delete that previously *failed* now *removes child rows*, possibly **chaining** through multiple tables; cascaded deletes may also bypass expected CDC/audit capture. None material to the *publish* (DROP+ADD never vetoes on data) — the danger is entirely behavioral.
+
+## How it flips (the specifics only)
+- the DROP+ADD is schema-only and never vetoes on data → M1, single-phase mechanically.
+- toward CASCADE → silent multi-table deletes → Tier 3; map the full cascade graph before shipping.
+- if you also tighten the FK (re-validate existing rows) → the create-fk orphan rules apply → could flip to script (see `../create-fk-orphan/SKILL.md`).
+- CDC-enabled → cascaded deletes may bypass expected capture → **+1 Tier** (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+Script the delta and confirm it is `DROP CONSTRAINT` + `ADD CONSTRAINT ... ON DELETE <action>` (NOT a table rebuild). For CASCADE, **prove the blast radius**: on the throwaway DB, delete one parent and snapshot which child rows vanish across the whole cascade chain. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`. Seed: the Order → OrderLine chain (KEY-01) makes the cascade visible across two levels. **Setup note:** the sample's `OrderLine → Order` FK is intentionally *undeclared* (it is a create-fk proof surface), so to prove a *rule change* first declare it `NO ACTION`, then change it to CASCADE — disclose that this NO_ACTION declaration is your setup, not the authored baseline.
+
+## Verdict to the developer
+"Changing the Delete Rule to Delete means `ON DELETE CASCADE`: deleting an Order now also deletes its OrderLines — I proved it on a copy (one Order delete removed its child lines, then rolled back). The change itself is Pure Declarative (drop and re-add the foreign key), but it's Tier 3 because a single delete now silently removes rows in a second table — and in a deeper reference graph it would chain further, which is why you map the full cascade before shipping."
+
+## Teach it (the graduation)
+A clean publish is not a safe change — some edits are dangerous in what they *do* at runtime, not in what they do to existing rows; *danger is not release-count*. Fail mode avoided: trusting "it deployed clean" for a CASCADE that silently deletes across tables.

--- a/sidecar/projection/ssdt-agent/skills/op/change-tracking/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/change-tracking/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: change-tracking
+description: Use when the developer says "I just need to know which rows changed since last sync", "change tracking for the mobile sync", "a lightweight what's-new since timestamp X", "tell me which records moved, I don't need the old values" — the light sibling of CDC. SSDT destination = an operational ALTER script (Mechanism 4 Script-Only), NOT declarative, with none of CDC's standing tax.
+---
+
+# Enable change tracking (CDC-vs-change-tracking conflation trap)
+
+> **Default (provisional — the data decides).** Mechanism 4 Script-Only, single-PR script, Tier 2 — much lighter than CDC: no capture instances, no per-feed management, all editions.
+
+## OutSystems phrasing
+"I just need to know *which* rows changed since last sync", "change tracking for the mobile sync", "a lightweight 'what's new' since timestamp X".
+
+## SSDT meaning
+`ALTER DATABASE … SET CHANGE_TRACKING = ON` + `ALTER TABLE … ENABLE CHANGE_TRACKING`. Lighter than CDC — it records **which rows / which columns changed** and a version number, but **not the changed values** (no historical data). All editions, much lower overhead, but still **not declarative** — it's an operational `ALTER`, outside the dacpac model. This is a script.
+
+## The named trap
+**Confusing it with CDC** — developers say "track changes" for both. Change tracking gives "row 42 changed" (sync-oriented); CDC gives "row 42 went from X to Y" (a full change feed). If the developer needs the old values, change tracking is the wrong tool; reaching for CDC when change tracking would do takes on the whole CDC tax for nothing. The intent-naming discipline is owned by `../../_index/cdc/SKILL.md` (change-tracking is its lighter sibling); do not re-derive the CDC weight here.
+
+## How it flips (the specifics only)
+- enable change tracking → **M4 Script-Only**, single-PR, Tier 2.
+- retention/cleanup configuration → operational, lives in DB settings, flag as job-owned.
+- it does **not** carry CDC's +1-tier standing consequence — that is the whole point of preferring it when values aren't needed.
+
+## Prove it
+Confirm the enable is an operational `ALTER` the dacpac does not own (declarative attempt produces nothing), run it on the isolated DB, and prove `CHANGETABLE(CHANGES …)` reports changed row keys but **not** old values — so the developer sees the boundary between change tracking and CDC concretely. Isolation still applies (see `../../_index/cdc/SKILL.md`, `talk-to-local-sql`). On the sample, `dbo.CdcCandidate` is the target (AUD-06).
+
+## Verdict to the developer
+"If you only need to know *which* rows changed for a sync — not what they changed from — change tracking is the light option: all editions, far less overhead, none of CDC's standing tax. It's still a script, not a schema edit. If you actually need the old values, that's CDC, and that's the heavier road."
+
+## Teach it (the graduation)
+Match the mechanism's weight to the requirement — "do you need the old values, or only which keys moved?" is the discriminator, and the cheaper answer is usually enough; the fail mode avoided is over-buying CDC (and its +1-forever tax) for a mobile sync. Full WHY (name your intent, pick the lightest tool): `../../_index/cdc/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/compat-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/compat-view/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: compat-view
+description: Use when the developer says "I renamed Customer to Account but the old reports still ask for Customer", "keep the old entity name working after the rename", "don't break the integrations that read the old table", "the SSIS package still expects the old name" — a bridge that keeps an old entity name readable after a rename/split. SSDT destination = a CREATE VIEW bearing the OLD name selecting from the renamed table, enumerated and temporary.
+---
+
+# Backward-compatibility view (SELECT * / forgotten-it-is-temporary trap) — recipe AUTHORED HERE
+
+> **AUTHORED-HERE NOTICE.** Handbook file 14 references §17.8 "backward-compatibility view" as the companion to a rename/split, but the template body is empty. The recipe below is authored here to fill the gap; treat it as the working contract and fold it back when file 14 is completed.
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative for the view itself, but part of a multi-PR rename/split program, Tier 3 (external dependency scope).
+
+## OutSystems phrasing
+"I renamed Customer to Account but the old reports still ask for Customer", "keep the old entity name working after the rename", "don't break the integrations that read the old table".
+
+## SSDT meaning
+After a rename or split changes the real table's name/shape, create a **view bearing the OLD name** that SELECTs from the new table, mapping the old column list to the new one. External consumers keep reading `dbo.Customer` (now a view) while the real data lives in `dbo.Account` (the table). The view is the bridge that lets old and new names coexist. Never write ALTER.
+
+## Why it exists
+A rename is only safe inside the dacpac if the refactorlog records it (so SSDT emits `sp_rename`, not the data-destroying DROP+CREATE — see `../../_index/identity-and-refactorlog/SKILL.md`). But the refactorlog protects only consumers **inside** the SSDT model. Anything outside it — SSIS, Power BI, hand-written procs, the SSAS feed — still asks for the old name and breaks the instant the table is renamed. The compat view restores the old name as a readable surface.
+
+## The named trap
+Making the compat view a `SELECT *` (re-triggers the *SELECT \* View* trap and defeats the purpose — enumerate and alias the old column names; see `../create-view/SKILL.md`), and forgetting it is **temporary** — a compat view is debt with a sunset date. Leaving it forever recreates the name ambiguity the rename resolved.
+
+## The recipe (authored here)
+1. **Inside the model**, perform the rename with the refactorlog entry so internal consumers and the dacpac see `sp_rename` (no data loss). Prove the delta is `sp_rename`, NOT DROP+CREATE.
+2. **Create a view bearing the OLD name**: `CREATE VIEW dbo.Customer AS SELECT AccountId AS Id, AccountName AS Name, … FROM dbo.Account;` — enumerate every old column, aliasing new names back to old so the external contract is byte-for-byte the same shape.
+3. **Mark it temporary**: comment the view with the consumers it serves and the sunset trigger ("drop when SSIS package X and report Y have migrated to dbo.Account").
+4. **Sunset (a later PR)**: once every external consumer has moved, drop the compat view as a clean subtractive change.
+
+## How it flips (the specifics only)
+- **no external consumers** of the old name (all inside the SSDT model) → you do not need the compat view; the refactorlog alone suffices. **M1**, no view.
+- **external consumers exist** → ship the compat view alongside the rename (M1 view + the rename's mechanism), **Tier 3**, and schedule the sunset PR.
+
+## Prove it
+(a) the rename delta is `sp_rename` not DROP+CREATE (prove the refactorlog is honored — see `../../_index/identity-and-refactorlog/SKILL.md`); (b) `SELECT` from the compat view returns the SAME shape and SAME row hashes as the pre-rename table — hash the old table before, hash the compat view after, prove **equal** (the bridge is transparent). See `prove-on-dacpac` / `talk-to-local-sql`. Exercise with the `Customer` rename scenario; `dbo.vOrderSummary` is the enumerated-view target (VIE-02).
+
+## Verdict to the developer
+"I renamed the entity safely (SSDT does an sp_rename, not a drop-and-recreate — I proved that). For the reports and integrations that still ask for the old name, I added a view named `Customer` that reads from the renamed table and returns the exact same shape — proven by matching row hashes. It's marked temporary: once those consumers move, a later PR drops it."
+
+## Teach it (the graduation)
+The refactorlog's reach stops at the model boundary, so a rename's true blast radius is everything outside it — the bridge is debt with a sunset date, not a permanent fixture; the fail mode avoided is renaming a table out from under an SSIS/Power BI consumer that still asks for the old name. Full WHY (identity vs. name): `../../_index/identity-and-refactorlog/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/create-entity/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-entity/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: create-entity
+description: Use when the developer says "add a new Entity", "create a new table", "I need a new CustomerPreference entity", "make a new entity for X" — a brand-new table that does not yet exist. The purest additive CREATE TABLE.
+---
+
+# Create entity
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 — additive and self-contained, but confirm the clean publish.
+
+## OutSystems phrasing
+"add a new Entity", "create a new table", "I need a new CustomerPreference entity".
+
+## SSDT meaning
+A new `.sql` file in `Modules/` holding a `CREATE TABLE` — PK, columns, FKs, defaults, all
+inline. The table does not exist, so SSDT emits the `CREATE TABLE` verbatim; nothing to
+transition. The canonical "describe the destination" move. Never write `ALTER`.
+
+## The named trap
+*FK to a non-existent parent* — if the new table references a table not in the project, the
+**build** fails (not the deploy); add the parent first or in the same change. And a file the
+project glob misses silently never deploys. Neither is a data flip — this is a **dependency**
+concern, not a veto concern.
+
+## How it flips (the specifics only)
+- new standalone table → **M1, single-phase, Tier 1** (nothing depends on it, nothing to transition)
+- table needs seed/lookup rows on creation → pairs with **M2 Declarative+Post-Deploy** (the guarded MERGE seed — see `../create-static-seed/SKILL.md` and `../../_index/idempotent-seed/SKILL.md`)
+- table must be CDC-enabled from birth → CDC is not in the dacpac model → **M4 Script-Only rider, +1 Tier** (see `../../_index/cdc/SKILL.md`)
+- FK to a parent not yet in the project → still M1, but the build gates it (dependency-order, not a data flip)
+
+## Prove it
+Strict publish must succeed clean; the generated delta must be a single `CREATE TABLE
+[schema].[Name]` with **no** `DROP`/`ALTER` of any sibling. If the delta touches a table you
+did not edit, stop — the change is not self-contained. For the publish loop that PROVES this,
+see `../../prove-on-dacpac/SKILL.md`; for the substrate, `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"New entity, nothing depends on it yet — I described the table and SSDT just creates it. Pure
+Declarative, single-phase, Tier 1. Proven clean on a copy of your data, and the delta is only
+the CREATE."
+
+## Teach it (the graduation)
+A create is the purest *model IS the schema* — there is no existing data for SSDT to be
+conservative about, so the only thing that can go wrong is a *dependency*, not a data flip. Ask
+"does anything already depend on this, or does this depend on anything not yet here?" — the fail
+mode avoided is over-tiering self-contained additive work.

--- a/sidecar/projection/ssdt-agent/skills/op/create-fk-clean/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-fk-clean/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: create-fk-clean
+description: Use when the developer says "add a reference to Customer", "draw the relationship from Order to Customer", "Order belongs to a Customer" AND the child data is clean (every child points at a real parent) — a FOREIGN KEY that SQL Server validates against every existing child row and lands as one clean ADD CONSTRAINT.
+---
+
+# Create a foreign key, clean data (Forgotten FK Check)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — but PROVE zero orphans first. If orphans exist, this is not your op — route to `../create-fk-orphan/SKILL.md`.
+
+## OutSystems phrasing
+"add a reference to Customer", "draw the relationship from Order to Customer", "Order belongs to a Customer".
+
+## SSDT meaning
+`CONSTRAINT [FK_Order_Customer] FOREIGN KEY ([CustomerId]) REFERENCES [dbo].[Customer]([CustomerId])`. SSDT emits `ALTER TABLE ... ADD CONSTRAINT ...` and SQL Server **validates every existing child row** against the parent. All `Order.CustomerId` present in `Customer` → lands clean.
+
+## The named trap
+**Forgotten FK Check** (handbook file 16 = §19.3): adding the FK without probing for **orphans** (child rows whose parent key does not exist) — the clean declarative FK then vetoes at deploy. Dodging with `WITH NOCHECK` leaves an untrusted constraint. This is the constraint-is-a-claim family (violation-on-a-value veto) — see `../../_index/constraint-is-a-claim/SKILL.md`; the orphan-reconcile-retrust path lives in `../create-fk-orphan/SKILL.md`.
+
+## How it flips (the specifics only)
+- no orphan rows → M1, single-phase, Tier 2 (inserts/updates now validated; new inter-table dependency).
+- orphan rows present → FK validation **vetoes** → route to `../create-fk-orphan/SKILL.md` (M4/M5, Tier 3).
+- parent table large → validation scans it → **+1 Tier** at >1M rows.
+- CDC-enabled → no capture impact from the FK itself; coordinate if either side is mid-migration (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+Run the orphan probe FIRST: `SELECT COUNT(*) FROM child c LEFT JOIN parent p ON c.<fk> = p.<pk> WHERE p.<pk> IS NULL`. Then Strict publish: clean data → the delta is one `ADD CONSTRAINT`; orphans → Strict vetoes (show the orphan count + offending child rows) and you switch ops. See `../../prove-on-dacpac/SKILL.md` (publish loop) + `../../talk-to-local-sql/SKILL.md` (probe). Seed: Order→Customer clean rows are the positive; the seeded orphan `Order.CustomerId=999` is the flip that routes you to create-fk-orphan; OrderLine→Order gives FK-graph depth (KEY-01).
+
+## Verdict to the developer
+"Adding the reference makes SQL Server check every Order against a real Customer. I proved there are no orphans on a copy of your data, so the foreign key lands clean — Pure Declarative, single-phase, Tier 2."
+
+## Teach it (the graduation)
+An FK is the textbook *only the data decides*: the same `ADD CONSTRAINT` is clean M1 or vetoed Tier 3 on one orphan — you classify from the orphan count, never the `.sql`. See `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: drawing the relationship without the orphan probe and shipping a deploy that vetoes.

--- a/sidecar/projection/ssdt-agent/skills/op/create-fk-orphan/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-fk-orphan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: create-fk-orphan
+description: Use when the developer says "add a reference to Customer" but the data is dirty — some child rows point at parents that do not exist (orphans). The NOCHECK → reconcile → WITH CHECK CHECK script path that ends with a TRUSTED foreign key.
+---
+
+# Create a foreign key with orphans (NOCHECK → reconcile → WITH CHECK CHECK)
+
+> **Default (provisional — the data decides).** Mechanism 4 Script-Only, single-PR, Tier 3 — the orphans force a reconcile before the constraint can be honest. Flips to Mechanism 5 Multi-Phase if the reconcile must stage across releases.
+
+## OutSystems phrasing
+Same as create-fk-clean ("add a reference to Customer", "Order belongs to a Customer"), but some child rows point at parents that do not exist.
+
+## SSDT meaning
+The clean declarative FK would veto. The script path: add the constraint `WITH NOCHECK` (constraint exists but **untrusted**) → reconcile the orphans (delete them, repoint them, or insert the missing parents) → `ALTER TABLE ... WITH CHECK CHECK CONSTRAINT [FK_...]` to validate and **restore trust** so the optimizer honors it.
+
+## The named trap
+Stopping at `WITH NOCHECK` — the constraint is present but **untrusted** (`is_not_trusted = 1`), protecting nothing and ignored by the optimizer. The `WITH CHECK CHECK` re-validation is mandatory. This is the NOCHECK→reconcile→re-trust ladder owned by the constraint-is-a-claim family — see `../../_index/constraint-is-a-claim/SKILL.md`; do not re-derive the trust mechanics here.
+
+## How it flips (the specifics only)
+- orphans reconcilable in one release → M4 Script-Only, single-PR, Tier 3.
+- reconcile must wait on an app change (orphans still being created) → M5 Multi-Phase, coexistence concern (see `../../_index/multi-phase/SKILL.md`).
+- orphan reconcile **deletes** child rows → data loss → Tier 4 consideration.
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+First prove the **veto** the clean FK produces (orphan count via `LEFT JOIN ... WHERE p.<pk> IS NULL`). Then prove the full script on the throwaway DB: `NOCHECK` adds the constraint untrusted (`SELECT is_not_trusted FROM sys.foreign_keys WHERE name='FK_...'` → 1), the reconcile clears the orphans, and `WITH CHECK CHECK` flips it back to trusted (`is_not_trusted = 0`) with no veto. That trusted re-validation is the proof. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`. Seed: the `Order.CustomerId=999` orphan drives the whole sequence.
+
+## Verdict to the developer
+"The reference vetoed on a copy — 8 Orders point at Customers that don't exist. So it's a Script-Only change this release: add the constraint without checking, fix the 8 orphans, then re-validate to make it trusted. I proved the whole sequence ends with a trusted foreign key. Tier 3 because we're changing existing data."
+
+## Teach it (the graduation)
+"The constraint exists" is not "the constraint is trusted" — after any NOCHECK shortcut, prove `is_not_trusted = 0` or you haven't finished. See `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: shipping a silent untrusted FK that guards nothing.

--- a/sidecar/projection/ssdt-agent/skills/op/create-static-seed/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-static-seed/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: create-static-seed
+description: Use when the developer says "add a Status lookup", "create a static entity for order types", "I need a reference table with these fixed values", "a lookup entity with Active/Inactive" — a new OutSystems Static Entity whose rows are part of the model. SSDT destination = a declarative CREATE TABLE plus an idempotent MERGE seed in the post-deploy script.
+---
+
+# Create static / lookup entity (non-idempotent-seed + IDENTITY-lookup traps)
+
+> **Default (provisional — the data decides).** Mechanism 2 Declarative + Post-Deploy, single-PR, Tier 1 — but PROVE the redeploy is silent.
+
+## OutSystems phrasing
+"add a Status lookup", "create a static entity for order types", "a reference table with these fixed values", "a lookup with Active/Inactive".
+
+## SSDT meaning
+A declarative `CREATE TABLE` for the lookup (schema slot) PLUS a seed in `Script.PostDeployment.sql` (data slot), usually `:r`-including `Data/Seed.sql`. The CREATE is pure structure; the rows are an idempotent MERGE. Lookup keys are **explicit IDs, NOT IDENTITY** — the IDs are part of the model and must be identical in every environment so the app can reference `StatusId = 3` by constant. Never write ALTER.
+
+## The named trap
+Two named traps, both owned elsewhere: the **non-idempotent seed** (a bare INSERT that duplicate-keys on the second deploy) and the **IDENTITY lookup** (auto-assigned IDs drift between environments). Both are the idempotent-seed concern — see `../../_index/idempotent-seed/SKILL.md`; do not re-derive the guarded-MERGE or explicit-ID reasoning here.
+
+## How it flips (the specifics only)
+- fresh lookup, explicit IDs, guarded MERGE → M2, single-PR, Tier 1.
+- lookup is an **FK target** for other entities → seed the lookup **before** its children (parents-first); still M2, but a missing parent row makes a child FK veto.
+- **+ CDC-tracked** (table or downstream consumer) → the `WHEN MATCHED` MUST be guarded or the redeploy over-captures — see `../../_index/cdc/SKILL.md`. +1 Tier.
+- **+ >1M reference rows** (rare) → +1 Tier for the data operation.
+
+## Prove it
+Deploy once (seed lands), then **deploy a SECOND time unchanged** and assert the post-deploy reports **0 rows affected** + an **identical data-hash** (order-independent `SHA2_256(FOR XML RAW)` sum). If CDC-tracked, assert the second deploy captures **0** rows. A changed hash on an unchanged seed means the MERGE is rewriting rows — fix the guard. See `prove-on-dacpac` for the publish loop and `talk-to-local-sql` for the hash probe. On the enriched sample, `dbo.Category` (explicit-id, `IsActive DEFAULT 1`) is the ready-made seed target.
+
+## Verdict to the developer
+"I created the Status lookup as a declarative table plus an idempotent seed with explicit IDs so they match across every environment. I proved it: the second deploy touched zero rows, so redeploys are silent and safe."
+
+## Teach it (the graduation)
+For reference data, *re-running changes nothing* is the correctness property, and a silent second deploy is how you prove it — the fail mode avoided is a seed that rewrites rows on every deploy (broken even when the values match). Full WHY: `../../_index/idempotent-seed/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/create-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-view/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: create-view
+description: Use when the developer says "give me a view that joins Order and Customer", "an Advanced Query entity for active customers", "expose a read-only combined entity", "a saved query I can read like a table" — a new OutSystems view / Advanced Query. SSDT destination = a declarative CREATE VIEW with columns enumerated explicitly (never SELECT *).
+---
+
+# Create a view (SELECT * View trap)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 — but enumerate the columns.
+
+## OutSystems phrasing
+"give me a view that joins Order and Customer", "an Advanced Query entity for active customers", "expose a read-only combined entity".
+
+## SSDT meaning
+`CREATE VIEW dbo.SomeView AS SELECT … FROM …`. SSDT publishes it declaratively as CREATE/ALTER VIEW; a view holds no data of its own, so there is no `BlockOnPossibleDataLoss` concern. Never write ALTER.
+
+## The named trap
+**SELECT \* View** (handbook 16 = §19). `SELECT * FROM dbo.Order` does not freeze the column list; its resolved shape is **cached metadata** that only updates when the module is rebound. SSDT auto-rebinds dependents on publish (`sp_refreshsqlmodule`), so *through SSDT* a `SELECT *` view stays current — but a base-table change made **out of band** (a raw `ALTER` outside the dacpac) leaves the view bound to the OLD shape until someone runs `sp_refreshview`. So the view's contract lives *outside* its own .sql and can drift with **no reviewable diff**. Always enumerate columns explicitly; SSDT will not flag the `*`. This trap recurs only in create-view and compat-view — it is NOT lifted to an index; it lives here and in `../compat-view/SKILL.md`.
+
+## How it flips (the specifics only)
+- plain enumerated-column view → **M1**, Tier 1.
+- view that downstream apps/reports/ETL depend on → still M1 mechanically, but **Tier 3** by dependency scope (external deps): changing it later is a cross-system change.
+- `SELECT *` view → mechanically M1, but a **latent defect** — fix the `*` before shipping, not a flip.
+- indexed/materialized view → see `../indexed-view/SKILL.md`; the materialization changes the mechanism.
+
+## Prove it
+Preview the Strict delta — a clean CREATE/ALTER VIEW, no rebuild, no veto. Proving the `SELECT *` trap needs care (verified on the proving ground): a **pure SSDT publish auto-emits `EXECUTE sp_refreshsqlmodule`** for the dependent view, so a *through-model* base-column add makes the `SELECT *` view **stay correct** (it picks up the new column) — that is NOT the trap, it's SSDT protecting you. To prove the trap as a *silent defect*, add the base column via a **non-SSDT path** (a raw `ALTER TABLE` outside the dacpac — a hotfix by another team), then show the `SELECT *` view is still bound to the OLD column set until someone runs `sp_refreshview` manually. That out-of-band drift is where a `SELECT *` view rots. See `prove-on-dacpac`. On the sample, `dbo.vOrderSummary` ships an enumerated variant plus a documented `SELECT *` variant for the scratch-copy drift proof (VIE-01).
+
+## Verdict to the developer
+"Your view publishes clean — it holds no data so there's nothing to lose. I enumerated the columns explicitly instead of SELECT *, so it won't silently change shape when the underlying entity does."
+
+## Teach it (the graduation)
+A definition that defers to "whatever's there" has no contract, and a change with no visible diff is the hardest to catch — freeze the surface explicitly so drift shows up as a reviewable diff; the fail mode avoided is a `SELECT *` view rotting silently as its base evolves.

--- a/sidecar/projection/ssdt-agent/skills/op/define-pk/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/define-pk/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: define-pk
+description: Use when the developer says "set the primary key", "the Identifier", "make this the unique key for the entity", "use a composite key on OrderId + LineNumber" — declaring a PRIMARY KEY inline in the CREATE (new table) or onto a populated table (a clustered-index build over every row that vetoes on duplicate/NULL keys).
+---
+
+# Define the primary key (the Identifier)
+
+> **Default (provisional — the data decides).** New table → Mechanism 1 Pure Declarative, single-phase, Tier 1. Existing populated table → Mechanism 1, single-phase, Tier 2 (the clustered-index build touches every row) — but PROVE the key is unique and non-NULL first.
+
+## OutSystems phrasing
+"the Identifier", "set the primary key", "make this the unique key for the entity", "use a composite key on OrderId + LineNumber".
+
+## SSDT meaning
+`CONSTRAINT [PK_Table] PRIMARY KEY CLUSTERED (...)` inline in the `CREATE`. On a new table it is part of the create. On an existing populated table, adding the PK **builds a clustered index** (scans and reorders every row) and **fails if the key column has duplicate or NULL values**.
+
+## The named trap
+A PK is a *claim of uniqueness proven at build time* — adding it to a populated table with duplicate or NULL key values vetoes on the index build. This is the constraint-is-a-claim family (populated-veto face) — see `../../_index/constraint-is-a-claim/SKILL.md`; do not re-derive the claim mechanics here. Separate trap: confusing an IDENTITY surrogate with a natural key — see `../identity-swap/SKILL.md`.
+
+## How it flips (the specifics only)
+- new table → M1, Tier 1 (PK inline in the create).
+- existing table, key column already unique & non-NULL → M1, Tier 2 (the index build touches every row).
+- existing table with duplicate/NULL key values → index build **vetoes** → M3 Pre-Deploy (dedupe/assign keys first) or M5 Multi-Phase — the veto is on the actual duplicate/NULL values, see `../../_index/constraint-is-a-claim/SKILL.md`.
+- \>1M rows → **+1 Tier** (blocking clustered-index build).
+- CDC-enabled → **+1** (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+Run the op-specific probes FIRST: `SELECT <keycols>, COUNT(*) FROM <table> GROUP BY <keycols> HAVING COUNT(*) > 1` (duplicate probe) and a NULL count on each key column. Then Strict publish: dups → the index build vetoes (show the offending keys); clean → the delta is the PK inline in the create (new) or a clean clustered-index build (existing). Author the dedupe/assign-keys pre-deploy, re-run Strict clean. See `../../prove-on-dacpac/SKILL.md` for the publish loop and `../../talk-to-local-sql/SKILL.md` for running the probes. Seed: OrderLine (KEY-01) proves the composite `OrderId + LineNumber`.
+
+## Verdict to the developer
+"Defining the Identifier on a new entity is free — it's part of the create. On your existing table it builds a clustered index over every row; I proved the key is unique with no NULLs, so it publishes clean. Tier 2 because the build touches the whole table."
+
+## Teach it (the graduation)
+A key constraint is a claim about existing rows — you prove the claim (duplicate + NULL probe) before you classify, per `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: assuming the key is clean and shipping a deploy that vetoes on dirty keys.

--- a/sidecar/projection/ssdt-agent/skills/op/delete-attribute/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/delete-attribute/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: delete-attribute
+description: Use when the developer says "remove the attribute", "delete the LegacyCode field nobody uses", "drop this column", "get rid of this field" — removing a column. The 4-phase deprecation; danger is not release-count.
+---
+
+# Delete attribute (4-phase deprecation)
+
+> **Default (provisional — the data decides).** EMPTY column-source → the drop lands (M1). POPULATED → the **tightening-class** data-blind row-presence veto fires (see `../../_index/tightening-class/SKILL.md`); the safe remedy is the M5 4-phase deprecation (or a named gate-relaxation). Tier 3–4 (Tier 4 once real data is destroyed) — *danger is not release-count.*
+
+## OutSystems phrasing
+"remove the attribute", "delete the LegacyCode field, we don't use it".
+
+## SSDT meaning
+Remove the column from the `CREATE`. SSDT emits `ALTER TABLE ... DROP COLUMN [Col]`. On a column
+that holds data, `BlockOnPossibleDataLoss=True` **vetoes** it; the values are irrecoverable
+without a backup. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+Dropping a column still referenced by a view/proc/computed-column/index (those break or block the
+drop); and dropping before the app has genuinely stopped reading it. The populated-column veto is
+the tightening-class row-presence gate — see `../../_index/tightening-class/SKILL.md`. The
+coexistence obligation (the 4-phase deprecation) is the multi-phase concern — see
+`../../_index/multi-phase/SKILL.md`. Do not re-derive either here.
+
+## How it flips (the specifics only)
+- column empty / provably unused, no dependents → mechanically **M1**, but danger keeps it **Tier 3**
+- column holds data → `BlockOnPossibleDataLoss` veto (row-presence — see `../../_index/tightening-class/SKILL.md`); irreversible → **Tier 4**
+- app still reads/writes the column → coexistence required → **M5 multi-PR** 4-phase deprecation (soft-deprecate → stop writes → verify unused → drop; see `../../_index/multi-phase/SKILL.md`)
+- referenced by a view/proc/index → drop those first → ordered multi-step
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Strict publish **vetoes** on `BlockOnPossibleDataLoss` when the column has data — show the veto.
+Run `sys.dm_sql_referencing_entities` to prove nothing still references it. Prove the ordered drop
+(dependents first) on the throwaway DB. The clean Strict re-run after the column is provably
+empty/unused is the proof. For the publish loop, see `../../prove-on-dacpac/SKILL.md`; probes,
+`../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Removing the attribute destroys its data for good — SSDT vetoed it on a copy because the column
+still holds values, and two views reference it. Safe path is the 4-phase deprecation across
+releases: stop writing it, confirm nothing reads it, then drop. Multi-Phase, multi-PR, Tier 4
+because the data is gone once it's gone."
+
+## Teach it (the graduation)
+A drop is a *sequence ending in an irreversible act*, not a single edit — old and new must coexist
+until cutover (see `../../_index/multi-phase/SKILL.md`), and danger lives in a different axis than
+the one-statement mechanics. Fail mode avoided: blind-dropping an "unused" column before
+`sys.dm_sql_referencing_entities` and a stop-writes phase prove it truly dead.

--- a/sidecar/projection/ssdt-agent/skills/op/delete-entity/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/delete-entity/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: delete-entity
+description: Use when the developer says "delete the Entity", "drop the table, we don't need it", "remove the old AuditLog" — removing a whole table. Danger is not release-count; the BlockOnPossibleDataLoss veto is the safety proof.
+---
+
+# Delete entity
+
+> **Default (provisional — the data decides).** Mechanically Mechanism 4 Script-Only / single-PR, but Tier 4 — data is lost irreversibly. The cleanest example of danger ≠ release-count.
+
+## OutSystems phrasing
+"delete the Entity", "drop the table, we don't need it", "remove the old AuditLog".
+
+## SSDT meaning
+Remove the `.sql` file; with `DropObjectsNotInSource=True` SSDT emits `DROP TABLE
+[schema].[Name]`. On a populated table `BlockOnPossibleDataLoss=True` **vetoes** the publish —
+that veto is your safety proof, not a failure. In prod `DropObjectsNotInSource` is usually
+**False**, so the drop needs an explicit pre-deploy `DROP`, not mere absence.
+
+## The named trap
+Dropping a table with inbound **FKs** (drop fails) or that is **CDC-enabled** (orphans the
+capture instance — see `../../_index/cdc/SKILL.md`). The populated-table veto is the row-presence
+gate — see `../../_index/tightening-class/SKILL.md` for why it is data-blind; do not re-derive
+the guard here.
+
+## How it flips (the specifics only)
+- table empty, no dependents → mechanically a clean drop, but still **Tier 4** if it held business data; Tier 3 if provably scratch
+- table populated → `BlockOnPossibleDataLoss` veto (row-presence — see `../../_index/tightening-class/SKILL.md`); the drop is the irreversible act → **Tier 4**
+- inbound FKs exist → drop those FKs **first** (own the sequence) → small multi-step script
+- CDC-enabled → **disable CDC first** or orphan the capture objects → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+- >1M rows / first-time drop → **+1 Tier**
+
+## Prove it
+Strict publish must **veto** on `BlockOnPossibleDataLoss` when rows exist — show that veto with
+the row count as the safety proof. Then prove the ordered remedy (drop FKs → disable CDC → drop)
+on the throwaway DB. Run `sys.dm_sql_referencing_entities` against the table to enumerate what
+still points at it. For the publish loop, see `../../prove-on-dacpac/SKILL.md`; probes,
+`../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Mechanically this is one drop in one PR. But it's Tier 4: the data is gone for good, and SSDT's
+BlockOnPossibleDataLoss vetoed it on a copy because the table holds N rows. Before shipping I
+drop the inbound FKs and disable CDC first — I proved that order clears the veto cleanly."
+
+## Teach it (the graduation)
+The veto is the gate being conservative because it cannot know your intent (see
+`../../_index/tightening-class/SKILL.md`), and danger lives in a different axis than mechanics —
+one statement in one PR can be Tier 4. Fail mode avoided: reaching for `DropObjectsNotInSource`
+to "make it work" instead of proving the table is truly safe to lose.

--- a/sidecar/projection/ssdt-agent/skills/op/delete-seed-value/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/delete-seed-value/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: delete-seed-value
+description: Use when the developer says "delete the Cancelled status value", "retire this lookup value", "remove the option nobody picks anymore", "drop this order type from the list" — retiring a row from an OutSystems Static Entity. SSDT destination = set IsActive = 0 in the seed MERGE, NOT a hard DELETE.
+---
+
+# Retire a static lookup value (hard-DELETE-orphans trap — deactivate, don't delete)
+
+> **Default (provisional — the data decides).** Deactivate via `IsActive = 0`: Mechanism 2 Declarative + Post-Deploy, single-PR, Tier 1–2 — REFUSE the hard DELETE if the value is referenced.
+
+## OutSystems phrasing
+"delete the Cancelled status value", "retire this lookup value", "remove this order type from the list".
+
+## SSDT meaning
+Set `IsActive = 0` on the seed row (the guarded `WHEN MATCHED` fires for that one row), preserving the row's identity and history. A hard `DELETE` of a seed row is the wrong move when anything references it. Never write ALTER.
+
+## The named trap
+**Deleting a lookup value the app still references** — a hard DELETE orphans every fact row pointing at it and breaks the app's `StatusId = 3` constant. The discipline is **deactivate, don't delete** — owned by `../../_index/idempotent-seed/SKILL.md`; do not re-derive it here.
+
+## How it flips (the specifics only)
+- value unreferenced, no fact rows point at it → a clean subtractive seed edit is defensible, but default to `IsActive = 0` anyway (Tier 1).
+- **value the app / fact rows reference** → `IsActive = 0` (single-PR, Tier 1–2); a hard DELETE that orphans fact rows is **Tier 3+** and usually wrong — refuse the DELETE, propose deactivation.
+- **+ CDC-tracked** → guarded `WHEN MATCHED` mandatory; +1 Tier — see `../../_index/cdc/SKILL.md`.
+
+## Prove it
+Prove the reference exists before choosing: `SELECT COUNT(*) FROM <factTable> WHERE <fk> = <valueId>` — nonzero means DELETE orphans, deactivate instead. After the `IsActive = 0` edit, redeploy unchanged and assert **0 rows affected** + identical hash + (if CDC-tracked) 0 captures. See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, `dbo.Category` is referenced by `dbo.Product.CategoryId`, so a hard DELETE of a Category value fires the orphan negative (STA-04N).
+
+## Verdict to the developer
+"For the retired value I set IsActive = 0 instead of deleting it — the N orders that still point at it keep their referential integrity. Nothing orphaned, proven."
+
+## Teach it (the graduation)
+Reference rows are referenced — retiring one is a referential decision, not a data edit, and the safe move preserves the identity; the fail mode avoided is a hard DELETE silently orphaning fact rows. Full WHY: `../../_index/idempotent-seed/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/drop-fk/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/drop-fk/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: drop-fk
+description: Use when the developer says "remove the reference", "we don't need the link to Customer anymore", "unhook these entities" — dropping a FOREIGN KEY. Always publishes clean (no data loss), but weakens integrity and can shift query plans.
+---
+
+# Drop a foreign key
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — dropping never vetoes, but it weakens integrity and can shift (regress) query plans.
+
+## OutSystems phrasing
+"remove the reference", "we don't need the link to Customer anymore", "unhook these entities".
+
+## SSDT meaning
+Remove the `CONSTRAINT` from the table definition. SSDT emits `ALTER TABLE ... DROP CONSTRAINT [FK_...]`. Data is untouched; the table just stops validating the reference.
+
+## The named trap
+Dropping a **trusted** FK removes a hint the **query optimizer** relied on — plans can change and regress. None material to the publish (dropping never loses rows). Edge: if you're dropping the FK only to unblock another change (a type change, a table drop), document *why* — re-adding it later re-runs the orphan validation (see `../create-fk-orphan/SKILL.md`).
+
+## How it flips (the specifics only)
+- permanent removal → M1, single-phase, Tier 2.
+- dropped as a temporary step inside a larger migration (type change, table drop) → a sub-step of a multi-step / multi-PR plan, not standalone (see `../../_index/multi-phase/SKILL.md`).
+- re-adding it later → that re-add re-runs create-fk orphan validation → can flip then.
+- CDC-enabled → no direct capture impact; the optimizer-plan risk is the real concern.
+
+## Prove it
+Strict publishes clean; the delta is a single `DROP CONSTRAINT`; no veto (dropping never loses rows). The proof is mostly confirming the delta touches *only* the constraint and nothing rebuilds. Flag the optimizer-plan and integrity-loss consequences to the developer since the publish itself can't fail. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Dropping the reference always publishes clean — removing a constraint never loses data. Pure Declarative, single-phase. Two things to know: the database stops enforcing that Orders point at real Customers, and query plans that trusted the foreign key may change. Tier 2 for that reason."
+
+## Teach it (the graduation)
+The absence of a data veto is not the absence of consequence — a trusted FK is information the optimizer *uses*, not just a guard, so dropping one has effects the publish can't show. Fail mode avoided: treating "unhook these entities" as zero-risk.

--- a/sidecar/projection/ssdt-agent/skills/op/drop-index/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/drop-index/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: drop-index
+description: Use when the developer says "we don't need that index anymore", "remove the index, it's not used" — dropping an index. Loses no data (always publishes clean), but "not used" is an assumption; the real proof is usage evidence, not a publish.
+---
+
+# Drop an index
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 — reversible, no data loss. But the risk is behavioral (a slower query), so the honest proof lives outside the dacpac.
+
+## OutSystems phrasing
+"we don't need that index anymore", "remove the index, it's not used".
+
+## SSDT meaning
+Delete the index definition from the `.sql`. SSDT emits `DROP INDEX`. No row data is touched — an index is derived structure, so dropping it loses no information.
+
+## The named trap
+No data loss, but a **silent performance regression** — the index might be the one keeping a hot query fast, and "not used" is an assumption until proven. Recognize it when the developer says "I don't think anything uses it" without evidence. None material to the publish.
+
+## How it flips (the specifics only)
+- genuinely unused index → M1, single-phase, Tier 1.
+- index backs a hot query / FK lookup → still M1 mechanically, but the regression risk pushes review to **Tier 2**; prove "unused" first.
+- \+ CDC-enabled table → **+1 Tier** (high-stakes table — see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+The proving ground carries no production query load, so the real proof is **usage evidence**, not a publish. Before dropping, demand usage stats from a prod-shaped source: `SELECT * FROM sys.dm_db_index_usage_stats WHERE object_id = OBJECT_ID('<table>')` — zero user_seeks / user_scans / user_lookups over a representative window is the evidence. On the proving ground, confirm the delta is a clean `DROP INDEX` with no collateral DROP of a constraint that depended on it. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Dropping the index loses no data — it's pure declarative and reversible. Before we ship it, I want the usage stats: if it's had zero seeks over the last month it's safe; if it's backing a hot query, dropping it slows that query down silently."
+
+## Teach it (the graduation)
+A clean publish is not a green light when the risk is *behavioral* (a slower query) rather than *structural* (lost rows) — for those, the evidence is measured usage, not a veto. Fail mode avoided: trusting a hunch that "nobody uses it".

--- a/sidecar/projection/ssdt-agent/skills/op/edit-seed/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/edit-seed/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: edit-seed
+description: Use when the developer says "add 'Refunded' to the Status list", "change the label on this lookup value", "we have a new order type", "rename the Cancelled option" — adding or amending rows in an existing OutSystems Static Entity. SSDT destination = extend or amend the VALUES block of the idempotent MERGE in the post-deploy seed.
+---
+
+# Edit static seed records (unconditional-WHEN-MATCHED trap)
+
+> **Default (provisional — the data decides).** Mechanism 2 Declarative + Post-Deploy, single-PR, Tier 1 — but PROVE the redeploy is silent and the label change touches ONE row.
+
+## OutSystems phrasing
+"add 'Refunded' to the Status list", "change the label on this lookup value", "we have a new order type".
+
+## SSDT meaning
+Extend or amend the `VALUES` block of the MERGE in the post-deploy seed. Adding a value = a new `WHEN NOT MATCHED THEN INSERT` row; changing a label = the **guarded** `WHEN MATCHED THEN UPDATE` path fires for that one row. Never write ALTER.
+
+## The named trap
+An **unconditional `WHEN MATCHED`** that rewrites every row on every deploy (the CDC-silence violation) — this is the idempotent-seed concern; see `../../_index/idempotent-seed/SKILL.md`. (Retiring a referenced value is `delete-seed-value` — route there; that op owns deactivate-don't-delete.)
+
+## How it flips (the specifics only)
+- add a new value / change a label → M2, single-PR, Tier 1.
+- retire a value the app references → route to `../delete-seed-value/SKILL.md` (deactivate, don't delete).
+- **+ CDC-tracked** → guarded `WHEN MATCHED` mandatory; +1 Tier — see `../../_index/cdc/SKILL.md`.
+
+## Prove it
+Deploy the new/changed seed, then redeploy unchanged and assert **0 rows affected** + identical data-hash. For a label change, additionally prove the guarded MERGE updates **only the one changed row** — snapshot the `WHEN MATCHED` branch rowcount; it must equal 1, not the table size. If CDC-tracked, the no-op redeploy captures 0. See `prove-on-dacpac` / `talk-to-local-sql` for how. On the sample, add a 'Refunded'-shaped value to `dbo.Category` (STA-02).
+
+## Verdict to the developer
+"I added 'Refunded' to the Status seed and proved it idempotent — the second deploy added nothing, and the label change touched exactly one row, not the whole table."
+
+## Teach it (the graduation)
+A label change must touch *one* row, not rewrite the table, or a CDC-tracked feed reports the whole table as phantom changes — the fail mode avoided. Full WHY: `../../_index/idempotent-seed/SKILL.md` (guarded MERGE) and `../../_index/cdc/SKILL.md` (the over-capture face).

--- a/sidecar/projection/ssdt-agent/skills/op/enable-cdc/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/enable-cdc/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: enable-cdc
+description: Use when the developer says "turn on Change Data Capture for Customer", "we need a change feed for the ETL", "track every insert/update/delete so the warehouse can pick it up", "enable CDC on this entity" — the CDC tripwire. SSDT destination = a post-deploy / operational SCRIPT (Mechanism 4 Script-Only) — CDC is NOT in the dacpac model.
+---
+
+# Enable CDC — THE TRIPWIRE (CDC Surprise trap)
+
+> **Default (provisional — the data decides).** Mechanism 4 Script-Only, single-PR script, Tier 3 baseline (+1 → Tier 4 for a first-time CDC enablement on the estate). The danger drives the tier, not the release count.
+
+## OutSystems phrasing
+"turn on Change Data Capture for Customer", "we need a change feed for the ETL", "track every insert/update/delete so the warehouse can pick it up".
+
+## SSDT meaning
+`sys.sp_cdc_enable_table` (and `sp_cdc_enable_db` at the database level) — this creates `sys`-owned change tables, a capture instance, and SQL Agent capture/cleanup jobs. **None of this is in the dacpac model.** SSDT cannot CREATE it, diff it, or publish it — CDC enablement lives in a post-deploy / operational script, full stop. Never write ALTER; never try to express it declaratively.
+
+## The named trap
+**CDC Surprise** (handbook 16 = §19) with three faces: (1) it's outside the declarative model — a declarative attempt is silently ignored; (2) it's Enterprise/Standard-licensed — the wrong edition fails at *runtime*, after deploy; (3) the standing consequence — every future schema change on this table now needs capture-instance management (+1 Tier forever). This whole concern is owned by `../../_index/cdc/SKILL.md`; do not re-derive the three faces here.
+
+## How it flips (the specifics only)
+CDC barely "flips" — it is heavy from the start:
+- enable CDC, no no-gap requirement → **M4 Script-Only**, single-PR script. **Tier 3** baseline, **+1 → Tier 4** for a first-time enablement on the estate.
+- enable CDC on a wrong-edition target → does not flip the mechanism; it **fails at runtime** — the proving ground must catch this.
+- any co-occurring schema change on a now-CDC table → see `../recreate-capture-instance/SKILL.md`; that change becomes Multi-Phase, multi-PR if no-gap is required.
+
+## Prove it
+(a) Prove attempting CDC declaratively produces **nothing** in the SSDT delta (the dacpac ignores it) — so the developer sees it must be a script. (b) Run the enable script against the throwaway DB and confirm the change tables + capture instance appear. (c) **Isolation is mandatory**: `sp_cdc_enable_db` flips instance-wide state — do CDC proving on a disposable isolated DB, **never** the shared warm container (CLAUDE.md survival rule 1; PROTOCOL §8; see `../../_index/cdc/SKILL.md` and `talk-to-local-sql`). (d) Confirm the edition supports CDC before claiming success. On the sample, `dbo.CdcCandidate` is the isolated-DB CDC target (AUD-04).
+
+## Verdict to the developer
+"Turning on CDC isn't a schema edit — SSDT can't describe it, so it lives in a script (I proved the dacpac ignores the declarative attempt). It needs Enterprise or Standard edition, and here's the part that lasts: once CDC is on this entity, every future change to it has to manage the capture instance, or the change feed silently drops records. That's why I'm rating this higher than the one-line script makes it look."
+
+## Teach it (the graduation)
+When a change isn't in the model, ask what *standing* obligation it imposes on all future changes, not just what it does today — CDC is +1 Tier on everything it touches forever after; the fail mode avoided is being ambushed months later when a column silently drops out of the warehouse feed. Full WHY: `../../_index/cdc/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/extract-to-lookup/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/extract-to-lookup/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: extract-to-lookup
+description: Use when the developer says "turn this text Status column into a proper Status entity", "these string values should be a lookup so we stop typos", "promote the free-text StatusText into a real reference entity" — replacing a free-text column with a Static Entity + FK. SSDT destination = a multi-phase create-lookup / seed / add-FK / backfill / drop-old-column program.
+---
+
+# Extract free-text column to a lookup entity (Forgotten-FK-Check / lost-unmapped-values trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 — but PROVE the mapping is total before the drop.
+
+## OutSystems phrasing
+"turn this text Status column into a proper Status entity", "these string values should be a lookup so we stop typos".
+
+## SSDT meaning
+A multi-step transform: **create** the lookup table, **seed** it with the distinct existing values, **add** a new FK column to the source, **backfill** by joining text → lookup key, then **drop** the old free-text column. Data is read, reshaped, and moved; old and new representations coexist during the transition. Never write ALTER.
+
+## The named trap
+Doing it in one publish and silently losing the unmapped values — any source text with no seeded lookup row becomes NULL or vetoes the FK. This is the **Forgotten-FK-Check** face (handbook 16 = §19.3) *and* a coexistence move. The staging/coexistence WHY is `../../_index/multi-phase/SKILL.md`; the seed leg's guarded MERGE + explicit IDs are `../../_index/idempotent-seed/SKILL.md`. Do not re-derive either here.
+
+## How it flips (the specifics only)
+- clean distinct values, all mappable → M5, multi-PR, Tier 3.
+- **unmapped / dirty source values present** → still M5, but a pre-backfill reconcile is required so nothing maps to NULL; +1 Tier toward 4 if values are lost.
+- **+ CDC-tracked** / **+ >1M rows** → +1 Tier — see `../../_index/cdc/SKILL.md`.
+
+## Prove it
+Prove the mapping is **total** BEFORE dropping the old column:
+`SELECT DISTINCT <oldcol> FROM <t> WHERE <oldcol> NOT IN (SELECT Code FROM <lookup>)` must return **zero rows**. Each phase must publish Strict-clean; the drop phase Strict-vetoes until the backfill hash proves the new shape holds every value (see `../../_index/multi-phase/SKILL.md` for the totality proof). See `prove-on-dacpac` / `talk-to-local-sql` for the loop. On the sample, promote `dbo.Order.StatusText` ('Pending'/'Shipped'/'Cancelled') into a Status FK (STA-03); a scratch seed with an unmapped value fires the total-mapping negative.
+
+## Verdict to the developer
+"Promoting that text column to a Status lookup moves existing data into a new shape across a new FK, so it's multi-phase, multi-PR — Tier 3. Before we drop the old column I proved every value maps to a lookup row (zero unmapped), so nothing silently becomes NULL."
+
+## Teach it (the graduation)
+When data *moves into a new shape* rather than the schema merely *gaining* shape, the app can't switch in one step — stage it and prove the mapping is total before the drop; the fail mode avoided is the one-publish version silently NULL-ing unmapped values. Full WHY: `../../_index/multi-phase/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/identity-swap/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/identity-swap/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: identity-swap
+description: Use when the developer says "turn on Auto Number for the Id", "make the Id auto-increment", "stop auto-numbering, I want to set Ids myself", "switch this entity to a database-generated key" — adding or removing IDENTITY. SSDT destination = a table rebuild (shadow table + IDENTITY_INSERT copy + reseed + FK drop/recreate), NOT a simple alter.
+---
+
+# Add / remove IDENTITY (Auto Number) (silent-table-rebuild trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase / Script-Only-grade orchestration, multi-PR on a populated table with FKs — but PREVIEW the delta and CONFIRM it is a rebuild with `SET IDENTITY_INSERT`.
+
+## OutSystems phrasing
+"turn on Auto Number for this entity's Id", "make the Id auto-increment", "stop auto-numbering, I want to set Ids myself".
+
+## SSDT meaning
+**You cannot `ALTER` a column into or out of `IDENTITY`** — it is a table property fixed at column creation. SSDT implements it as a **table rebuild**: create a shadow table with the new IDENTITY property, copy all data with `SET IDENTITY_INSERT ON` to preserve key values, reseed IDENTITY to `MAX(Id)+1`, recreate every FK that pointed at the table, drop the old table, rename the shadow into place. Handbook file 14 (=§17.3). Never write ALTER.
+
+## The named trap
+**The silent rebuild** — the .sql edit (adding `IDENTITY(1,1)` to the CREATE) looks trivial but SSDT's generated delta is a full shadow-table swap that drops and recreates the table. If FKs aren't all recreated or `IDENTITY_INSERT` isn't used, existing keys are re-minted and every FK points at the wrong rows. This is the most dangerous "one-line edit" in the catalog. Adjacent: the *Naked Rename* family (a rebuild that loses the mapping re-mints keys the way a naked rename loses a column) — see `../../_index/identity-and-refactorlog/SKILL.md`. This shadow-table-rebuild mechanic is owned here; `../retype-explicit/SKILL.md` and `../indexed-view/SKILL.md` cross-reference it.
+
+## How it flips (the specifics only)
+- table **empty, no FKs** → the rebuild is trivial; effectively **M1** (still confirm the delta is a rebuild). Tier 2.
+- table populated, **no incoming FKs** → **M3/4**, single-PR with `IDENTITY_INSERT` reseed proven. Tier 3.
+- table populated **WITH incoming FKs** → **M5 Multi-Phase, multi-PR**; the FK drop/recreate must bracket the rebuild. Tier 3, +1 if first-time.
+- **+ CDC** → +1 Tier; the rebuild invalidates the capture instance — disable CDC first, rebuild, re-enable — see `../../_index/cdc/SKILL.md`.
+- **+ >1M rows** → +1 Tier; the data copy is the expensive part.
+
+## Prove it
+Preview the Strict delta and CONFIRM it is a **shadow-table rebuild with `SET IDENTITY_INSERT`**, not a no-op — if SSDT does not show the rebuild, the IDENTITY edit did not register. After a permissive publish, hash every Id before/after and prove they are **unchanged** (reseed preserved them) and that every FK still resolves (zero orphans introduced). See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, add IDENTITY to `dbo.Category` (explicit-id, NO IDENTITY — the source) with `dbo.Order` / `dbo.OrderLine` as the incoming-FK shape (STR-04).
+
+## Verdict to the developer
+"Turning on Auto Number can't be a simple alter — SSDT has to rebuild the whole table. I proved on a copy that the rebuild preserves every existing Id and every foreign key still resolves; without the IDENTITY_INSERT step your keys would be re-minted and references broken. It's sequenced across multiple PRs because the FKs have to be dropped and recreated around the rebuild."
+
+## Teach it (the graduation)
+The size of an .sql edit predicts nothing about the size of the deploy — the most dangerous change in the catalog is a one-line edit whose delta is a table swap, and the only honest way to know is to preview the journey and confirm key preservation. Full WHY (identity vs. name): `../../_index/identity-and-refactorlog/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/indexed-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/indexed-view/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: indexed-view
+description: Use when the developer says "materialize this aggregation for speed", "cache the joined view", "make the summary view fast", "store the results of this view physically" — a SCHEMABINDING view with a unique clustered index. SSDT destination = a declarative view + UNIQUE CLUSTERED index that physically stores results and binds its base columns.
+---
+
+# Indexed / materialized view (SCHEMABINDING) (deterministic-only / base-column-binding trap)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative to create on a small/empty base — but it flips toward Multi-Phase as the base grows.
+
+## OutSystems phrasing
+"materialize this aggregation for speed", "cache the joined view", "make the summary view fast".
+
+## SSDT meaning
+A view with `WITH SCHEMABINDING` plus a `UNIQUE CLUSTERED` index, which causes SQL Server to **physically store** the view's result and maintain it on every base-table write. Unlike a plain view, this one holds data, costs storage and write-time, and **binds the base tables** so they cannot be altered out from under it. Never write ALTER.
+
+## The named trap
+The **deterministic-only / SCHEMABINDING coupling** — an indexed view requires every expression to be deterministic (no `GETDATE()`, no non-deterministic functions) and `WITH SCHEMABINDING`, which means **you cannot change any bound base column** without first dropping the index/view. A "trivial" base-table widen now fails because the indexed view binds it — SSDT's delta shows the index/view dropped and rebuilt, expensive and blocking on a large base. This is the closest a view gets to the table-rebuild family (`../identity-swap/SKILL.md` owns that mechanic; cross-referenced here). A single-op coupling — kept inline, not lifted.
+
+## How it flips (the specifics only)
+- **small base table** → **M1**, single-phase. Tier 2 (a stored object, not a plain view).
+- **large base table** → the unique-clustered-index build is expensive/blocking → **M3/5**, single-PR-with-care or multi-phase; **Tier 3**.
+- any later change to a **bound base column** → SSDT must drop+rebuild the indexed view → treat that downstream change as **+1 complexity**; prove the rebuild in the delta.
+- **+ >1M rows in the base** → +1 Tier; the maintenance cost on writes is real and ongoing.
+
+## Prove it
+Preview the delta and CONFIRM the unique clustered index is built (not just a view CREATE). Then prove the binding cost: edit a bound base column and show SSDT's delta **drops and rebuilds** the indexed view — that rebuild is the hidden price of materialization, and the developer must see it before committing. See `prove-on-dacpac`. On the sample, add `WITH SCHEMABINDING` + `UNIQUE CLUSTERED` to `dbo.vOrderSummary` in a scratch edit (VIE-04).
+
+## Verdict to the developer
+"Materializing this view stores its results physically and keeps them in sync on every write — that's the speed you want, but it locks the underlying entities: I proved that changing a bound column forces SSDT to rebuild the whole indexed view, which is expensive on a large table. Worth it for reads, but it raises the cost of future schema changes."
+
+## Teach it (the graduation)
+Materialization is not a read-only optimization — it imposes a standing tax on every future change to the bound columns, so the speed-up is bought with rigidity downstream; the fail mode avoided is a later "trivial" base widen turning into a blocking indexed-view rebuild nobody scheduled.

--- a/sidecar/projection/ssdt-agent/skills/op/junction/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/junction/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: junction
+description: Use when the developer says "make this a many-to-many", "a Student can have many Courses and a Course many Students", "add a bridge entity", "add a join/link table" — an M:N bridge table with a composite PK over two FKs.
+---
+
+# Junction (M:N bridge table)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — additive, but it introduces two inter-table dependencies.
+
+## OutSystems phrasing
+"make this a many-to-many", "a Student can have many Courses and a Course many Students", "add a bridge entity".
+
+## SSDT meaning
+A new `CREATE TABLE` whose PK is the **composite of two FK columns**, each FK referencing one
+parent's PK. It is a `create-entity` with two inbound dependencies and one composite key. Never
+write `ALTER`.
+
+## The named trap
+Declaring the FKs when the parent rows the bridge will reference do not yet exist (orphans on
+seed) — the **Forgotten FK Check** in disguise. That is the constraint-is-a-claim concern — see
+`../../_index/constraint-is-a-claim/SKILL.md`. Forgetting the composite PK lets duplicate pairs
+in. Do not re-derive the orphan/claim mechanics here.
+
+## How it flips (the specifics only)
+- brand-new empty bridge, both parents present → **M1**, Tier 2
+- bridge seeded with pairs referencing missing parents → the FK validation **vetoes** → flips to the orphan path (`../create-fk-orphan/SKILL.md`, `../../_index/constraint-is-a-claim/SKILL.md`), M4/M5
+- either parent table is large → FK validation scans both → **+1 Tier** at >1M rows
+
+## Prove it
+Strict publish creates the bridge clean and **no FK veto fires** — proving every seeded pair has
+both parents present. Author one orphan pair and watch the veto to demonstrate the failure mode
+the composite-PK + two-FK shape guards against. Probe: `LEFT JOIN` each FK column to its parent
+looking for NULL parents. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"A many-to-many is a bridge table: a composite primary key over two foreign keys. I described it
+and SSDT creates it clean — Pure Declarative, single-phase. Tier 2 because it now ties two
+entities together. I checked there are no orphan pairs, so the FK validation passes."
+
+## Teach it (the graduation)
+The composite-PK-over-two-FKs shape *is* the guarantee (PK stops duplicate pairs, the two FKs
+stop orphan pairs) — the same orphan-check discipline as every FK (see
+`../../_index/constraint-is-a-claim/SKILL.md`). Fail mode avoided: treating "many-to-many" as
+just two columns and seeding orphan pairs.

--- a/sidecar/projection/ssdt-agent/skills/op/make-mandatory/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/make-mandatory/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: make-mandatory
+description: Use when the developer says "make Email required", "tick the Mandatory checkbox", "this attribute must be filled", "change it from optional to required" — an existing column NULL→NOT NULL. THE canonical table-has-rows tightening flip.
+---
+
+# Make mandatory (NULL → NOT NULL) — the tightening-class spine
+
+> **Default (provisional — the data decides).** EMPTY table → Mechanism 1, single-phase, Tier 1. POPULATED table (NULLs OR zero NULLs) → NOT a clean M1 and NOT a clean M3 — it needs a conscious gate decision. Prove before you classify.
+
+## OutSystems phrasing
+"make Email required", "tick the Mandatory checkbox on this attribute".
+
+## SSDT meaning
+Change an existing column from `NULL` to `NOT NULL`. SSDT emits `ALTER TABLE ... ALTER COLUMN
+[Col] <type> NOT NULL` — but on a populated table it guards that ALTER with a **data-blind
+`BlockOnPossibleDataLoss` check that fires on table-has-rows, NOT column-has-NULLs**. Edit the
+CREATE; never write `ALTER`.
+
+## The named trap
+This is **the tightening class** — see `../../_index/tightening-class/SKILL.md` for the
+`IF EXISTS(SELECT TOP 1 1 FROM <t>) RAISERROR(...,16,127)` guard, the empty-vs-populated ladder,
+and the proven **why** (SSDT computes the whole deploy script once, up front, so a same-release
+backfill cannot satisfy it). **Do not re-derive the guard here.** The showcase failure this op
+exists to catch: classifying from the `.sql` text or a clean NULL probe — both *look* green, yet
+the engine refuses. **The old "backfill → clean NOT NULL under Strict = Mechanism 3" recipe is
+BANNED — it was disproven: a pre-deploy backfill cleared every NULL and Strict STILL vetoed.**
+
+## How it flips (the specifics only)
+- **table EMPTY** → **M1 Pure Declarative, single-phase, Tier 1** (the `IF EXISTS` is false; the ALTER lands — verify genuinely empty first)
+- **table POPULATED — NULLs present OR zero NULLs, does not matter** → cannot pass the prod-strict gate by backfill alone (see `../../_index/tightening-class/SKILL.md`). After proving `COUNT(*) WHERE Col IS NULL = 0` (necessary, not sufficient), choose ONE:
+    - **(a) named gate-relaxation** — operationally M4/Script-Only: disable `BlockOnPossibleDataLoss` for this one targeted change, logged, with the proof packet carrying **both** the zero-NULL probe and the relaxation decision.
+    - **(b) restructure as M5 Multi-Phase** so the engine never has to relax its guard (see `../../_index/multi-phase/SKILL.md`).
+  Tier 2 baseline; **+1** for CDC / >1M / first-time.
+- **+ CDC, no-gap** → push toward M5 Multi-Phase, +1 Tier (see `../../_index/cdc/SKILL.md`)
+
+## Prove it (COL-03 / COL-03C — discover, don't assert)
+1. Edit `NULL` → `NOT NULL`, build, Strict publish → prove the veto fires, and **read the delta**
+   to SEE the `IF EXISTS(...) RAISERROR(...,16,127)` guard ABOVE the `ALTER COLUMN` (table-has-rows).
+2. Author the pre-deploy backfill, re-run the NULL probe → prove `0` NULLs remain.
+3. Re-run Strict → prove it **STILL vetoes** and the column **stays nullable**. This step is the showcase finding.
+4. Deliver the corrected verdict: (a) named gate-relaxation after proven-zero-NULL, or (b) multi-phase — and PROVE the chosen path lands the `NOT NULL`.
+
+The `COL-03C` twin (zero NULLs from the start) still vetoes; the `COL-03B` twin (EMPTY) publishes
+clean M1. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"You said make Email mandatory. On a copy SSDT vetoed it — the guard is `IF EXISTS (SELECT TOP 1
+1 FROM Customer) RAISERROR(...)` *before* the ALTER: table-has-rows, not NULL-has-rows. I proved
+it — backfilled every NULL (0 remain) and Strict STILL vetoed and left the column nullable. So on
+your populated table this needs a conscious call: I deliberately relax BlockOnPossibleDataLoss
+for this one change *after* proving zero NULLs (logged, script-only), or we stage it multi-phase.
+Tier 2 (+1 if CDC). On an EMPTY table it would have been a clean one-liner, Tier 1 — the
+difference is entirely the rows."
+
+## Teach it (the graduation)
+This is the sharpest lesson in trusting the oracle over the recipe — the guard is table-has-rows
+(see `../../_index/tightening-class/SKILL.md`), so a clean data probe is *necessary but never
+sufficient*. Fail mode avoided: trusting backfill-alone and running the banned recipe instead of
+making the conscious, documented gate call.

--- a/sidecar/projection/ssdt-agent/skills/op/make-optional/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/make-optional/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: make-optional
+description: Use when the developer says "make this attribute optional", "uncheck Mandatory", "let it be blank now", "it doesn't have to be filled anymore" — an existing column NOT NULL→NULL. A pure loosening; the risk is downstream, not at deploy.
+---
+
+# Make optional (NOT NULL → NULL)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1–2 (Tier 2 if consumers assume non-NULL). Loosening never vetoes.
+
+## OutSystems phrasing
+"make this attribute optional", "uncheck Mandatory", "let MiddleName be blank now".
+
+## SSDT meaning
+Change `NOT NULL` to `NULL`. SSDT emits `ALTER COLUMN [Col] <type> NULL`. A pure loosening — no
+existing row can violate "allows NULL", so SQL Server never refuses it. Edit the CREATE; never
+write `ALTER`.
+
+## The named trap
+No deploy-time trap. The risk is **downstream**: code, reports, and ETL that never expected a
+NULL in this column may now break on one — an application/consumer concern, not an SSDT veto.
+None material at the deploy layer.
+
+## How it flips (the specifics only)
+- any table state → **M1, single-phase** (loosening never vetoes)
+- downstream consumers assume the column is always populated → consumer risk → **Tier 2**, flag the consumers (not a mechanism flip)
+- CDC-enabled → nullability change still alters the capture-instance shape → **+1 Tier**, recreate (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Strict publishes clean; delta is a single `ALTER COLUMN ... NULL`; no veto. The proof is really
+about reminding the developer of the *downstream* NULL risk, since the publish itself cannot
+fail. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Making it optional always publishes clean — loosening a rule never trips SSDT. Pure Declarative,
+single-phase. The thing to watch is downstream: any report or code that assumed this is always
+filled will now meet a NULL. Tier 2 for that reason."
+
+## Teach it (the graduation)
+The absence of a publish veto is not the absence of risk — a clean Mechanism 1 can still be Tier 2
+because the danger lives where the engine cannot see it (the consumers). Ask "who *relies* on this
+being non-NULL?" Fail mode avoided: assuming loosening is free and breaking a report that assumed
+the column was always filled.

--- a/sidecar/projection/ssdt-agent/skills/op/merge-tables/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/merge-tables/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: merge-tables
+description: Use when the developer says "merge CustomerAddress back into Customer", "we don't need two entities, combine them", "fold the lookup into its parent", "collapse these two entities into one" — two entities becoming one, with data moving. SSDT destination = a multi-phase add-absorbing-columns / copy / repoint / drop-absorbed-table program with a cardinality proof.
+---
+
+# Merge two entities into one (collision / silent-1:many-drop trap) — recipe AUTHORED HERE
+
+> **AUTHORED-HERE NOTICE.** Handbook file 14 lists §17.7 "merge-entities" in its index but the template body is empty. The multi-phase recipe below is authored here to fill the gap and is the working contract; fold it back into the handbook when file 14 is completed.
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 — but PROVE cardinality (1:1) BEFORE copying anything.
+
+## OutSystems phrasing
+"merge CustomerAddress back into Customer", "we don't need two entities, combine them", "fold the lookup into its parent".
+
+## SSDT meaning
+The inverse of a split. ADD the absorbing columns to the surviving table's CREATE, copy data from the entity being absorbed, repoint every FK and view that referenced the absorbed entity, then drop the absorbed table. SSDT ADDs the columns and (if nullable) publishes clean; it will **not** copy the data and **will veto** the final `DROP TABLE` under `BlockOnPossibleDataLoss`. Never write ALTER.
+
+## The named trap
+**Collision and cardinality.** A merge silently assumes the absorbed entity is **1:1 or 1:0..1** with the survivor. If it is actually 1:many, a naive copy keeps one row per parent and **silently drops the rest** — and a value-hash will NOT flag it (the hash only compares surviving rows). Treat any merge as suspected 1:many until proven otherwise. Companion trap: a *SELECT \* View* (see `../create-view/SKILL.md`) over the absorbed entity left unenumerated through the merge. The coexistence + subtractive-licensing WHY is `../../_index/multi-phase/SKILL.md`; do not re-derive it.
+
+## How it flips (the specifics only)
+- absorbed entity **empty** → drop it as a clean subtractive change (**M3**, single-PR) and add the survivor's columns as **M1**. No data to move.
+- absorbed populated, **proven 1:1** with survivor → **M5 Multi-Phase, multi-PR** (three phases below). Tier 3.
+- absorbed populated, **1:many** (collision) → STILL M5 but the merge is *semantically wrong as stated*: STOP and tell the developer the cardinality — a design decision, not a mechanism flip.
+- **+ CDC on either table** → +1 Tier and capture-instance management on both — see `../../_index/cdc/SKILL.md`.
+- **+ >1M rows / first-time** → +1 Tier.
+
+**The three phases (each its own PR):**
+- **Phase 1 (additive, M1/2):** ADD the absorbing columns (nullable) to the survivor CREATE, post-deploy-copy from the absorbed entity, dual-write new rows. Prove cardinality here: count absorbed rows vs. distinct parents — equal = 1:1, safe; unequal = 1:many, STOP. Strict publishes clean. Tier 2.
+- **Phase 2 (cutover, M2):** repoint app reads, FKs, and views from the absorbed entity to the survivor's new columns. Leave a backward-compat view named for the absorbed entity if any external consumer still references it (`../compat-view/SKILL.md`).
+- **Phase 3 (subtractive, M3):** drop the absorbed table. Strict MUST veto under `BlockOnPossibleDataLoss` until Phase-1 hashes prove every value is now in the survivor.
+
+## Prove it
+Phase 1 — the **row-count cardinality check** (absorbed rows == distinct parent keys) BEFORE anything else; then hash the absorbed columns vs. the new survivor columns and prove equal. Phase 3 — Strict vetoes the `DROP TABLE` until the hashes match. See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, merge `CustomerAddress` (seeded 1:1) into `Customer` (STR-02); a scratch seed adding a 2nd CustomerAddress row for one Customer fires the 1:many refusal (STR-02N).
+
+## Verdict to the developer
+"Before merging CustomerAddress into Customer I proved on a copy of your data that it's 1:1 (row counts match) — if it had been one-to-many the merge would have silently dropped rows. The data-copy publishes clean; the old-table drop SSDT vetoes until the copy is proven. Three PRs."
+
+## Teach it (the graduation)
+A row-count proof is a different proof from a value-hash, and you need the count *first* — "combine these" hides the unstated question *how many of the absorbed side per parent*, and only the data answers it; the fail mode avoided is a naive copy silently discarding 1:many rows. Full WHY (coexistence): `../../_index/multi-phase/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/modify-default/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/modify-default/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: modify-default
+description: Use when the developer says "change the default value", "new orders should default to Shipped now, not Pending", "stop defaulting this attribute" — changing or removing a DEFAULT constraint. SSDT does a DROP-then-ADD; still Pure Declarative, never backfills.
+---
+
+# Modify or remove a default
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 in any state — changing or removing a default never touches existing row values.
+
+## OutSystems phrasing
+"change the default value", "new orders should default to Shipped now, not Pending", "stop defaulting this attribute".
+
+## SSDT meaning
+**Modify** = SSDT `DROP`s then re-`ADD`s the named constraint (a brief no-default window inside the deploy transaction). **Remove** = `DROP CONSTRAINT`. Neither touches existing row values — a default only ever governed future inserts.
+
+## The named trap
+Same as add-default: the **unnamed default** makes the DROP-then-ADD fragile across environments — insist the constraint is named `DF_<Table>_<Col>`. And a modified default still does NOT retro-change existing rows that were written under the old default; if the developer wants old rows re-stamped, that is a separate backfill (see `../add-default/SKILL.md` and `../../_index/idempotent-seed/SKILL.md`).
+
+## How it flips (the specifics only)
+- modify / remove a default → M1, single-phase, Tier 1 (any state).
+- developer ALSO wants existing rows re-stamped to the new value → separate op: M2 Declarative+Post-Deploy (idempotent UPDATE — see `../../_index/idempotent-seed/SKILL.md`).
+- \+ CDC-enabled → CDC does not track constraints (handbook file 15 = §18.5); no +1 for the default change alone.
+
+## Prove it
+Build + Strict `sqlpackage /Action:Script`; for a *modify*, confirm SSDT emits DROP-then-ADD of `DF_…` and the Strict publish is clean with **no UPDATE of existing rows**. For a *remove*, confirm a clean `DROP CONSTRAINT DF_…` with no row touch. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Changing the default is a pure declarative change — SSDT drops the old default constraint and adds the new one, and I proved on a copy that no existing rows are touched. Old rows keep the value they were written with; if you want those re-stamped, that's a separate backfill I can prove."
+
+## Teach it (the graduation)
+A default is a rule about *future* inserts — changing or dropping it never reaches back to yesterday's rows; a retro re-stamp is a separate, proven backfill. Fail mode avoided: expecting a modified default to rewrite history.

--- a/sidecar/projection/ssdt-agent/skills/op/modify-index/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/modify-index/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: modify-index
+description: Use when the developer says "change the index to cover these columns too", "make this index unique so we stop getting duplicates", "the index should be on a different attribute now" — editing an index definition. SSDT does a DROP+CREATE rebuild; adding UNIQUE vetoes on duplicates.
+---
+
+# Modify an index (change key columns / non-unique → unique / change include list)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1–2 for a non-unique key change. Adding UNIQUE is a claim over the data — PROVE no duplicates, or it flips.
+
+## OutSystems phrasing
+"change the index to cover these columns too", "make this index unique so we stop getting duplicates", "the index should be on a different attribute now".
+
+## SSDT meaning
+You edit the index definition in the `.sql`. SSDT does **not** ALTER in place — it emits `DROP INDEX` + `CREATE INDEX` (a full rebuild over all rows). Changing a non-unique index to **UNIQUE** additionally enforces uniqueness at build time.
+
+## The named trap
+The **non-unique → unique build fails on duplicates** — SSDT emits the unique index and the deploy fails the instant a duplicate key value exists. This is the index-grade constraint-is-a-claim veto (a value collision, not row-presence) — see `../../_index/constraint-is-a-claim/SKILL.md`; do not re-derive the duplicate mechanics here. A key/include change with no uniqueness added never vetoes on data.
+
+## How it flips (the specifics only)
+- key/include change, no uniqueness added → M1, single-phase, Tier 1–2 (the DROP+CREATE rebuild blocks writes like add-index; size pushes the tier).
+- non-unique → unique, NO duplicates → still M1, single-phase (prove it).
+- non-unique → unique, duplicates PRESENT → **FLIP to M3 Pre-Deploy+Declarative, single-PR**: a pre-deploy de-dupe clears duplicates BEFORE the unique build, Tier 3 — the veto is on the actual duplicate values, see `../../_index/constraint-is-a-claim/SKILL.md`.
+- \+ >1M rows → **+1 Tier** (rebuild + dedupe cost).
+- \+ CDC-enabled → **+1 Tier** (see `../../_index/cdc/SKILL.md`).
+
+## Prove it
+For a uniqueness change, run the duplicate probe FIRST: `SELECT <keycols>, COUNT(*) FROM <table> GROUP BY <keycols> HAVING COUNT(*) > 1`. Then build + Strict publish: clean → no duplicates; a build failure ("CREATE UNIQUE INDEX … terminated because a duplicate key was found") is the veto. Author the pre-deploy de-dupe, re-run Strict, the clean re-run is the proof. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`. Seed: Product's `DUPE` rows drive the unique-veto flip.
+
+## Verdict to the developer
+"You asked to make that index unique. I published it to a copy of your data and SSDT refused — 3 rows share the same value, so a unique index can't be built. This is a Pre-Deploy + Declarative change: I dedupe those 3 rows first, then the unique index builds clean. Proven."
+
+## Teach it (the graduation)
+Any change that adds a *constraint* over existing data (UNIQUE here) could flip on the data — probe first (`GROUP BY … HAVING COUNT(*) > 1`); the duplicate probe *is* the mechanism decision. See `../../_index/constraint-is-a-claim/SKILL.md`. Fail mode avoided: guessing single-vs-multi from the SQL.

--- a/sidecar/projection/ssdt-agent/skills/op/move-attribute/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/move-attribute/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: move-attribute
+description: Use when the developer says "move the Region attribute from Customer to Account", "this field is on the wrong entity", "relocate DiscountRate to the parent" — a single attribute moving from one entity to another, with data. SSDT destination = a multi-phase add-column-to-destination / copy / repoint / drop-from-source program.
+---
+
+# Move an attribute between entities (relationship-ambiguity / Naked-Rename trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 when the source is populated — but PROVE the join is 1:1 first.
+
+## OutSystems phrasing
+"move the Region attribute from Customer to Account", "this field is on the wrong entity", "relocate DiscountRate to the parent".
+
+## SSDT meaning
+A one-column split. ADD the column to the destination CREATE, copy the values keyed by whatever relationship links the two entities, repoint readers, then drop the column from the source CREATE. SSDT ADDs declaratively; the copy is post-deploy; the source-column drop is a `BlockOnPossibleDataLoss` veto. Never write ALTER.
+
+## The named trap
+**Relationship ambiguity** — the copy needs a join key, and if the relationship is not 1:1 the value is ambiguous (which Customer's Region wins for an Account with many Customers?). Same collision shape as `../merge-tables/SKILL.md`. Second trap: *Naked Rename* if the agent treats "move" as a rename and lets SSDT DROP+CREATE — a **cross-table move has NO refactorlog identity mapping**, so it must be copy-then-drop, never a rename. See `../../_index/identity-and-refactorlog/SKILL.md`. The coexistence WHY is `../../_index/multi-phase/SKILL.md`. Do not re-derive either.
+
+## How it flips (the specifics only)
+- source column empty / all-NULL → drop from source as **M3** and add to destination as **M1**, single-PR each. No data to move.
+- source populated, **1:1 relationship** → **M5 Multi-Phase, multi-PR**. Tier 3.
+- relationship **not 1:1** → STOP; ambiguous, a design decision, not a flip.
+- **+ CDC / >1M rows / first-time** → +1 Tier — see `../../_index/cdc/SKILL.md`.
+
+## Prove it
+Prove the join is 1:1 (count check), then hash the moving values source-vs-destination and prove **equal** before the source-column drop. Strict must veto the drop until equal. See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, move `Customer.Region` to `Account` via the seeded 1:1 `Customer.AccountId` (STR-03).
+
+## Verdict to the developer
+"Moving Region from Customer to Account is a column moving between tables — I proved the relationship is 1:1 so the values aren't ambiguous, copied them (hashes match), and SSDT vetoes the source drop until that's proven. Multi-PR."
+
+## Teach it (the graduation)
+The word the developer uses ("move") does not determine the mechanism; the *relationship between the two tables* does, and only the data tells you whether it's 1:1 — a move crosses tables and has no identity mapping, so it's copy-then-drop, never a rename. Full WHY: `../../_index/multi-phase/SKILL.md` + `../../_index/identity-and-refactorlog/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/move-schema/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/move-schema/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: move-schema
+description: Use when the developer says "move the entity to the archive schema", "put this table under a different namespace/module", "change its schema" — a schema change on an existing table. The rename trap wearing a different hat.
+---
+
+# Move schema (between schemas)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative (with refactorlog) OR Mechanism 4 Script-Only (`ALTER SCHEMA TRANSFER`), Tier 3 — cross-boundary references break. Without refactorlog → DROP+CREATE data loss.
+
+## OutSystems phrasing
+"move the entity to the archive schema", "put this table under a different namespace/module".
+
+## SSDT meaning
+Change the schema in the `CREATE TABLE` header. With a **refactorlog** entry SSDT treats it as a
+move; the cleaner, `object_id`-preserving path is a script: `ALTER SCHEMA target TRANSFER
+source.Table`. Without refactorlog, SSDT reads it as **drop the old + create the new** — data
+loss, the same shape as Naked Rename. Never write `ALTER COLUMN` here.
+
+## The named trap
+Same family as **Naked Rename** — no refactorlog → `DROP`+`CREATE`, and every fully-qualified
+`dbo.X` reference breaks. This is the identity-vs-name concern — see
+`../../_index/identity-and-refactorlog/SKILL.md`, which explicitly names that the two-part
+`schema.Table` name is just an address. Do not re-derive it here.
+
+## How it flips (the specifics only)
+- refactorlog present, table empty/small → **M1**, Tier 3
+- prefer `object_id` preservation / large table → **M4 Script** (`ALTER SCHEMA TRANSFER`), one operation, data untouched
+- refactorlog MISSING → **drop+create data loss** — STOP, same remedy as rename (see `../../_index/identity-and-refactorlog/SKILL.md`)
+- CDC-enabled → capture instance references the old two-part name → **+1 Tier**, recreate (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Script the delta. A move must be `sp_rename` (schema-qualified) or your authored `ALTER SCHEMA
+TRANSFER` that leaves row counts and `object_id` intact — prove both. A `DROP`+`CREATE` in the
+delta is the catastrophe signal. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Moving the entity to another schema is the same trap as a rename: with the refactorlog SSDT
+keeps the data, without it SSDT drops and recreates. I proved the move with `ALTER SCHEMA
+TRANSFER` — row counts unchanged. Tier 3 because every `schema.Table` reference has to follow."
+
+## Teach it (the graduation)
+Identity is separate from name — the two-part name is an address (see
+`../../_index/identity-and-refactorlog/SKILL.md`). Fail mode avoided: relearning the DROP+CREATE
+proof per operation instead of recognizing "this is the rename trap again."

--- a/sidecar/projection/ssdt-agent/skills/op/narrow/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/narrow/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: narrow
+description: Use when the developer says "shorten Code to 10 chars", "tighten this field", "reduce the precision", "make it smaller" — shrinking length/precision. The Ambitious Narrowing trap; a member of the table-has-rows tightening class.
+---
+
+# Narrow (Ambitious Narrowing) — tightening class
+
+> **Default (provisional — the data decides).** EMPTY table → Mechanism 1, single-phase, Tier 1. POPULATED table → NOT clean single-phase, regardless of whether every value fits. Prove first.
+
+## OutSystems phrasing
+"shorten Code to 10 characters", "tighten this field", "reduce the precision".
+
+## SSDT meaning
+Shrink length/precision (`NVARCHAR(50)`→`NVARCHAR(10)`). SSDT emits `ALTER COLUMN` to the
+narrower type. Any existing value longer than the new size would **truncate** (data loss), so
+`BlockOnPossibleDataLoss=True` vetoes it. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+**Ambitious Narrowing** (handbook 16 = §19.4) — the build succeeds; the deploy either vetoes
+(Block on) or **silently truncates** (Block off). This is **the tightening class** — SSDT injects
+the same data-blind `IF EXISTS(SELECT TOP 1 1 FROM <t>) RAISERROR` guard, so Strict vetoes
+narrowing on any non-empty table **even when every value already fits** (proven via the
+make-mandatory zero-NULL twin). See `../../_index/tightening-class/SKILL.md`; do not re-derive the
+guard here.
+
+## How it flips (empty-vs-populated dominates; fit is a second axis)
+- **empty table** → **M1 Pure Declarative, single-phase, Tier 1** (guard false)
+- **populated, `MAX(LEN) <= new size`** (every value fits) → **STILL vetoes under Strict** — not clean M1. Honest verdict: a named `BlockOnPossibleDataLoss` gate-relaxation for this one change after proving `MAX(LEN)` fits (operationally M4/Script-Only, logged). Tier 2. (Same shape as make-mandatory with zero NULLs — see `../../_index/tightening-class/SKILL.md`.)
+- **populated, any value exceeds new size** → real truncation: reconcile the over-length rows first (a data change) **and** still face the gate → **M5 Multi-Phase** if data must be preserved (see `../../_index/multi-phase/SKILL.md`), or a gate-relaxation after a truncate-with-intent reconcile. Tier 3+.
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Run the `MAX(LEN(Col))` probe AND a `WHERE LEN(Col) > <new>` count to **quantify** how many rows
+truncate. Strict publish must **veto** on data loss when over-length rows exist — show the count.
+Run Permissive (`BlockOnPossibleDataLoss=False`) and the before/after data hash to show *exactly*
+which values would have been chopped. Author the reconcile, re-run Strict. For the publish loop,
+see `../../prove-on-dacpac/SKILL.md`; probes, `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Shortening to 10 looks like a one-liner, but I probed your data: the longest Code is 14
+characters and 37 rows exceed 10. SSDT vetoed the change on a copy to protect them, and the
+permissive run showed exactly what would have been chopped. Pre-Deploy+Declarative, single-PR,
+Tier 3 — here's the reconcile that makes it pass. (On an empty table it would have been a clean
+one-liner.)"
+
+## Teach it (the graduation)
+Narrow shares ONE gate behavior and ONE remedy shape with make-mandatory and delete-attribute — the
+first question is never `MAX(LEN)`, it is *is the table empty?* (see
+`../../_index/tightening-class/SKILL.md`). Fail mode avoided: re-discovering the same veto op by
+op instead of learning the class.

--- a/sidecar/projection/ssdt-agent/skills/op/rebuild-index/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/rebuild-index/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: rebuild-index
+description: Use when the developer says "the index is fragmented, rebuild it", "reorganize the index to fix performance", "run index maintenance on this table", "make SSDT rebuild the index on deploy" — OPERATIONAL maintenance with NO declarative destination. Refuse-and-route to the maintenance job.
+---
+
+# Rebuild / reorganize an index — ⚠️ OPERATIONAL, NOT DECLARATIVE
+
+> **Default (provisional).** NOT a declarative mechanism at all. Job-owned, operational work. There is no bucket — the correct output is a refuse-and-route to the maintenance job.
+
+## OutSystems phrasing
+"the index is fragmented, rebuild it", "reorganize the index to fix performance", "run index maintenance on this table".
+
+## SSDT meaning
+`ALTER INDEX … REBUILD` / `ALTER INDEX … REORGANIZE`. A **maintenance operation against the data**, not a change to the described destination — the index's *definition* is identical before and after; only its physical storage is defragmented. **There is no declarative destination for "rebuild me"** (handbook file 15 = §18.3: "Rebuild/reorganize → ❌ No — maintenance operation, not schema").
+
+## The named trap
+Trying to express maintenance declaratively. If a developer asks you to "make SSDT rebuild the index on deploy", **stop** — that does not belong in the dacpac. Putting `ALTER INDEX … REBUILD` in a post-deploy script makes it re-run on EVERY publish (a recurring blocking operation disguised as a deploy step; anti-idempotent by construction). This operational-not-declarative one-liner is shared with `../toggle-trust/SKILL.md` but not lifted (only two ops share it — below the N≥3 bar).
+
+## How it flips (the specifics only)
+It does not flip between SSDT buckets — it is outside the SSDT model. The only escalation is operational: a REBUILD on a large table takes a lock (online vs offline, Enterprise-gated) with a real duration. **Always flag it as out-of-band.**
+
+## Prove it
+None from the dacpac — there is no delta. The "proof" is that you correctly **refused** to put it in the schema project and routed it to the maintenance job. If the developer insists it be on-deploy, prove the harm: show a post-deploy `ALTER INDEX … REBUILD` re-runs on every redeploy (the opposite of idempotent intent). See `../../prove-on-dacpac/SKILL.md` for the no-delta demonstration.
+
+## Verdict to the developer
+"Rebuilding the index isn't a schema change — it's maintenance, like vacuuming. It doesn't go in the SSDT project; it lives in a scheduled job that runs when fragmentation crosses a threshold. I'll flag it for the DBA/maintenance plan instead of putting it in this PR."
+
+## Teach it (the graduation)
+The moment a request is about *the state of the data's storage* rather than *the shape SSDT can converge to*, it has left the declarative world and belongs in a job keyed to measured fragmentation. Fail mode avoided: a blocking rebuild re-running on every single publish.

--- a/sidecar/projection/ssdt-agent/skills/op/recreate-capture-instance/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/recreate-capture-instance/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: recreate-capture-instance
+description: Use when the developer says "I added a column but CDC isn't picking it up", "the ETL feed is missing the new field", "why doesn't the change feed see my new attribute", "the warehouse stopped getting the new column" — a schema change on a CDC-tracked table. SSDT destination = a dual-instance (v1/v2) capture-instance migration script, multi-phase when no-gap is required.
+---
+
+# Recreate the CDC capture instance (CDC Surprise realized — silent-missing-column trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR whenever no-gap is required (dual-instance v1/v2), Tier 3 (+1 → Tier 4 because a mistake silently loses change records).
+
+## OutSystems phrasing
+"I added a column to Customer but CDC isn't picking it up", "the ETL feed is missing the new field", "why doesn't the change feed see my new attribute".
+
+## SSDT meaning
+A CDC capture instance is **frozen at the table shape it was created for** — adding/altering a column does not retrofit it. The safe procedure is the **dual-instance pattern**: create a *second* capture instance (`Customer_v2`) for the new shape with `sp_cdc_enable_table @capture_instance = 'Customer_v2'`, let consumers drain the old instance (`Customer_v1`), cut them over to v2, then drop v1. Handbook file 14 (=§17.9). Never write ALTER; this is a script.
+
+## The named trap
+**CDC Surprise realized** — the developer's "trivial" add-column change is now a multi-phase capture-instance migration, and if they skip it the new column's changes are **silently absent from the feed** (no error, just missing data downstream). Also the *Refactorlog Cleanup* family: a schema change the refactorlog handles for the dacpac still needs the capture instance rebuilt independently. The standing-tax WHY is `../../_index/cdc/SKILL.md`; the coexistence WHY is `../../_index/multi-phase/SKILL.md`. Do not re-derive either.
+
+## How it flips (the specifics only)
+- schema change on a CDC table, **no-gap NOT required** (consumers tolerate a brief gap) → drop and recreate the single capture instance: **M4 Script-Only**, single-PR, Tier 3.
+- schema change on a CDC table, **no-gap required** → **dual-instance v1/v2, M5 Multi-Phase, multi-PR**. Tier 3, **+1 → Tier 4** (a mistake silently loses change records).
+- **+ >1M rows** → +1 Tier; both capture instances are populated during the overlap.
+
+## Prove it
+Prove the gap exists — add a column to a CDC-enabled table on the isolated DB, then show the existing capture instance does **not** surface the new column (`sys.sp_cdc_get_captured_columns` lacks it). Then prove the dual-instance fix: `Customer_v2` surfaces the new column while `Customer_v1` is still drainable. Isolation is mandatory (see `../../_index/cdc/SKILL.md`, `talk-to-local-sql`). On the sample, add a column to `dbo.CdcCandidate` after capture (AUD-05).
+
+## Verdict to the developer
+"Your new column isn't trivial because CDC is on this entity — the change feed is frozen to the old shape and silently won't include the new field. I proved that on a copy. The fix runs two capture instances side by side so the ETL never misses a change during the switch — that's why it's staged across releases, not a one-line add."
+
+## Teach it (the graduation)
+With CDC the dangerous outcome isn't a loud veto, it's a quiet gap — so the proof is showing the existing instance does NOT surface the new column, then showing the dual instance does; the fail mode avoided is the warehouse silently missing a column for a month. Full WHY: `../../_index/cdc/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/rename-attribute/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/rename-attribute/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: rename-attribute
+description: Use when the developer says "rename the attribute", "change FirstName to GivenName", "I renamed the field in Service Studio", "rename this column" — an existing column getting a new name. The Naked Rename trap at column grain.
+---
+
+# Rename attribute (Naked Rename)
+
+> **Default (provisional — the data decides).** With refactorlog → Mechanism 1 Pure Declarative (a metadata `sp_rename`), Tier 3 (every caller breaks). Without refactorlog → CATASTROPHE (DROP COLUMN+ADD, all values lost).
+
+## OutSystems phrasing
+"rename the attribute", "change FirstName to GivenName", "I renamed the field in Service Studio".
+
+## SSDT meaning
+With a **refactorlog entry**, SSDT emits `EXEC sp_rename 'schema.Table.Old', 'New', 'COLUMN'` —
+data preserved. **Without** it, SSDT sees the old column gone and a new one appear and emits `DROP
+COLUMN [Old]` + `ADD [New]` — all values in that column lost. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+**Naked Rename** (handbook 16 = §19.1), with its companion **Refactorlog Cleanup** (§19.6). This
+is the identity-vs-name concern — see `../../_index/identity-and-refactorlog/SKILL.md`; do not
+re-derive the refactorlog mechanics here.
+
+## How it flips (the specifics only)
+- refactorlog entry present → **M1**, delta is `sp_rename ... 'COLUMN'`, Tier 3 (views, procs, ORM mappings, reports, ETL break)
+- **refactorlog entry MISSING → CATASTROPHE** — delta is `DROP COLUMN`+`ADD`; STOP and demand the refactorlog (see `../../_index/identity-and-refactorlog/SKILL.md`)
+- CDC-enabled → capture instance names the old column → **M5, +1 Tier**, recreate (see `../../_index/cdc/SKILL.md`)
+- external consumers must keep the old name → backward-compat view (`../compat-view/SKILL.md`) → multi-PR coexistence
+
+## Prove it
+Script the delta and **read it** — it MUST be `sp_rename ... 'COLUMN'`. If you see `DROP
+COLUMN`/`ADD`, the refactorlog is missing; catch it in the delta, never after deploy. Confirm the
+`.refactorlog` changed when the rename was authored. For the publish loop, see
+`../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Renaming the attribute keeps the data only if the refactorlog entry exists — I read the
+generated delta and confirmed it's `sp_rename`, not a drop-and-add. Without that entry SSDT would
+have dropped the column and lost every value. Pure Declarative with refactorlog, Tier 3 because
+every caller of that column name has to change."
+
+## Teach it (the graduation)
+The refactorlog carries identity, not cosmetics (see
+`../../_index/identity-and-refactorlog/SKILL.md`). Fail mode avoided: renaming a field by editing
+text alone — read the delta every time and catch the loss in the script where it's free, not in
+production where it isn't.

--- a/sidecar/projection/ssdt-agent/skills/op/rename-entity/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/rename-entity/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: rename-entity
+description: Use when the developer says "rename the Entity", "change the table name from Customer to Client", "I renamed it in Service Studio" — an existing table getting a new name. The Naked Rename trap; identity must be carried by the refactorlog.
+---
+
+# Rename entity (Naked Rename)
+
+> **Default (provisional — the data decides).** With refactorlog → Mechanism 1 Pure Declarative (a metadata `sp_rename`), Tier 3 (every caller breaks). Without refactorlog → CATASTROPHE (DROP+CREATE, all rows lost).
+
+## OutSystems phrasing
+"rename the Entity", "change the table name from Customer to Client", "I renamed it in Service Studio".
+
+## SSDT meaning
+With a **refactorlog entry**, SSDT emits `EXEC sp_rename 'schema.Old', 'New', 'OBJECT'` — data
+and `object_id` preserved. **Without** the entry SSDT sees one table vanish and a new one
+appear and emits `DROP TABLE [Old]` + `CREATE TABLE [New]` — all rows lost. Never write `ALTER`.
+
+## The named trap
+**Naked Rename** (handbook 16 = §19.1), with its companion **Refactorlog Cleanup** (§19.6).
+This is the identity-vs-name concern — see `../../_index/identity-and-refactorlog/SKILL.md`; do
+not re-derive the refactorlog mechanics here.
+
+## How it flips (the specifics only)
+- refactorlog entry present → **M1**, delta is `sp_rename`, Tier 3 (cross-boundary: FKs, views, procs, ETL, reports all reference the name)
+- **refactorlog entry MISSING → CATASTROPHE** — delta is `DROP`+`CREATE`; STOP and demand the refactorlog before anything else (see `../../_index/identity-and-refactorlog/SKILL.md`)
+- table is CDC-enabled → the capture instance still names the old table → **M5 Multi-Phase, +1 Tier**, recreate (see `../../_index/cdc/SKILL.md`)
+- external consumers must keep the old name → add a backward-compat view (`../compat-view/SKILL.md`), pushing toward multi-PR coexistence
+
+## Prove it
+Run `sqlpackage /Action:Script` and **read the delta** — it MUST be `sp_rename`. If you see
+`DROP TABLE`/`CREATE TABLE`, the refactorlog is missing; this is the single most important
+delta-read in the whole catalog. Confirm the `.refactorlog` file changed when the rename was
+authored. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"You renamed the entity. I published it to a copy — SSDT generated `sp_rename`, so the rows are
+preserved. That only works because the refactorlog entry exists; without it SSDT would DROP and
+re-CREATE and lose everything. Pure Declarative with refactorlog, Tier 3 because every caller
+breaks."
+
+## Teach it (the graduation)
+The refactorlog carries *identity, not text* — see `../../_index/identity-and-refactorlog/SKILL.md`
+for the full why. The fail mode avoided: renaming by editing the CREATE alone, the most
+expensive silent loss in the catalog.

--- a/sidecar/projection/ssdt-agent/skills/op/retype-explicit/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/retype-explicit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: retype-explicit
+description: Use when the developer says "change the text field to a date", "store it as a number now", "make this Text into an Integer", "convert this column's type" where not every value converts — a value-reshaping, lossy cast.
+---
+
+# Retype explicit (value-reshaping conversion)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3–4 — not all values convert, and old and new types must coexist while you migrate.
+
+## OutSystems phrasing
+"change the Text attribute to a Date", "make this an Integer", "store it as a number now".
+
+## SSDT meaning
+Change the column's data type in a value-reshaping direction (`VARCHAR`→`DATE`,
+`INT`→`UNIQUEIDENTIFIER`, `DATETIME`→`DATE`, any cast where not all values convert). This cannot
+be a safe single `ALTER COLUMN`. Edit the CREATE toward the destination, but you own the staging;
+never write a bare `ALTER`.
+
+## The named trap
+SSDT may *attempt* a single-step `ALTER COLUMN` on an explicit conversion that then fails (or
+truncates) mid-deploy — you must **own the multi-phase shape manually**; the engine will not.
+Old and new types coexisting is the multi-phase concern — see `../../_index/multi-phase/SKILL.md`;
+the add-new → convert → swap tail follows `../rename-attribute/SKILL.md` rules. Do not re-derive
+coexistence here.
+
+## How it flips (the specifics only)
+- explicit/narrowing → **M5 Multi-Phase, multi-PR**: add a new column of the target type → `UPDATE ... SET new = TRY_CONVERT(<type>, old)` → app transitions → drop old, rename new in. Tier 3–4. (See `../../_index/multi-phase/SKILL.md`.)
+- any value fails `TRY_CONVERT` (returns NULL) → those rows need explicit handling → stays multi-PR, escalate Tier
+- direction is actually widening/lossless → **wrong op** → `../retype-implicit/SKILL.md`
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Prove a `TRY_CONVERT` probe over the real data — count how many rows return NULL (would not
+convert) — and prove the add-new → `TRY_CONVERT` → drop-old sequence on the throwaway DB. If you
+ever see SSDT emit a bare `ALTER COLUMN` for an explicit conversion, stop and force the
+multi-phase path. For the publish loop, see `../../prove-on-dacpac/SKILL.md`; probes,
+`../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Text→Date is value-reshaping: not every value parses. I ran TRY_CONVERT over your data — 12 rows
+don't convert. So it's Multi-Phase across releases: add the new column, convert what's
+convertible, fix the 12, then swap. Tier 3."
+
+## Teach it (the graduation)
+An explicit conversion needs proof because not all values convert, and old and new types must
+coexist while you migrate (see `../../_index/multi-phase/SKILL.md`). Fail mode avoided: letting
+SSDT attempt a bare single-step ALTER that fails mid-deploy — count the non-convertible rows
+before you promise anything.

--- a/sidecar/projection/ssdt-agent/skills/op/retype-implicit/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/retype-implicit/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: retype-implicit
+description: Use when the developer says "change to a bigger number", "INT to BIGINT", "make this VARCHAR into NVARCHAR", "store it as a wider type" — a widening/implicit type change where every value already fits. Lossless.
+---
+
+# Retype implicit (widening conversion)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — every value already fits the bigger type, so the engine has nothing to refuse.
+
+## OutSystems phrasing
+"change to a bigger number", "INT to BIGINT", "make this VARCHAR into NVARCHAR".
+
+## SSDT meaning
+Change the column's data type in the widening direction (`INT`→`BIGINT`,
+`VARCHAR(n)`→`NVARCHAR(n)`, `DECIMAL(10,2)`→`DECIMAL(18,2)`). These are lossless — SSDT emits a
+single `ALTER COLUMN`. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+None material for a true widening — every value converts. The one edge: `VARCHAR`→`NVARCHAR`
+**doubles storage**, which can tip an indexed column over the index-key byte limit (see
+`../widen/SKILL.md`). If the "retype" is actually value-reshaping (Text→Date, DATETIME→DATE),
+it is NOT this op — route to `../retype-explicit/SKILL.md`.
+
+## How it flips (the specifics only)
+- implicit/widening, all values convert → **M1, single-phase, Tier 2**
+- VARCHAR→NVARCHAR on an indexed column → storage doubles → the index-key byte-limit edge (see `../widen/SKILL.md`)
+- direction is actually narrowing/reshaping → **wrong op** → `../retype-explicit/SKILL.md`
+- CDC-enabled / >1M rows → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Strict publishes clean; the delta is one `ALTER COLUMN` to the wider type with no veto and no
+rebuild of unrelated objects. If you ever see the delta do more than the single ALTER, stop and
+check whether the conversion is actually value-reshaping. For the publish loop, see
+`../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Going INT→BIGINT is lossless — SSDT just widens it, Pure Declarative, single-phase. Every
+existing value already fits the bigger type, so there's nothing for the engine to refuse. Tier 2."
+
+## Teach it (the graduation)
+Direction is everything: a widening retype is free because every value already fits, so only the
+*explicit/narrowing* sibling needs per-row proof. Fail mode avoided: classifying "retype" as one
+thing — always ask "is this widening (free) or value-reshaping (prove each row)?" before
+promising anything.

--- a/sidecar/projection/ssdt-agent/skills/op/split-table/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/split-table/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: split-table
+description: Use when the developer says "split Customer into Customer and CustomerAddress", "pull the address fields out into their own entity", "this entity is doing too much, break it up" — one entity becoming two, with data moving. SSDT destination = a multi-phase additive-CREATE / copy / cutover / drop-old-columns program.
+---
+
+# Split one entity into two (one-PR / Naked-Rename-per-column trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 — but PROVE the source is empty first (it may collapse to M1).
+
+## OutSystems phrasing
+"split Customer into Customer and CustomerAddress", "pull the address fields out into their own entity", "break this entity up".
+
+## SSDT meaning
+CREATE the new table, copy the moving columns' data keyed by the source PK, add the FK, then (much later) drop the old columns from the source CREATE. SSDT will CREATE the new table and ADD the FK declaratively but will **never move the data** — the copy is a post-deploy script, and the column drop is a `BlockOnPossibleDataLoss` veto until the copy is proven. Handbook file 14 (=§17.6). Never write ALTER.
+
+## The named trap
+Treating it as one PR — dropping the old columns in the same release that creates the new table breaks any app code still reading them. The related trap is *Naked Rename* applied per-column when the developer "renames" columns into the new table instead of copying — see `../../_index/identity-and-refactorlog/SKILL.md`. The coexistence + subtractive-licensing WHY is `../../_index/multi-phase/SKILL.md`; do not re-derive either.
+
+## How it flips (the specifics only)
+- new entity, **source table empty** (greenfield split) → collapses to **M1**, single-phase: just CREATE both tables. Prove the source is empty first.
+- source populated, app reads old columns → **M5 Multi-Phase, multi-PR** (Phase 1 additive CREATE+FK+copy+dual-write, Tier 2 · Phase 2 repoint reads · Phase 3 drop old columns, the `BlockOnPossibleDataLoss` veto moment, Tier 3).
+- **+ CDC on the source** → +1 Tier; the final column drop needs a capture-instance refresh — see `../../_index/cdc/SKILL.md` and `../recreate-capture-instance/SKILL.md`.
+- **+ >1M rows / first-time** → +1 Tier; the copy is a long-running batched operation.
+
+## Prove it
+Phase 1 — Strict publishes the additive CREATE+FK clean; the post-deploy copy runs; hash the moving columns source-vs-new-table and prove **equal**. Phase 3 — edit the source CREATE to drop the moved columns; Strict MUST veto on data loss, and only the proven-equal Phase-1 hash licenses the drop (see `../../_index/multi-phase/SKILL.md` for the totality proof). See `prove-on-dacpac` / `talk-to-local-sql` for the loop. On the sample, split `Customer` into `Customer` + `CustomerAddress` (STR-01; the seeded 1:1 CustomerAddress row is the copy target).
+
+## Verdict to the developer
+"Splitting Customer into two entities moves data, so it can't be one release. I proved the additive half publishes clean and copies all N rows (hashes match); the column-drop half SSDT vetoes until the copy is proven — three PRs, in order."
+
+## Teach it (the graduation)
+Any change that *relocates data between shapes* is additive-then-cutover-then-subtractive, and the proof that licenses the subtractive phase is a BEFORE/AFTER hash showing the new home holds every value; the fail mode avoided is a one-PR split that breaks live reads or loses data. Full WHY: `../../_index/multi-phase/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/synonym/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/synonym/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: synonym
+description: Use when the developer says "point this entity at a table in another database/server", "alias a table that lives elsewhere", "we moved Customer to the shared DB but keep the local name", "reference a table in the linked database" — a runtime-resolved alias to an external object. SSDT destination = a declarative CREATE SYNONYM whose target is NOT validated at publish time.
+---
+
+# Synonym (unvalidated-target / invisible-dependency trap)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 1 for the synonym itself — but name the runtime-resolution gap.
+
+## OutSystems phrasing
+"point this entity at a table in another database/server", "alias a table that lives elsewhere", "we moved Customer to the shared DB but keep the local name".
+
+## SSDT meaning
+`CREATE SYNONYM dbo.Customer FOR OtherDb.dbo.Customer;`. A synonym is a **runtime-resolved alias** — it holds no data and its target is resolved when queried, not when created. SSDT publishes it declaratively. Never write ALTER.
+
+## The named trap
+The synonym's target is **not validated at publish time** — SSDT will happily create a synonym pointing at a database, table, or server that does not exist (or that the deploy account cannot see); the failure surfaces only at runtime, on the first query. A synonym also silently bypasses the dacpac's dependency tracking: SSDT does not know what is on the other side, so it cannot warn when that side changes. This is a single-op coupling (below the lift bar) — the gap lives here, not in an index.
+
+## How it flips (the specifics only)
+- synonym to an **in-model** object → **M1**, Tier 1.
+- synonym to an **external** DB/server (the usual case) → M1 mechanically but **Tier 3**: the target is a cross-system dependency SSDT cannot see, so changes on the other side are invisible to the proving ground.
+
+## Prove it
+Preview the delta — a clean CREATE SYNONYM. Then prove the **runtime-resolution gap**: the synonym publishes clean even if the target is absent, so demonstrate that a query through the synonym fails at runtime when the target is missing — that is the thing the dacpac will not catch, and the developer must know it. See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, a synonym (VIE-03) needs no local table — it targets an external DB and is proven by the runtime-resolution gap.
+
+## Verdict to the developer
+"The synonym publishes clean, but SSDT can't see what's on the other side of it — it won't tell you if the target table moves or disappears. That's a runtime dependency to track outside the proving ground."
+
+## Teach it (the graduation)
+A clean deploy proves the local half of a cross-system dependency and nothing about the remote half — whenever a change reaches outside the model's horizon (synonym, linked server, external feed), the proof is necessarily partial and the runtime gap must be named, not assumed away; the fail mode avoided is reading a green synonym deploy as proof the link works.

--- a/sidecar/projection/ssdt-agent/skills/op/temporal-convert/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/temporal-convert/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: temporal-convert
+description: Use when the developer says "add full history to our existing populated entity", "turn on system versioning for Customer which already has data", "make this live table temporal", "start keeping history on an entity that's already in production" — converting an EXISTING populated table to temporal. SSDT destination = a multi-phase add-period-columns / backfill / enable-versioning program.
+---
+
+# Convert an existing populated table to temporal (backfilled-ROW-START trap)
+
+> **Default (provisional — the data decides).** Mechanism 5 Multi-Phase, multi-PR, Tier 3 when the table is populated — but PROVE the period-column backfill produces sane start times. (A NEW entity is `../temporal-new/SKILL.md`, single-phase.)
+
+## OutSystems phrasing
+"add full history to our existing populated entity", "turn on system versioning for Customer which already has data", "make this live table temporal".
+
+## SSDT meaning
+Add the (hidden) `GENERATED ALWAYS AS ROW START/END` period columns with backfilled start times, create the paired history table, then turn `SYSTEM_VERSIONING = ON` against live data. Staged because you cannot swap the shape under a running app atomically. Never write ALTER.
+
+## The named trap
+Adding the period columns to a populated table needs **sensible historical defaults for `ROW START`**, or every existing row claims to have begun at conversion time. Also conflating temporal with CDC (see `../temporal-new/SKILL.md`). The coexistence WHY is `../../_index/multi-phase/SKILL.md`; do not re-derive it.
+
+## How it flips (the specifics only)
+- existing **populated** table (this op) → **M5 Multi-Phase, multi-PR**: add period columns with backfilled start times, create the history table, enable versioning. Tier 3.
+- existing **empty** table → collapses to **M1**, single-phase.
+- **+ CDC already on the table** → +1 Tier and CDC sequencing (stacking two history mechanisms — confirm intent) — see `../../_index/cdc/SKILL.md`.
+- **+ >1M rows / first-time** → +1 Tier.
+
+## Prove it
+Prove the period-column backfill produces sane `ROW START` values and that enabling versioning does not veto on the populated table; hash the data before/after to prove the rows themselves are untouched. See `prove-on-dacpac` / `talk-to-local-sql`. On the sample, convert the existing populated `Customer` in a scratch copy (AUD-02).
+
+## Verdict to the developer
+"Converting your existing populated entity to keep history is staged, because the period columns have to be backfilled first — otherwise every existing row would falsely claim it began at conversion time. I proved the backfill produces sane start times and that the rows themselves are untouched."
+
+## Teach it (the graduation)
+Converting an *existing populated* table is multi-phase for the coexistence reason — old and new must coexist while the period columns are added and backfilled; the fail mode avoided is every historical row falsely dated to conversion time. Full WHY: `../../_index/multi-phase/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/temporal-new/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/temporal-new/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: temporal-new
+description: Use when the developer says "I want full history on this new entity", "keep every version of every row (new table)", "system-versioned table from the start", "show me what this record looked like last Tuesday — for a brand-new entity" — temporal versioning on a NEW entity. SSDT destination = a declarative system-versioned CREATE (SYSTEM_VERSIONING = ON + history table + period columns).
+---
+
+# Add temporal versioning — new entity (temporal-vs-CDC conflation trap)
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — SSDT builds a new system-versioned table cleanly. (Converting an EXISTING populated table is a different op — route to `../temporal-convert/SKILL.md`.)
+
+## OutSystems phrasing
+"I want full history on this new entity", "keep every version of every row (new table)", "point-in-time history from birth".
+
+## SSDT meaning
+`SYSTEM_VERSIONING = ON` with a paired history table and two `GENERATED ALWAYS AS ROW START/END` `datetime2` period columns. SQL Server maintains the history table on every write. Unlike CDC, **temporal IS expressible declaratively for a new table** — SSDT can publish the system-versioned CREATE. Never write ALTER.
+
+## The named trap
+**Conflating temporal with CDC.** They are different mechanisms — different licensing (temporal is all editions; CDC is Enterprise/Standard) and different shapes (temporal gives point-in-time row history; CDC gives a change feed). Picking the wrong one is a design error the agent must catch at **intake**, before building. If the developer needs a *change feed* (old→new values for an ETL), route to `../enable-cdc/SKILL.md`. See `../../_index/cdc/SKILL.md` for the CDC weight this avoids.
+
+## How it flips (the specifics only)
+- **new table** (this op) → **M1**, single-phase, Tier 2.
+- existing empty table → **M1**, single-phase.
+- existing **populated** table → NOT this op; route to `../temporal-convert/SKILL.md` (multi-phase).
+- **+ CDC already on the table** → +1 Tier and CDC sequencing (you are stacking two history mechanisms — confirm the developer wants both) — see `../../_index/cdc/SKILL.md`.
+- **+ >1M rows / first-time** → +1 Tier.
+
+## Prove it
+Preview the Strict delta and confirm it publishes the system-versioned CREATE clean — the history table and period columns appear, no veto. See `prove-on-dacpac`. On the sample, temporal-new (AUD-01) is a scratch-authored brand-new system-versioned table (greenfield — no authored seed needed).
+
+## Verdict to the developer
+"You want history — there are two kinds. Temporal gives you point-in-time row history with no licensing cost, and for a new entity it publishes clean in one release. (CDC is the other kind — a change feed — and it's a much heavier commitment; tell me which you actually need.)"
+
+## Teach it (the graduation)
+When a developer's word covers two mechanisms with different bills, disambiguate at intake — "track changes" and "keep history" are exactly such words; the fail mode avoided is building CDC's heavy machinery when point-in-time editions were all that was wanted. Full WHY (name your intent): `../../_index/cdc/SKILL.md`.

--- a/sidecar/projection/ssdt-agent/skills/op/toggle-trust/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/toggle-trust/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: toggle-trust
+description: Use when the developer says "trust the constraint now that the data is clean", "turn the FK back on", "temporarily disable the check so this load can run" — toggling a constraint's enforcement/trust state. OPERATIONAL, NOT declarative; refuse-and-route to a script, prove it ends TRUSTED.
+---
+
+# Enable / disable constraint trust — ⚠️ OPERATIONAL, NOT DECLARATIVE
+
+> **Default (provisional).** NOT a declarative mechanism — operational / script-only work. There is no bucket; the correct output routes it to a pre/post-deploy script (or runbook) and proves the *ending* trust state.
+
+## OutSystems phrasing
+"trust the constraint now that the data is clean", "turn the FK back on", "temporarily disable the check so this load can run".
+
+## SSDT meaning
+`ALTER TABLE … WITH CHECK CHECK CONSTRAINT <name>` (re-validate and mark trusted) / `ALTER TABLE … NOCHECK CONSTRAINT <name>` (stop enforcing). This toggles the runtime **enforcement/trust state** of an existing constraint — **not a change to the described destination**. Handbook file 15 = §18.3: "Enable/disable constraint → ❌ No — Script-only (operational, not declarative)."
+
+## The named trap
+An **untrusted constraint** — left in NOCHECK, the constraint exists but the optimizer ignores it (`is_not_trusted = 1`), so it neither enforces nor helps plans. The pairing to remember is the FK-with-orphans remedy: `NOCHECK` → reconcile → `WITH CHECK CHECK` to re-trust (see `../create-fk-orphan/SKILL.md` and `../../_index/constraint-is-a-claim/SKILL.md` for the trust ladder). This operational-not-declarative one-liner is shared with `../rebuild-index/SKILL.md` but not lifted (two ops — below the N≥3 bar).
+
+## How it flips (the specifics only)
+It does not flip between declarative SSDT buckets — it is outside the declarative model. As a script step within a larger change it inherits that change's tier (e.g. the FK-with-orphans remedy is Tier 3). **Always flag it as operational / script-only.**
+
+## Prove it
+The proof is the **trust state before and after**. Snapshot `SELECT name, is_disabled, is_not_trusted FROM sys.check_constraints` (and `sys.foreign_keys`) before and after your script. The pass condition is `is_not_trusted = 0` **after** the `WITH CHECK CHECK` — proving the constraint ends trusted, not merely present. Ending at `is_not_trusted = 1` is the failure to catch here, not in prod. See `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
+
+## Verdict to the developer
+"Toggling whether a constraint is trusted isn't a schema change — it's an operational step that lives in a script, not the SSDT project. I'll wire it as disable → clean the data → re-trust WITH CHECK CHECK, and I'll prove the constraint ends up TRUSTED, because a left-untrusted constraint silently stops protecting you."
+
+## Teach it (the graduation)
+When a request is about *transitioning* enforcement rather than *declaring* the resting shape, it belongs in a script, and the proof is the *after* state (`is_not_trusted = 0`), not the act. Fail mode avoided: leaving a permanently untrusted constraint that guards nothing.

--- a/sidecar/projection/ssdt-agent/skills/op/widen/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/widen/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: widen
+description: Use when the developer says "make the field longer", "increase Email to 256", "give Total more precision", "make it a bigger number" — enlarging length/precision. Data-preserving; the one coupling is the index-key byte limit.
+---
+
+# Widen length/type
+
+> **Default (provisional — the data decides).** Mechanism 1 Pure Declarative, single-phase, Tier 2 — usually metadata-only, additive to callers.
+
+## OutSystems phrasing
+"make the field longer", "increase Email to 256", "give Total more precision".
+
+## SSDT meaning
+Enlarge length/precision (`NVARCHAR(100)`→`NVARCHAR(200)`, `DECIMAL(10,2)`→`DECIMAL(18,2)`,
+`INT`→`BIGINT`). Every existing value still fits, so it is data-preserving. SSDT emits `ALTER
+COLUMN` to the wider type. Edit the CREATE; never write `ALTER`.
+
+## The named trap
+**Index-key byte limit** — a column inside a non-clustered index key cannot push the key past
+1700 bytes (900 in older versions); widening it then fails. And `NVARCHAR` widening **doubles
+storage** vs `VARCHAR`, which can tip an index over that limit. This is a single-op coupling (it
+recurs only here), so it stays inline — not lifted to an index skill.
+
+## How it flips (the specifics only)
+- widen a non-indexed column → **M1, single-phase, Tier 1–2**
+- the column sits in an index key and the widen blows the byte limit → publish **vetoes** / build complains → drop/redesign the index → multi-step single-PR
+- very large table on an old SQL version → may rebuild rather than metadata-only → **+1 Tier** at >1M rows
+- CDC-enabled → type change → recreate capture instance → **+1 Tier** (see `../../_index/cdc/SKILL.md`)
+
+## Prove it
+Strict publishes clean; delta is `ALTER COLUMN` to the wider type with no veto and no rebuild of
+unrelated objects. If the column is indexed, prove the index either survives or is the only thing
+the delta also touches. For the publish loop, see `../../prove-on-dacpac/SKILL.md`.
+
+## Verdict to the developer
+"Widening preserves every existing value, so it publishes clean — Pure Declarative, single-phase.
+The one thing I checked: this column isn't in an index whose key would blow the byte limit, and
+NVARCHAR doubling didn't tip anything over. Tier 2."
+
+## Teach it (the graduation)
+Widening is data-preserving by definition — only the data could make it unsafe, and here it
+can't — so the risk is *structural* (the index byte budget), not data. Widen and narrow are
+mirror images (widen's risk is the byte budget, narrow's is `MAX(LEN)`). Fail mode avoided:
+treating a type change as obviously-safe without looking one hop out at what the column
+participates in.

--- a/sidecar/projection/ssdt-agent/skills/operations/audit-cdc.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/audit-cdc.md
@@ -1,0 +1,52 @@
+# Operations — Audit, temporal versioning & CDC (FAMILY INDEX)
+
+> ⚠️ **CDC IS THE TEAM'S SINGLE BIGGEST TRIPWIRE.** Read `../_index/cdc/SKILL.md` BEFORE touching
+> any CDC-related change. CDC is **not expressible in the declarative dacpac model**, is
+> **Enterprise/Standard-licensed**, and once on, **every subsequent schema change on that table
+> needs capture-instance management** — a **+1 Tier escalation on everything it touches, forever**.
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under `../op/`; the
+> shared reasoning lives in `../_index/`. Nothing here restates a guard or a flip mechanism.
+
+**Family framing.** The audit/versioning family the developer reaches for when they say "track
+changes": temporal (system-versioned) tables, manual audit columns, CDC, recreating a capture
+instance after a schema change, and change-tracking. Your job is to find out **which kind of
+history** they mean and to make the CDC consequence loud, because it is the thing that bites the
+whole team for months. The dominant state-variable here is **(3) CDC-enabled + no-gap required?** —
+a no-gap requirement turns almost any co-occurring change into Multi-Phase, multi-PR.
+
+## Ops in this family
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| temporal-new | `../op/temporal-new/SKILL.md` | system-versioning on a NEW entity; M1/Tier2 declarative from birth |
+| temporal-convert | `../op/temporal-convert/SKILL.md` | system-versioning on an EXISTING populated table; M5 multi-PR/Tier3; backfill ROW START |
+| audit-columns | `../op/audit-columns/SKILL.md` | CreatedBy/On etc.; nullable ⇒ M1/Tier1; NOT NULL + populated ⇒ M3 pre-deploy backfill (tightening class) |
+| enable-cdc | `../op/enable-cdc/SKILL.md` | **THE TRIPWIRE**; M4 Script-Only, Tier3 (+1 first-time); NOT in the dacpac; +1-forever tax |
+| recreate-capture-instance | `../op/recreate-capture-instance/SKILL.md` | schema change on a CDC table; dual-instance v1/v2; M5 multi-PR when no-gap required; silent-missing-column |
+| change-tracking | `../op/change-tracking/SKILL.md` | the light CDC sibling; M4 Script-Only/Tier2; which-rows not old-values; no standing tax |
+
+## Shared concerns for this family
+- **`../_index/cdc/SKILL.md`** — the +1 tripwire, the CDC-Surprise three faces, dual-instance
+  capture management, silence-as-the-failure-mode, and the **mandatory isolation rule**
+  (`sp_cdc_enable_db` flips instance-wide state — unique DB only, never the shared warm container;
+  CLAUDE.md survival rule 1 + PROTOCOL §8). (Governs enable-cdc, recreate-capture-instance,
+  change-tracking, and the +1 face of every op on a CDC table.)
+- **`../_index/multi-phase/SKILL.md`** — the coexistence staging behind temporal-convert and the
+  no-gap dual-instance migration.
+- **`../_index/tightening-class/SKILL.md`** — the row-presence veto behind NOT-NULL audit columns
+  on a populated table (audit-columns delegates the guard here; `make-mandatory` owns the spine).
+
+> Handbook offset reminder (+3): file `14` = §17 (`§17.9` recreate-capture-instance), `16` = §19
+> (the **CDC Surprise** anti-pattern), `12` = CDC-and-Schema-Evolution, `27` = CDC-Table-Registry.
+> Cite by filename.
+
+## Connector points
+- CDC proving **must** run on an isolated, disposable DB, never the shared warm container — a hard
+  boundary (CLAUDE.md survival rule 1; `../_index/cdc/SKILL.md` and `talk-to-local-sql` carry the
+  isolation pattern).
+- The F# engine's `PostDeployEmitter` can generate the CDC/change-tracking enable scripts from a
+  real catalog (see `CONNECTORS.md`); the "dacpac ignores the declarative attempt, so it must be a
+  script" proof is unchanged.
+- Any review packet shipping a CDC-touching change should carry the **standing +1-tier
+  consequence** explicitly so the reviewer and the promotion gate both see the future cost.

--- a/sidecar/projection/ssdt-agent/skills/operations/columns.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/columns.md
@@ -1,0 +1,40 @@
+# Operations — Columns (Attributes) — FAMILY INDEX
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under
+> `../op/<slug>/SKILL.md`; the shared reasoning lives in `../_index/`. Nothing here restates a
+> guard or a flip mechanism.
+
+Attribute-level operations. The developer thinks in **Entity Attributes**; you think in `ALTER
+COLUMN` destinations and what SSDT does to existing rows. This is the **densest, most flip-heavy**
+family in the catalog: the *same* one-line edit (make-mandatory, narrow, retype) lands in a
+different mechanism depending entirely on the data — the `.sql` text cannot tell you which.
+**Proving is classifying.** Never report a mechanism you have not confirmed on the proving ground
+(`../prove-on-dacpac/SKILL.md`). And **you never write `ALTER`** — edit the CREATE to the
+destination; SSDT computes the ALTER.
+
+## The ops (table of contents)
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| add-optional | `../op/add-optional/SKILL.md` | New NULL column. Safest change — M1/Tier 1 any table state (NULL is always valid). |
+| add-mandatory | `../op/add-mandatory/SKILL.md` | New NOT NULL column (Optimistic NOT NULL). Populated needs a DEFAULT or it vetoes. |
+| make-mandatory | `../op/make-mandatory/SKILL.md` | NULL→NOT NULL. **THE tightening-class spine** — empty=M1, populated vetoes on row-presence even with zero NULLs. |
+| make-optional | `../op/make-optional/SKILL.md` | NOT NULL→NULL. Loosening never vetoes; risk is downstream consumers. |
+| widen | `../op/widen/SKILL.md` | Enlarge type. M1/Tier 2; the one coupling is the index-key byte limit. |
+| narrow | `../op/narrow/SKILL.md` | Shrink type (Ambitious Narrowing). Tightening class — populated vetoes even when every value fits. |
+| retype-implicit | `../op/retype-implicit/SKILL.md` | Widening/lossless cast (INT→BIGINT). M1/Tier 2. |
+| retype-explicit | `../op/retype-explicit/SKILL.md` | Value-reshaping/lossy cast (Text→Date). M5 Multi-Phase; TRY_CONVERT count. |
+| rename-attribute | `../op/rename-attribute/SKILL.md` | Naked Rename at column grain. refactorlog `sp_rename` or DROP COLUMN+ADD catastrophe. |
+| delete-attribute | `../op/delete-attribute/SKILL.md` | Drop a column. 4-phase deprecation; populated-column veto; Tier 4 once data destroyed. |
+
+## Shared concerns for this family (the `_index` layer)
+
+- `../_index/tightening-class/SKILL.md` — the flagship: governs **make-mandatory, narrow, delete-attribute** (the data-blind table-has-rows guard). The `.sql`-text-classification failure lives here.
+- `../_index/identity-and-refactorlog/SKILL.md` — governs **rename-attribute**: identity is separate from name.
+- `../_index/multi-phase/SKILL.md` — **retype-explicit, delete-attribute** coexistence + conservation proof.
+- `../_index/cdc/SKILL.md` — the `+1` face of every column op on a CDC-tracked table (a new tracked column is silent until the capture instance is recreated).
+
+## Handbook citation reminder
+
+Handbook files are cited by FILENAME with a **+3 offset**: `13` = §16 (Operation Reference),
+`14` = §17 (patterns), `15` = §18, `16` = §19 (anti-patterns).

--- a/sidecar/projection/ssdt-agent/skills/operations/constraints.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/constraints.md
@@ -1,0 +1,31 @@
+# Operations — Constraints (FAMILY INDEX)
+
+> Constraints — DEFAULTs, UNIQUE, CHECK, and constraint-trust state — are where "the text
+> builds but the data refuses" bites hardest: a UNIQUE on duplicates and a CHECK on violating
+> rows both build clean and **veto at deploy**. You cannot classify these from the `.sql` text.
+> **Proving is classifying.** One op here — enable/disable constraint *trust* — is
+> **OPERATIONAL, not declarative**.
+
+**This file is now an INDEX.** The op specifics live in the per-op skills; the shared reasoning
+lives in `_index/`. Nothing here restates a guard or a flip mechanism.
+
+## The ops (table of contents)
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| add-default | `../op/add-default/SKILL.md` | Named DEFAULT for new rows. Always M1 Tier 1; never backfills existing rows. |
+| modify-default | `../op/modify-default/SKILL.md` | Change/remove default = DROP-then-ADD. Still M1 Tier 1; never re-stamps old rows. |
+| add-unique | `../op/add-unique/SKILL.md` | UNIQUE over all rows. Duplicates veto → M3 Pre-Deploy; one-NULL-only bites nullable cols (filtered-index fix). |
+| add-check | `../op/add-check/SKILL.md` | CHECK WITH CHECK over all rows. Violators veto → M3; NOCHECK leaves it untrusted. |
+| toggle-trust | `../op/toggle-trust/SKILL.md` | ⚠️ OPERATIONAL — refuse-and-route. NOCHECK/WITH CHECK CHECK is a script verb; prove it ends `is_not_trusted=0`. |
+
+## Shared concerns for this family
+
+- **UNIQUE / CHECK vetoes, the NOCHECK→re-trust ladder, UNIQUE-one-NULL + filtered index** — a constraint is a claim proven at apply time → `../_index/constraint-is-a-claim/SKILL.md`.
+- **Multi-phase** when violators can't be fixed in-place (grandfather / quarantine) → `../_index/multi-phase/SKILL.md`.
+- **Backfill** of existing rows after a default (the separate idempotent-UPDATE op) → `../_index/idempotent-seed/SKILL.md`.
+- **CDC** +1 on a tracked table → `../_index/cdc/SKILL.md` (CDC does not track constraints; the +1 is the high-stakes-table rule).
+
+## Handbook offset reminder
+Uniform +3: file `13` = §16 (Operation Reference), `14` = §17 (patterns), `15` = §18 (decision
+cascade / declarative table), `16` = §19 (anti-patterns gallery). Cite by filename.

--- a/sidecar/projection/ssdt-agent/skills/operations/indexes.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/indexes.md
@@ -1,0 +1,29 @@
+# Operations — Indexes (FAMILY INDEX)
+
+> Index changes look harmless ("just an index") but two of them are NOT declarative at all —
+> they are operational, job-owned work that has no home in the dacpac. The declarative ones
+> still flip on data: a non-unique → unique change vetoes on duplicates, and a large-table
+> index build blocks writes for the build's duration. Never classify an index change from the
+> `.sql` text alone — the row count and the duplicate count decide the tier.
+
+**This file is now an INDEX.** The op specifics live in the per-op skills; the shared reasoning
+lives in `_index/`. Nothing here restates a guard or a flip mechanism.
+
+## The ops (table of contents)
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| add-index | `../op/add-index/SKILL.md` | Additive, always M1 clean. Build over all rows takes a write-blocking lock; row count is the cost predictor; ONLINE=Enterprise-only. |
+| modify-index | `../op/modify-index/SKILL.md` | DROP+CREATE rebuild. Non-unique→unique vetoes on duplicates → M3 Pre-Deploy. |
+| drop-index | `../op/drop-index/SKILL.md` | M1 clean, reversible. "Unused" is an assumption — the proof is `sys.dm_db_index_usage_stats`, not a publish. |
+| rebuild / reorganize | `../op/rebuild-index/SKILL.md` | ⚠️ OPERATIONAL — refuse-and-route. No declarative destination; a post-deploy REBUILD is anti-idempotent. |
+
+## Shared concerns for this family
+
+- **The unique-veto** (non-unique → unique on duplicates) is a claim about the data proven at build time → `../_index/constraint-is-a-claim/SKILL.md` (duplicate probe).
+- **CDC** +1 on a tracked table → `../_index/cdc/SKILL.md`.
+- Single-op couplings NOT lifted: ONLINE=Enterprise (add-index) and the operational-not-declarative one-liner (rebuild-index, shared only with toggle-trust) stay inline in their op skills.
+
+## Handbook offset reminder
+Uniform +3: file `13` = §16 (Operation Reference), `14` = §17 (patterns), `15` = §18 (decision
+cascade / declarative table), `16` = §19 (anti-patterns gallery). Cite by filename.

--- a/sidecar/projection/ssdt-agent/skills/operations/keys-and-refs.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/keys-and-refs.md
@@ -1,0 +1,31 @@
+# Operations — Keys and References (FAMILY INDEX)
+
+> In OutSystems the **Identifier** was automatic and **References** were lines you drew between
+> entities; now you declare primary keys and foreign keys explicitly, and SSDT validates them
+> against the **existing rows** at deploy time. That validation is exactly where the bucket
+> flips: a foreign key against clean data is single-phase; the same foreign key against one
+> orphan row vetoes and becomes a script. The `.sql` text cannot tell you which. **Proving is
+> classifying.** This is the sharpest constraint-is-a-claim family in the catalog.
+
+**This file is now an INDEX.** The op specifics live in the per-op skills; the shared reasoning
+lives in `_index/`. Nothing here restates a guard or a flip mechanism.
+
+## The ops (table of contents)
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| define-PK | `../op/define-pk/SKILL.md` | The Identifier. New table = M1 inline; populated = clustered-index build, vetoes on duplicate/NULL keys → M3/M5. |
+| create-FK clean | `../op/create-fk-clean/SKILL.md` | Clean child data. M1 Tier 2. Prove zero orphans; if orphans, route to create-fk-orphan. |
+| create-FK with orphans | `../op/create-fk-orphan/SKILL.md` | Dirty data. M4 Script-Only Tier 3: NOCHECK → reconcile → WITH CHECK CHECK, ends trusted. |
+| change-delete-rule / cascade | `../op/change-delete-rule/SKILL.md` | Protect/Ignore/Delete → ON DELETE action via DROP+ADD. M1 publish, Tier 3 behavioral (CASCADE blast radius). |
+| drop-FK | `../op/drop-fk/SKILL.md` | Remove the reference. Always M1 clean; Tier 2 for lost integrity + optimizer-plan shift. |
+
+## Shared concerns for this family
+
+- **Every FK/PK veto** is a claim about existing data proven at apply time → `../_index/constraint-is-a-claim/SKILL.md` (orphan probe, duplicate/NULL probe, the NOCHECK→reconcile→WITH CHECK CHECK trust ladder, `is_not_trusted=0` end-state).
+- **Multi-phase** staging when a reconcile spans releases (orphan FK, coexistence) → `../_index/multi-phase/SKILL.md`.
+- **CDC** +1 tripwire on a tracked table → `../_index/cdc/SKILL.md`.
+
+## Handbook offset reminder
+Uniform +3: file `13` = §16 (Operation Reference), `14` = §17 (patterns), `15` = §18 (decision
+cascade / declarative table), `16` = §19 (anti-patterns gallery). Cite by filename.

--- a/sidecar/projection/ssdt-agent/skills/operations/static-data.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/static-data.md
@@ -1,0 +1,34 @@
+# Operations — Static Data (FAMILY INDEX)
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under `../op/`; the
+> shared reasoning lives in `../_index/`. Nothing here restates a guard or a flip mechanism.
+
+**Family framing.** OutSystems "Static Entities" — the small, enumerated tables (Status, Country,
+OrderType) whose rows are part of the model, not user input. In SSDT their rows ride in a
+**post-deployment idempotent MERGE**: the schema project describes structure, seed *data* rides in
+the deploy's data slot. The family's shared character is **silence-as-proof** — a no-op redeploy
+must touch zero rows, keep an identical hash, and (if CDC-tracked) capture zero changes.
+
+## Ops in this family
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| create-static-seed | `../op/create-static-seed/SKILL.md` | new lookup entity + idempotent MERGE seed; M2/Tier1, +1 if CDC-tracked, FK-target ⇒ parents-first |
+| edit-seed | `../op/edit-seed/SKILL.md` | add/amend seed rows; M2/Tier1; label change must touch ONE row |
+| extract-to-lookup | `../op/extract-to-lookup/SKILL.md` | promote a free-text column to a lookup + FK; M5 multi-PR/Tier3; prove total mapping before drop |
+| delete-seed-value | `../op/delete-seed-value/SKILL.md` | retire a lookup value; **deactivate (`IsActive=0`), don't delete**; refuse hard DELETE if referenced |
+
+## Shared concerns for this family
+- **`../_index/idempotent-seed/SKILL.md`** — the guarded null-safe MERGE, explicit-IDs-not-IDENTITY,
+  deactivate-don't-delete, and silence-is-the-proof. (Owns every seed discipline in this family.)
+- **`../_index/cdc/SKILL.md`** — the CDC-silence / over-capture face when a seeded table (or its
+  downstream consumer) is CDC-tracked.
+- **`../_index/multi-phase/SKILL.md`** — the coexistence + total-mapping proof behind extract-to-lookup.
+
+> Handbook offset reminder (+3): file `13` = §16, `14` = §17, `15` = §18, `16` = §19. `07` =
+> Idempotency 101, `06` = Pre/Post-Deployment scripts. Cite by filename.
+
+## Connector points
+- The hand-authored `proving-ground/SampleCatalog` seed can be replaced by the F# engine's
+  `PostDeployEmitter` output from a real OutSystems catalog (see `CONNECTORS.md`) — the
+  idempotent-MERGE / silent-redeploy proving loop is unchanged; only the source data becomes real.

--- a/sidecar/projection/ssdt-agent/skills/operations/structural.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/structural.md
@@ -1,0 +1,46 @@
+# Operations — Structural reshapes (FAMILY INDEX)
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under `../op/`; the
+> shared reasoning lives in `../_index/`. Nothing here restates a guard or a flip mechanism.
+> The two AUTHORED-HERE recipes (merge-entities §17.7; the rename-with-compat-view companion
+> §17.8) have moved their full bodies into the per-op skills (`../op/merge-tables/` and
+> `../op/compat-view/`) with the AUTHORED-HERE notice preserved verbatim.
+
+**Family framing.** These are the heavy ops — one entity becoming two, two becoming one, a field
+crossing entities, or Auto-Number toggled. None is a single CREATE edit; most **cannot** be one
+declarative destination because they move *data* between shapes while the app keeps reading. That
+is why almost everything here is **Multi-Phase (Mechanism 5), multi-PR** by default, and why the
+proving ground matters most: the danger is not in the DDL, it is in the gap between "old table
+still has the data" and "new table now owns it." Translate back for the developer — a split is
+*one entity becoming two*, a merge is *two becoming one*, "Auto Number" is `IDENTITY`.
+
+## Ops in this family
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| split-table | `../op/split-table/SKILL.md` | one entity → two; M5 multi-PR (empty source ⇒ M1); drop-old-columns is the BlockOnPossibleDataLoss veto |
+| merge-tables | `../op/merge-tables/SKILL.md` | two entities → one; M5 multi-PR; **prove cardinality (1:1) BEFORE copy** or 1:many rows drop silently *(AUTHORED-HERE §17.7)* |
+| move-attribute | `../op/move-attribute/SKILL.md` | one column crossing entities; M5 multi-PR when populated; prove the join is 1:1; a move is copy-then-drop, never a rename |
+| identity-swap | `../op/identity-swap/SKILL.md` | add/remove IDENTITY (Auto Number); a **table rebuild** (shadow + IDENTITY_INSERT + FK drop/recreate), not an alter |
+
+## Shared concerns for this family
+- **`../_index/multi-phase/SKILL.md`** — additive→cutover→subtractive coexistence, the totality
+  proof that licenses the drop, the BlockOnPossibleDataLoss veto as the licensing gate. (Governs
+  split, merge, move-attribute.)
+- **`../_index/identity-and-refactorlog/SKILL.md`** — identity is separate from name; a cross-table
+  move / a rebuild that loses the mapping re-mints keys the way a naked rename loses a column.
+  (Governs move-attribute and identity-swap.)
+- **`../_index/cdc/SKILL.md`** — the +1 face when a reshaped table is CDC-tracked (capture-instance
+  refresh; rebuild invalidates the instance).
+
+> Handbook offset reminder (+3): file `14` = §17 (`§17.3` identity, `§17.6` split, `§17.7`
+> merge-AUTHORED, `§17.8` compat-view-AUTHORED, `§17.9` recreate-capture-instance), `16` = §19
+> (anti-patterns). Cite by filename.
+
+## Connector points
+- The hand-authored `proving-ground/SampleCatalog` can be replaced by the F# engine's
+  `SqlprojEmitter`/`DacpacEmitter`/`PostDeployEmitter` output from a real catalog (see
+  `CONNECTORS.md`) — the multi-phase copy/hash/drop loop is unchanged; only the source schema
+  becomes real.
+- The §17.7 and §17.8 authored recipes (now in `../op/merge-tables/` and `../op/compat-view/`) are
+  the natural first candidates to push **back into the handbook** once its bodies are completed.

--- a/sidecar/projection/ssdt-agent/skills/operations/tables.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/tables.md
@@ -1,0 +1,36 @@
+# Operations — Tables (Entities) — FAMILY INDEX
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under
+> `../op/<slug>/SKILL.md`; the shared reasoning lives in `../_index/`. Nothing here restates a
+> guard or a flip mechanism.
+
+Whole-table operations. The developer thinks in **Entities**; you think in `CREATE TABLE`
+destinations and what SSDT's publish engine does to existing data. This family's character:
+*additive at one end (create, junction) and irreversible at the other (delete, archive)* — the
+danger axis and the release axis diverge most sharply here (a one-PR `DROP TABLE` is Tier 4).
+**Proving is classifying.** Never report a mechanism you have not confirmed on the proving
+ground (`../prove-on-dacpac/SKILL.md`).
+
+## The ops (table of contents)
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| create-entity | `../op/create-entity/SKILL.md` | New table. Additive M1/Tier 1; the only risk is a dependency (missing FK parent), not a data flip. |
+| rename-entity | `../op/rename-entity/SKILL.md` | Naked Rename. With refactorlog → `sp_rename` M1/Tier 3; without → DROP+CREATE catastrophe. |
+| delete-entity | `../op/delete-entity/SKILL.md` | Drop a table. M4/single-PR mechanically but Tier 4; the populated-table veto is the safety proof. |
+| move-schema | `../op/move-schema/SKILL.md` | Schema change. The rename trap again — refactorlog or `ALTER SCHEMA TRANSFER`, else DROP+CREATE. |
+| archive-entity | `../op/archive-entity/SKILL.md` | Data move, not a shape change. M5 Multi-Phase; conservation-count proof. |
+| junction | `../op/junction/SKILL.md` | M:N bridge — composite PK over two FKs. M1/Tier 2; the shape *is* the guarantee (no orphans, no dup pairs). |
+
+## Shared concerns for this family (the `_index` layer)
+
+- `../_index/identity-and-refactorlog/SKILL.md` — governs **rename-entity, move-schema** (and the compat-view bridge): identity is separate from name; a cross-table move has no refactorlog identity mapping.
+- `../_index/tightening-class/SKILL.md` — the **delete-entity** populated-table row-presence veto.
+- `../_index/multi-phase/SKILL.md` — **archive-entity** coexistence + the conservation proof before any subtractive move.
+- `../_index/constraint-is-a-claim/SKILL.md` — **junction** orphan-pair FK validation.
+- `../_index/cdc/SKILL.md` — the `+1` face of every op on a CDC-tracked table.
+
+## Handbook citation reminder
+
+Handbook files are cited by FILENAME with a **+3 offset**: `13` = §16 (Operation Reference),
+`14` = §17 (patterns), `15` = §18, `16` = §19 (anti-patterns).

--- a/sidecar/projection/ssdt-agent/skills/operations/views-synonyms.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/views-synonyms.md
@@ -1,0 +1,40 @@
+# Operations — Views & synonyms (FAMILY INDEX)
+
+> **This file is now an INDEX.** The op specifics live in the per-op skills under `../op/`; the
+> shared reasoning lives in `../_index/`. Nothing here restates a guard or a flip mechanism.
+> The AUTHORED-HERE backward-compat-view recipe (§17.8) has moved its full body into
+> `../op/compat-view/SKILL.md` with the AUTHORED-HERE notice preserved verbatim.
+
+**Family framing.** Views, synonyms, and their materialized cousins are the *indirection layer*.
+Most are benign **Pure Declarative** changes — a view is a saved SELECT with no data to lose. The
+danger here is rarely data loss; it is **stale shape** (a `SELECT *` view that silently drifts as
+its base changes), the **backward-compat view** that keeps an old entity name readable through a
+rename/split, and the **binding tax** of materialization. Name each view in terms of the entity it
+stands in for (an OutSystems "External Entity" / "Advanced Query" is often a view underneath).
+
+## Ops in this family
+
+| Op | Per-op skill | What it is / how it flips |
+|---|---|---|
+| create-view | `../op/create-view/SKILL.md` | a saved SELECT; M1/Tier1; **enumerate columns** — `SELECT *` is a latent defect (the SELECT-* trap) |
+| compat-view | `../op/compat-view/SKILL.md` | a view bearing the OLD name after a rename/split; M1 view inside a multi-PR program, Tier3; temporary, enumerated *(AUTHORED-HERE §17.8)* |
+| synonym | `../op/synonym/SKILL.md` | a runtime-resolved alias to an external object; M1/Tier1 (Tier3 external); target NOT validated at publish |
+| indexed-view | `../op/indexed-view/SKILL.md` | SCHEMABINDING + unique clustered index; stores data, binds base columns; flips to Multi-Phase as the base grows |
+
+## Shared concerns for this family
+- **`../_index/identity-and-refactorlog/SKILL.md`** — the refactorlog `sp_rename` that makes a
+  rename safe *inside* the model, and why its reach stops at the model boundary (the reason
+  compat-view exists).
+- **The SELECT-\* trap is NOT lifted to an index** — it recurs only in create-view and compat-view,
+  below the N≥3 bar; it lives inline in those two per-op skills.
+- **The shadow-table-rebuild mechanic** (which indexed-view brushes against) is owned by
+  `../op/identity-swap/SKILL.md`; indexed-view cross-references it rather than restating it.
+
+> Handbook offset reminder (+3): file `14` = §17 (`§17.8` compat-view-AUTHORED), `16` = §19
+> (anti-patterns, incl. the SELECT-\* View). Cite by filename.
+
+## Connector points
+- The §17.8 backward-compat-view recipe (now in `../op/compat-view/`) is a prime candidate to push
+  **back into the handbook**; flag it in any review packet that ships a rename-with-compat-view.
+- The hand-authored `proving-ground` views can come from the F# engine's `SqlprojEmitter` output
+  against a real catalog (see `CONNECTORS.md`) — the view/synonym proving loop is unchanged.

--- a/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: prove-on-dacpac
+description: Use when a data-model change has a PROVISIONAL mechanism from classify-mechanism and must be confirmed (or flipped) against real-shaped data. Builds the .sqlproj to a dacpac, previews the REAL SSDT-generated delta, then publishes to a throwaway DB under a Strict (veto-detector) and Permissive (consequence-oracle) profile to discover whether the data vetoes the change. Invoke whenever classification depends on table state — populated? rule-violating rows? — which is ALWAYS for anything past the purely-additive corner. Scaffolds commands; the developer's agent runs them.
+---
+
+# Prove on dacpac
+
+> **Why this (and what it teaches).** The veto **is** the classification: SSDT's own publish engine
+> is a more honest oracle than any rule table, because it computes the real delta against the real
+> rows. We prove instead of advise because the `.sql` text cannot tell you the mechanism — only the
+> data on the proving ground can, and the moment SSDT refuses, you have learned the bucket. What
+> this teaches: a green-looking schema diff and a clean data probe are *necessary but not
+> sufficient* — the deciding evidence is what the engine actually does when you publish. The
+> sharpest lesson the proving ground teaches (below) is that a `NULL -> NOT NULL` veto is
+> **table-has-rows, not column-has-NULLs** — so even backfilling every NULL does not clear it.
+> Surface this to the developer: a developer who watches the engine veto a change they were sure
+> was clean graduates from trusting their reading of the SQL to demanding the proof.
+
+You are helping an **OutSystems-native developer** land a safe schema change. The classification
+you were handed is **provisional** — a reading of intent. **Proving is classifying.** The data
+decides the mechanism, and the only way to know the data is to publish the change to a copy of it
+and watch what SSDT's publish engine actually does.
+
+This is the capability the team's decks never taught: a **proving ground** — a throwaway copy of
+real-shaped data — and `sqlpackage` driving the real dacpac delta against it. You introduce this
+vocabulary **gently**, always tied back to a phrase the team already owns:
+**"You describe the destination, SSDT computes the journey."** The dacpac is the described
+destination; `sqlpackage` computes the journey; the proving ground lets you watch the journey
+before it ever runs on production.
+
+## When to use
+
+- `classify-mechanism` handed you a provisional Mechanism + Tier and said **must-prove**.
+- The verdict depends on any of the four state-variables (populated / violates / CDC-no-gap /
+  coexist). Prove before you tell the developer anything.
+- A named trap is suspected (especially **Naked Rename** — always read the delta).
+
+If `classify-mechanism` said **on-sight** (the purely-additive Tier 1 corner), you still run one
+clean Strict publish to confirm no surprise delta — but no flip is possible.
+
+## Running in parallel — see self-test/PROTOCOL.md
+
+When MANY executors prove cases at once (the self-test fleet), do **not** publish to the shared
+default `ProvingGround` catalog and do **not** edit the authored `proving-ground/` tree. Each
+executor copies the tree to its own scratch dir and publishes to a **unique database**
+(`/TargetDatabaseName:PG_<testId>_<rand>`, which overrides the profile's `Initial Catalog`), then
+drops the DB and deletes the scratch on exit. The full parallel-safe, idempotent isolation
+protocol is **`self-test/PROTOCOL.md`** — read it before running any prove loop alongside other
+executors. (Single-developer, one-at-a-time use can target `ProvingGround` directly per
+`talk-to-local-sql`.)
+
+## The vocabulary you are teaching (gently)
+
+| Term | What it is | Tie it back to |
+|---|---|---|
+| **dacpac** | the compiled "destination" (your edited CREATEs, built) | "describe the destination" |
+| **sqlpackage** | the tool that computes + applies the delta | "SSDT computes the journey" |
+| **publish profile** | the rules SSDT publishes under (a `.publish.xml`) | the team's prod safety settings |
+| **BlockOnPossibleDataLoss** | the **veto** — refuses any step that could lose data | "it stops you before you hurt the data" |
+| **GenerateSmartDefaults** | the **silent backfill** — stamps a default into NOT-NULL columns | "what it would have done quietly" |
+| **proving ground** | a throwaway copy of real-shaped data to publish against | "a sandbox that looks like prod" |
+
+## The proving loop (you scaffold; the developer's agent runs each command)
+
+> All commands assume you are at the repo root and the proving ground is warm — see
+> `talk-to-local-sql` for the container, the connection string, and the **runtime shim** (the
+> `DOTNET_ROOT` + `DOTNET_ROLL_FORWARD=Major` exports are **required on this machine**, because
+> `sqlpackage` targets .NET 8 and the box has .NET 9 at a non-standard path). On Git Bash also
+> export `MSYS_NO_PATHCONV=1` so the `/Action:` / `/SourceFile:` switches and any `/opt/...`
+> docker-exec paths are not mangled.
+
+```bash
+# 0. Runtime shim (REQUIRED here) + warm DB — details in talk-to-local-sql
+export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROLL_FORWARD=Major
+export MSYS_NO_PATHCONV=1                  # Git Bash: keep /Action: + /opt/... paths intact
+scripts/warm-sql.sh start                 # container projection-mssql-warm, localhost,11433
+
+# 1. Establish the BEFORE state once: deploy current CREATEs + seed (the 'real-shaped data')
+#    (see proving-ground/README.md — first Strict publish of the unedited project + post-deploy seed)
+
+# 2. Edit the CREATE to the destination in proving-ground/Modules/*.sql. NEVER write ALTER.
+#    "Edit the CREATE, never write ALTER."
+
+# 3. BUILD the destination to a dacpac
+dotnet build ssdt-agent/proving-ground/SampleCatalog.sqlproj -c Release
+#    -> ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac
+
+# 4. PREVIEW the REAL delta (changes NOTHING — this is the script SSDT would run)
+sqlpackage /Action:Script \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml \
+  /OutputPath:ssdt-agent/proving-ground/bin/Release/delta.sql
+
+# 5. VETO CHECK — Strict = the veto detector. Does the data refuse the change?
+sqlpackage /Action:Publish \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Strict.publish.xml
+
+# 6. ON VETO ONLY — Permissive = the consequence oracle. Let it proceed past the veto so you can
+#    snapshot WHAT it was protecting against (see the content-hash oracle in talk-to-local-sql).
+sqlpackage /Action:Publish \
+  /SourceFile:ssdt-agent/proving-ground/bin/Release/SampleCatalog.dacpac \
+  /Profile:ssdt-agent/proving-ground/profiles/ProvingGround.Permissive.publish.xml
+```
+
+> For a **parallel** run, every command above also carries `/TargetDatabaseName:PG_<testId>_<rand>`
+> and points at a scratch copy of the tree — see `self-test/PROTOCOL.md`.
+
+## Reading the result -> the classification
+
+**Read the generated `delta.sql` AND the Strict publish outcome together.** Map what you see:
+
+- **Strict publishes clean, the delta is an in-place `ALTER` (or nothing), no veto**
+  -> **Mechanism 1 Pure Declarative** (single-phase). Confirmed.
+- **Strict vetoes** with `BlockOnPossibleDataLoss` / "rows that would be affected" / NOT NULL on
+  populated data / truncation -> the data **flipped the bucket up**. The remedy that clears the
+  veto is your proof:
+  - backfill before the schema change -> **Mechanism 3 Pre-Deploy+Declarative**, single-PR.
+    (But see the make-mandatory caveat below — for `NULL -> NOT NULL` on a populated table, the
+    backfill alone does **not** clear the veto; that is the corrected finding.)
+  - the fix is a post-deploy seed/reconcile -> **Mechanism 2 Declarative+Post-Deploy**.
+  - the change isn't declarative at all (FK `NOCHECK`->`WITH CHECK CHECK`, CDC, IDENTITY swap)
+    -> **Mechanism 4 Script-Only**.
+  - old+new app code must coexist, or a no-gap CDC rollout -> **Mechanism 5 Multi-Phase**, multi-PR.
+- **The delta shows `DROP <col/table>` + `CREATE` on something you asked to RENAME**
+  -> **Naked Rename. STOP.** The refactorlog entry is missing; publishing this loses the data
+  silently. Demand the refactorlog entry (it turns the DROP+CREATE into `sp_rename`), rebuild,
+  re-preview, and confirm the delta is now a rename. This is the single most important read in the
+  set.
+- **The delta shows a shadow-table rebuild** (CREATE new table -> copy -> drop old -> rename) or
+  **drop-by-absence** (an object vanishes because it's no longer in source) -> name it to the
+  developer explicitly; these are expensive and/or destructive and they did not ask for them.
+
+## The make-mandatory finding: the guard is TABLE-HAS-ROWS, not column-has-NULLs (VERIFIED)
+
+This is the showcase result the proving ground exists to teach, and it **corrects an earlier,
+wrong recipe.** The old advice said "a pre-deploy backfill clears the NULLs, then the declarative
+NOT NULL lands clean under Strict = Mechanism 3." **That was disproven empirically here.**
+
+For a `NULL -> NOT NULL` change, `sqlpackage` generates the `BlockOnPossibleDataLoss` guard as:
+
+```sql
+IF EXISTS (SELECT TOP 1 1 FROM [dbo].[Customer])
+    RAISERROR (N'Rows were detected. The schema update is terminating because data loss might occur.', 16, 127);
+-- ... and BELOW it, the actual:
+ALTER TABLE [dbo].[Customer] ALTER COLUMN [Email] NVARCHAR(256) NOT NULL;
+```
+
+That guard fires on `IF EXISTS (... FROM Table)` — **the table merely having rows** — and is placed
+**before** the `ALTER COLUMN`. It **does not inspect the `Email` column at all.** Why: **SSDT
+computes the entire deploy script once, up front, from the pre-publish model state, and is
+conservative by design** — it cannot know that a pre-deploy backfill (which runs at deploy time,
+after the script is already generated) will have emptied the NULLs, so it refuses the moment the
+table has any row. The gate cannot know your intent, so it assumes the worst.
+
+**Proven on the proving ground:** a pre-deploy backfill cleared **all** NULLs (a fresh
+`SELECT COUNT(*) WHERE Email IS NULL` returned **0**), and Strict **STILL vetoed**, leaving the
+column nullable. **Zero NULLs is necessary but NOT sufficient** to pass the prod-strict gate on a
+populated table.
+
+The **honest, corrected recipe:**
+
+- **EMPTY table** -> clean **Mechanism 1, single-phase, Tier 1.** No rows, the `IF EXISTS` is false,
+  the RAISERROR never fires, the `ALTER COLUMN NOT NULL` lands. (Confirm the table is genuinely
+  empty first.)
+- **POPULATED table (NULLs present OR zero NULLs — it makes no difference)** -> the make-mandatory
+  change **cannot pass the prod-strict gate by backfill alone.** It needs a **conscious, documented
+  decision taken AFTER a verified backfill** (prove `COUNT(*) WHERE col IS NULL = 0` first —
+  necessary, not sufficient), then ONE of:
+  - **(a) Targeted gate-relaxation** — operationally **Mechanism 4 / Script-Only with a named
+    relax.** Having proven zero NULLs remain, deliberately disable `BlockOnPossibleDataLoss` for
+    **this one targeted change** (a scoped profile override or a script-only path), so the
+    `ALTER COLUMN NOT NULL` proceeds against the now-clean column. The proof packet must carry
+    **both** the zero-NULL probe AND the explicit record of the relaxation decision.
+  - **(b) Restructure as Mechanism 5 — Multi-Phase, multi-PR** — stage it so the engine never has
+    to relax its guard. Tier 2 baseline; **+1** for CDC / >1M rows / first-time.
+
+**What the proof must EMPIRICALLY show (do not assert it — discover it):**
+
+1. Edit `Email ... NULL` -> `NOT NULL`, build, Strict publish -> prove the veto fires, and read
+   the delta to **SEE** the `IF EXISTS(...) RAISERROR(...,16,127)` guard placed **above** the
+   `ALTER COLUMN` (confirming table-has-rows).
+2. Author the pre-deploy backfill, re-run the NULL probe -> prove `0` NULL emails remain.
+3. Re-run Strict -> prove it **STILL vetoes** and the column **stays nullable** — the backfill did
+   not satisfy the gate. **This step is the showcase finding.**
+4. Deliver the corrected verdict and prove the chosen path ((a) named gate-relaxation after
+   proven-zero-NULL, or (b) multi-phase) actually lands the NOT NULL.
+
+This is the spine proof that the tree's *prove-don't-advise* thesis holds: the agent discovers a
+finding that **contradicts its own earlier skill text** rather than parroting it.
+
+## Strict vs Permissive — what the diff tells you
+
+Strict and Permissive aim at the **same throwaway DB** and differ on two settings
+(`BlockOnPossibleDataLoss` and `GenerateSmartDefaults`). The difference between their outcomes is
+the proof:
+
+- **Strict refused, Permissive proceeded** -> the change *does* touch data. Now snapshot the data
+  **before vs after** the Permissive publish using the content-hash oracle (see
+  `talk-to-local-sql`). The rows whose hash changed are exactly what `GenerateSmartDefaults`
+  stamped, or what truncated. **That set is the magic line's row count.**
+- **Both proceeded clean** -> no data at risk; the Strict-clean result already proved Mechanism 1.
+- A **rename** changes a row's hash **by design** (the column name is part of the row shape) — so a
+  hash diff on a rename is *correct*, and confirms the rename touched the right rows. The diff IS
+  the proof, not a false alarm.
+
+## The content-hash data oracle (the "did values change" question)
+
+The oracle is a per-row `SHA2_256` over `(SELECT x.* FOR XML RAW)`, summed **order-independently**
+across the table (so row order doesn't matter), with **NULL kept distinct from `''`**. Snapshot it
+before and after a Permissive publish; an unchanged total means no value moved. The exact SQL lives
+in `talk-to-local-sql` (one query, reusable). Use it to **quantify** a flip — "1,240 rows would be
+stamped" — not merely assert "data might change."
+
+## Two named proof moves (scope them by op class)
+
+Two moves the fitness runs invented and proved — use them where they fit, and do **not** fabricate
+them where they cannot fire:
+
+- **CONSEQUENCE ORACLE** — for a Tier-4 *destroying* op (`delete-attribute`, `delete-entity`,
+  `narrow` past the data, drop-table): after Strict vetoes, run Permissive to let the irreversible
+  act happen on the throwaway copy and snapshot the corpse — the exact rows/values lost — so the
+  Tier-4 claim is **observed, not asserted.** (This is the Strict→Permissive pattern above, named.)
+- **VETO-INJECTION LEG** — for a *constraint / tightening* op that has a data veto (`define-pk`,
+  `add-unique`, `add-check`, `create-fk-orphan`, `make-mandatory`): if the seeded data happens to be
+  clean, inject one violating row (a dup, an orphan, an over-length value, a NULL) into your scratch
+  DB, then publish — to capture the **exact `Msg` number and the offending value** the developer will
+  hit. It turns "this could fail on bad data" into "here is the failure, verbatim."
+
+**Scope discipline.** These apply only to op classes that HAVE a data consequence/veto. Ops with
+**no** data veto — `edit-seed` (a MERGE), `enable-cdc` (Script-Only), `create-view` (no rows) —
+must **not** manufacture a veto that structurally cannot fire. Naming the absence is itself the
+honest result.
+
+## What you hand back (the verdict + the magic line)
+
+The **proven** Mechanism + Tier, the real generated delta, the named veto **with row counts from
+the oracle**, and the remedy that makes Strict pass clean — all phrased for the developer. Then
+re-run the Strict publish after applying the remedy: **that clean re-run is the proof.** Deliver
+the magic line:
+
+> "You said *make it mandatory*. I published that to a copy of your data — SSDT **vetoed** it, and
+> when I read the generated script the guard is `IF EXISTS (SELECT TOP 1 1 FROM Customer)
+> RAISERROR(...)` placed *before* the ALTER. That's **table-has-rows, not NULL-has-rows** — SSDT
+> builds the deploy script up front and can't know I'll backfill, so it refuses the moment the
+> table has any rows. I proved it: I backfilled every NULL (0 remain) and Strict **STILL** vetoed
+> and left the column nullable. So on your populated table this isn't a clean backfill-then-NOT-NULL
+> — it needs a conscious call: either I deliberately relax BlockOnPossibleDataLoss for this one
+> change *after* proving zero NULLs (a logged, script-only gate decision), or we stage it
+> multi-phase. Here is the proof for the path you choose — Tier 2 (+1 if CDC). On an EMPTY table it
+> would have been a clean one-liner, Tier 1; the difference is entirely the rows."
+
+## The named traps to catch in the delta (handbook file 16 = §19)
+
+Naked Rename, Optimistic NOT NULL, Ambitious Narrowing, Forgotten FK Check, CDC Surprise,
+Refactorlog Cleanup, SELECT * View. **Catch them in the generated delta / Strict veto — not after
+a hypothetical deploy.** That timing is the whole value of the proving ground.
+
+> **SELECT \* View nuance (proven).** SSDT **auto-emits `EXECUTE sp_refreshsqlmodule`** for
+> dependent views on publish, so a `SELECT *` view stays correct through a *normal SSDT* base-column
+> add — the drift is **invisible through SSDT** and only bites when a base column is added **out of
+> band** (a raw `ALTER` outside the dacpac). Prove the trap with a non-SSDT column-add, not a
+> through-model one.
+
+## What the proving ground HONESTLY CANNOT prove
+
+Be truthful with the developer about the edges:
+
+- **Reversibility — the proving ground proves the FORWARD publish only.** Every command in the
+  loop runs `/Action:Publish` forward; nothing here exercises a rollback, a down-migration, or
+  backing the change out. A clean forward Strict publish says **nothing** about whether the change
+  can be safely reversed. Reversibility is one of the team's **Four Dimensions**, but it stays an
+  *asserted Tier dimension, not a proven one* — when an operation entry calls a change "reversible"
+  (e.g. drop-index "re-add the definition", or a multi-phase add->backfill->cut-over->drop), that is
+  a **claim**, not something this loop demonstrated. Say so: "I proved the forward change is safe for
+  the data; I did not prove you can back it out."
+- **Application impact — the proving ground cannot prove the running app keeps working.** This is
+  state-variable 4 (must old + new app code coexist), and it is the very thing that splits Tier 2
+  SINGLE-PR from Tier 1 SINGLE-PHASE in the cascade. A single-connection publish against a
+  throwaway DB cannot show whether the live OutSystems app — or old and new app code mid-rollout —
+  still compiles and reads correctly against the new shape. That answer comes from the developer
+  and the architecture, **not** from a publish. A clean Strict publish proves the *schema*
+  transition is safe for the *data*; it is silent on the *app*.
+- **Production scale and timing.** The throwaway DB is real-*shaped*, not real-*sized*. It proves
+  *whether* a veto fires and *what* changes; it does **not** prove how long an index build or a
+  table rebuild takes at 50M rows, or whether a lock will block. That stays a Tier escalation
+  (>1M rows, +1), not a proof.
+- **CDC capture-instance behavior over time.** CDC is **Script-Only** and not in the dacpac model;
+  the proving ground cannot demonstrate the downstream capture-instance management burden. Flag
+  **CDC Surprise** as a standing consequence, don't try to publish-prove it away.
+- **Concurrency, blocking, and online-vs-offline.** `ONLINE` index builds (Enterprise) and lock
+  behavior under live traffic are not modeled by a single-connection publish.
+- **External Entities and downstream consumers** (ETL, reports, procs in other databases). The
+  proving ground holds one catalog; cross-database / external effects are out of frame and must be
+  named as **Tier 3 dependency scope**, not proven here.
+- **A profile pointed anywhere but the throwaway DB is a foot-gun.** Both profiles target
+  `localhost,11433 / ProvingGround` only (or a per-executor `PG_<testId>_<rand>` via
+  `/TargetDatabaseName`). Never repoint one at anything else — the whole point is that this DB is
+  disposable.
+
+When you hit one of these, say so plainly: *"I can prove the veto and the row count; I cannot prove
+the rebuild duration at production scale — that's why this stays Tier 3."*
+
+## The two publish profiles (fenced examples; the live files are under `proving-ground/profiles/`)
+
+Both aim at the **same throwaway DB**. They differ only in the veto + smart-default settings.
+
+**Strict = the VETO DETECTOR** (`proving-ground/profiles/ProvingGround.Strict.publish.xml`):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetConnectionString>Server=localhost,11433;Initial Catalog=ProvingGround;User ID=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False</TargetConnectionString>
+    <BlockOnPossibleDataLoss>True</BlockOnPossibleDataLoss>
+    <GenerateSmartDefaults>False</GenerateSmartDefaults>
+    <IgnoreColumnOrder>True</IgnoreColumnOrder>
+    <DropObjectsNotInSource>True</DropObjectsNotInSource>
+    <IncludeTransactionalScripts>True</IncludeTransactionalScripts>
+    <AllowIncompatiblePlatform>False</AllowIncompatiblePlatform>
+    <IgnorePermissions>True</IgnorePermissions>
+  </PropertyGroup>
+</Project>
+```
+
+Why each setting: `BlockOnPossibleDataLoss=True` mirrors prod's refusal — it is the veto you want
+to trip (and, per the finding above, it fires on table-has-rows for a `NULL -> NOT NULL` change,
+not on the column's NULL count). `GenerateSmartDefaults=False` means SSDT will **not** quietly
+paper over a NOT-NULL gap, so the veto surfaces instead of a silent stamp. `DropObjectsNotInSource=
+True` is safe **because the proving ground is disposable** — you *want* to see drop-by-absence here,
+where production never would. `IgnoreColumnOrder=True` keeps cosmetic ordering from masquerading as
+a real change.
+
+**Permissive = the CONSEQUENCE ORACLE**
+(`proving-ground/profiles/ProvingGround.Permissive.publish.xml`): identical to Strict except the
+two flipped settings, so the change **proceeds past the veto** and you can snapshot what it did:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetConnectionString>Server=localhost,11433;Initial Catalog=ProvingGround;User ID=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False</TargetConnectionString>
+    <BlockOnPossibleDataLoss>False</BlockOnPossibleDataLoss>
+    <GenerateSmartDefaults>True</GenerateSmartDefaults>
+    <IgnoreColumnOrder>True</IgnoreColumnOrder>
+    <DropObjectsNotInSource>True</DropObjectsNotInSource>
+    <IncludeTransactionalScripts>True</IncludeTransactionalScripts>
+    <AllowIncompatiblePlatform>False</AllowIncompatiblePlatform>
+    <IgnorePermissions>True</IgnorePermissions>
+  </PropertyGroup>
+</Project>
+```
+
+Never run Permissive **first** — you'd destroy the evidence the veto was protecting. Strict
+proves the refusal; Permissive, only after, shows the consequence.
+
+## Hard rules
+
+- You **scaffold** commands; you do **not** ship a wrapper script. The developer's agent runs
+  `docker` / `dotnet` / `sqlpackage` itself.
+- Everything you touch lives under `ssdt-agent/`.
+- For parallel/self-test runs, obey `self-test/PROTOCOL.md`: scratch copy + unique DB + teardown.
+  Never edit the authored tree and never publish to a shared catalog while others run.
+- The F# Projection engine is an **optional accelerant**, not wired here.
+
+## Connector points
+
+The hand-authored `SampleCatalog` can be replaced by the F# engine's `SqlprojEmitter` /
+`DacpacEmitter` / `PostDeployEmitter` output (in `src/Projection.Targets.SSDT`) from a **real**
+OutSystems catalog — same proving loop, real schema. The engine emits the artifacts but never
+*drives* `sqlpackage`; **this skill is that missing driver**, kept as agent-run commands by
+design. See `CONNECTORS.md` for the `Render` / `SsdtBundle` seam.

--- a/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: talk-to-local-sql
+description: The throwaway-DB substrate for the proving ground. Use whenever prove-on-dacpac needs a warm local SQL Server to publish against, a fresh-or-reset ProvingGround database, ad-hoc sqlcmd queries (row counts, MAX(LEN), NULL counts), or the content-hash data oracle that answers "did the values actually change". Brings up the existing warm-sql container, supplies the connection string, the required runtime shim, and the docker-exec sqlcmd form (the host has NO sqlcmd) — the developer's agent runs the commands. No wrapper script.
+---
+
+# Talk to local SQL
+
+> **Why this (and what it teaches).** The hash and the probe are the proof because **a number you
+> measured beats a claim you asserted** — "1,240 rows are blank" is evidence; "some rows might be
+> blank" is a guess. And the strongest result this substrate produces is **silence**: a no-op
+> redeploy that captures 0 rows and an unchanged content digest is the proof a deploy is
+> idempotent. What this teaches: quantify before you classify (run the probe, get the count), and
+> treat an unchanged digest on a re-run as a *positive* guarantee, not a non-event. Surface this to
+> the developer — handing them "I measured 0 NULLs remain, and the second deploy moved nothing"
+> graduates them from trusting recollection to trusting measurement.
+
+You are helping an **OutSystems-native developer** prove a schema change safely. This skill owns
+the **substrate** the proving lives on: a **throwaway** SQL Server database, real-*shaped* but
+disposable, that `prove-on-dacpac` publishes against. Nothing here ever touches production. The
+whole point is that this database can be reset between scenarios and dropped without a thought.
+
+You **scaffold** the commands and SQL; the developer's agent runs them. There is **no wrapper
+script** — you reuse the existing `scripts/warm-sql.sh` (plain bash, already in the repo) and run
+`sqlcmd` (via `docker exec`, see below) / `sqlpackage` directly.
+
+## The runtime shim (REQUIRED on this machine)
+
+`sqlpackage` targets .NET 8; this box has .NET 9 at a non-standard path. Export these **before**
+any `dotnet`/`sqlpackage` call in the session, or the tool fails to start. On Git Bash also export
+`MSYS_NO_PATHCONV=1` so the `sqlpackage /Action:` switches **and** the `docker exec /opt/...`
+sqlcmd paths below are not mangled:
+
+```bash
+export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROLL_FORWARD=Major
+export MSYS_NO_PATHCONV=1   # Git Bash: keep /Action: + /SourceFile: + /opt/... paths intact
+```
+
+(The durable alternative is installing the .NET 8 runtime; until then, these exports are the fix.)
+`sqlpackage` itself is the dotnet tool `microsoft.sqlpackage` at
+`C:\Users\danny\.dotnet\tools\sqlpackage.exe`.
+
+## sqlcmd lives in the CONTAINER, not on the host (IMPORTANT)
+
+**This machine has NO host `sqlcmd`.** Do **not** invoke a bare `sqlcmd -S localhost,11433 ...` —
+it does not exist on the PATH and will fail. Issue every SQL round-trip through the warm container
+with `docker exec`, using the bundled tools at `/opt/mssql-tools18/bin/sqlcmd`:
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q "<sql>"
+```
+
+Notes that matter:
+
+- **From inside the container, the server is `localhost`** (NOT `localhost,11433`) — `11433` is the
+  host-side published port; inside the container SQL Server listens on the default `1433`.
+- **`-C`** trusts the server certificate; **`-i`** keeps stdin usable for heredocs / piped SQL.
+- **`MSYS_NO_PATHCONV=1` is required on Git Bash** or it rewrites `/opt/mssql-tools18/...` into a
+  Windows path and the exec fails. (Same flag the `sqlpackage /Action:` switches need.)
+- `sqlpackage`, by contrast, runs on the **host** and connects over the published port, so its
+  profiles use `localhost,11433`. Two different vantage points: `sqlpackage` from outside
+  (`,11433`), `sqlcmd` from inside the container (`localhost`).
+
+## Bring up the warm container
+
+The repo already owns the container lifecycle — do **not** write a new `docker run`. The script is
+the single source of truth for the name / port / password.
+
+```bash
+scripts/warm-sql.sh start      # start the container (or no-op if already up)
+scripts/warm-sql.sh status     # container + readiness check — run this FIRST when in doubt
+scripts/warm-sql.sh restart    # clean instance (use after a memory-grant stall / login failures)
+```
+
+This yields the container `projection-mssql-warm` listening on **localhost,11433** (host side).
+
+> **Note (from project survival rules):** on Git Bash, `scripts/warm-sql.sh status` can give a
+> **false "NOT ready"** due to MSYS path mangling. If `status` looks wrong, confirm with a direct
+> `docker exec` sqlcmd round-trip (below) before assuming the container is down.
+
+### Connection parameters
+
+| Field | Value |
+|---|---|
+| Container | `projection-mssql-warm` |
+| Server (from host, e.g. sqlpackage) | `localhost,11433` |
+| Server (from inside the container, sqlcmd) | `localhost` (default port 1433) |
+| User | `sa` |
+| Password | `Projection@Strong1` |
+| Options | `TrustServerCertificate=True;Encrypt=False` (or `-C` on sqlcmd) |
+| Throwaway DB | `ProvingGround` (or a per-executor `PG_<testId>_<rand>`, see PROTOCOL.md) |
+
+Full connection string (what the host-side publish profiles use):
+
+```
+Server=localhost,11433;Initial Catalog=ProvingGround;User ID=sa;Password=Projection@Strong1;TrustServerCertificate=True;Encrypt=False
+```
+
+## Run sqlcmd against it (via docker exec)
+
+Use `sqlcmd` for the cheap data probes that classification leans on. Confirm connectivity first:
+
+```bash
+# liveness round-trip (also the antidote to a false "NOT ready" status)
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q "SELECT @@VERSION"
+```
+
+(`-C` = trust the server certificate; quote the password for the shell; remember
+`MSYS_NO_PATHCONV=1` on Git Bash for the `/opt/...` path.)
+
+The probes that predict a flip **before** you even build the dacpac (wrap each in the same
+`docker exec ... -Q "<sql>"` form):
+
+```sql
+-- make-mandatory: how many rows would the NOT NULL veto on?
+-- (NOTE: the veto fires on table-has-rows, not this NULL count — but you still want the count
+--  to prove the backfill cleared it; see prove-on-dacpac's make-mandatory finding.)
+SELECT COUNT(*) AS NullRows FROM dbo.Customer WHERE Email IS NULL;
+
+-- narrow (Ambitious Narrowing): does any value exceed the new length?
+SELECT MAX(LEN(Code)) AS LongestCode FROM dbo.Product;
+
+-- add-unique: are there duplicates that would fail the unique index?
+SELECT Code, COUNT(*) AS n FROM dbo.Product GROUP BY Code HAVING COUNT(*) > 1;
+
+-- create-FK (Forgotten FK Check): are there orphan children with no parent?
+SELECT o.Id, o.CustomerId
+FROM dbo.[Order] o
+LEFT JOIN dbo.Customer c ON c.Id = o.CustomerId
+WHERE c.Id IS NULL;
+```
+
+Example, fully wired:
+
+```bash
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C \
+  -Q "SELECT COUNT(*) AS NullRows FROM dbo.Customer WHERE Email IS NULL;"
+```
+
+These probes **predict**; the Strict publish in `prove-on-dacpac` **proves**. Run the probe to know
+what to look for, then let the veto confirm it.
+
+## Create / reset / drop the throwaway DB (via docker exec)
+
+Reset between scenarios so each flip starts from the known seed. The proving ground is disposable —
+dropping and recreating is the normal path, not a last resort.
+
+```bash
+# create (idempotent)
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q \
+  "IF DB_ID('ProvingGround') IS NULL CREATE DATABASE ProvingGround;"
+
+# hard reset: drop + recreate so the next scenario starts clean
+docker exec -i projection-mssql-warm /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P 'Projection@Strong1' -C -Q \
+  "IF DB_ID('ProvingGround') IS NOT NULL BEGIN ALTER DATABASE ProvingGround SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE ProvingGround; END; CREATE DATABASE ProvingGround;"
+```
+
+After a reset, re-establish the BEFORE state (deploy the current CREATEs + post-deploy seed) per
+`proving-ground/README.md` — that seed is the "real-shaped data" every flip is measured against.
+
+> **Parallel runs:** when many executors prove cases at once, each owns a **unique** DB
+> (`PG_<testId>_<rand>`) created and dropped exactly the same `docker exec` way, and never touches
+> the shared `ProvingGround` catalog. The full isolation + idempotent-teardown protocol is
+> **`self-test/PROTOCOL.md`** — and it honours survival rule 2 (leaked per-run DBs degrade the warm
+> container), so every executor reaps its own DB on exit.
+
+## The content-hash data oracle ("did the values actually change?")
+
+When a Permissive publish proceeds past a Strict veto, you need to know **exactly what moved**.
+The oracle is a per-row `SHA2_256` over the row's full shape, combined **order-independently** so
+row order is irrelevant, with **NULL kept distinct from `''`**. Snapshot it **before** and
+**after** the Permissive publish; an unchanged total means no value changed. (Run it through the
+same `docker exec ... -Q` form.)
+
+```sql
+-- Content hash of a table, order-independent over rows.
+-- (SELECT x.* FOR XML RAW) serializes the full row shape (column names included),
+-- so a rename changes the hash BY DESIGN — that is correct, the diff is the proof.
+-- NULL stays distinct from '' because FOR XML RAW omits NULL attributes entirely.
+SELECT
+  COUNT(*)                                            AS RowCount,
+  CONVERT(VARBINARY(8000),
+    SUM(CONVERT(BIGINT,
+      CONVERT(INT, SUBSTRING(
+        HASHBYTES('SHA2_256',
+          (SELECT x.* FOR XML RAW)
+        ), 1, 4))                                      -- 32-bit slice, summed order-independently
+    ))
+  )                                                   AS ContentDigest
+FROM dbo.Customer AS x;
+```
+
+Run it once before the Permissive publish, once after, and compare `RowCount` + `ContentDigest`:
+
+- **digest unchanged** -> no value moved (the change was structural-only, or truly benign).
+- **digest changed** -> values moved; the rows that differ are exactly what
+  `GenerateSmartDefaults` stamped, or what truncated. **That is the row count for the magic line.**
+- **digest changed on a rename** -> expected and correct; the column name is part of the row shape.
+
+> The digest is a *change detector*, not a forensic diff: a changed digest tells you values moved
+> and how many rows; to see the specific old-vs-new values, query the affected rows directly
+> (e.g. `WHERE Email = '' ` after a smart-default stamp). Pair the digest with a targeted SELECT
+> when the developer needs the actual values, not just the count.
+>
+> **The no-op redeploy case is the silent-proof:** publish an unchanged tree twice; the second run
+> should produce **zero delta**, the guarded seed MERGE should report **0 rows**, and the digest
+> should be **identical** — and on a CDC-tracked table, CDC should capture **0 changes**. That
+> silence is the idempotency / CDC-silence guarantee; surface it as the strongest result, not a
+> non-event.
+
+## Honest limits of this substrate
+
+- It is real-*shaped*, not real-*sized* — it cannot prove production-scale timing or blocking
+  (that stays a `>1M rows` Tier escalation, see `classify-mechanism`).
+- It is a single instance — concurrency, online index builds, and live-traffic locks are not
+  modeled.
+- It holds one catalog — External Entities and cross-database / ETL / report consumers are out of
+  frame and must be named as dependency scope, not proven here.
+- It runs the **forward** publish only — it cannot prove a change is reversible, and it cannot
+  prove the running application keeps working against the new shape (see `prove-on-dacpac`'s
+  honest-limits section).
+- Point profiles and the `docker exec` sqlcmd at **`ProvingGround` (or a per-executor
+  `PG_<testId>_<rand>`) only**. Never at anything you cannot afford to drop.
+
+## Hard rules
+
+- **No new wrapper / orchestration script.** Reuse `scripts/warm-sql.sh`; run `sqlcmd` (via
+  `docker exec`) / `sqlpackage` directly. The agent runs the commands.
+- **Host has no sqlcmd — always `docker exec` into `projection-mssql-warm`**, server `localhost`
+  inside the container, with `MSYS_NO_PATHCONV=1` on Git Bash.
+- Everything authored for this tree lives under `ssdt-agent/`; the substrate itself reuses the
+  existing repo container.
+
+## Connector points
+
+- The throwaway substrate reuses the **existing** `scripts/warm-sql.sh` — the connector boundary
+  is that the proving ground lives only on that warm container and is disposable. See
+  `CONNECTORS.md`.
+- A future build could replace the hand-seeded `ProvingGround` with data shaped by the F# engine
+  from a real OutSystems catalog (same connection, same oracle). Highlighted, not wired.


### PR DESCRIPTION
An agentic skill tree that helps an OutSystems-native developer make a **safe SSDT data-model change by *proving* it** — publishing the change to a throwaway dacpac copy of real-shaped data and reading SSDT's own engine verdict — rather than advising.

## What's here (all under `sidecar/projection/ssdt-agent/`; no F# codebase changes)
- **6 index skills** (`skills/_index/`) own the cross-cutting concerns — including the *verified* **tightening-class** finding: `BlockOnPossibleDataLoss` guards `NULL→NOT NULL` / narrow / drop on **table-has-rows**, not on whether the data actually violates the rule (a wrong "backfill → NOT NULL" recipe, disproven empirically on the proving ground).
- **48 per-op skills** (`skills/op/`) + 9 thin family-index pointers; `intake` / `change-author` / `reviewer`(deferred) roles; 4 capability skills (classify-mechanism, prove-on-dacpac, talk-to-local-sql, confirm-intent).
- **dacpac proving ground** — a 12-table `SampleCatalog` + **Strict** (veto-detector) / **Permissive** (consequence-oracle) publish profiles on a throwaway local SQL Server.
- **self-test** — 59+ cases, a parallel-safe idempotent isolation `PROTOCOL`, and a **fitness rubric** that grades *how well* (proved-vs-asserted), not just pass/fail.

## Verified
- Sample builds → dacpac; deploys + seeds idempotently on a throwaway DB.
- 6 isolated executors ran in parallel, 6/6, zero residue.
- A fitness batch graded 6 cold-agent runs at **~95/100** — "the tree converts a cold agent into a prover, not an asserter" — and surfaced 3 authoring gaps, all fixed in this PR.

Additive only; the F# Projection engine is an optional accelerant, not wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
