### PR TITLE
The operator shell: Spectre TTY completion — the hang, the flood, and one door for every verb

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26568,3 +26568,95 @@ capture transport — a named label-population change.
 (width − pk − deferred)/width on cycle kinds; the reverse-leg scale
 suite is the measuring surface (its wall-clock rides the same docker
 pool run).
+
+## 2026-07-03 — The operator-shell chapter: one door for channel 2; the drain-loop law amended; notices roll up; the publish spine completes
+
+**Context.** Operator reports from real publish runs: the `--pretty` surface
+largely failed to materialize on full-export/publish; per-column nullability
+notices flooded the screen; the spinner hung. The audit found four inconsistent
+channel-2 paths (direct `Watch.renderWatch` for publish; `withRun` panel-only;
+gated `Face.watchInline`; ~10 verbs with no bracket at all), three drain-loop
+defects, and `LiveModelRead` printing-and-discarding one raw stderr line per
+divergence 2–3× per run over the Live region.
+
+**Decisions.**
+
+1. **The drain-loop law (amends 2026-06-06 minimum-dwell and 2026-06-19 #20).**
+   The board's drain loop COALESCES queued envelopes into one frame per batch;
+   the dwell floor paces stage TRANSITIONS only (progress frames render
+   promptly, never dwelled — one dwell per envelope is how a 10k-progress
+   backlog replayed for minutes after the run ended). The spinner heartbeats on
+   WALL CLOCK, independent of queue traffic (the timeout-branch-only heartbeat
+   starved under floods). Liveness splits from render pacing: `stalled` keys
+   off the last DEQUEUED envelope (a chatty pipeline is alive), and a
+   progress-less active stage says `stalled` in words. `PROJECTION_WATCH_STALL_MS`
+   joins the dwell as an env seam. `Watch.applyKind` carries the fold's weight
+   (`NoChange | Progressed | Transitioned`); `apply` stays the did-it-change
+   shim for `boardOfStored` (R1e unchanged).
+
+2. **Notice routing (amends F9 2026-06-17 surface-never-discard).** A model
+   read's divergences still surface, now constant-size: per-item envelopes at
+   Debug (visible under `-v`), the full detail merged-deduped into
+   `notices/<tag>/<runId>.json` (`NoticeSink`, R1c-addressed, in the §10
+   artifact table), and ONE Warn rollup envelope
+   (`adapter.ossys.modelRead.noticeRollup`) carrying fact counts per family +
+   the first samples + the artifact path. The producer owns the aggregation —
+   the verbosity filter drops sub-threshold envelopes before the accumulator
+   and subscribers, so Debug per-item events can never feed a rollup
+   downstream. Deploy's parallelism/warm-conn advisories become coded
+   envelopes for the same reason; sink-failure warnings stay last-resort
+   stderr (they fire when the sink itself fails). The §19-Q5 escalation
+   deferral's re-open trigger FIRED (operator report, 2026-07-02); this is
+   its resolution.
+
+3. **The operator shell (`Shell.execute`) — every PlanAction walks one door.**
+   Not pretty → the run-envelope bracket + body (byte-identical NDJSON) + the
+   ledger append. Pretty + spine → the live board inside a rounded PANEL (the
+   contained, fixed-viewport instrument box; NO alternate screen — the final
+   frame and verdict stay in scrollback). Pretty without a spine → a static
+   framed open (a Preview says "nothing will be written") + scoped channel-1
+   null + the verdict panel. **The A3 wire change rides this**: the
+   previously-unbracketed verbs (preview / check drift·data·shape / diff /
+   compare / explain / seal / report / slice / capture) now emit
+   `config.runStart` + `summary.runComplete` on pipes too — one law, no
+   pretty-only forks (channel 2 renders what channel 1 writes). ReadOnly-
+   register runs never join the run ledger (the `check ready` no-append
+   contract, now structural). Prompts keep the 2026-06-17 hoist rule.
+   `prettyMode`/`verboseMode` live on `Shell`; `OperatorConsole` aliases.
+
+4. **The publish spine completes (amends the pipeline-umbrella scope).** The
+   store leg and the publish-and-load seed leg become DECLARED stages
+   (`Stages.store`, `Stages.seedLoad`) bracketed with the same wire shape as
+   `Staged.stage`; the arc is chosen at DISPATCH (`Spines.publishWith`) — an
+   optional seeded stage would hold the done-frame back forever
+   (`Watch.isTerminal` requires every seeded line to close). The `pipeline`
+   umbrella brackets the emission arc only.
+
+5. **Flow framing.** `Intent.Flow` seeds the shell frame: the box title, the
+   verdict panel, and the ledger record read the flow's own words
+   ("publish: cloud-dev → on-prem-dev — preview"). The dispatch prologue
+   voices every pre-run note (`plan.note`, `survey.advisory`) BEFORE any Live
+   region; the transfer faces' raw advisory loops retire. The no-arg flow
+   menu is a `View` (pretty/plain/json/`--query`, one document).
+
+6. **A redirected sink renders PLAIN (`View.consoleFor`).** Spectre cannot
+   detect redirection through an injected `AnsiConsoleOutput`; the prior
+   "Spectre strips color of its own accord" assumption sprayed ANSI into
+   pipes and files. `CLICOLOR_FORCE` still forces color; `NO_COLOR` still wins.
+
+7. **Nice-to-haves shipped**: #19-lite extract progress (the snapshot runner's
+   `OnRowsetComplete` seam → `summary.stageProgress`, 23 rowsets); #6
+   echo-the-fix (the board's live `suggestedConfig` teaser,
+   `watch.suggestedEdits`); `--stat` (the §11 aggregates table on stdout).
+   #26 Threshold stays design-only.
+
+**Witnesses.** `ShellTests.fs`; `WatchTests`/`WatchInjectionTests` (flood-
+never-starves-heartbeat, backlog-coalesces wall-time bound, dwell-on-
+transitions-only, Active-None stalled, teardown scope); `NoticeRoutingTests.fs`
+(+ `LogSinkSubscriberTests` null-writer law); `FullExportStoreTests` publish-
+spine wire + `boardOfStored` terminal proofs; `VoiceTotalityTests` (new codes
+forced same-commit). Known residuals (HANDOFF): stdout narration inside watch
+bodies renders adjacent to teardown rather than after the panel; adapter-layer
+one-shot `eprintfn` warnings (ReadSide / BatchSplitter / SqlPolicy) cannot
+reach LogSink without cross-assembly plumbing; narrow-terminal Panel wrap is
+known-cosmetic.

--- a/sidecar/projection/HANDOFF.md
+++ b/sidecar/projection/HANDOFF.md
@@ -1,3 +1,26 @@
+# Handoff addendum — 2026-07-03 (sixth letter), THE OPERATOR SHELL: the hang, the flood, and the four-path TTY unified behind one door. Branch `claude/spectre-tty-export-publish-d5vcis`
+
+To the next agent.
+
+**The operator's three complaints from real publish runs (pretty not materializing on full-export/publish; the nullability-notice flood; the hung spinner) are remediated, and the channel-2 surface is unified.** The rationale and the amended laws live in ONE consolidated DECISIONS entry (2026-07-03, "The operator-shell chapter") — read it before touching `Watch.fs`, `Shell.fs`, or `LiveModelRead.fs`. SPECTRE_REFINEMENTS carries the shipped section + the #19/#21 status flips. Six commits, each independently green on the fast pool.
+
+**What you now operate:**
+- `Shell.execute` (`Shell.fs`) is the ONE door for every PlanAction. Under pretty + a spine: the live board inside a rounded Panel (the contained instrument box; no alternate screen — scrollback keeps the record). Under pretty without a spine: a static preview frame + scoped channel-1 null + the verdict panel. Piped: run envelopes, byte-clean. Every path appends the ledger (ReadOnly registers excepted — the `check ready` no-append contract is structural now).
+- The drain loop coalesces; the dwell floors TRANSITIONS only; the spinner heartbeats on wall clock; `stalled` keys off dequeued envelopes. `PROJECTION_WATCH_STALL_MS` is the test seam.
+- Model-read divergences roll up: Debug per-item + `notices/model-read/<runId>.json` + ONE Warn rollup the board's notice strip renders with the artifact pointer.
+- The publish arc is whole: `Spines.publishWith store load` (dispatch-chosen; never an optional seeded stage — `isTerminal` waits for every seeded line), with the store/seed-load legs bracketed in `Compose.stagedLeg`.
+- Flow runs present in their own words (box title, verdict panel, ledger record); the no-arg menu is a `View`; `--stat` appends the aggregates table.
+
+**What I deliberately did NOT do (the named residuals):**
+1. **Stdout narration inside watch bodies** (Export.fs artifact list, `narrateTransferReport`, Migrate's execute-leg lines): still emitted at the body's tail, so under pretty they render adjacent to the board's teardown rather than after the verdict panel. The clean fix splits face bodies into core+narration (the face returns data; the arm narrates after `Shell.execute`) — mechanical but wide; do it face-by-face.
+2. **Adapter-layer one-shot warnings** (`ReadSide` zero-column/FK-row, `BatchSplitter` ScriptDom fallback, `SqlPolicy` timeout): they cannot reach LogSink without cross-assembly plumbing (Adapters/Targets compile below Pipeline). Rare and one-line; if they ever flood, thread a diagnostics callback the way `MetadataSnapshotRunner.RunOptions` does.
+3. **Panel wrap on narrow terminals** is known-cosmetic (title/notice rows are not width-truncated inside the box).
+4. **#26 Threshold** stays design-only (§G); **profile/emit intra-stage progress** is Core-touching and skipped (extract now progresses via the `OnRowsetComplete` seam — the pattern to copy if you light the others).
+
+**Traps for you:** the verbosity filter drops sub-threshold envelopes BEFORE the accumulator and subscribers — never design a rollup that expects Debug events to aggregate downstream (that premise died in this chapter's A1 finding; the producer owns aggregation). `renderWatchOn` now takes a SEED BOARD, not a spine — frame it with `{ Watch.seededOf spine with Title = … }`. And the A3 wire change means the previously-unbracketed verbs emit run envelopes on pipes: if a downstream consumer chokes on the new `config.runStart`/`summary.runComplete` lines, the fallback is named (bracket-under-pretty-only) but violates one-substrate — bring it to the operator first.
+
+Hold the spine.
+
 # Handoff addendum — 2026-07-03 (fifth letter), THE PAY-ONCE COMPLETION: all eleven plan items executed (PL-6/7/9 landed this session); one named residue (PL-6c/S24). Branch `claude/pay-once-program-86mevu`, PR #649
 
 To the next agent.

--- a/sidecar/projection/SPECTRE_REFINEMENTS.md
+++ b/sidecar/projection/SPECTRE_REFINEMENTS.md
@@ -20,6 +20,31 @@ This chapter began as a survey: *25 ways to keep improving the Spectre
 implementation.* The first slice shipped on this branch; the rest are sequenced
 below, each with the technical note to start from.
 
+### Shipped 2026-07-03 — the operator-shell chapter (the hang, the flood, the one door)
+
+Grep the symbols: `Shell.execute` / `Shell.Frame` (`Shell.fs`), `Watch.applyKind`
+/ `Watch.Fold` / `Board.Notices` / `Board.SuggestedEdits`, `NoticeSink`,
+`LiveModelRead.noticeRollup`, `Spines.publishWith`, `TtyRenderer.buildFlowMenuView`
+/ `buildStatView`. The DECISIONS entry (2026-07-03, operator-shell chapter) is the
+rationale; `ShellTests.fs` + the new `WatchTests`/`WatchInjectionTests` cases are
+the proofs.
+
+- **The drain-loop rework** (the hang family): wall-clock heartbeat, coalesce-to-
+  latest, the dwell floors stage TRANSITIONS only, liveness (`stalled`) keyed off
+  dequeued envelopes, `Active None` stages say `stalled` in words.
+- **The notice rollup** (the flood): `LiveModelRead` divergences ride channel 1 at
+  Debug + the `notices/<tag>/<runId>.json` artifact + ONE Warn rollup envelope;
+  the board's notice strip renders it as one calm row with the artifact pointer.
+- **The operator shell**: every PlanAction walks one door — the live PANEL-BOXED
+  board for spined runs, a static preview frame for gated/answer verbs, run
+  envelopes + the ledger + the verdict panel on every path (the A3 wire change).
+- **Flow framing**: the box, panel, and ledger read the flow's own words
+  ("publish: cloud-dev → on-prem-dev — preview"); the no-arg menu is a `View`.
+- **#19 (extract) / #21 / #6 / `--stat`** — see the ranking-table rows below.
+- **A pre-existing spray fixed**: `View.consoleFor` now strips color for ANY
+  redirected sink (Spectre cannot detect redirection through an injected
+  `AnsiConsoleOutput`); `CLICOLOR_FORCE` still wins.
+
 ### Shipped this slice (2026-06-18)
 
 **The console factory — `View.consoleFor` / `View.consoleTo` (items #5 + #7).**
@@ -1189,7 +1214,7 @@ Rough triage to spend a time-box well. Effort: **S** ≈ an hour, **M** ≈ a se
 | Item | Value | Effort | Note |
 |---|---|---|---|
 | #1 PanelRow + #6 | **High** | S | A *live* lens-drift bug; the test is the proof. Do first. |
-| #19 stageProgress | Med | M–L | **Premise corrected** — transfer/migration already emit; only full-export's stages remain, an adapter-deep change (not the one-liner). |
+| #19 stageProgress | Med | M–L | **◐ → ● (extract) 2026-07-03** — `LiveModelRead` threads the snapshot runner's `OnRowsetComplete` seam into `summary.stageProgress` for the extract leg. Residual: profile/emit progress (Core-touching; assess-only, skipped). |
 | #17 `--query` | **High** | M | **● shipped** — `Query` walker over `toJson`, global `--query` flag. |
 | #23 Explore TUI | **High** | L | The marquee; gated by #18 + #20. |
 | #4 RenderOptions | Med (enabler) | M | Unblocks #11/#15/#18; land alone. |
@@ -1199,7 +1224,7 @@ Rough triage to spend a time-box well. Effort: **S** ≈ an hour, **M** ≈ a se
 | #14 trends | Med | S–M | `Theme.sparkline` already exists, zero callers. |
 | #24 diff verb | — | — | **● already reachable** — `diff @runA @runB` via the `Ref` uniformity; the new part folds into #23. |
 | #25 explain dig | Med | M | Needs #15 so a deep trail isn't a wall. |
-| #21 spine | Med | M | `--watch` for the other verbs. |
+| #21 spine | Med | M | **● 2026-07-03** — every verb routes through `Shell.execute` (the operator shell): canary + synth-load get their boards; the publish spines gain the store/seed-load legs; the previously-unbracketed verbs run enveloped. |
 | #12 → #13 table | Med | M / S | #13 is cheap once #12 exists. |
 | #18 ViewPath | Med | M | Build *with* #23, not speculatively. |
 | #3 defensive render | Med | S | Cheap insurance against a markup crash. |

--- a/sidecar/projection/src/Projection.Cli/Faces/Common.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Common.fs
@@ -38,9 +38,12 @@ module Face =
     /// live `Watch` board, else run it inline. For faces whose live stage sits APART
     /// from their `dumpBench` tail (the migrate legs render the execute leg under the
     /// board deep inside a `task`, then dump bench at the outer return).
+    /// The board seeds FRAMED (2026-07-02): the shell's ambient frame titles the
+    /// box, so a flow-dispatched face reads "publish: cloud-dev → on-prem-dev".
     let watchInline (gateOpen: bool) (spine: RunSpine) (body: unit -> int) : int =
         if gateOpen && Watch.shouldWatch prettyMode.Value then
-            Watch.renderWatch spine (Watch.resolveDwellMs ()) body
+            let seed = { Watch.seededOf spine with Title = Some (Shell.titleOf Shell.currentFrame.Value) }
+            Watch.renderWatch seed (Watch.resolveDwellMs ()) body
         else body ()
 
     /// The watch-preamble + `dumpBench` tail combined, for faces whose live stage and

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -153,7 +153,6 @@ let runTransfer
     (tables: string list)
     (revertPolicy: RevertPolicy)
     (revertDir: string option)
-    (surveyAdvisory: string list)
     : int =
     let collect = function Ok _ -> [] | Error es -> es
     let parsedSource    = TransferSpec.parseConnectionSpec sourceSpec
@@ -248,11 +247,9 @@ let runTransfer
     // raised over the touched environments as a STDERR ADVISORY WARNING, then
     // PROCEED regardless. V2 owns no production write path during dual-track
     // (CLAUDE.md R6; DECISIONS 2026-06-09 S3), so the gate is advisory until the
-    // per-pair flip — the run's own exit stands; the advisory never borrows the
-    // standalone `survey` verb's exit-7. Computed at the dispatch layer (where
-    // config is in scope) and threaded in as `surveyAdvisory`; a dry-run carries
-    // no advisory (the empty list), so the preview path is byte-identical.
-    if executeGated then for line in surveyAdvisory do Console.Error.WriteLine line
+    // per-pair flip — the run's own exit stands. Since 2026-07-02 the advisory
+    // lines render VOICED in the dispatch prologue (`runPlan`), before any Live
+    // region — never raw stderr from inside a face.
     // --pretty + a real TTY → the live data-load board (§13); the transfer leg
     // streams the "load" stage with per-table progress. Only on a real --execute
     // (a dry-run writes no rows, so the load stage would never advance).
@@ -286,7 +283,6 @@ let runReverseLegTransfer
     (revertPolicy: RevertPolicy)
     (revertDir: string option)
     (sinkCapability: SinkLoadCapability)
-    (surveyAdvisory: string list)
     : int =
     let collect = function Ok _ -> [] | Error es -> es
     let parsedSource = TransferSpec.parseConnectionSpec sourceSpec
@@ -409,9 +405,8 @@ let runReverseLegTransfer
         | Error errors ->
             printErrors Console.Error errors
             (Preflight.refusalOf errors).ExitCode
-    // G0c — the advisory capability survey (R6 warn-not-stop); same channel
-    // and same advisory-only posture as the peer transfer's Execute path.
-    if executeGated then for line in surveyAdvisory do Console.Error.WriteLine line
+    // G0c — the advisory capability survey renders in the dispatch prologue
+    // (voiced, pre-Live) since 2026-07-02; same posture as the peer transfer.
     Face.staged "transfer" executeGated Spines.transfer runBody
 
 // ---------------------------------------------------------------------------

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -49,7 +49,9 @@ let printErrors (writer: TextWriter) (errors: ValidationError list) : unit =
 /// Polish — `-v` / `--verbose` surfaces the per-label bench table (and other
 /// depth); set in `main`. Default is calm: the bench snapshot persists for the
 /// perf gate + rides the `runComplete` aggregates, but the table is opt-in.
-let verboseMode = ref false
+/// (An ALIAS since 2026-07-02 — the ref lives on the `Shell`, which compiles
+/// first; every `open …OperatorConsole` site keeps reading the same cell.)
+let verboseMode = Shell.verboseMode
 
 let dumpBench (tag: string) : unit =
     let stats = Bench.snapshot ()
@@ -85,51 +87,26 @@ let dumpBench (tag: string) : unit =
 /// the run, then the verdict panel as the resolved final frame. (`--watch` was
 /// folded into this 2026-06-17 — the board is simply what pretty shows while a
 /// run is in flight; the standalone flag is deprecated.)
-let prettyMode = ref false
+/// (An ALIAS since 2026-07-02 — the ref lives on the `Shell`.)
+let prettyMode = Shell.prettyMode
 
 // The per-face stage arcs retired 2026-06-12 (card S2): the live Watch board
 // pre-seeds from the declared `Spines` (`RunSpine` — one definition site per
 // arc), no longer from hand-rolled string lists here.
 
 let withRun (command: string) (body: unit -> int) : int =
-    // Tier-3 channel 2 (§15.1) — when --pretty + a real TTY, the panel
-    // REPLACES the NDJSON on stderr (never both on the same TTY); route
-    // channel 1 to the null sink for this run. (The writer is not run
-    // state, so it is set before the bracket's reset.)
-    let pretty = TtyRenderer.shouldRender prettyMode.Value
-    if pretty then LogSink.setWriter System.IO.TextWriter.Null
-    // Card S4a — the run envelope bracket has ONE owner (`RunEnvelope`,
-    // shared with `FullExportRun.executeCore`): runStart first, the §7.4
-    // registry inventory, the terminal runComplete always — now including
-    // crashed bodies, which previously escaped without their §10 close.
-    let code =
-        // NM-34b — the generic verb wrapper is content-blind (it brackets an
-        // arbitrary `body : unit -> int`), so it declares no hashable inputs.
-        // A digest-bearing verb runs through its own face (e.g. full-export),
-        // not this generic console bracket.
-        RunEnvelope.bracket command ignore Map.empty (fun () -> "", []) (fun () ->
-            let code = body ()
-            code, (if code = 0 then LogSink.Succeeded else LogSink.Failed))
-    // Tier-4 reporting — append this run to the cross-run ledger when one is
-    // configured (`PROJECTION_LEDGER_DIR`), so the readiness gauge can read
-    // the canary streak. Opt-in: default runs don't accumulate.
-    (match RunLedger.configuredDir () with
-     | Some dir ->
-         let registered, applied, declined = LogSink.transformCounts ()
-         try
-             RunLedger.append dir
-                 { RunId      = LogSink.runId ()
-                   Ts         = System.DateTime.UtcNow.ToString("o")  // LINT-ALLOW: wall-clock timestamp at the operator-console IO boundary (ISO-8601 round-trip o format)
-                   Command    = command
-                   Outcome    = (if code = 0 then "succeeded" else "failed")
-                   Canary     = LogSink.canaryVerdict ()
-                   Registered = registered
-                   Applied    = applied
-                   Declined   = declined }
-         with ex -> eprintfn "  WARNING: failed to append ledger record: %s" ex.Message
-     | None -> ())
-    if pretty then TtyRenderer.renderSummary command code
-    code
+    // Since 2026-07-02 this is a THIN alias over the operator shell — the one
+    // door (`Shell.execute`): the run-envelope bracket (S4a, one owner),
+    // channel-1 suppression under pretty (§15.1, now SCOPED so an outer
+    // writer restores), the cross-run ledger append, and the verdict panel.
+    // NM-34b — the generic verb wrapper is content-blind (it brackets an
+    // arbitrary `body : unit -> int`); a digest-bearing verb runs through its
+    // own face (e.g. full-export), not this generic bracket.
+    Shell.execute
+        { Shell.currentFrame.Value with Command = command }
+        Shell.Bracket.Bracketed
+        None
+        body
 
 let parseEnvironment (defaultLabel: string) (label: string option) : Projection.Core.Environment =
     match label with

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -103,7 +103,7 @@ let withRun (command: string) (body: unit -> int) : int =
     // arbitrary `body : unit -> int`); a digest-bearing verb runs through its
     // own face (e.g. full-export), not this generic bracket.
     Shell.execute
-        { Shell.currentFrame.Value with Command = command }
+        (Shell.framed command)
         Shell.Bracket.Bracketed
         None
         body

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -97,7 +97,8 @@ let private usageLines : string list =
         ""
         "Every verb persists a bench snapshot to bench/<verb>/<utc-iso>.json; -v surfaces the"
         "table. --pretty / --json force the channel (default AUTO: a TTY gets the live stage"
-        "board + verdict panel, a pipe gets NDJSON). --query <path> narrows any answer to a"
+        "board + verdict panel, a pipe gets NDJSON). --stat appends the run's event rollup"
+        "(category · code · count) to stdout. --query <path> narrows any answer to a"
         "JSONPath-subset slice of its structured form (e.g. --query 'blocks[?status=warn]')."
         "--open <path> force-reveals just that dotted child-index branch of a pretty answer"
         "(e.g. --open 1.0), the rest staying at --depth — the headless half of the dig."
@@ -509,6 +510,9 @@ let main argv =
             else None)
     let has flag = Array.contains flag argv
     verboseMode := has "-v" || has "--verbose"
+    // `--stat` (2026-07-02) — after the run closes, the §11 aggregates table
+    // on stdout (the headless rollup lens).
+    Shell.statMode := has "--stat"
     let forceJson = has "--json" || has "--no-pretty"
     let forcePretty = has "--pretty"
     // "operator wants pretty" — explicit, or auto when stderr is a real TTY
@@ -519,7 +523,7 @@ let main argv =
     // `--watch` is DEPRECATED (2026-06-17 — folded into `--pretty`/auto-TTY; the
     // live board is what pretty shows). Still stripped so an old habit doesn't
     // error, but it no longer carries its own behavior.
-    let globalFlags = set [ "--pretty"; "--json"; "--no-pretty"; "-v"; "--verbose"; "--watch" ]
+    let globalFlags = set [ "--pretty"; "--json"; "--no-pretty"; "-v"; "--verbose"; "--watch"; "--stat" ]
     let argv = argv |> Array.filter (fun a -> not (Set.contains a globalFlags))
     match argv with
     | [| "--help" |] | [| "-h" |] ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -116,12 +116,17 @@ let private usageLines : string list =
     ]
 
 let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan: ExecutionPlan) : int =
-    for n in plan.Notes do eprintfn "Note — %s" n
-    // A7 (no-silent-drop) — the module-filter include flags without a
-    // `model.modules` selection are inert; note it on the same channel.
+    // The dispatch PROLOGUE (2026-07-02) — every pre-run note renders here,
+    // voiced, structurally BEFORE any Live region or bracket: the plan notes,
+    // the inert-flag note (A7 no-silent-drop), and the G0c capability-survey
+    // advisory (previously raw stderr from inside the transfer faces).
+    let note (code: string) (text: string) =
+        TtyRenderer.renderVoicedTo Console.Error code (Map.ofList [ "text", box text ])
+    for n in plan.Notes do note "plan.note" n
     (match ModuleFilterBinding.inertFlagNote shaping.Model with
-     | Some n -> eprintfn "Note — %s" n
+     | Some n -> note "plan.note" n
      | None -> ())
+    for line in surveyAdvisory do note "survey.advisory" line
     // The shell wrapper for the answer / preview / one-shot verbs (2026-07-02,
     // the A3 sweep — every verb now runs bracketed through the ONE door: run
     // envelopes on the wire for pipes, channel-1 suppression + the framed
@@ -129,7 +134,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     // stdout answer surface is unchanged.
     let shellRun (command: string) (register: Shell.Register) (body: unit -> int) : int =
         Shell.execute
-            { Shell.currentFrame.Value with Command = command; Register = register }
+            { Shell.framed command with Register = register }
             Shell.Bracket.Bracketed
             None
             body
@@ -179,7 +184,9 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // run — an optional seeded stage would hold the done-frame back forever.
         let hasStore = match store with Some s -> not (String.IsNullOrWhiteSpace s) | None -> false
         Shell.execute
-            { Shell.currentFrame.Value with Command = "projection full-export" }
+            // A bundle emission writes files regardless of --go (the safe
+            // default act), so the register is Go even under a preview flow.
+            { Shell.framed "projection full-export" with Register = Shell.Go }
             Shell.Bracket.SelfBracketed
             (Some (Spines.publishWith hasStore false))
             run
@@ -201,7 +208,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // events, so their streams now open with `config.runStart` and
         // close with the §10 terminal — and the run is capturable.
         withRun "projection transfer" (fun () ->
-            runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables opts.RevertPolicy opts.RevertDir surveyAdvisory)
+            runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables opts.RevertPolicy opts.RevertDir)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE
@@ -212,7 +219,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // align — the original residual's premise, now honored structurally).
         needCatalog modelOssys model (fun cat ->
             withRun "projection reverse-leg" (fun () ->
-                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability surveyAdvisory))
+                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability))
     | PlanAction.MigrateWithData (model, modelOssys, sink, src, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
             withRun "projection migrate --with-data" (fun () ->
@@ -224,8 +231,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // silent until the trailing panel). A preview writes nothing, so its
         // load line would never advance: no spine, the static frame instead.
         Shell.execute
-            { Shell.currentFrame.Value with
-                Command = "projection synth-load"
+            { Shell.framed "projection synth-load" with
                 Register = if execute then Shell.currentFrame.Value.Register else Shell.Preview }
             Shell.Bracket.Bracketed
             (if execute then Some Spines.transfer else None)
@@ -238,7 +244,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // (2026-07-02 — a declared stage, so the board covers the whole run;
         // the episode record, when a store rides, happens inside that leg).
         Shell.execute
-            { Shell.currentFrame.Value with Command = "projection full-export --load" }
+            { Shell.framed "projection full-export --load" with Register = Shell.Go }
             Shell.Bracket.SelfBracketed
             (Some (Spines.publishWith false true))
             run
@@ -253,11 +259,11 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     // to flow to the nulled writer with no subscriber).
     | PlanAction.CheckCanary (ddl, false) ->
         Shell.execute
-            { Shell.currentFrame.Value with Command = "projection check" }
+            (Shell.framed "projection check")
             Shell.Bracket.Bracketed (Some Spines.canary) (fun () -> runCanary ddl)
     | PlanAction.CheckCanary (ddl, true)  ->
         Shell.execute
-            { Shell.currentFrame.Value with Command = "projection check --cdc-silence" }
+            (Shell.framed "projection check --cdc-silence")
             Shell.Bracket.Bracketed (Some Spines.canary) (fun () -> runCanaryCdcSilence ddl)
     | PlanAction.CheckDrift (m, conn)      -> shellRun "projection check drift" Shell.ReadOnly (fun () -> runDrift m conn)
     | PlanAction.CheckData (before, after) -> shellRun "projection check data" Shell.ReadOnly (fun () -> runVerifyData before after)
@@ -265,7 +271,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // Self-bracketed: `runReadiness` owns its RunEnvelope (the documented
         // no-append contract rides the ReadOnly register).
         Shell.execute
-            { Shell.currentFrame.Value with Command = "projection check ready"; Register = Shell.ReadOnly }
+            { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
     // explain ------------------------------------------------------------
@@ -429,7 +435,7 @@ let private flowSourceText (s: FlowSource) : string =
 
 /// `projection` with no args lists the flows as `name: from → to (spec)` —
 /// the config IS the menu (THE_CLI.md §4.4). No flows configured → the help.
-let private runList () : int =
+let private runList (asJson: bool) : int =
     match discoverConfig () with
     | Error es ->
         Console.Error.WriteLine "projection: projection.json is invalid:"
@@ -438,13 +444,16 @@ let private runList () : int =
     | Ok cfg ->
         if Map.isEmpty cfg.Flows then printLines Console.Out usageLines
         else
-            Console.Out.WriteLine "Flows (projection <flow> [--go] [--fresh] [--allow-drops]):"
-            for KeyValue (name, f) in cfg.Flows do
-                let extra =
-                    [ if Option.isSome f.Rekey then yield "rekey"
-                      if not (List.isEmpty f.Tables) then yield sprintf "tables: %s" (String.concat "," f.Tables) ]
-                let suffix = if List.isEmpty extra then "" else sprintf "  (%s)" (String.concat "; " extra)
-                Console.Out.WriteLine(sprintf "  %-16s %s → %s%s" name (flowSourceText f.From) f.To suffix)
+            // The menu is a `View` (2026-07-02) — pretty / plain / `--format
+            // json` / `--query` are the one document's lenses, like every
+            // other answer surface.
+            let rows =
+                [ for KeyValue (name, f) in cfg.Flows ->
+                    let extra =
+                        [ if Option.isSome f.Rekey then yield "rekey"
+                          if not (List.isEmpty f.Tables) then yield sprintf "tables: %s" (String.concat "," f.Tables) ]
+                    name, flowSourceText f.From, f.To, String.concat "; " extra ]
+            TtyRenderer.renderAnswer asJson View.defaultDepth (TtyRenderer.buildFlowMenuView rows)
         0
 
 [<EntryPoint>]
@@ -516,7 +525,7 @@ let main argv =
     | [| "--help" |] | [| "-h" |] ->
         printLines Console.Out usageLines
         0
-    | [||] -> runList ()
+    | [||] -> runList forceJson
     | [| "init" |] -> runInit ()
     | [| "inspect" |] -> runInspectHistory forceJson
     | [| "inspect"; runId |] -> runInspect runId None forceJson
@@ -569,4 +578,17 @@ let main argv =
                         | Some flowShaping -> Config.overlay cfg.Shaping flowShaping
                         | None -> cfg.Shaping
                     | _ -> cfg.Shaping
+                // The flow frame (2026-07-02) — a flow-dispatched run presents
+                // in the daily surface's own words: the box title, the verdict
+                // panel, and the ledger record read "publish: cloud-dev →
+                // on-prem-dev — preview", never the engine verb the plan chose.
+                // Seeded here (the one place the Intent is in scope); the verb
+                // arms preserve it via `Shell.framed`.
+                (match intent with
+                 | Intent.Flow (flow, opts) ->
+                     Shell.currentFrame.Value <-
+                         { Command  = sprintf "projection %s" flow.Name
+                           Flow     = Some { Name = flow.Name; From = flowSourceText flow.From; To = flow.To }
+                           Register = if opts.Go then Shell.Go else Shell.Preview }
+                 | _ -> ())
                 runPlan effectiveShaping surveyAdvisory (Command.plan cfg intent)

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -191,14 +191,19 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             Shell.Bracket.SelfBracketed
             (Some (Spines.publishWith hasStore false))
             run
+    // The emit family writes its bundle regardless of --go (a bundle target
+    // "produces files (always safe)"), and the docker deploy writes to a
+    // throwaway container — so the register pins Go even under a preview
+    // flow: a frame that says "nothing will be written" over a file-writing
+    // arm would misstate (the PublishBundle precedent).
     | PlanAction.EmitSkeleton (model, modelOssys, dir) ->
-        needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmitSkeletonOnly cat dir))
+        needCatalog modelOssys model (fun cat -> shellRun "projection project" Shell.Go (fun () -> runEmitSkeletonOnly cat dir))
     | PlanAction.EmitManifest (model, modelOssys, dir) ->
-        needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmitManifestOnly shaping cat dir))
+        needCatalog modelOssys model (fun cat -> shellRun "projection project" Shell.Go (fun () -> runEmitManifestOnly shaping cat dir))
     | PlanAction.EmitBundle (model, modelOssys, dir) ->
-        needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmit shaping cat dir))
+        needCatalog modelOssys model (fun cat -> shellRun "projection project" Shell.Go (fun () -> runEmit shaping cat dir))
     | PlanAction.DeployDocker (model, modelOssys) ->
-        needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runDeploy shaping cat))
+        needCatalog modelOssys model (fun cat -> shellRun "projection project" Shell.Go (fun () -> runDeploy shaping cat))
     | PlanAction.PreviewSchema (model, modelOssys, conn, decl) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
             shellRun "projection preview" Shell.Preview (fun () -> runProjectLivePreview shapedCat conn decl)))

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -160,8 +160,12 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         let verbosity = if verboseMode.Value then LogSink.Verbosity.Verbose else LogSink.Verbosity.Quiet
         let run () = runFullExport c (Some dir) verbosity Set.empty store env
         // --pretty + a real TTY → the live stage board (§13), pre-seeded with the
-        // pipeline's planned stages so the whole arc is visible from the first frame.
-        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch Spines.pipeline (Watch.resolveDwellMs ()) run
+        // pipeline's planned stages so the whole arc is visible from the first
+        // frame. The spine is chosen HERE (2026-07-02): a store-bearing publish
+        // seeds the store leg's line, so the board covers the whole run —
+        // an optional seeded stage would hold the done-frame back forever.
+        let hasStore = match store with Some s -> not (String.IsNullOrWhiteSpace s) | None -> false
+        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch (Spines.publishWith hasStore false) (Watch.resolveDwellMs ()) run
         else run ()
     | PlanAction.EmitSkeleton (model, modelOssys, dir) ->
         needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmitSkeletonOnly cat dir))
@@ -202,9 +206,10 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     | PlanAction.ProposeCorrection (model, modelOssys, out) -> runProposeCorrection model modelOssys out
     | PlanAction.PublishAndLoad (c, conn, store, env) ->
         let run () = runFullExportLoad c conn None store env
-        // The load flow runs the same publish pipeline, so it streams the same
-        // stage arc; --pretty shows the live board (§13).
-        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch Spines.pipeline (Watch.resolveDwellMs ()) run
+        // The load flow runs the same publish pipeline plus the seed-load leg
+        // (2026-07-02 — a declared stage, so the board covers the whole run;
+        // the episode record, when a store rides, happens inside that leg).
+        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch (Spines.publishWith false true) (Watch.resolveDwellMs ()) run
         else run ()
     | PlanAction.Migrate (model, modelOssys, conn, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -122,6 +122,17 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     (match ModuleFilterBinding.inertFlagNote shaping.Model with
      | Some n -> eprintfn "Note — %s" n
      | None -> ())
+    // The shell wrapper for the answer / preview / one-shot verbs (2026-07-02,
+    // the A3 sweep — every verb now runs bracketed through the ONE door: run
+    // envelopes on the wire for pipes, channel-1 suppression + the framed
+    // verdict panel under pretty; see the DECISIONS amendment). The body's
+    // stdout answer surface is unchanged.
+    let shellRun (command: string) (register: Shell.Register) (body: unit -> int) : int =
+        Shell.execute
+            { Shell.currentFrame.Value with Command = command; Register = register }
+            Shell.Bracket.Bracketed
+            None
+            body
     // Resolve the model to a Catalog under the live-OSSYS-primary / file-
     // fallback policy (ModelResolution), then run the Catalog-accepting face.
     //
@@ -159,14 +170,19 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     | PlanAction.PublishBundle (c, dir, store, env) ->
         let verbosity = if verboseMode.Value then LogSink.Verbosity.Verbose else LogSink.Verbosity.Quiet
         let run () = runFullExport c (Some dir) verbosity Set.empty store env
-        // --pretty + a real TTY → the live stage board (§13), pre-seeded with the
-        // pipeline's planned stages so the whole arc is visible from the first
-        // frame. The spine is chosen HERE (2026-07-02): a store-bearing publish
-        // seeds the store leg's line, so the board covers the whole run —
-        // an optional seeded stage would hold the done-frame back forever.
+        // The one door (2026-07-02): --pretty + a real TTY → the live boxed
+        // stage board (§13) then the verdict panel; the run now also joins the
+        // cross-run ledger (parity with the withRun verbs — the old direct
+        // renderWatch path skipped both). Self-bracketed: FullExportRun owns
+        // its RunEnvelope. The spine is chosen at dispatch: a store-bearing
+        // publish seeds the store leg's line, so the board covers the whole
+        // run — an optional seeded stage would hold the done-frame back forever.
         let hasStore = match store with Some s -> not (String.IsNullOrWhiteSpace s) | None -> false
-        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch (Spines.publishWith hasStore false) (Watch.resolveDwellMs ()) run
-        else run ()
+        Shell.execute
+            { Shell.currentFrame.Value with Command = "projection full-export" }
+            Shell.Bracket.SelfBracketed
+            (Some (Spines.publishWith hasStore false))
+            run
     | PlanAction.EmitSkeleton (model, modelOssys, dir) ->
         needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runEmitSkeletonOnly cat dir))
     | PlanAction.EmitManifest (model, modelOssys, dir) ->
@@ -176,7 +192,8 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
     | PlanAction.DeployDocker (model, modelOssys) ->
         needCatalog modelOssys model (fun cat -> withRun "projection project" (fun () -> runDeploy shaping cat))
     | PlanAction.PreviewSchema (model, modelOssys, conn, decl) ->
-        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat -> runProjectLivePreview shapedCat conn decl))
+        needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
+            shellRun "projection preview" Shell.Preview (fun () -> runProjectLivePreview shapedCat conn decl)))
     | PlanAction.Transfer (src, sink, opts, execute) ->
         // R1b — the envelope-emitting faces move under `withRun` (the law:
         // a verb that mints envelopes runs bracketed; RI-11's census). The
@@ -201,55 +218,88 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             withRun "projection migrate --with-data" (fun () ->
                 runMigrateWithData shapedCat sink src opts.Reconcile opts.Rekey opts.Declaration opts.AllowCdc opts.Atomic opts.Store opts.Env opts.SinkCapability)))
     | PlanAction.SynthesizeAndLoad (model, modelOssys, profile, conn, opts, execute, modelSection, syntheticSection) ->
-        withRun "projection synth-load" (fun () -> runSyntheticLoad model modelOssys profile conn opts execute modelSection syntheticSection)
-    | PlanAction.CaptureProfile (conn, out) -> runCaptureProfile conn out
-    | PlanAction.ProposeCorrection (model, modelOssys, out) -> runProposeCorrection model modelOssys out
+        // The synthetic load emits the transfer spine's load stage — under
+        // pretty an EXECUTING run now gets the live board (2026-07-02; it was
+        // the one long-running verb with no Watch wiring at all — completely
+        // silent until the trailing panel). A preview writes nothing, so its
+        // load line would never advance: no spine, the static frame instead.
+        Shell.execute
+            { Shell.currentFrame.Value with
+                Command = "projection synth-load"
+                Register = if execute then Shell.currentFrame.Value.Register else Shell.Preview }
+            Shell.Bracket.Bracketed
+            (if execute then Some Spines.transfer else None)
+            (fun () -> runSyntheticLoad model modelOssys profile conn opts execute modelSection syntheticSection)
+    | PlanAction.CaptureProfile (conn, out) -> shellRun "projection capture-profile" Shell.Go (fun () -> runCaptureProfile conn out)
+    | PlanAction.ProposeCorrection (model, modelOssys, out) -> shellRun "projection synth-correct" Shell.Go (fun () -> runProposeCorrection model modelOssys out)
     | PlanAction.PublishAndLoad (c, conn, store, env) ->
         let run () = runFullExportLoad c conn None store env
         // The load flow runs the same publish pipeline plus the seed-load leg
         // (2026-07-02 — a declared stage, so the board covers the whole run;
         // the episode record, when a store rides, happens inside that leg).
-        if Watch.shouldWatch prettyMode.Value then Watch.renderWatch (Spines.publishWith false true) (Watch.resolveDwellMs ()) run
-        else run ()
+        Shell.execute
+            { Shell.currentFrame.Value with Command = "projection full-export --load" }
+            Shell.Bracket.SelfBracketed
+            (Some (Spines.publishWith false true))
+            run
     | PlanAction.Migrate (model, modelOssys, conn, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
             withRun "projection migrate" (fun () ->
                 runMigrateExecute shapedCat conn opts.Declaration opts.AllowCdc opts.Atomic opts.Store opts.Env)))
     // check --------------------------------------------------------------
-    | PlanAction.CheckCanary (ddl, false) -> withRun "projection check" (fun () -> runCanary ddl)
-    | PlanAction.CheckCanary (ddl, true)  -> withRun "projection check --cdc-silence" (fun () -> runCanaryCdcSilence ddl)
-    | PlanAction.CheckDrift (m, conn)      -> runDrift m conn
-    | PlanAction.CheckData (before, after) -> runVerifyData before after
-    | PlanAction.CheckReady                -> runReadiness ()
-    | PlanAction.CheckShape (al, ar, confirm, asJson) -> runCheckShape al ar confirm asJson
+    // The canary verbs already emit the canary stage's spine events (the
+    // Pipeline `staged Spines.canary` CE) — under pretty they now get the
+    // live board those events always deserved (2026-07-02; the events used
+    // to flow to the nulled writer with no subscriber).
+    | PlanAction.CheckCanary (ddl, false) ->
+        Shell.execute
+            { Shell.currentFrame.Value with Command = "projection check" }
+            Shell.Bracket.Bracketed (Some Spines.canary) (fun () -> runCanary ddl)
+    | PlanAction.CheckCanary (ddl, true)  ->
+        Shell.execute
+            { Shell.currentFrame.Value with Command = "projection check --cdc-silence" }
+            Shell.Bracket.Bracketed (Some Spines.canary) (fun () -> runCanaryCdcSilence ddl)
+    | PlanAction.CheckDrift (m, conn)      -> shellRun "projection check drift" Shell.ReadOnly (fun () -> runDrift m conn)
+    | PlanAction.CheckData (before, after) -> shellRun "projection check data" Shell.ReadOnly (fun () -> runVerifyData before after)
+    | PlanAction.CheckReady                ->
+        // Self-bracketed: `runReadiness` owns its RunEnvelope (the documented
+        // no-append contract rides the ReadOnly register).
+        Shell.execute
+            { Shell.currentFrame.Value with Command = "projection check ready"; Register = Shell.ReadOnly }
+            Shell.Bracket.SelfBracketed None runReadiness
+    | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
     // explain ------------------------------------------------------------
-    | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) -> runDiff a b asJson (defaultArg depthOpt View.defaultDepth) channel onlyModule
-    | PlanAction.Compare (a, b, asJson)      -> runCompare a b asJson
-    | PlanAction.ExplainPolicy (a, b)        -> runPolicyDiff a b
-    | PlanAction.ExplainNode (c, k, asJson, depthOpt) -> runExplain c k asJson (defaultArg depthOpt View.defaultDepth)
-    | PlanAction.ExplainSuggest (c, applyTo) -> runSuggestConfig c applyTo
+    | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->
+        shellRun "projection diff" Shell.ReadOnly (fun () -> runDiff a b asJson (defaultArg depthOpt View.defaultDepth) channel onlyModule)
+    | PlanAction.Compare (a, b, asJson)      -> shellRun "projection compare" Shell.ReadOnly (fun () -> runCompare a b asJson)
+    | PlanAction.ExplainPolicy (a, b)        -> shellRun "projection explain policy" Shell.ReadOnly (fun () -> runPolicyDiff a b)
+    | PlanAction.ExplainNode (c, k, asJson, depthOpt) ->
+        shellRun "projection explain node" Shell.ReadOnly (fun () -> runExplain c k asJson (defaultArg depthOpt View.defaultDepth))
+    | PlanAction.ExplainSuggest (c, applyTo) -> shellRun "projection explain suggest" Shell.ReadOnly (fun () -> runSuggestConfig c applyTo)
     | PlanAction.ExplainRegistry ->
         // Self-description (NORTH_STAR "self-describing" leg) — the engine names
         // its own registered transforms (the `registered ⇔ executed` registry).
-        let all = RegisteredAllTransforms.all
-        let stageBindingText (s: StageBinding) =
-            match s with
-            | StageBinding.Adapter        -> "adapter"
-            | StageBinding.Pass           -> "pass"
-            | StageBinding.OrderingPolicy -> "ordering"
-            | StageBinding.Emitter        -> "emitter"
-            | StageBinding.Pipeline       -> "pipeline"
-        printfn "projection: %d registered transform(s)" (List.length all)
-        for rt in all |> List.sortBy (fun r -> stageBindingText r.StageBinding, r.Name) do
-            printfn "  %-12s %s" (stageBindingText rt.StageBinding) rt.Name
-        0
-    | PlanAction.ExplainMigratePreview (fromP, toP, decl)   -> runMigratePreview fromP toP decl
-    | PlanAction.ExplainMigrateFromStore (store, toP, decl, forceGenesis) -> runMigrateFromStore store toP decl forceGenesis
+        shellRun "projection explain registry" Shell.ReadOnly (fun () ->
+            let all = RegisteredAllTransforms.all
+            let stageBindingText (s: StageBinding) =
+                match s with
+                | StageBinding.Adapter        -> "adapter"
+                | StageBinding.Pass           -> "pass"
+                | StageBinding.OrderingPolicy -> "ordering"
+                | StageBinding.Emitter        -> "emitter"
+                | StageBinding.Pipeline       -> "pipeline"
+            printfn "projection: %d registered transform(s)" (List.length all)
+            for rt in all |> List.sortBy (fun r -> stageBindingText r.StageBinding, r.Name) do
+                printfn "  %-12s %s" (stageBindingText rt.StageBinding) rt.Name
+            0)
+    | PlanAction.ExplainMigratePreview (fromP, toP, decl)   -> shellRun "projection explain migrate" Shell.ReadOnly (fun () -> runMigratePreview fromP toP decl)
+    | PlanAction.ExplainMigrateFromStore (store, toP, decl, forceGenesis) -> shellRun "projection explain migrate" Shell.ReadOnly (fun () -> runMigrateFromStore store toP decl forceGenesis)
     // seal ---------------------------------------------------------------
-    | PlanAction.SealEject store -> runEject store
-    | PlanAction.SealApprove (version, approver, rationale, store) -> runApprove version approver rationale store
+    | PlanAction.SealEject store -> shellRun "projection seal" Shell.Go (fun () -> runEject store)
+    | PlanAction.SealApprove (version, approver, rationale, store) -> shellRun "projection seal approve" Shell.Go (fun () -> runApprove version approver rationale store)
     // report -------------------------------------------------------------
     | PlanAction.ReportBundle (store, outputDir) ->
+        shellRun "projection report" Shell.ReadOnly (fun () ->
         match ReportRun.fromStore store with
         | Ok bundle ->
             printLines Console.Out (ReportRun.render bundle)
@@ -277,15 +327,15 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             0
         | Error msg ->
             Console.Error.WriteLine (sprintf "projection report: %s" msg)
-            6
+            6)
     // slice (data portability) -------------------------------------------
     // The slice faces own their bespoke flag parsing + config resolution and
-    // their own bench/narration; they run directly (no `withRun` envelope), the
-    // same as they did under the old `argv.[0]` dispatch — now reached through
-    // the one typed plan (recon #3).
-    | PlanAction.RunSliceExtract args        -> runSliceExtract args
-    | PlanAction.RunSliceApply (reset, args) -> runSliceApply reset args
-    | PlanAction.RunSliceFlow args           -> runSliceFlow args
+    // their own bench/narration; since 2026-07-02 they run through the shell
+    // like every other verb (the A3 sweep) — run envelopes on the wire,
+    // channel-1 suppression + the verdict panel under pretty.
+    | PlanAction.RunSliceExtract args        -> shellRun "projection slice-extract" Shell.Go (fun () -> runSliceExtract args)
+    | PlanAction.RunSliceApply (reset, args) -> shellRun (if reset then "projection slice-reset" else "projection slice-apply") Shell.Go (fun () -> runSliceApply reset args)
+    | PlanAction.RunSliceFlow args           -> shellRun "projection slice-run" Shell.Go (fun () -> runSliceFlow args)
     // refused ------------------------------------------------------------
     | PlanAction.Refused (exit, error) -> TtyRenderer.renderVoicedError error; exit
 

--- a/sidecar/projection/src/Projection.Cli/Projection.Cli.fsproj
+++ b/sidecar/projection/src/Projection.Cli/Projection.Cli.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Voice.fs" />
     <Compile Include="TtyRenderer.fs" />
     <Compile Include="Watch.fs" />
+    <Compile Include="Shell.fs" />
     <Compile Include="Intervene.fs" />
     <Compile Include="Navigator.fs" />
     <Compile Include="OperatorConsole.fs" />

--- a/sidecar/projection/src/Projection.Cli/Shell.fs
+++ b/sidecar/projection/src/Projection.Cli/Shell.fs
@@ -1,0 +1,185 @@
+namespace Projection.Cli
+
+// LINT-ALLOW-FILE: CLI operator-shell substrate — terminal operator-facing prose
+//   at the CLI boundary; the structural surface is the typed Frame / RunSpine.
+
+open System
+open Projection.Pipeline
+
+/// THE OPERATOR SHELL (2026-07-02) — the ONE door every verb's run walks
+/// through under the channel-2 surface. Before this, the TTY treatment was
+/// four inconsistent paths (a direct `Watch.renderWatch` for publish, the
+/// `withRun` verdict-panel-only bracket for the move verbs, the gated
+/// `Face.watchInline` boards, and ~10 verbs with no bracket at all spraying
+/// raw NDJSON under `--pretty`). The shell is the unification:
+///
+///   - **not pretty** → the run-envelope bracket + the body, byte-identical
+///     NDJSON for pipes, plus the cross-run ledger append.
+///   - **pretty + a spine** → the live stage board inside the contained
+///     instrument box (the `Watch` Live region), then the verdict panel.
+///   - **pretty + no spine** (answer / preview verbs) → a static framed open
+///     (a preview names "nothing will be written"), the body with channel 1
+///     nulled for the span, then the verdict panel — never raw NDJSON over a
+///     TTY, never a dead Live region.
+///
+/// Prompts keep the 2026-06-17 rule: a gate/`Intervene` prompt hoists BEFORE
+/// `Shell.execute` — a Spectre Live region and a blocking prompt cannot share
+/// the terminal. `Navigator` (inspect) stays outside by the same law.
+[<RequireQualifiedAccess>]
+module Shell =
+
+    /// The per-invocation presentation modes — moved here from
+    /// `OperatorConsole` (2026-07-02; the shell owns the display globals and
+    /// compiles first; `OperatorConsole` aliases them so every existing
+    /// `open …OperatorConsole` site keeps reading the same refs).
+    let prettyMode : bool ref = ref false
+    let verboseMode : bool ref = ref false
+
+    /// The run's register — what kind of act the operator is watching. A
+    /// `Preview` writes nothing (the daily `projection <flow>` without
+    /// `--go`); `Go` is a live write; `ReadOnly` is an answer verb (diff /
+    /// explain / check).
+    type Register =
+        | Preview
+        | Go
+        | ReadOnly
+
+    /// A named flow's route — threaded from the dispatch layer so the box is
+    /// titled with the daily surface's own words ("publish: cloud-dev →
+    /// on-prem-dev"), never just the engine verb.
+    type FlowRoute = { Name: string; From: string; To: string }
+
+    /// The frame every run presents inside: the command, the flow route when
+    /// the run IS a named flow, and the register.
+    type Frame =
+        { Command  : string
+          Flow     : FlowRoute option
+          Register : Register }
+
+    [<RequireQualifiedAccess>]
+    module Frame =
+        let ofCommand (command: string) : Frame =
+            { Command = command; Flow = None; Register = Go }
+
+    /// The ambient frame for this invocation — set by `Shell.execute` on
+    /// entry (and pre-seeded by the dispatcher for flow runs), read by the
+    /// inner face combinators (`Face.watchInline`) so per-face signatures
+    /// stay unchanged. The same per-invocation-global pattern as
+    /// `prettyMode`.
+    let currentFrame : Frame ref = ref (Frame.ofCommand "projection")
+
+    /// Whether the body self-brackets its run envelope (`FullExportRun`
+    /// carries its own `RunEnvelope` orchestration) or the shell brackets it.
+    type Bracket =
+        | Bracketed
+        | SelfBracketed
+
+    /// The box title: the flow route with its register for a flow frame
+    /// ("publish: cloud-dev → on-prem-dev — preview"), the bare command
+    /// otherwise. Feeds `watch.runTitle` through the Board's title seam.
+    let titleOf (frame: Frame) : string =
+        let register =
+            match frame.Register with
+            | Preview  -> " — preview"
+            | Go       -> ""
+            | ReadOnly -> ""
+        match frame.Flow with
+        | Some f -> sprintf "%s: %s %s %s%s" f.Name f.From Theme.arrow f.To register
+        | None   -> frame.Command + register
+
+    let private bracketed (bracket: Bracket) (command: string) (body: unit -> int) : int =
+        match bracket with
+        | SelfBracketed -> body ()
+        | Bracketed ->
+            // R1b / RI-11 — a verb that mints envelopes runs bracketed: the
+            // stream opens with `config.runStart` and closes with the §10
+            // terminal, crashed bodies included (the S4a law).
+            RunEnvelope.bracket command ignore Map.empty (fun () -> "", []) (fun () ->
+                let code = body ()
+                code, (if code = 0 then LogSink.Succeeded else LogSink.Failed))
+
+    /// The ledger tail every run shares (from the old `withRun`): append the
+    /// run to the cross-run ledger when one is configured (Tier-4 reporting —
+    /// the readiness gauge reads the canary streak; opt-in via
+    /// `PROJECTION_LEDGER_DIR`).
+    let private appendLedger (frame: Frame) (code: int) : unit =
+        match RunLedger.configuredDir () with
+        | Some dir ->
+            let registered, applied, declined = LogSink.transformCounts ()
+            try
+                RunLedger.append dir
+                    { RunId      = LogSink.runId ()
+                      Ts         = System.DateTime.UtcNow.ToString("o")  // LINT-ALLOW: wall-clock timestamp at the operator-shell IO boundary (ISO-8601 round-trip o format)
+                      Command    = frame.Command
+                      Outcome    = (if code = 0 then "succeeded" else "failed")
+                      Canary     = LogSink.canaryVerdict ()
+                      Registered = registered
+                      Applied    = applied
+                      Declined   = declined }
+            with ex -> eprintfn "  WARNING: failed to append ledger record: %s" ex.Message
+        | None -> ()
+
+    /// The static open for a run with no live arc — under pretty, a PREVIEW
+    /// frame says so up front ("nothing will be written"), so a gated dry-run
+    /// reads as a deliberate preview rather than a dead board.
+    let private renderStaticOpenOn (console: Spectre.Console.IAnsiConsole) (frame: Frame) : unit =
+        match frame.Register with
+        | Preview ->
+            let payload : Voice.Payload = Map.ofList [ "title", box (titleOf frame) ]
+            let surface =
+                match Voice.surfaceOf "shell.previewFrame" payload with
+                | Some s -> s
+                | None   -> Voice.fallbackSurface "shell.previewFrame" payload
+            View.write console (Surface.render surface)
+        | Go | ReadOnly -> ()
+
+    /// The console-injected core — the TestConsole seam (mirrors
+    /// `Watch.renderWatchOn` / `TtyRenderer.renderSummaryTo`). `pretty` and
+    /// `live` arrive RESOLVED (production resolves them from `prettyMode` +
+    /// the real TTY; tests pin them), so the behavior matrix is assertable
+    /// without a terminal.
+    let executeOn
+        (console: Spectre.Console.IAnsiConsole)
+        (pretty: bool)
+        (live: bool)
+        (frame: Frame)
+        (bracket: Bracket)
+        (spine: RunSpine option)
+        (body: unit -> int)
+        : int =
+        currentFrame.Value <- frame
+        let run () = bracketed bracket frame.Command body
+        let code =
+            match spine with
+            | Some spine when live ->
+                let seed = { Watch.seededOf spine with Title = Some (titleOf frame) }
+                Watch.renderWatchOn console seed (Watch.resolveDwellMs ()) run
+            | _ when pretty ->
+                renderStaticOpenOn console frame
+                // Channel 1 is suppressed for the span (never NDJSON and a
+                // panel on the same TTY — §15.1); scoped, so an outer writer
+                // is restored (an improvement over the old unscoped null).
+                LogSink.withWriter IO.TextWriter.Null run
+            | _ -> run ()
+        // A ReadOnly answer verb (diff / explain / the check queries) never
+        // joins the run ledger — the gauge reads the canary streak, and a
+        // query about the ledger must not write to it (the `check ready`
+        // no-append contract, now structural for the whole register). Go and
+        // Preview runs append exactly as `withRun` always did.
+        (match frame.Register with
+         | ReadOnly -> ()
+         | Go | Preview -> appendLedger frame code)
+        if pretty then TtyRenderer.renderSummaryTo console frame.Command code
+        code
+
+    /// THE one door. Runs `body` inside the frame: the live boxed board when
+    /// a spine rides and the terminal is real; the static framed open + nulled
+    /// channel 1 when pretty without a spine; the bare bracket for pipes.
+    /// Every path closes with the ledger append + (under pretty) the verdict
+    /// panel.
+    let execute (frame: Frame) (bracket: Bracket) (spine: RunSpine option) (body: unit -> int) : int =
+        executeOn
+            (View.consoleTo Console.Error)
+            (TtyRenderer.shouldRender prettyMode.Value)
+            (Watch.shouldWatch prettyMode.Value)
+            frame bracket spine body

--- a/sidecar/projection/src/Projection.Cli/Shell.fs
+++ b/sidecar/projection/src/Projection.Cli/Shell.fs
@@ -35,6 +35,11 @@ module Shell =
     let prettyMode : bool ref = ref false
     let verboseMode : bool ref = ref false
 
+    /// `--stat` (2026-07-02) — after the run closes, render the §11 event
+    /// aggregates as one table on stdout (the headless rollup lens; the
+    /// pipe-friendly answer to "where did my notices go").
+    let statMode : bool ref = ref false
+
     /// The run's register — what kind of act the operator is watching. A
     /// `Preview` writes nothing (the daily `projection <flow>` without
     /// `--go`); `Go` is a live write; `ReadOnly` is an answer verb (diff /
@@ -181,6 +186,10 @@ module Shell =
          | ReadOnly -> ()
          | Go | Preview -> appendLedger frame code)
         if pretty then TtyRenderer.renderSummaryTo console frame.Command code
+        // `--stat` — the aggregates table on stdout (an ANSWER, so it rides
+        // the answer channel + lenses, not the injected stderr console).
+        if statMode.Value then
+            TtyRenderer.renderAnswer false View.defaultDepth (TtyRenderer.buildStatView (LogSink.aggregates ()))
         code
 
     /// THE one door. Runs `body` inside the frame: the live boxed board when

--- a/sidecar/projection/src/Projection.Cli/Shell.fs
+++ b/sidecar/projection/src/Projection.Cli/Shell.fs
@@ -68,6 +68,17 @@ module Shell =
     /// `prettyMode`.
     let currentFrame : Frame ref = ref (Frame.ofCommand "projection")
 
+    /// The frame for a verb arm: a FLOW-dispatched run keeps its flow frame —
+    /// the daily surface's own words title the box, the verdict panel, and
+    /// the ledger record ("projection publish", never the engine verb it
+    /// planned to) — while a direct verb takes its command. The register is
+    /// untouched (the dispatcher's preview/go posture holds).
+    let framed (command: string) : Frame =
+        let ambient = currentFrame.Value
+        match ambient.Flow with
+        | Some _ -> ambient
+        | None   -> { ambient with Command = command }
+
     /// Whether the body self-brackets its run envelope (`FullExportRun`
     /// carries its own `RunEnvelope` orchestration) or the shell brackets it.
     type Bracket =

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -306,6 +306,21 @@ let benchView (stats: Bench.Stats list) : View.View =
           string s.MaxMs,          View.Neutral ]
     View.Doc [ View.Note "Bench (sorted by total time)"; View.Table(headers, stats |> List.map row) ]
 
+/// Build the `--stat` rollup `View` (2026-07-02) — the run's §11 aggregates
+/// as one table (category / code / count / first samples' grain elided): the
+/// headless "where did my notices go" lens, sorted most-frequent first.
+let buildStatView (groups: LogSink.GroupAccumulator list) : View.View =
+    let headers = [ "category"; "code"; "count" ]
+    let row (g: LogSink.GroupAccumulator) : (string * View.Status) list =
+        [ LogSink.categoryToString g.Category, View.Neutral
+          g.Code,                              View.Neutral
+          string g.Count,                      View.Neutral ]
+    let rows =
+        groups
+        |> List.sortByDescending (fun g -> g.Count)
+        |> List.map row
+    View.Doc [ View.Note "Run events, rolled up (category · code · count)"; View.Table(headers, rows) ]
+
 /// Build the flow-menu `View` — the no-argument `projection` answer ("the
 /// config IS the menu", THE_CLI.md §4.4), as one document the three lenses
 /// share: a hero naming the daily act, then the flows as a table

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -306,6 +306,22 @@ let benchView (stats: Bench.Stats list) : View.View =
           string s.MaxMs,          View.Neutral ]
     View.Doc [ View.Note "Bench (sorted by total time)"; View.Table(headers, stats |> List.map row) ]
 
+/// Build the flow-menu `View` — the no-argument `projection` answer ("the
+/// config IS the menu", THE_CLI.md §4.4), as one document the three lenses
+/// share: a hero naming the daily act, then the flows as a table
+/// (name / route / notes). 2026-07-02 — previously plain Console.Out lines,
+/// invisible to `--json` / `--query` and unstyled under pretty.
+let buildFlowMenuView (flows: (string * string * string * string) list) : View.View =
+    let headers = [ "flow"; "from"; "to"; "notes" ]
+    let row (name, source, target, extras) : (string * View.Status) list =
+        [ name,   View.Neutral
+          source, View.Neutral
+          target, View.Neutral
+          extras, View.Neutral ]
+    View.Doc
+        [ View.Note "Flows — the daily act is `projection <flow>` (preview by default; --go applies)."
+          View.Table(headers, flows |> List.map row) ]
+
 let renderReadinessBoard (r: RunLedger.Readiness) (recent: string list) (series: int list) (ledgerPath: string) : unit =
     // The board renders on every `readiness` (not just on a TTY). The factory
     // pins a width when piped (Spectre's auto-width collapses lines on a non-TTY)

--- a/sidecar/projection/src/Projection.Cli/View.fs
+++ b/sidecar/projection/src/Projection.Cli/View.fs
@@ -467,7 +467,16 @@ let consoleFor (writer: System.IO.TextWriter) (redirected: bool) : IAnsiConsole 
     (match envColorOverride () with
      | Some false -> settings.ColorSystem <- ColorSystemSupport.NoColors
      | Some true  -> settings.Ansi <- AnsiSupport.Yes
-     | None       -> ())
+     | None       ->
+         // A redirected sink renders PLAIN (2026-07-02). Spectre cannot detect
+         // redirection through an injected `AnsiConsoleOutput` (the prior
+         // "Spectre strips its color of its own accord" assumption held only
+         // for the DEFAULT console), so ANSI was spraying into pipes and
+         // files. `CLICOLOR_FORCE` above still forces color into a pipe when
+         // the operator declares it.
+         if redirected then
+             settings.ColorSystem <- ColorSystemSupport.NoColors
+             settings.Ansi <- AnsiSupport.No)
     let console = AnsiConsole.Create settings
     if redirected then console.Profile.Width <- plainWidth
     console

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -848,6 +848,34 @@ module Voice =
           Action         = fun _ -> None }
 
     // ------------------------------------------------------------------
+    /// `plan.note` — a dispatch-prologue note (a plan note; the A7 inert-flag
+    /// note). The engine authored the text at the plan layer; the Voice frames
+    /// it on the note register so the prologue renders one way everywhere.
+    let private planNote : Copy =
+        { Code           = "plan.note"
+          DocSection     = "§14"
+          Statement      =
+            fun p ->
+                match text "text" p with
+                | Some t -> View.Note(sprintf "Note — %s" t)
+                | None   -> View.Note "Note."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
+    /// `survey.advisory` — the G0c capability-survey advisory for a live
+    /// (`--go`) flow: a connected environment cannot do what the flow asks.
+    /// Warns, never gates (R6 — the run's own exit stands).
+    let private surveyAdvisory : Copy =
+        { Code           = "survey.advisory"
+          DocSection     = "§14"
+          Statement      =
+            fun p ->
+                match text "text" p with
+                | Some t -> View.Note t
+                | None   -> View.Note "A connected environment reported a capability gap."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `shell.previewFrame` — the operator shell's static open for a run that
     /// writes nothing (`THE_VOICE.md` §5's consequence-as-meaning, carried to
     /// the preview register): the frame says so up front, so a gated dry-run
@@ -951,6 +979,9 @@ module Voice =
           summaryStageCompleted
           // §5 — the operator shell's preview frame
           shellPreviewFrame
+          // §14 — the dispatch prologue's notes + the G0c survey advisory
+          planNote
+          surveyAdvisory
           // §12 — the at-scale rollups (constant-size surfaces over growing counts)
           modelReadNoticeRollup
           // §14 / §10 — config & errors

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -106,6 +106,8 @@ module Voice =
         | "deploy"    -> "Deploy"
         | "canary"    -> "Round-trip verification"
         | "load"      -> "Data load"
+        | "store"     -> "Provenance record"
+        | "seed-load" -> "Seed load"
         | other       -> other
 
     /// The §13 follow-on for a run whose terminal stage is `terminalStage` — "the
@@ -123,6 +125,8 @@ module Voice =
         | "deploy"    -> "Verification follows."
         | "canary"    -> "The record follows."
         | "load"      -> "Verification follows."
+        | "store"     -> "The bundle is published and the change is recorded."
+        | "seed-load" -> "The data is loaded. Verification follows."
         | _           -> "The run is complete."
 
     /// The §13 follow-on for a run whose terminal stage HALTED — NM-46: a run that
@@ -523,6 +527,26 @@ module Voice =
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
+    /// `store.started` — the publish store leg is in progress (`THE_VOICE.md`
+    /// §13; the 2026-07-02 publish-spine completion). Gerund-in-progress: the
+    /// change is measured against the prior emission and the episode recorded.
+    let private storeStarted : Copy =
+        { Code           = "store.started"
+          DocSection     = "§13"
+          Statement      = fun _ -> View.Note "Recording the change against the prior emission."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
+    /// `seed-load.started` — the publish-and-load seed leg is in progress
+    /// (`THE_VOICE.md` §13). The idempotent MERGE seed, distinct from the
+    /// transfer's data load.
+    let private seedLoadStarted : Copy =
+        { Code           = "seed-load.started"
+          DocSection     = "§13"
+          Statement      = fun _ -> View.Note "Loading the seed."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `watch.runTitle` — the live board's run-title header (`THE_VOICE.md` §13 —
     /// "the instrument speaks about its own running"). A neutral, agentless naming
     /// of the run in flight (the command is the subject, never "you"); the board
@@ -904,6 +928,8 @@ module Voice =
           deployStarted
           canaryStarted
           loadStarted
+          storeStarted
+          seedLoadStarted
           watchRunTitle
           watchRunDone
           watchStageHalted

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -848,6 +848,21 @@ module Voice =
           Action         = fun _ -> None }
 
     // ------------------------------------------------------------------
+    /// `watch.suggestedEdits` — the live board's config-edit teaser (#6
+    /// echo-the-fix): envelopes carrying a `suggestedConfig` payload tick this
+    /// count as the run happens; the verdict panel ranks the single biggest
+    /// lever afterward.
+    let private watchSuggestedEdits : Copy =
+        { Code           = "watch.suggestedEdits"
+          DocSection     = "§13"
+          Statement      =
+            fun p ->
+                match text "count" p with
+                | Some n -> View.Note(sprintf "%s config edit(s) suggested so far — the verdict panel ranks the lever." (humane n))
+                | None   -> View.Note "Config edits suggested — the verdict panel ranks the lever."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `plan.note` — a dispatch-prologue note (a plan note; the A7 inert-flag
     /// note). The engine authored the text at the plan layer; the Voice frames
     /// it on the note register so the prologue renders one way everywhere.
@@ -976,6 +991,7 @@ module Voice =
           watchRunTitle
           watchRunDone
           watchStageHalted
+          watchSuggestedEdits
           summaryStageCompleted
           // §5 — the operator shell's preview frame
           shellPreviewFrame

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -824,6 +824,38 @@ module Voice =
           Action         = fun _ -> None }
 
     // ------------------------------------------------------------------
+    /// `adapter.ossys.modelRead.noticeRollup` — a model read's divergence notices,
+    /// condensed to one calm line (`THE_VOICE.md` §12 at-scale law: the surface is
+    /// a constant size; only the numbers grow). The per-item detail is the run's
+    /// notice artifact; the action points there — never a wall of lines.
+    let private modelReadNoticeRollup : Copy =
+        { Code           = "adapter.ossys.modelRead.noticeRollup"
+          DocSection     = "§12"
+          Statement      =
+            fun p ->
+                let families =
+                    [ "nullability", "nullability"
+                      "identity",    "identity"
+                      "primaryKey",  "primary key"
+                      "other",       "other" ]
+                    |> List.choose (fun (key, label) ->
+                        text key p |> Option.map (fun n -> sprintf "%s %s" label (humane n)))
+                let total = humane (textOr "total" "0" p)
+                match families with
+                | [] -> View.Note(sprintf "%s model-reality notices. The model's declared values were kept." total)
+                | fs -> View.Note(sprintf "%s model-reality notices — %s. The model's declared values were kept." total (String.concat ", " fs))
+          Substantiation =
+            fun p ->
+                match text "samples" p with
+                | Some s when s <> "" -> [ View.Disclosure("the first notices", View.Neutral, [ View.Note s ]) ]
+                | _ -> []
+          Action         =
+            fun p ->
+                text "artifactPath" p
+                |> Option.filter (fun s -> s <> "")
+                |> Option.map (fun path -> View.Action(sprintf "Review the full list at %s." path)) }
+
+    // ------------------------------------------------------------------
     // The harvest — `all` gathers every declared copy into one catalog.
     // The `code ⇔ copy` totality test reads this (the sibling of the
     // registry's `registered ⇔ executed`), so the copy can't drift from
@@ -876,6 +908,8 @@ module Voice =
           watchRunDone
           watchStageHalted
           summaryStageCompleted
+          // §12 — the at-scale rollups (constant-size surfaces over growing counts)
+          modelReadNoticeRollup
           // §14 / §10 — config & errors
           configValidationFailed
           canarySourceMissing

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -848,6 +848,21 @@ module Voice =
           Action         = fun _ -> None }
 
     // ------------------------------------------------------------------
+    /// `shell.previewFrame` — the operator shell's static open for a run that
+    /// writes nothing (`THE_VOICE.md` §5's consequence-as-meaning, carried to
+    /// the preview register): the frame says so up front, so a gated dry-run
+    /// reads as a deliberate preview rather than a dead board.
+    let private shellPreviewFrame : Copy =
+        { Code           = "shell.previewFrame"
+          DocSection     = "§5"
+          Statement      =
+            fun p ->
+                match text "title" p with
+                | Some t -> View.Note(sprintf "%s. Nothing will be written." t)
+                | None   -> View.Note "A preview. Nothing will be written."
+          Substantiation = fun _ -> []
+          Action         = fun _ -> None }
+
     /// `adapter.ossys.modelRead.noticeRollup` — a model read's divergence notices,
     /// condensed to one calm line (`THE_VOICE.md` §12 at-scale law: the surface is
     /// a constant size; only the numbers grow). The per-item detail is the run's
@@ -934,6 +949,8 @@ module Voice =
           watchRunDone
           watchStageHalted
           summaryStageCompleted
+          // §5 — the operator shell's preview frame
+          shellPreviewFrame
           // §12 — the at-scale rollups (constant-size surfaces over growing counts)
           modelReadNoticeRollup
           // §14 / §10 — config & errors

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -80,10 +80,14 @@ module Watch =
           /// for its store/load legs, so identical rollups fold to one row —
           /// the counts never double). Rendered muted between the stage arc
           /// and the done-frame; the copy is the Voice catalog's (one register).
-          Notices: (string * Map<string, objnull>) list }
+          Notices: (string * Map<string, objnull>) list
+          /// #6 echo-the-fix (2026-07-02) — how many envelopes so far carried a
+          /// `suggestedConfig` payload (the operator's prioritized to-do). The
+          /// board teases the count live; the verdict panel ranks the lever.
+          SuggestedEdits: int }
 
     let empty : Board =
-        { Stages = []; Title = None; RunIdentity = None; Umbrella = Some "pipeline"; Notices = [] }
+        { Stages = []; Title = None; RunIdentity = None; Umbrella = Some "pipeline"; Notices = []; SuggestedEdits = 0 }
 
     /// A board pre-seeded with the run's planned stages, each `Pending` — so the
     /// operator sees the whole arc before the first stage starts, the stages
@@ -97,7 +101,8 @@ module Watch =
           Title = None
           RunIdentity = None
           Umbrella = Some "pipeline"
-          Notices = [] }
+          Notices = []
+          SuggestedEdits = 0 }
 
     /// A seeded board carrying the run frame — the run-title header voiced above
     /// the arc (`THE_VOICE.md` §13) and, when known up front, the run's ordinal for
@@ -116,7 +121,8 @@ module Watch =
           Title = None
           RunIdentity = None
           Umbrella = RunSpine.rootKey spine
-          Notices = [] }
+          Notices = []
+          SuggestedEdits = 0 }
 
     /// The umbrella root scope (e.g. full-export's "pipeline") wraps the whole
     /// run; it is not a sub-stage the operator watches, so the board elides its
@@ -237,6 +243,12 @@ module Watch =
                 else
                     board.Notices @ [ (code, payload) ]
             { board with Notices = replaced }, Fold.Progressed
+        elif Map.containsKey "suggestedConfig" payload then
+            // #6 echo-the-fix — an envelope carrying a suggested config edit
+            // ticks the live teaser (the same predicate the §11 rollup's
+            // `suggestedConfigEdits` counter uses; the verdict panel ranks the
+            // single biggest lever after the run).
+            { board with SuggestedEdits = board.SuggestedEdits + 1 }, Fold.Progressed
         else board, Fold.NoChange
 
     /// Fold one envelope into the board as a plain did-it-change — the stored-run
@@ -494,6 +506,13 @@ module Watch =
             board.Notices
             |> List.map (fun (code, payload) ->
                 Markup(sprintf "%s  %s" (Theme.yellow Theme.warn) (Theme.muted (Markup.Escape(noticeText code payload)))) :> IRenderable)
+        // #6 echo-the-fix — the live teaser for accumulated config-edit
+        // suggestions; the copy rides the catalog (`watch.suggestedEdits`).
+        let suggestedRow =
+            if board.SuggestedEdits = 0 then []
+            else
+                let text = statementText "watch.suggestedEdits" (Map.ofList [ "count", box board.SuggestedEdits ])
+                [ Markup(sprintf "%s  %s" (Theme.yellow Theme.warn) (Theme.muted (Markup.Escape text))) :> IRenderable ]
         let doneRow =
             match doneFrameText board with
             | Some t ->
@@ -504,7 +523,7 @@ module Watch =
                     else Theme.ok, Theme.green
                 [ Markup(sprintf "%s  %s" glyph (paint (Markup.Escape t))) :> IRenderable ]
             | None   -> []
-        titleRow @ stageRows @ noticeRows @ doneRow
+        titleRow @ stageRows @ noticeRows @ suggestedRow @ doneRow
 
     /// Project the board onto a Spectre renderable — the live target the
     /// `LiveDisplayContext` updates in place. A STATIC render (stored board, tests)

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -128,19 +128,40 @@ module Watch =
         | Some (:? int64 as l) -> int l
         | _                    -> 0
 
-    /// Fold one envelope into the board. Returns the updated board and whether it
-    /// produced a *renderable* transition (so the shell sleeps + refreshes only on
-    /// real changes, never on every envelope). The board reacts to exactly two
-    /// event kinds: a `<stage>.started` (→ `Active`) and a `summary.stageCompleted`
+    /// The visible weight of one envelope's fold into the board — what the drain
+    /// loop renders and paces on (#20 rework). `Transitioned` is a stage-arc change
+    /// (a line started or closed): the dwell floor paces these so each stays
+    /// legible. `Progressed` is an in-place progress update on an active line:
+    /// rendered promptly, never dwelled (dwelling per progress frame is how the
+    /// backlog replay hang happened). `NoChange` is every other envelope.
+    [<RequireQualifiedAccess>]
+    type Fold =
+        | NoChange
+        | Progressed
+        | Transitioned
+
+    /// The stronger of two folds — a coalesced batch renders once, paced by the
+    /// strongest change it contained.
+    let strongestFold (a: Fold) (b: Fold) : Fold =
+        match a, b with
+        | Fold.Transitioned, _ | _, Fold.Transitioned -> Fold.Transitioned
+        | Fold.Progressed, _ | _, Fold.Progressed     -> Fold.Progressed
+        | _                                           -> Fold.NoChange
+
+    /// Fold one envelope into the board. Returns the updated board and the fold's
+    /// visible weight (so the shell dwells only on stage transitions and refreshes
+    /// only on real changes, never on every envelope). The board reacts to exactly
+    /// three event kinds: a `<stage>.started` (→ `Active`), a `summary.stageProgress`
+    /// (→ progress in place) and a `summary.stageCompleted`
     /// (→ `Done` with the measured duration on a `succeeded` outcome; → `Halted`
     /// on `failed` / `aborted`, so a closed-unsuccessful stage reads `✕`, never a
     /// `✓` that misstates and never a hung Active line — the R2 Aborted arm). The
     /// redundant `<stage>.completed` markers are ignored — `summary.stageCompleted`
     /// carries the duration.
-    let apply (board: Board) (code: string) (payload: Map<string, objnull>) : Board * bool =
+    let applyKind (board: Board) (code: string) (payload: Map<string, objnull>) : Board * Fold =
         if code.EndsWith ".started" then
             let key = code.Substring(0, code.Length - ".started".Length)
-            if isUmbrella board key then board, false
+            if isUmbrella board key then board, Fold.NoChange
             else
                 // A pre-seeded `Pending` stage flips to `Active` in place (keeping
                 // its planned position); an unseeded stage appends; an already
@@ -150,9 +171,9 @@ module Watch =
                     { board with
                         Stages =
                             board.Stages
-                            |> List.map (fun s -> if s.Key = key then { s with State = Active None } else s) }, true
-                | Some _ -> board, false
-                | None -> { board with Stages = board.Stages @ [ { Key = key; State = Active None } ] }, true
+                            |> List.map (fun s -> if s.Key = key then { s with State = Active None } else s) }, Fold.Transitioned
+                | Some _ -> board, Fold.NoChange
+                | None -> { board with Stages = board.Stages @ [ { Key = key; State = Active None } ] }, Fold.Transitioned
         elif code = "summary.stageProgress" then
             // An active stage reports how far it has come. The board updates that
             // line's progress in place — a renderable change, but never a new
@@ -166,14 +187,14 @@ module Watch =
                     { board with
                         Stages =
                             board.Stages
-                            |> List.map (fun ln -> if ln.Key = key then { ln with State = Active(Some prog) } else ln) }, true
-                | _ -> board, false
-            | _ -> board, false
+                            |> List.map (fun ln -> if ln.Key = key then { ln with State = Active(Some prog) } else ln) }, Fold.Progressed
+                | _ -> board, Fold.NoChange
+            | _ -> board, Fold.NoChange
         elif code = "summary.stageCompleted" then
             match Map.tryFind "stage" payload with
             | Some s when not (isNull s) ->
                 let key = string s
-                if isUmbrella board key then board, false
+                if isUmbrella board key then board, Fold.NoChange
                 else
                     let dur = durationOf payload
                     // The wire outcome decides the closed state: `succeeded`
@@ -187,15 +208,27 @@ module Watch =
                         { board with
                             Stages =
                                 board.Stages
-                                |> List.map (fun ln -> if ln.Key = key then { ln with State = closed } else ln) }, true
+                                |> List.map (fun ln -> if ln.Key = key then { ln with State = closed } else ln) }, Fold.Transitioned
                     else
-                        { board with Stages = board.Stages @ [ { Key = key; State = closed } ] }, true
-            | _ -> board, false
-        else board, false
+                        { board with Stages = board.Stages @ [ { Key = key; State = closed } ] }, Fold.Transitioned
+            | _ -> board, Fold.NoChange
+        else board, Fold.NoChange
+
+    /// Fold one envelope into the board as a plain did-it-change — the stored-run
+    /// reconstruction (`boardOfStored`) and the pure board tests fold on this; the
+    /// live drain loop folds on `applyKind` (it paces on the fold's weight).
+    let apply (board: Board) (code: string) (payload: Map<string, objnull>) : Board * bool =
+        let board', fold = applyKind board code payload
+        board', (fold <> Fold.NoChange)
 
     /// Fold an envelope into the board (the `LogSink.Envelope` form).
     let applyEnvelope (board: Board) (env: LogSink.Envelope) : Board * bool =
         apply board env.Code env.Payload
+
+    /// Fold an envelope into the board carrying the fold's weight (the live drain
+    /// loop's form — dwell pacing keys off `Fold.Transitioned`).
+    let applyEnvelopeKind (board: Board) (env: LogSink.Envelope) : Board * Fold =
+        applyKind board env.Code env.Payload
 
     /// R1e — reconstruct the board from a STORED run's serialized envelopes
     /// (`Run.Events`, the NDJSON lines `Run.capture` persists): each line
@@ -321,7 +354,10 @@ module Watch =
             let baseText = statementText (line.Key + ".started") Map.empty
             match prog with
             | Some p -> sprintf "%s · %s" baseText (progressTextStalled stalled p)
-            | None   -> baseText
+            // A progress-less stage that has gone quiet says so in words, the same
+            // register the progress fragment uses — a frozen dimmed spinner with no
+            // explanation left the operator guessing (#20 rework; §13 honesty).
+            | None   -> if stalled then sprintf "%s · stalled" baseText else baseText
         | Done dur ->
             let baseText = statementText "summary.stageCompleted" (Map.ofList [ "stage", box line.Key ])
             match dur with
@@ -466,6 +502,17 @@ module Watch =
             | true, v when v >= 0L -> v
             | _ -> defaultDwellMs
 
+    /// The stall threshold for this process — the default, overridable via
+    /// `PROJECTION_WATCH_STALL_MS` (perceptual tuning + a deterministic seam for
+    /// the stall-render tests, the same shape as the dwell override).
+    let resolveStallThresholdMs () : int64 =
+        match Environment.GetEnvironmentVariable "PROJECTION_WATCH_STALL_MS" with
+        | null -> stallThresholdMs
+        | s ->
+            match Int64.TryParse s with
+            | true, v when v >= 0L -> v
+            | _ -> stallThresholdMs
+
     /// The cutover timeline strip line (pretty markup) — the canary-history dots
     /// with the present marker, the R6 gate meter, and the ratio (`●●●●✕●●▸
     /// ▇▇▇▇▇▇▇░░░ 7/10`). Pure over (cells, filled, total) so the content is
@@ -514,7 +561,22 @@ module Watch =
         let board = ref (seededOf spine)
         let header = cutoverHeader ()
         let sw = System.Diagnostics.Stopwatch.StartNew()
-        let mutable lastRenderAt = 0L
+        let stallMs = resolveStallThresholdMs ()
+        // Three clocks (#20 rework, 2026-07-02). Splitting them is the fix for the
+        // hang family: one clock cannot honestly pace the dwell, the heartbeat AND
+        // the stall verdict at once.
+        //   lastTransitionAt — dwell pacing: only stage TRANSITIONS are floored, so
+        //     each arc change stays legible without turning a progress flood into a
+        //     backlog replay.
+        //   lastPaintAt — heartbeat pacing: the spinner breathes on wall clock,
+        //     regardless of whether the queue is chatty (the old loop only breathed
+        //     on a TryTake TIMEOUT, so a continuous envelope stream froze it).
+        //   lastEventAt — liveness: ANY dequeued envelope proves the pipeline is
+        //     alive; `stalled` is now-lastEventAt, never now-lastRender (the old
+        //     conflation called a quiet-but-working stage stalled at 3s).
+        let mutable lastTransitionAt = 0L
+        let mutable lastPaintAt = 0L
+        let mutable lastEventAt = 0L
         let mutable code = 0
         // House-NEW concurrency primitive (grep: the first BlockingCollection in src) — its
         // re-open is gated by the live board going off-thread (CLAUDE.md §7; DECISIONS 2026-06-19).
@@ -540,32 +602,61 @@ module Watch =
                 // The breathing spinner's render tick (#20 follow-on) — advanced on EVERY
                 // render (a folded frame OR an idle wake), so the active stage visibly breathes.
                 let mutable phase = 0
+                // One paint path — every repaint advances the spinner and stamps the
+                // heartbeat clock, whatever prompted it.
+                let paint (stalled: bool) =
+                    phase <- phase + 1
+                    lastPaintAt <- sw.ElapsedMilliseconds
+                    ctx.UpdateTarget(toRenderableWith header phase stalled board.Value)
+                    ctx.Refresh()
                 while draining do
                     let mutable env = Unchecked.defaultof<LogSink.Envelope>
                     if queue.TryTake(&env, 100) then
-                        let board', changed = applyEnvelope board.Value env
-                        if changed then
+                        // COALESCE (#20 rework): fold everything already queued into ONE
+                        // frame, stopping after the first stage TRANSITION — transitions
+                        // are bounded by the spine and each deserves its dwelled frame;
+                        // progress and foreign envelopes are the unbounded flood, and
+                        // folding them one-frame-per-envelope (each dwelled 120ms) is how
+                        // the board lagged minutes behind and replayed a backlog after the
+                        // run had already finished.
+                        let mutable batch = Fold.NoChange
+                        let mutable take = true
+                        while take do
+                            lastEventAt <- sw.ElapsedMilliseconds
+                            let board', fold = applyEnvelopeKind board.Value env
                             board.Value <- board'
-                            let sleep = dwellMs floorMs lastRenderAt sw.ElapsedMilliseconds
+                            batch <- strongestFold batch fold
+                            if batch = Fold.Transitioned then take <- false
+                            elif not (queue.TryTake(&env, 0)) then take <- false
+                        match batch with
+                        | Fold.Transitioned ->
+                            // The dwell floor paces stage transitions ONLY — the previous
+                            // arc frame stays legible ≥ the floor before this one replaces
+                            // it. Progress frames render immediately below.
+                            let sleep = dwellMs floorMs lastTransitionAt sw.ElapsedMilliseconds
                             if sleep > 0L then System.Threading.Thread.Sleep(int sleep)
-                            lastRenderAt <- sw.ElapsedMilliseconds
-                            phase <- phase + 1
-                            // a fold JUST happened — never stalled
-                            ctx.UpdateTarget(toRenderableWith header phase false board.Value)
-                            ctx.Refresh()
+                            lastTransitionAt <- sw.ElapsedMilliseconds
+                            paint false
+                        | Fold.Progressed ->
+                            paint false
+                        | Fold.NoChange ->
+                            // A batch of foreign envelopes changed nothing visible — but
+                            // the pipeline is chatty-alive, so keep the spinner breathing
+                            // on the wall-clock heartbeat (the old loop never repainted
+                            // here, which froze the board for the whole flood).
+                            if hasActiveStage board.Value && sw.ElapsedMilliseconds - lastPaintAt >= 100L then
+                                paint (sw.ElapsedMilliseconds - lastEventAt > stallMs)
                     elif queue.IsCompleted then
                         draining <- false
                     elif hasActiveStage board.Value then
-                        // Idle wake (no new frame in 100ms) with a stage in progress — advance
+                        // Idle wake (no envelope in 100ms) with a stage in progress — advance
                         // the spinner and refresh so the active line breathes between events. No
-                        // fold, no dwell sleep (the dwell is a floor on CHANGES, not added here).
-                        // If the active stage has gone quiet past the threshold, render it STALLED
-                        // (frozen spinner + the estimate degrades to `stalled`) — honest, not a
-                        // countdown that keeps lying while nothing moves.
-                        let stalled = sw.ElapsedMilliseconds - lastRenderAt > stallThresholdMs
-                        phase <- phase + 1
-                        ctx.UpdateTarget(toRenderableWith header phase stalled board.Value)
-                        ctx.Refresh()
+                        // fold, no dwell sleep (the dwell is a floor on TRANSITIONS, not added
+                        // here). If the pipeline has gone quiet past the threshold, render it
+                        // STALLED (frozen spinner + the line reads `stalled`) — honest, not a
+                        // countdown that keeps lying while nothing moves. Liveness keys off
+                        // lastEventAt: any envelope proves work, board-visible or not.
+                        paint (sw.ElapsedMilliseconds - lastEventAt > stallMs)
                 // Join the producer for its exit code — `GetAwaiter().GetResult()` so a body
                 // exception propagates as ITSELF, not wrapped in `AggregateException`.
                 code <- bodyTask.GetAwaiter().GetResult()

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -55,6 +55,12 @@ module Watch =
     /// current visible state. Ordered by first appearance.
     type StageLine = { Key: string; State: StageState }
 
+    /// The rollup codes the board's notice strip folds (2026-07-02) — each is a
+    /// producer-aggregated Warn envelope (one calm line per notice family, the
+    /// §12 at-scale law), never a per-item stream.
+    let noticeCodes : Set<string> =
+        Set.ofList [ LiveModelRead.noticeRollupCode ]
+
     /// The board — the stage lines, plus the optional run frame (`THE_VOICE.md`
     /// §13: "the instrument speaks about its own running"). `Title` is the
     /// run-in-flight header voiced above the arc; `RunIdentity` is the run's
@@ -68,10 +74,16 @@ module Watch =
         { Stages: StageLine list
           Title: string option
           RunIdentity: string option
-          Umbrella: string option }
+          Umbrella: string option
+          /// The notice strip (2026-07-02) — the run's Warn ROLLUP envelopes,
+          /// keyed by code, replace-by-code (a publish re-reads the same model
+          /// for its store/load legs, so identical rollups fold to one row —
+          /// the counts never double). Rendered muted between the stage arc
+          /// and the done-frame; the copy is the Voice catalog's (one register).
+          Notices: (string * Map<string, objnull>) list }
 
     let empty : Board =
-        { Stages = []; Title = None; RunIdentity = None; Umbrella = Some "pipeline" }
+        { Stages = []; Title = None; RunIdentity = None; Umbrella = Some "pipeline"; Notices = [] }
 
     /// A board pre-seeded with the run's planned stages, each `Pending` — so the
     /// operator sees the whole arc before the first stage starts, the stages
@@ -84,7 +96,8 @@ module Watch =
             |> List.map (fun k -> { Key = k; State = Pending })
           Title = None
           RunIdentity = None
-          Umbrella = Some "pipeline" }
+          Umbrella = Some "pipeline"
+          Notices = [] }
 
     /// A seeded board carrying the run frame — the run-title header voiced above
     /// the arc (`THE_VOICE.md` §13) and, when known up front, the run's ordinal for
@@ -102,7 +115,8 @@ module Watch =
         { Stages = RunSpine.keys spine |> List.map (fun k -> { Key = k; State = Pending })
           Title = None
           RunIdentity = None
-          Umbrella = RunSpine.rootKey spine }
+          Umbrella = RunSpine.rootKey spine
+          Notices = [] }
 
     /// The umbrella root scope (e.g. full-export's "pipeline") wraps the whole
     /// run; it is not a sub-stage the operator watches, so the board elides its
@@ -212,6 +226,17 @@ module Watch =
                     else
                         { board with Stages = board.Stages @ [ { Key = key; State = closed } ] }, Fold.Transitioned
             | _ -> board, Fold.NoChange
+        elif Set.contains code noticeCodes then
+            // A Warn ROLLUP envelope → the notice strip, replace-by-code (the
+            // 2-3 identical model reads of one publish fold to ONE row; the
+            // counts never double). A progressed fold: rendered promptly,
+            // never dwelled — it is a strip update, not an arc transition.
+            let replaced =
+                if board.Notices |> List.exists (fun (c, _) -> c = code) then
+                    board.Notices |> List.map (fun (c, p) -> if c = code then (c, payload) else (c, p))
+                else
+                    board.Notices @ [ (code, payload) ]
+            { board with Notices = replaced }, Fold.Progressed
         else board, Fold.NoChange
 
     /// Fold one envelope into the board as a plain did-it-change — the stored-run
@@ -374,6 +399,15 @@ module Watch =
     /// The stage line with no stall (the calm default — every existing caller / test).
     let lineText (line: StageLine) : string = lineTextWith false line
 
+    /// The operator line for a notice-strip row — the Voice statement for the
+    /// rollup code, with its action (the artifact pointer) appended when one
+    /// rides. Pure + voiced, so the strip is testable like the stage lines.
+    let noticeText (code: string) (payload: Map<string, objnull>) : string =
+        let statement = statementText code payload
+        match Voice.lookup code |> Option.bind (fun c -> c.Action payload) with
+        | Some (View.Action a) -> sprintf "%s %s" statement a
+        | _ -> statement
+
     /// The run's terminal stage — the last line on the board (the arc's final
     /// stage). `None` for an empty board. The done-frame's follow-on is keyed off
     /// it (§13 — "a finished change build offers the verify").
@@ -454,6 +488,12 @@ module Watch =
             | Some t -> [ Markup(Theme.muted (Markup.Escape t)) :> IRenderable ]
             | None   -> []
         let stageRows = board.Stages |> List.map (fun s -> Markup(rowMarkup phase stalled s) :> IRenderable)
+        // The notice strip (2026-07-02) — the rollup rows, muted with the warn
+        // glyph, between the arc and the done-frame: present, calm, never a wall.
+        let noticeRows =
+            board.Notices
+            |> List.map (fun (code, payload) ->
+                Markup(sprintf "%s  %s" (Theme.yellow Theme.warn) (Theme.muted (Markup.Escape(noticeText code payload)))) :> IRenderable)
         let doneRow =
             match doneFrameText board with
             | Some t ->
@@ -464,7 +504,7 @@ module Watch =
                     else Theme.ok, Theme.green
                 [ Markup(sprintf "%s  %s" glyph (paint (Markup.Escape t))) :> IRenderable ]
             | None   -> []
-        titleRow @ stageRows @ doneRow
+        titleRow @ stageRows @ noticeRows @ doneRow
 
     /// Project the board onto a Spectre renderable — the live target the
     /// `LiveDisplayContext` updates in place. A STATIC render (stored board, tests)
@@ -557,8 +597,18 @@ module Watch =
     /// JOIN `body` for its exit code — so the caller still sees one synchronous, deterministic
     /// call (`Live.Start` blocks here), which is why `WatchInjectionTests` can assert on the
     /// final board with the dwell pinned to 0.
-    let renderWatchOn (console: IAnsiConsole) (spine: RunSpine) (floorMs: int64) (body: unit -> int) : int =
-        let board = ref (seededOf spine)
+    /// The contained instrument box (2026-07-02, the operator-shell charter) —
+    /// the live target wraps in a rounded panel so every run presents as ONE
+    /// fixed-viewport box on the terminal. No alternate screen: the Live
+    /// region repaints in place and the final frame stays in scrollback (the
+    /// operator keeps the record after exit).
+    let private boxed (inner: IRenderable) : IRenderable =
+        let panel = Panel(inner)
+        panel.Border <- BoxBorder.Rounded
+        panel :> IRenderable
+
+    let renderWatchOn (console: IAnsiConsole) (seed: Board) (floorMs: int64) (body: unit -> int) : int =
+        let board = ref seed
         let header = cutoverHeader ()
         let sw = System.Diagnostics.Stopwatch.StartNew()
         let stallMs = resolveStallThresholdMs ()
@@ -581,7 +631,7 @@ module Watch =
         // House-NEW concurrency primitive (grep: the first BlockingCollection in src) — its
         // re-open is gated by the live board going off-thread (CLAUDE.md §7; DECISIONS 2026-06-19).
         let queue = new System.Collections.Concurrent.BlockingCollection<LogSink.Envelope>()
-        console.Live(toRenderableWith header 0 false board.Value).Start(fun ctx ->
+        console.Live(boxed (toRenderableWith header 0 false board.Value)).Start(fun ctx ->
             // Enqueue-and-return: the subscriber holds emit's lock only for the `Add`. A late
             // emit after `CompleteAdding` throws — swallowed; no such emit exists in practice
             // (the body's `withWriter` returns before the queue is completed). FORWARD NOTE:
@@ -607,7 +657,7 @@ module Watch =
                 let paint (stalled: bool) =
                     phase <- phase + 1
                     lastPaintAt <- sw.ElapsedMilliseconds
-                    ctx.UpdateTarget(toRenderableWith header phase stalled board.Value)
+                    ctx.UpdateTarget(boxed (toRenderableWith header phase stalled board.Value))
                     ctx.Refresh()
                 while draining do
                     let mutable env = Unchecked.defaultof<LogSink.Envelope>
@@ -672,13 +722,16 @@ module Watch =
         code
 
     /// Production wrapper — the live board on stderr (channel 2), mirroring
-    /// `TtyRenderer`'s console creation. Tests drive `renderWatchOn` with a
-    /// `Spectre.Console.Testing.TestConsole` to assert the board (and the
-    /// channel-1 suppression / prior-writer restoration) without a real TTY.
-    let renderWatch (spine: RunSpine) (floorMs: int64) (body: unit -> int) : int =
+    /// `TtyRenderer`'s console creation. Takes the SEED board (2026-07-02 —
+    /// the shell frames it with the run title before handing it over; a bare
+    /// `seededOf spine` renders the unframed arc exactly as before). Tests
+    /// drive `renderWatchOn` with a `Spectre.Console.Testing.TestConsole` to
+    /// assert the board (and the channel-1 suppression / prior-writer
+    /// restoration) without a real TTY.
+    let renderWatch (seed: Board) (floorMs: int64) (body: unit -> int) : int =
         // The live board only runs on a real terminal (`shouldWatch` gates on a
         // non-redirected stderr), so the factory pins no width here; it does honor
         // `NO_COLOR` / `CLICOLOR_FORCE` so a no-color operator watching a run gets
         // the plain board, the same as the verdict panel.
         let console = View.consoleTo Console.Error
-        renderWatchOn console spine floorMs body
+        renderWatchOn console seed floorMs body

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -387,17 +387,19 @@ module Deploy =
                     // without matched server capacity wastes
                     // connection-pool slots without throughput gain.
                     let clamped = max MinParallelism (min 8 clientCpus)
-                    eprintfn
-                        "deploy.detectParallelism: SQL Server DMV unavailable; falling back to Environment.ProcessorCount = %d (clamped to %d)"
-                        clientCpus clamped
+                    // Coded envelope, not raw stderr (2026-07-02) — a raw eprintfn
+                    // tears the live board's region; channel 1 carries the advisory.
+                    LogSink.emit
+                        (LogSink.envelope LogSink.Info LogSink.Deploy "deploy.parallelism.dmvUnavailable"
+                            (Map.ofList [ "clientCpus", box clientCpus; "resolved", box clamped ]))
                     Bench.recordSample "deploy.detectParallelism.clientCpus" (int64 clientCpus)
                     Bench.recordSample "deploy.detectParallelism.resolved" (int64 clamped)
                     return clamped
                 else
                     // Layer 3: static fallback (last resort).
-                    eprintfn
-                        "deploy.detectParallelism: both SQL Server DMV and Environment.ProcessorCount unavailable; falling back to %d"
-                        FallbackParallelism
+                    LogSink.emit
+                        (LogSink.envelope LogSink.Info LogSink.Deploy "deploy.parallelism.staticFallback"
+                            (Map.ofList [ "resolved", box FallbackParallelism ]))
                     Bench.recordSample "deploy.detectParallelism.resolved" (int64 FallbackParallelism)
                     return FallbackParallelism
         }
@@ -424,9 +426,9 @@ module Deploy =
                     Bench.recordSample "deploy.resolveParallelism.envOverride" (int64 n)
                     return n
                 | _ ->
-                    eprintfn
-                        "PROJECTION_DEPLOY_PARALLELISM='%s' is not a positive integer; auto-detecting"
-                        s
+                    LogSink.emit
+                        (LogSink.envelope LogSink.Warn LogSink.Deploy "deploy.parallelism.envOverrideMalformed"
+                            (Map.ofList [ "value", box s ]))
                     match parallelismCache.TryGetValue connectionString with
                     | true, cached -> return cached
                     | false, _ ->
@@ -480,9 +482,9 @@ module Deploy =
             // Halve to leave headroom for concurrent connections.
             let safeCeil = max 1 (maxPool / 2)
             if requested > safeCeil then
-                eprintfn
-                    "deploy.executeBatchParallel: requested parallelism %d exceeds half of MaxPoolSize %d; capping to %d"
-                    requested maxPool safeCeil
+                LogSink.emit
+                    (LogSink.envelope LogSink.Info LogSink.Deploy "deploy.parallelism.poolCapped"
+                        (Map.ofList [ "requested", box requested; "maxPoolSize", box maxPool; "capped", box safeCeil ]))
                 safeCeil
             else
                 requested
@@ -808,11 +810,10 @@ module Deploy =
                 let codes =
                     errors
                     |> List.map (fun e -> e.Code)
-                    |> String.concat ", "  // LINT-ALLOW: terminal stderr-emission boundary; typed code list joined for human-readable warning
-                eprintfn
-                    "  WARNING: %s is set but malformed (%s); falling back to ephemeral container."
-                    WarmConnStringEnvVar
-                    codes
+                    |> String.concat ", "  // LINT-ALLOW: typed code list joined for the envelope payload
+                LogSink.emit
+                    (LogSink.envelope LogSink.Warn LogSink.Deploy "deploy.warmConnMalformed"
+                        (Map.ofList [ "envVar", box WarmConnStringEnvVar; "codes", box codes ]))
                 None
 
     /// Run `body` with a master connection string sourced from either

--- a/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
@@ -20,6 +20,83 @@ open Projection.Adapters.OssysSql
 [<RequireQualifiedAccess>]
 module LiveModelRead =
 
+    /// The rollup envelope's code — the ONE Warn line a model read's divergence
+    /// notices condense to on channel 1 (and the live board's notice strip).
+    [<Literal>]
+    let noticeRollupCode : string = "adapter.ossys.modelRead.noticeRollup"
+
+    let private severityText (s: DiagnosticSeverity) : string =
+        match s with
+        | DiagnosticSeverity.Info    -> "info"
+        | DiagnosticSeverity.Warning -> "warning"
+        | DiagnosticSeverity.Error   -> "error"
+
+    let private toNotice (d: DiagnosticEntry) : NoticeSink.Notice =
+        { Code = d.Code; Severity = severityText d.Severity; Message = d.Message; Metadata = d.Metadata }
+
+    /// How many underlying FACTS a divergence entry stands for. The nullability
+    /// entry is already producer-aggregated (one entry carrying `count` columns
+    /// in its metadata); every other entry names one concrete divergence.
+    let private factCount (d: DiagnosticEntry) : int =
+        match Map.tryFind "count" d.Metadata with
+        | Some c ->
+            match System.Int32.TryParse c with
+            | true, n when n > 0 -> n
+            | _ -> 1
+        | None -> 1
+
+    /// The rollup payload over a read's divergence entries — pure, so the
+    /// constant-size law ("one calm line whether 3 or 3,000 diverge") is
+    /// testable without a connection or a console. Family counts are FACT
+    /// counts: 180 nullability-divergent columns count as 180, not as the one
+    /// producer-aggregated entry that carries them.
+    let noticeRollup (artifactPath: string) (entries: DiagnosticEntry list) : Map<string, objnull> =
+        let familyOf (d: DiagnosticEntry) : string =
+            if d.Code.EndsWith ".nullabilityDivergence" then "nullability"
+            elif d.Code.EndsWith ".identityDivergence" then "identity"
+            elif d.Code.StartsWith "adapter.ossys.primaryKey" then "primaryKey"
+            else "other"
+        let counts =
+            entries
+            |> List.groupBy familyOf
+            |> List.map (fun (family, ds) -> family, ds |> List.sumBy factCount)
+        let total = counts |> List.sumBy snd
+        let samples = entries |> List.truncate 3 |> List.map (fun d -> d.Message)
+        Map.ofList
+            ([ "total",        box total
+               "artifactPath", box artifactPath
+               "samples",      box (String.concat " | " samples) ]
+             @ (counts |> List.map (fun (family, n) -> family, box n)))
+
+    /// Surface a model read's divergence entries (F9 — never silently
+    /// discarded; and since 2026-07-02 never a per-item stderr wall over the
+    /// live board either): each entry rides channel 1 at Debug (visible under
+    /// `-v`/`--debug`), the full detail lands in the run's notice artifact
+    /// (`notices/model-read/<runId>.json`, merge-deduped across the run's 2-3
+    /// read legs), and ONE Warn rollup envelope names the counts + the path.
+    let private surfaceDivergences (entries: DiagnosticEntry list) : unit =
+        if not (List.isEmpty entries) then
+            for d in entries do
+                let payload : Map<string, objnull> =
+                    Map.ofList
+                        ([ "message", box d.Message ]
+                         @ (d.Metadata |> Map.toList |> List.map (fun (k, v) -> k, box v)))
+                LogSink.emit (LogSink.envelope LogSink.Debug LogSink.Extract d.Code payload)
+            let artifactPath =
+                NoticeSink.runPath (System.IO.Directory.GetCurrentDirectory()) "model-read" (LogSink.runId ())
+            let persisted =
+                try
+                    NoticeSink.append artifactPath (entries |> List.map toNotice) |> ignore
+                    LogSink.recordArtifact { Kind = "notices"; Path = artifactPath; SizeBytes = None; FileCount = None }
+                    true
+                with ex ->
+                    // LINT-ALLOW: last-resort stderr — the notice SINK itself
+                    // failed, so this warning cannot ride the artifact it is about.
+                    eprintfn "  WARNING: failed to persist the notice artifact: %s" ex.Message
+                    false
+            let path = if persisted then artifactPath else ""
+            LogSink.emit (LogSink.envelope LogSink.Warn LogSink.Extract noticeRollupCode (noticeRollup path entries))
+
     /// Read the model from an already-open OSSYS connection under the
     /// supplied scope parameters: snapshot → bundle → Catalog (native
     /// SsKey). Reconciliation slice 4 (DECISIONS 2026-06-13) — the
@@ -37,19 +114,15 @@ module LiveModelRead =
                 // F9 (audit 2026-06-17) — surface, never silently discard, every
                 // logical-vs-deployed `#ColumnReality` divergence the snapshot
                 // carries (the adapter keeps the LOGICAL value; the operator is
-                // told so they can confirm which source is authoritative). The
-                // carried value is unchanged — diagnostic only, no auto-resolve.
-                for d in MetadataSnapshotRunner.columnRealityDivergences snapshot do
-                    // LINT-ALLOW: operator-facing boundary warning (channel 2),
-                    // sibling to the tightening-relax acknowledgment.
-                    eprintfn "%s: %s" d.Code d.Message
-                // PK identity carries twice in OSSYS (attribute flag +
-                // entity key); the reader recovers from a missing flag via
-                // the entity key but never resolves a contradiction — that
-                // is named here.
-                for d in MetadataSnapshotRunner.primaryKeyDivergences snapshot do
-                    // LINT-ALLOW: operator-facing boundary warning (channel 2).
-                    eprintfn "%s: %s" d.Code d.Message
+                // told so they can confirm which source is authoritative), and
+                // every attribute-flag-vs-entity-key primary-key contradiction.
+                // The carried value is unchanged — diagnostic only, no
+                // auto-resolve. Since 2026-07-02 the surface is the notice
+                // rollup (one Warn envelope + the detail artifact), never a
+                // per-item stderr wall fighting the live board.
+                surfaceDivergences
+                    (MetadataSnapshotRunner.columnRealityDivergences snapshot
+                     @ MetadataSnapshotRunner.primaryKeyDivergences snapshot)
                 let bundle = MetadataSnapshotRunner.toBundle snapshot
                 // Slice 4 — under a pushed scope, prune reference rows
                 // whose target entity the server-side narrowing excluded

--- a/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
@@ -108,7 +108,22 @@ module LiveModelRead =
         (cnn: SqlConnection)
         : Task<Result<Catalog>> =
         task {
-            match! MetadataSnapshotRunner.runAsync cnn parameters with
+            // #19-lite (2026-07-02) — the extract leg reports per-rowset
+            // progress through the matrix-row-36 seam (`OnRowsetComplete`),
+            // so a live board's extract line counts up (`n of 23`) instead of
+            // sitting frozen through a long OSSYS read. The callback only
+            // emits an envelope — no sleep, no render (the board's drain loop
+            // owns pacing).
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let options =
+                { MetadataSnapshotRunner.defaultOptions with
+                    OnRowsetComplete =
+                        fun obs ->
+                            LogSink.recordStageProgress "extract"
+                                (obs.ResultSetIndex + 1)
+                                MetadataSnapshotRunner.ExpectedResultSets
+                                sw.ElapsedMilliseconds }
+            match! MetadataSnapshotRunner.runAsyncWithOptions cnn parameters options with
             | Error es -> return Result.failure es
             | Ok snapshot ->
                 // F9 (audit 2026-06-17) — surface, never silently discard, every

--- a/sidecar/projection/src/Projection.Pipeline/LogSink.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LogSink.fs
@@ -433,6 +433,12 @@ module LogSink =
     let clearSubscribers () : unit =
         lock lockObj (fun () -> subscribers.Clear())
 
+    /// How many subscribers are attached — the executable witness for the
+    /// renderer-teardown law (`renderWatchOn` detaches on EVERY exit path);
+    /// no production consumer, read by the teardown tests only.
+    let subscriberCount () : int =
+        lock lockObj (fun () -> subscribers.Count)
+
     /// Deliver one envelope to every subscriber, in registration order.
     /// PRECONDITION: the caller holds `lockObj` — only `emit` / `runComplete`
     /// call this, both already inside the lock (`Monitor` is reentrant). The
@@ -632,7 +638,13 @@ module LogSink =
                 ()
             else
                 updateAccumulator env
-                writer.Value.WriteLine(serializeEnvelope env)
+                // #20 rework — under a nulled channel 1 (the live board's span, the
+                // `--pretty` bracket) serialization is skipped: the null writer would
+                // discard the line anyway, and serializing every envelope under the
+                // global lock taxed the emitting (pipeline) thread for nothing. The
+                // accumulator and the subscribers still see every envelope.
+                if not (System.Object.ReferenceEquals(writer.Value, TextWriter.Null)) then
+                    writer.Value.WriteLine(serializeEnvelope env)
                 // Channel 2 sees exactly what channel 1 wrote, in order.
                 notifySubscribers env)
 
@@ -689,7 +701,9 @@ module LogSink =
     /// (`done` of `total`, with the elapsed time so the live board can compute an
     /// honest estimate, §13). A mid-stage event between `<stage>.started` and the
     /// `summary.stageCompleted`; producers call it from their write loops at a
-    /// modest cadence (the board coalesces, the dwell floor paces the frames).
+    /// modest cadence (the board coalesces queued progress into one frame; the
+    /// dwell floor paces stage TRANSITIONS only, so a fast producer never builds
+    /// a render backlog).
     let recordStageProgress (stage: string) (doneCount: int) (total: int) (elapsedMs: int64) : unit =
         let payload : Map<string, objnull> =
             Map.ofList [
@@ -1070,7 +1084,10 @@ module LogSink =
             match s.EventCounts.TryGetValue Info with
             | true, n -> s.EventCounts.[Info] <- n + 1
             | false, _ -> s.EventCounts.[Info] <- 1
-            writer.Value.WriteLine(serializeEnvelope env)
+            // Same null-writer skip as `emit` (#20 rework) — the terminal envelope
+            // still reaches the accumulator above and the subscribers below.
+            if not (System.Object.ReferenceEquals(writer.Value, TextWriter.Null)) then
+                writer.Value.WriteLine(serializeEnvelope env)
             // The terminal envelope reaches subscribers too — the "watch"
             // renderer draws its final verdict panel off this event.
             notifySubscribers env

--- a/sidecar/projection/src/Projection.Pipeline/NoticeSink.fs
+++ b/sidecar/projection/src/Projection.Pipeline/NoticeSink.fs
@@ -1,0 +1,73 @@
+namespace Projection.Pipeline
+
+open System.IO
+open System.Text.Json
+
+/// File-system sink for operator **notice detail** — the constant-size answer
+/// to the notice-flood failure mode (2026-07-02; the F9 surface-never-discard
+/// law kept, the per-item stderr flood retired). The screen carries ONE Warn
+/// rollup envelope (count + families + first samples); the full per-item
+/// detail lands here as the run's notice artifact, addressed like the bench
+/// snapshot (R1c — keyed by the run that produced it):
+///
+///     notices/<tag>/<runId>.json
+///
+/// The rollup envelope and the board's done-frame name this path, so the
+/// operator can always reach ALL of it — never a silent cap.
+[<RequireQualifiedAccess>]
+module NoticeSink =
+
+    /// One surfaced notice — the operator-relevant projection of a
+    /// `DiagnosticEntry` (source elided: the tag names the producing surface).
+    type Notice =
+        {
+            Code     : string
+            Severity : string
+            Message  : string
+            Metadata : Map<string, string>
+        }
+
+    /// Subdirectory under `rootDir` collecting notice artifacts.
+    [<Literal>]
+    let private NoticeSubdirectory : string = "notices"
+
+    [<Literal>]
+    let private ArtifactExtension : string = ".json"
+
+    /// Compose the per-run `notices/<tag>/<runId>.json` path under `rootDir`.
+    let runPath (rootDir: string) (tag: string) (runId: string) : string =
+        Path.Combine(rootDir, NoticeSubdirectory, tag, runId + ArtifactExtension)  // LINT-ALLOW: terminal filesystem path; runId is the LogSink-minted ULID
+
+    let private jsonOptions : JsonSerializerOptions =
+        JsonSerializerOptions(WriteIndented = true)
+
+    /// The lock serializing read-modify-write appends. Appenders today are
+    /// sequential (the 2-3 model-read legs of one publish run); the lock is
+    /// insurance for the concurrent realization stream the live board's
+    /// off-thread move anticipates.
+    let private appendLock = obj ()
+
+    /// Append `notices` to the artifact at `path`, creating it (and its
+    /// directory) on first write. Appends MERGE-DEDUPE on full notice
+    /// equality: a publish run reads the same model 2-3 times (extract +
+    /// store leg + load leg), and repeating identical facts per leg would
+    /// misstate the estate's notice count.
+    let append (path: string) (notices: Notice list) : Notice list =
+        lock appendLock (fun () ->
+            let existing : Notice list =
+                if File.Exists path then
+                    try
+                        match JsonSerializer.Deserialize<Notice list>(File.ReadAllText path, jsonOptions) with
+                        | null -> []
+                        | notices -> notices
+                    with _ -> []
+                else []
+            let merged =
+                (existing @ notices)
+                |> List.distinct
+            match Path.GetDirectoryName path with
+            | null -> ()
+            | dir when System.String.IsNullOrEmpty dir -> ()
+            | dir -> Directory.CreateDirectory dir |> ignore
+            File.WriteAllText(path, JsonSerializer.Serialize(merged, jsonOptions))
+            merged)

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -2689,6 +2689,32 @@ module Compose =
     /// displacement, or a non-monotone record surface as `Error` on the run,
     /// *after* the bundle has landed (the operator knows the emission succeeded
     /// but provenance did not).
+    /// Bracket a post-root publish leg (`store` / `seed-load`) in the stage
+    /// wire events (2026-07-02 — the legs join the declared publish spine so
+    /// the live board covers the whole run). Same wire shape as
+    /// `Staged.stage`: `<key>.started` → `summary.stageCompleted` with
+    /// `succeeded`/`failed` off the Result and `aborted` on a throw — the
+    /// board's line always closes, never a hang. The legs run AFTER the
+    /// pipeline CE's root scope closed, so they bracket via the primitives
+    /// rather than inside the CE (the umbrella brackets the emission arc).
+    let private stagedLeg (key: string) (body: unit -> Task<Result<'a>>) : Task<Result<'a>> =
+        task {
+            LogSink.recordStageStart key
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            try
+                let! result = body ()
+                sw.Stop()
+                match result with
+                | Ok _    -> LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Succeeded
+                | Error _ -> LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Failed
+                return result
+            with ex ->
+                sw.Stop()
+                LogSink.recordStageEvent key sw.ElapsedMilliseconds LogSink.Aborted
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw()
+                return Unchecked.defaultof<_>
+        }
+
     let runWithConfigAndStore
         (cfg: Config.Config)
         (storePath: string option)
@@ -2700,12 +2726,26 @@ module Compose =
             // PL-1 — one estate acquisition: the store leg consumes the
             // publish's own read catalog instead of re-extracting the model.
             let! acquiredR = runWithConfigAcquiring cfg
-            return
-                match acquiredR with
-                | Error errors -> Result.failure errors
-                | Ok (report, acquired) ->
-                    storeLegFromAcquisition cfg acquired storePath timeline environment at report.Manifest.AppliedTransforms
-                    |> Result.map (fun legOpt -> report, legOpt)
+            match acquiredR with
+            | Error errors -> return Result.failure errors
+            | Ok (report, acquired) ->
+                match storePath with
+                | Some p when not (System.String.IsNullOrWhiteSpace p) ->
+                    // The store leg is a declared stage on the publish spine
+                    // (`Spines.publishWith true …`) — bracketed so the board's
+                    // store line opens, works, and closes honestly.
+                    let! legR =
+                        stagedLeg (StageName.value Stages.store) (fun () ->
+                            Task.FromResult
+                                (storeLegFromAcquisition cfg acquired storePath timeline environment at report.Manifest.AppliedTransforms))
+                    return legR |> Result.map (fun legOpt -> report, legOpt)
+                | _ ->
+                    // No store — the genesis emission; no store stage was
+                    // seeded (dispatch chose the bare pipeline spine), so no
+                    // bracket fires.
+                    return
+                        storeLegFromAcquisition cfg acquired storePath timeline environment at report.Manifest.AppliedTransforms
+                        |> Result.map (fun legOpt -> report, legOpt)
         }
 
     /// AC-X1 (part B) — the **live data-load leg core**: load the idempotent
@@ -2879,6 +2919,12 @@ module Compose =
             match acquiredR with
             | Error errors -> return Result.failure errors
             | Ok (report, acquired) ->
-                let! loadResult = loadFromAcquisition cdcCaptureTotal executeLeveled cfg acquired sink storePath timeline environment at
+                // The seed-load leg is a declared stage on the publish-and-load
+                // spine (`Spines.publishWith … true`, 2026-07-02) — bracketed so
+                // the board covers the potentially-longest leg of the run (the
+                // episode record, when a store rides, happens INSIDE this leg).
+                let! loadResult =
+                    stagedLeg (StageName.value Stages.seedLoad) (fun () ->
+                        loadFromAcquisition cdcCaptureTotal executeLeveled cfg acquired sink storePath timeline environment at)
                 return loadResult |> Result.map (fun (leg, cdcDelta) -> report, leg, cdcDelta)
         }

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="RunLedger.fs" />
     <Compile Include="Run.fs" />
     <Compile Include="ConnectionSpec.fs" />
+    <Compile Include="NoticeSink.fs" />
     <Compile Include="LiveModelRead.fs" />
     <Compile Include="Source.fs" />
     <Compile Include="Ref.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RunSpine.fs
@@ -393,6 +393,15 @@ module Stages =
     let deploy    : StageName = name "deploy"
     let canary    : StageName = name "canary"
     let load      : StageName = name "load"
+    /// The publish store leg (diff-vs-prior + the episode record) — a declared
+    /// post-root stage (2026-07-02) so the live board covers the WHOLE publish
+    /// run: before this, the board hit its done-frame while the store leg was
+    /// still working.
+    let store     : StageName = name "store"
+    /// The publish-and-load seed leg — a distinct key from the transfer
+    /// `load` (its Voice gerund speaks the idempotent-seed act, not the
+    /// transfer's row movement).
+    let seedLoad  : StageName = name "seed-load"
 
 /// The declared spines — one definition site per run face's arc (the
 /// per-face display string lists retire onto these; the Watch pre-seeds
@@ -403,6 +412,18 @@ module Spines =
     /// `full-export`: the "pipeline" umbrella over extract → profile → emit.
     let pipeline : RunSpine =
         RunSpine.createWithRoot Stages.pipeline [ Stages.extract; Stages.profile; Stages.emit ]
+        |> Result.value
+
+    /// The publish arcs — `pipeline` plus the store leg (when a lifecycle
+    /// store is supplied) and the seed-load leg (publish-and-load). Chosen at
+    /// DISPATCH, never as an optional seeded stage: the board's done-frame
+    /// waits for every seeded stage to close, so a seeded-but-skipped stage
+    /// would hold it back forever (2026-07-02).
+    let publishWith (store: bool) (load: bool) : RunSpine =
+        RunSpine.createWithRoot Stages.pipeline
+            ([ Stages.extract; Stages.profile; Stages.emit ]
+             @ (if store then [ Stages.store ] else [])
+             @ (if load then [ Stages.seedLoad ] else []))
         |> Result.value
 
     /// The in-place migrate leg: build → safety gates → apply → verify.

--- a/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
@@ -400,3 +400,87 @@ let ``NM-33: the recorded episode carries the run's AppliedTransforms (withProve
             leg.Manifest.AppliedTransforms, recorded.AppliedTransforms)
     finally
         safeRm outDir; safeDel cfg; safeDel store; safeDel modelPath
+
+// ===========================================================================
+// The publish spine (2026-07-02) — the store leg is a DECLARED stage, so the
+// live board covers the whole run (before this, the board hit its done-frame
+// while the store leg was still working). Wire assertions ride the same
+// harness; the board law is R1e — the stored stream reconstructs the same
+// terminal board the live subscriber built.
+// ===========================================================================
+
+let private captureEnvelopes (body: unit -> unit) : string list =
+    let sw = new StringWriter()
+    LogSink.withWriter sw (fun () -> body ())
+    sw.ToString().Split([| '\n'; '\r' |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.toList
+
+[<Fact>]
+let ``publish spine: a store-bearing run brackets the store leg on the wire, after the emission arc`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outDir = tempOutputDir ()
+    let cfg = writeTempConfig modelPath outDir
+    let store = tempStorePath ()
+    try
+        let at = DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)
+        let mutable outcome = FullExportRun.RunOutcome.Aborted (exn "unset")
+        let lines =
+            captureEnvelopes (fun () ->
+                let o, _ =
+                    FullExportRun.executeWithStore
+                        cfg None LogSink.Verbosity.Quiet Set.empty (Some store) tl Environment.Dev at
+                outcome <- o)
+        (match outcome with
+         | FullExportRun.RunOutcome.Succeeded _ -> ()
+         | other -> Assert.Fail(sprintf "expected Succeeded, got %A" other))
+        let idxOf (needle: string) =
+            match lines |> List.tryFindIndex (fun l -> l.Contains needle) with
+            | Some i -> i
+            | None -> Assert.Fail(sprintf "no envelope line contains %s" needle); -1
+        // the store leg opens AFTER the emission arc closed (a post-root stage)
+        Assert.True(idxOf "\"store.started\"" > idxOf "\"emit.started\"")
+        // and it CLOSES — the summary.stageCompleted for the store stage rides
+        Assert.True(lines |> List.exists (fun l -> l.Contains "summary.stageCompleted" && l.Contains "\"store\""))
+
+        // R1e — the stored stream, seeded from the store-bearing publish spine,
+        // reconstructs a TERMINAL board: every seeded line (extract, profile,
+        // emit, store) closed. This is the exact projection the live board folds.
+        let board =
+            Projection.Cli.Watch.boardOfStored
+                (Projection.Cli.Watch.seededOf (Spines.publishWith true false))
+                lines
+        Assert.True(Projection.Cli.Watch.isTerminal board, "the store-bearing spine must close every seeded line")
+    finally
+        safeRm outDir; safeDel cfg; safeDel store; safeDel modelPath
+
+[<Fact>]
+let ``publish spine: a store-less run emits NO store stage events — the bare pipeline spine stays byte-identical`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outDir = tempOutputDir ()
+    let cfg = writeTempConfig modelPath outDir
+    try
+        let at = DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)
+        let lines =
+            captureEnvelopes (fun () ->
+                FullExportRun.executeWithStore
+                    cfg None LogSink.Verbosity.Quiet Set.empty None tl Environment.Dev at
+                |> ignore)
+        Assert.False(lines |> List.exists (fun l -> l.Contains "store.started"))
+        // the bare spine still reaches terminal off the same stream
+        let board =
+            Projection.Cli.Watch.boardOfStored
+                (Projection.Cli.Watch.seededOf (Spines.publishWith false false))
+                lines
+        Assert.True(Projection.Cli.Watch.isTerminal board)
+    finally
+        safeRm outDir; safeDel cfg; safeDel modelPath
+
+[<Fact>]
+let ``publish spine: publishWith declares the dispatch-selected arcs — bare, store, load, both`` () =
+    let keys (spine: RunSpine) = RunSpine.keys spine
+    Assert.Equal<string list>([ "extract"; "profile"; "emit" ], keys (Spines.publishWith false false))
+    Assert.Equal<string list>([ "extract"; "profile"; "emit"; "store" ], keys (Spines.publishWith true false))
+    Assert.Equal<string list>([ "extract"; "profile"; "emit"; "seed-load" ], keys (Spines.publishWith false true))
+    Assert.Equal<string list>([ "extract"; "profile"; "emit"; "store"; "seed-load" ], keys (Spines.publishWith true true))
+    // the umbrella root stays the pipeline (never a watched line)
+    Assert.Equal(Some "pipeline", RunSpine.rootKey (Spines.publishWith true true))

--- a/sidecar/projection/tests/Projection.Tests/LogSinkSubscriberTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LogSinkSubscriberTests.fs
@@ -103,3 +103,22 @@ let ``clearSubscribers: detaches — no delivery after clear`` () =
         Assert.Equal<string list>([ "config.runStart" ], codesOf (List.ofSeq received))
     finally
         LogSink.clearSubscribers ()
+
+[<Fact>]
+let ``emit under a Null writer still notifies subscribers and counts transforms (#20 rework)`` () =
+    // The serialization skip for a nulled channel 1 (the live board's span) must
+    // not change WHAT flows: the accumulator counters and the subscribers see
+    // every visible envelope — only the wasted NDJSON serialization is skipped.
+    LogSink.reset ()
+    LogSink.clearSubscribers ()
+    let received = ResizeArray<LogSink.Envelope>()
+    LogSink.addSubscriber (fun e -> received.Add e)
+    try
+        LogSink.withWriter TextWriter.Null (fun () ->
+            LogSink.emit (info LogSink.Transform "transform.applied")
+            LogSink.emit (info LogSink.Extract "extract.started"))
+        Assert.Equal<string list>([ "transform.applied"; "extract.started" ], codesOf (List.ofSeq received))
+        let _, applied, _ = LogSink.transformCounts ()
+        Assert.Equal(1, applied)
+    finally
+        LogSink.clearSubscribers ()

--- a/sidecar/projection/tests/Projection.Tests/NoticeRoutingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NoticeRoutingTests.fs
@@ -1,0 +1,129 @@
+[<Xunit.Collection("Global-MutableState")>]
+module Projection.Tests.NoticeRoutingTests
+
+open System
+open System.IO
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+/// The notice-flood remediation (2026-07-02): a model read's divergence notices
+/// condense to ONE Warn rollup envelope + a detail artifact (`NoticeSink`),
+/// with the per-item entries riding channel 1 at Debug — the F9
+/// surface-never-discard law kept, the per-item stderr wall retired. These
+/// tests pin the pure rollup payload, the sink's merge-dedupe append, and the
+/// verbosity split (per-item hidden under Quiet; the rollup always visible).
+
+let private entry code (metadata: (string * string) list) : DiagnosticEntry =
+    { DiagnosticEntry.create "adapter:OSSYS" DiagnosticSeverity.Warning code (code + " message")
+        with Metadata = Map.ofList metadata }
+
+// ---------------------------------------------------------------------------
+// the pure rollup payload (the §12 constant-size law)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``noticeRollup counts FACTS per family — the aggregated nullability entry counts its columns`` () =
+    let entries =
+        [ entry "adapter.ossys.columnReality.nullabilityDivergence" [ "count", "180" ]
+          entry "adapter.ossys.columnReality.identityDivergence" []
+          entry "adapter.ossys.columnReality.identityDivergence" []
+          entry "adapter.ossys.primaryKey.divergence" [] ]
+    let payload = LiveModelRead.noticeRollup "notices/model-read/r1.json" entries
+    Assert.Equal(box 183, payload.["total"])
+    Assert.Equal(box 180, payload.["nullability"])
+    Assert.Equal(box 2,   payload.["identity"])
+    Assert.Equal(box 1,   payload.["primaryKey"])
+    Assert.Equal(box "notices/model-read/r1.json", payload.["artifactPath"])
+
+[<Fact>]
+let ``noticeRollup samples the first three messages only — the surface is a constant size`` () =
+    let entries = [ for i in 1 .. 40 -> entry "adapter.ossys.columnReality.identityDivergence" [ "n", string i ] ]
+    let payload = LiveModelRead.noticeRollup "p.json" entries
+    let samples = string payload.["samples"]
+    // three samples joined by the separator — two separators, never forty
+    Assert.Equal(2, samples.Split(" | ").Length - 1)
+    Assert.Equal(box 40, payload.["total"])
+
+[<Fact>]
+let ``noticeRollup names an unrecognized family honestly as other`` () =
+    let payload = LiveModelRead.noticeRollup "p.json" [ entry "adapter.ossys.somethingNew" [] ]
+    Assert.Equal(box 1, payload.["other"])
+
+// ---------------------------------------------------------------------------
+// the notice artifact (NoticeSink — merge-deduped across a run's read legs)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``NoticeSink.append round-trips notices and dedupes identical re-reads`` () =
+    let dir = Path.Combine(Path.GetTempPath(), "proj-notices-" + Guid.NewGuid().ToString("N"))
+    try
+        let path = NoticeSink.runPath dir "model-read" "01RUN"
+        let notices : NoticeSink.Notice list =
+            [ { Code = "a.code"; Severity = "warning"; Message = "m1"; Metadata = Map.ofList [ "k", "v" ] }
+              { Code = "b.code"; Severity = "info";    Message = "m2"; Metadata = Map.empty } ]
+        let first = NoticeSink.append path notices
+        // a publish run re-reads the model for the store/load legs — identical
+        // facts must not double the artifact
+        let second = NoticeSink.append path notices
+        let third = NoticeSink.append path [ { Code = "c.code"; Severity = "warning"; Message = "m3"; Metadata = Map.empty } ]
+        Assert.Equal(2, List.length first)
+        Assert.Equal(2, List.length second)
+        Assert.Equal(3, List.length third)
+        Assert.True(File.Exists path)
+    finally
+        (try Directory.Delete(dir, true) with _ -> ())
+
+[<Fact>]
+let ``NoticeSink.runPath addresses the artifact by run — notices slash tag slash runId`` () =
+    let path = NoticeSink.runPath "/root" "model-read" "01RUN"
+    Assert.Equal(Path.Combine("/root", "notices", "model-read", "01RUN.json"), path)
+
+// ---------------------------------------------------------------------------
+// the verbosity split (per-item Debug hidden under Quiet; rollup Warn visible)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``per-item divergence envelopes are Debug — hidden under Quiet, visible under Verbose; the Warn rollup always rides`` () =
+    LogSink.reset ()
+    LogSink.clearSubscribers ()
+    use quiet = new StringWriter()
+    LogSink.withWriter quiet (fun () ->
+        LogSink.emit (LogSink.envelope LogSink.Debug LogSink.Extract "adapter.ossys.columnReality.identityDivergence" Map.empty)
+        LogSink.emit (LogSink.envelope LogSink.Warn LogSink.Extract LiveModelRead.noticeRollupCode Map.empty))
+    Assert.DoesNotContain("identityDivergence", quiet.ToString())
+    Assert.Contains(LiveModelRead.noticeRollupCode, quiet.ToString())
+    LogSink.reset ()
+    LogSink.setVerbosity LogSink.Verbosity.Verbose
+    use verbose = new StringWriter()
+    try
+        LogSink.withWriter verbose (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Debug LogSink.Extract "adapter.ossys.columnReality.identityDivergence" Map.empty))
+        Assert.Contains("identityDivergence", verbose.ToString())
+    finally
+        LogSink.reset ()
+
+// ---------------------------------------------------------------------------
+// the voiced rollup line (the copy the board's notice strip renders)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``the rollup copy reads as one calm line naming families, and points at the artifact`` () =
+    match Projection.Cli.Voice.lookup LiveModelRead.noticeRollupCode with
+    | None -> Assert.Fail "the rollup code must be voiced"
+    | Some copy ->
+        let payload : Map<string, objnull> =
+            Map.ofList
+                [ "total",        box 214
+                  "nullability",  box 180
+                  "identity",     box 34
+                  "artifactPath", box "notices/model-read/01RUN.json" ]
+        match copy.Statement payload with
+        | Projection.Cli.View.Note t ->
+            Assert.Contains("214", t)
+            Assert.Contains("nullability 180", t)
+            Assert.Contains("identity 34", t)
+        | other -> Assert.Fail(sprintf "expected a Note statement, got %A" other)
+        match copy.Action payload with
+        | Some (Projection.Cli.View.Action a) -> Assert.Contains("notices/model-read/01RUN.json", a)
+        | other -> Assert.Fail(sprintf "expected an artifact-pointing action, got %A" other)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -31,6 +31,7 @@
     <Compile Include="CapabilityRefusalTests.fs" />
     <Compile Include="LogSinkTests.fs" />
     <Compile Include="LogSinkSubscriberTests.fs" />
+    <Compile Include="NoticeRoutingTests.fs" />
     <Compile Include="RunSpineTests.fs" />
     <Compile Include="StagedTests.fs" />
     <Compile Include="RunLedgerTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="RelaxationStoreTests.fs" />
     <Compile Include="VoiceTotalityTests.fs" />
     <Compile Include="WatchTests.fs" />
+    <Compile Include="ShellTests.fs" />
     <Compile Include="WatchInjectionTests.fs" />
     <Compile Include="CapabilitySurveyTests.fs" />
     <Compile Include="CapabilitySurveyTotalityTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -53,7 +53,7 @@ let ``reverse-leg face: a MALFORMED reconcile spec refuses by name (arg error, e
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "Customer" ] None   // no ':' — transfer.reconcile.specShape
-            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural []
+            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 
 [<Fact>]
@@ -65,7 +65,7 @@ let ``reverse-leg face: a reconcile spec naming an unknown table refuses by name
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "OSUSR_NOPE:ID" ] None   // table not in the contract — transfer.reconcile.tableNotFound
-            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural []
+            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 
 [<Fact>]
@@ -77,7 +77,7 @@ let ``reverse-leg face: a WELL-FORMED resolvable reconcile spec is ACCEPTED (no 
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [ "OSUSR_B_CUSTOMER:ID" ] None   // resolves to MatchByColumn (Id)
-            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural []
+            false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     // Past the parse/resolve gate the run reaches connection-opening, which
     // fails on the unset env vars — a connection-class exit, NEVER the arg/
     // resolve exit 2. The point: reconcile is no longer refused at the face.
@@ -196,7 +196,7 @@ let ``streaming face: an explicit --streaming with --tables refuses at the face 
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
             [] None
-            false true false EmissionMode.Incremental false true None [ "Customer" ] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural []
+            false true false EmissionMode.Incremental false true None [ "Customer" ] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 
 // -- reserved follow-on contracts (Skip stubs with promotion triggers) --------

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -246,3 +246,31 @@ let ``flow menu: the view renders as a table and its toJson carries every flow (
     let json = (View.toJson view).ToJsonString()
     Assert.Contains("publish", json)
     Assert.Contains("local", json)
+
+[<Fact>]
+let ``echo-the-fix: a suggestedConfig-bearing envelope ticks the board's live teaser (#6)`` () =
+    let payload : Map<string, objnull> =
+        Map.ofList [ "suggestedConfig", box (Map.ofList [ "path", box "$.profiling.samplingCap" ] : Map<string, objnull>) ]
+    let b1, f1 = Watch.applyKind Watch.empty "transform.diagnostic" payload
+    Assert.Equal(Watch.Fold.Progressed, f1)
+    Assert.Equal(1, b1.SuggestedEdits)
+    let b2, _ = Watch.applyKind b1 "transform.diagnostic" payload
+    Assert.Equal(2, b2.SuggestedEdits)
+    // the teaser renders through the catalog (one register)
+    let console = new TestConsole()
+    console.Write(Watch.toRenderableWith [] 0 false b2)
+    Assert.Contains("2 config edit(s) suggested", console.Output)
+
+[<Fact>]
+let ``stat view: the aggregates table names category, code, and count, most-frequent first`` () =
+    LogSink.reset ()
+    LogSink.withWriter TextWriter.Null (fun () ->
+        for _ in 1 .. 3 do LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "transform.applied" Map.empty)
+        LogSink.emit (LogSink.envelope LogSink.Warn LogSink.Extract "adapter.ossys.modelRead.noticeRollup" Map.empty))
+    let view = TtyRenderer.buildStatView (LogSink.aggregates ())
+    use sw = new StringWriter()
+    View.write (View.consoleTo sw) view
+    let plain = sw.ToString()
+    Assert.Contains("transform.applied", plain)
+    Assert.Contains("noticeRollup", plain)
+    Assert.Contains("3", plain)

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -1,0 +1,191 @@
+[<Xunit.Collection("Global-MutableState")>]
+module Projection.Tests.ShellTests
+
+open System
+open System.IO
+open Xunit
+open Spectre.Console.Testing
+open Projection.Pipeline
+open Projection.Cli
+
+/// THE OPERATOR SHELL (2026-07-02) — `Shell.execute` is the ONE door every
+/// verb's run walks through. These tests pin the behavior matrix on the
+/// injected-console core (`Shell.executeOn` — pretty/live arrive resolved, so
+/// no real TTY is needed): the live boxed board + verdict panel for a spined
+/// run; the static preview frame + suppressed channel 1 for an answer verb;
+/// byte-identical bracketed NDJSON for pipes; the notice rollup row on the
+/// board; the ledger append on every path.
+
+let private goFrame (command: string) : Shell.Frame =
+    { Command = command; Flow = None; Register = Shell.Go }
+
+let private newConsole () =
+    let c = new TestConsole()
+    c.Profile.Capabilities.Interactive <- true
+    c
+
+[<Fact>]
+let ``shell: a spined pretty run renders the live boxed board, then the verdict panel`` () =
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    LogSink.reset ()
+    try
+        let console = newConsole ()
+        let code =
+            Shell.executeOn console true true (goFrame "projection check") Shell.Bracket.Bracketed (Some Spines.canary) (fun () ->
+                LogSink.emit (LogSink.envelope LogSink.Info LogSink.Canary "canary.started" Map.empty)
+                LogSink.recordStageEvent "canary" 5L LogSink.Succeeded
+                0)
+        Assert.Equal(0, code)
+        let out = console.Output
+        // the contained box — the Live region wraps in the rounded panel
+        Assert.Contains("╭", out)
+        Assert.Contains("╰", out)
+        // the frame titles the box
+        Assert.Contains("projection check", out)
+        // the stage line ran
+        Assert.Contains("Verifying the round-trip", out)
+        // the verdict panel rendered after the board (the resolved final frame)
+        Assert.Contains("verdict", out)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``shell: a pretty run without a spine renders the preview frame and suppresses channel 1`` () =
+    LogSink.reset ()
+    use outer = new StringWriter()
+    LogSink.setWriter outer
+    try
+        let console = newConsole ()
+        let frame = { goFrame "projection preview" with Register = Shell.Preview }
+        let code =
+            Shell.executeOn console true false frame Shell.Bracket.Bracketed None (fun () ->
+                LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "transform.midRun" Map.empty)
+                0)
+        Assert.Equal(0, code)
+        // the preview frame said so up front
+        Assert.Contains("Nothing will be written", console.Output)
+        // channel 1 was suppressed for the span (scoped null)
+        Assert.DoesNotContain("transform.midRun", outer.ToString())
+        // the verdict panel closed the run
+        Assert.Contains("verdict", console.Output)
+    finally
+        LogSink.setWriter Console.Error
+
+[<Fact>]
+let ``shell: a non-pretty run is the bare bracket — run envelopes on the wire, no panels`` () =
+    LogSink.reset ()
+    use wire = new StringWriter()
+    LogSink.setWriter wire
+    try
+        let console = newConsole ()
+        let code =
+            Shell.executeOn console false false (goFrame "projection check drift") Shell.Bracket.Bracketed None (fun () -> 0)
+        Assert.Equal(0, code)
+        let ndjson = wire.ToString()
+        // the A3 sweep: previously-unbracketed verbs now open and close the envelope
+        Assert.Contains("config.runStart", ndjson)
+        Assert.Contains("summary.runComplete", ndjson)
+        // and NOTHING rendered on the console (a pipe stays clean)
+        Assert.Equal("", console.Output)
+    finally
+        LogSink.setWriter Console.Error
+
+[<Fact>]
+let ``shell: a failing body closes the bracket failed and returns its code`` () =
+    LogSink.reset ()
+    use wire = new StringWriter()
+    LogSink.setWriter wire
+    try
+        let console = newConsole ()
+        let code =
+            Shell.executeOn console false false (goFrame "projection check data") Shell.Bracket.Bracketed None (fun () -> 8)
+        Assert.Equal(8, code)
+        Assert.Contains("summary.runComplete", wire.ToString())
+    finally
+        LogSink.setWriter Console.Error
+
+[<Fact>]
+let ``shell: the notice rollup rides the live board as one calm strip row`` () =
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    LogSink.reset ()
+    try
+        let console = newConsole ()
+        Shell.executeOn console true true (goFrame "projection full-export") Shell.Bracket.SelfBracketed (Some (Spines.publishWith false false)) (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Extract "extract.started" Map.empty)
+            // the producer-aggregated Warn rollup (the flood, condensed)
+            LogSink.emit
+                (LogSink.envelope LogSink.Warn LogSink.Extract LiveModelRead.noticeRollupCode
+                    (Map.ofList
+                        [ "total",        box 214
+                          "nullability",  box 180
+                          "identity",     box 34
+                          "artifactPath", box "notices/model-read/01RUN.json" ]))
+            LogSink.recordStageEvent "extract" 3L LogSink.Succeeded
+            LogSink.recordStageStart "profile"
+            LogSink.recordStageEvent "profile" 3L LogSink.Succeeded
+            LogSink.recordStageStart "emit"
+            LogSink.recordStageEvent "emit" 3L LogSink.Succeeded
+            0)
+        |> ignore
+        let out = console.Output
+        // one calm line naming the families — never a wall
+        Assert.Contains("214", out)
+        Assert.Contains("nullability 180", out)
+        // and the artifact pointer rides the strip row
+        Assert.Contains("notices/model-read/01RUN.json", out)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``shell: boardOfStored reconstructs the notice row from a stored run (R1e)`` () =
+    let payload =
+        sprintf
+            """{"code":"%s","payload":{"total":214,"nullability":180,"identity":34,"artifactPath":"notices/model-read/01RUN.json"}}"""
+            LiveModelRead.noticeRollupCode
+    let board =
+        Watch.boardOfStored
+            (Watch.seededOf (Spines.publishWith false false))
+            [ """{"code":"extract.started","payload":{}}"""
+              payload ]
+    match board.Notices with
+    | [ (code, p) ] ->
+        Assert.Equal(LiveModelRead.noticeRollupCode, code)
+        Assert.Equal(box 214L, p.["total"])
+    | other -> Assert.Fail(sprintf "expected one notice row, got %A" other)
+
+[<Fact>]
+let ``shell: identical rollups from the run's repeated read legs fold to ONE row — counts never double`` () =
+    let payload : Map<string, objnull> = Map.ofList [ "total", box 214 ]
+    let b1, f1 = Watch.applyKind Watch.empty LiveModelRead.noticeRollupCode payload
+    Assert.Equal(Watch.Fold.Progressed, f1)
+    let b2, _ = Watch.applyKind b1 LiveModelRead.noticeRollupCode payload
+    Assert.Equal(1, List.length b2.Notices)
+
+[<Fact>]
+let ``shell: the run joins the cross-run ledger on every path (the full-export parity gap, closed)`` () =
+    let dir = Path.Combine(Path.GetTempPath(), "proj-shell-ledger-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory dir |> ignore
+    Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", dir)
+    LogSink.reset ()
+    try
+        let console = newConsole ()
+        // the publish path (SelfBracketed) — the arm that used to skip the ledger
+        Shell.executeOn console false false (goFrame "projection full-export") Shell.Bracket.SelfBracketed None (fun () -> 0) |> ignore
+        let records = RunLedger.read dir
+        Assert.Equal(1, List.length records)
+        Assert.Equal("projection full-export", (List.head records).Command)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_LEDGER_DIR", null)
+        (try Directory.Delete(dir, true) with _ -> ())
+
+[<Fact>]
+let ``shell: titleOf frames a flow with its route and register`` () =
+    let flow : Shell.FlowRoute = { Name = "publish"; From = "cloud-dev"; To = "on-prem-dev" }
+    let go : Shell.Frame = { Command = "projection publish"; Flow = Some flow; Register = Shell.Go }
+    let preview = { go with Register = Shell.Preview }
+    Assert.Contains("publish: cloud-dev", Shell.titleOf go)
+    Assert.Contains("on-prem-dev", Shell.titleOf go)
+    Assert.DoesNotContain("preview", Shell.titleOf go)
+    Assert.Contains("— preview", Shell.titleOf preview)
+    let readOnly : Shell.Frame = { Command = "projection diff"; Flow = None; Register = Shell.ReadOnly }
+    Assert.Equal("projection diff", Shell.titleOf readOnly)

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -189,3 +189,60 @@ let ``shell: titleOf frames a flow with its route and register`` () =
     Assert.Contains("— preview", Shell.titleOf preview)
     let readOnly : Shell.Frame = { Command = "projection diff"; Flow = None; Register = Shell.ReadOnly }
     Assert.Equal("projection diff", Shell.titleOf readOnly)
+
+[<Fact>]
+let ``shell: a flow frame titles the live board with name, route, and register`` () =
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    LogSink.reset ()
+    try
+        let console = newConsole ()
+        let frame : Shell.Frame =
+            { Command  = "projection publish"
+              Flow     = Some { Name = "publish"; From = "cloud-dev"; To = "on-prem-dev" }
+              Register = Shell.Go }
+        Shell.executeOn console true true frame Shell.Bracket.Bracketed (Some Spines.canary) (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Canary "canary.started" Map.empty)
+            LogSink.recordStageEvent "canary" 2L LogSink.Succeeded
+            0)
+        |> ignore
+        let out = console.Output
+        Assert.Contains("publish: cloud-dev", out)
+        Assert.Contains("on-prem-dev", out)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``shell: framed preserves the ambient flow frame for a verb arm, and takes the command otherwise`` () =
+    let flowFrame : Shell.Frame =
+        { Command  = "projection publish"
+          Flow     = Some { Name = "publish"; From = "cloud-dev"; To = "on-prem-dev" }
+          Register = Shell.Preview }
+    Shell.currentFrame.Value <- flowFrame
+    try
+        // a flow-dispatched verb keeps the flow's words
+        Assert.Equal("projection publish", (Shell.framed "projection transfer").Command)
+        Assert.Equal(Shell.Preview, (Shell.framed "projection transfer").Register)
+        // a direct verb takes its own command
+        Shell.currentFrame.Value <- Shell.Frame.ofCommand "projection"
+        Assert.Equal("projection diff", (Shell.framed "projection diff").Command)
+    finally
+        Shell.currentFrame.Value <- Shell.Frame.ofCommand "projection"
+
+[<Fact>]
+let ``flow menu: the view renders as a table and its toJson carries every flow (one substrate)`` () =
+    let view =
+        TtyRenderer.buildFlowMenuView
+            [ "publish", "cloud-dev", "on-prem-dev", ""
+              "try",     "cloud-dev", "local",       "rekey" ]
+    // plain lens
+    use sw = new StringWriter()
+    let console = View.consoleTo sw
+    View.write console view
+    let plain = sw.ToString()
+    Assert.Contains("publish", plain)
+    Assert.Contains("on-prem-dev", plain)
+    Assert.Contains("rekey", plain)
+    // machine lens — the same document, full
+    let json = (View.toJson view).ToJsonString()
+    Assert.Contains("publish", json)
+    Assert.Contains("local", json)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -24,6 +24,9 @@ let private inScopeCodes : Set<string> =
           "profile.started"; "profile.completed"
           "emit.started"; "emit.completed"
           "preflight.started"; "deploy.started"; "canary.started"; "load.started"
+          // the publish spine's post-root legs (2026-07-02 — store / seed-load
+          // join the declared arc so the board covers the whole run)
+          "store.started"; "seed-load.started"
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
           "summary.stageCompleted"
           "config.validationFailed"
@@ -78,6 +81,7 @@ let private knownEmittableCodes : Set<string> =
           // the migrate leg's live stage stream (build → apply → verify) + the
           // data-transfer leg's load stage
           "preflight.started"; "deploy.started"; "canary.started"; "load.started"
+          "store.started"; "seed-load.started"
           // the live Watch board's render-synthesized frame codes (§13) — the
           // run-title header, the terminal done-frame, and the halted stage line
           // (the R2 Aborted arm). Not LogSink envelopes: the board is a
@@ -532,7 +536,7 @@ let ``Voice stageName: an unknown stage passes through unchanged`` () =
 /// spines, not a hand-list, so a stage is covered the moment it joins a spine. The
 /// umbrella root (`RunSpine.rootKey`) is elided: the board never watches it.
 let private boardStageKeys : Set<string> =
-    [ Spines.pipeline; Spines.migrate; Spines.migrateData
+    [ Spines.pipeline; Spines.publishWith true true; Spines.migrate; Spines.migrateData
       Spines.deploy; Spines.canary; Spines.transfer ]
     |> List.collect RunSpine.keys
     |> Set.ofList

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -28,6 +28,7 @@ let private inScopeCodes : Set<string> =
           // join the declared arc so the board covers the whole run)
           "store.started"; "seed-load.started"
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
+          "watch.suggestedEdits"
           "summary.stageCompleted"
           "config.validationFailed"
           // the run-face verdict codes (`RunFaces` register migration) — the
@@ -92,6 +93,7 @@ let private knownEmittableCodes : Set<string> =
           // *rendering* of the run, so its frame copy is voiced through the
           // catalog (one register) and consumed at render, never emitted.
           "watch.runTitle"; "watch.runDone"; "watch.stageHalted"
+          "watch.suggestedEdits"
           // round-trip verification verdict
           "canary.diffEmpty"; "canary.divergence"
           // the run-face verdict codes — like the watch frames, these are not

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -54,7 +54,10 @@ let private inScopeCodes : Set<string> =
           // migration recon #11): preview / applied / drop refusal, and the
           // migrate execute-leg applied / verification-failed verdicts
           "transfer.previewPlan"; "transfer.applied"; "transfer.rowsDropped"
-          "migrate.applied"; "migrate.verificationFailed" ]
+          "migrate.applied"; "migrate.verificationFailed"
+          // the §12 at-scale rollup — the model read's divergence notices
+          // condensed to one Warn envelope (LiveModelRead.surfaceDivergences)
+          "adapter.ossys.modelRead.noticeRollup" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -108,6 +111,9 @@ let private knownEmittableCodes : Set<string> =
           // the §4 transfer / migrate move verdicts (recon #11)
           "transfer.previewPlan"; "transfer.applied"; "transfer.rowsDropped"
           "migrate.applied"; "migrate.verificationFailed"
+          // the model read's notice rollup (LiveModelRead.surfaceDivergences —
+          // one Warn envelope condensing the divergence notices; §12 at-scale law)
+          "adapter.ossys.modelRead.noticeRollup"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]
@@ -190,7 +196,7 @@ let ``Voice totality: no copy is authored for a code the engine cannot emit`` ()
 
 [<Fact>]
 let ``Voice totality: every entry cites a recognized THE_VOICE section`` () =
-    let recognized = Set.ofList [ "§3"; "§5"; "§6"; "§10"; "§13"; "§14" ]
+    let recognized = Set.ofList [ "§3"; "§5"; "§6"; "§10"; "§12"; "§13"; "§14" ]
     for c in Voice.all do
         Assert.False(System.String.IsNullOrWhiteSpace c.DocSection, sprintf "%s has no DocSection" c.Code)
         Assert.True(Set.contains c.DocSection recognized, sprintf "%s cites unrecognized section %s" c.Code c.DocSection)

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -60,7 +60,9 @@ let private inScopeCodes : Set<string> =
           "migrate.applied"; "migrate.verificationFailed"
           // the §12 at-scale rollup — the model read's divergence notices
           // condensed to one Warn envelope (LiveModelRead.surfaceDivergences)
-          "adapter.ossys.modelRead.noticeRollup" ]
+          "adapter.ossys.modelRead.noticeRollup"
+          // the operator shell's §5 preview frame (Shell.execute, render-only)
+          "shell.previewFrame" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -118,6 +120,9 @@ let private knownEmittableCodes : Set<string> =
           // the model read's notice rollup (LiveModelRead.surfaceDivergences —
           // one Warn envelope condensing the divergence notices; §12 at-scale law)
           "adapter.ossys.modelRead.noticeRollup"
+          // the operator shell's preview frame — render-synthesized (like the
+          // watch.* frames), consumed at `Shell.execute`'s static open
+          "shell.previewFrame"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -62,7 +62,9 @@ let private inScopeCodes : Set<string> =
           // condensed to one Warn envelope (LiveModelRead.surfaceDivergences)
           "adapter.ossys.modelRead.noticeRollup"
           // the operator shell's §5 preview frame (Shell.execute, render-only)
-          "shell.previewFrame" ]
+          "shell.previewFrame"
+          // the dispatch prologue's voiced notes (runPlan, render-only)
+          "plan.note"; "survey.advisory" ]
 
 // The codes the engine can actually emit today (the inventory — the contract the
 // totality test holds Voice to). Voicing a code outside this set would be copy for
@@ -123,6 +125,8 @@ let private knownEmittableCodes : Set<string> =
           // the operator shell's preview frame — render-synthesized (like the
           // watch.* frames), consumed at `Shell.execute`'s static open
           "shell.previewFrame"
+          // the dispatch prologue's voiced notes — render-synthesized at runPlan
+          "plan.note"; "survey.advisory"
           // emitted but voiced by mechanism-1 / later slices (not in `Voice.all` yet)
           "transform.registered"; "transform.applied"; "transform.declined"
           "transform.lineage"; "transform.diagnostic"; "bench.label" ]

--- a/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
@@ -23,7 +23,7 @@ let ``renderWatchOn runs the body under the live board on an injected console`` 
         console.Profile.Capabilities.Interactive <- true
         let ran = ref false
         let code =
-            Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+            Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () ->
                 ran.Value <- true
                 7)
         Assert.True(ran.Value, "the body must run inside the live region")
@@ -61,7 +61,7 @@ let ``renderWatchOn shows the cutover timeline header from the ledger's canary h
                   Declined = 0 }
         let console = new TestConsole()
         console.Profile.Capabilities.Interactive <- true
-        Watch.renderWatchOn console Spines.canary 0L (fun () -> 0) |> ignore
+        Watch.renderWatchOn console (Watch.seededOf Spines.canary) 0L (fun () -> 0) |> ignore
         let out = console.Output
         Assert.Contains("▇", out)     // the R6 meter rode the header
         Assert.Contains("3/10", out)  // three consecutive green
@@ -82,7 +82,7 @@ let ``renderWatchOn suppresses channel 1 during the body and restores the prior 
     try
         let console = new TestConsole()
         console.Profile.Capabilities.Interactive <- true
-        Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+        Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () ->
             LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "transform.midRun" Map.empty)
             0)
         |> ignore
@@ -106,7 +106,7 @@ let ``renderWatchOn keeps the dwell OFF the emitting thread — emit never sleep
     let console = new TestConsole()
     console.Profile.Capabilities.Interactive <- true
     let bodyEmitMs = ref 0L
-    Watch.renderWatchOn console Spines.pipeline 200L (fun () ->
+    Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 200L (fun () ->
         let sw = System.Diagnostics.Stopwatch.StartNew()
         // each unique "<key>.started" appends a stage → applyEnvelope changed=true → the dwell
         // path. Info/Transform clears the emit filter (same shape as the suppression test).
@@ -134,7 +134,7 @@ let ``renderWatchOn propagates a body exception as itself and never hangs (#20 t
         let boom = InvalidOperationException("body boom")
         let thrown =
             try
-                Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+                Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () ->
                     LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "alpha.started" Map.empty)
                     raise boom)
                 |> ignore
@@ -169,7 +169,7 @@ let ``renderWatchOn: a flood of foreign envelopes never starves the spinner hear
     try
         let console = new TestConsole()
         console.Profile.Capabilities.Interactive <- true
-        Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+        Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () ->
             LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
             let sw = System.Diagnostics.Stopwatch.StartNew()
             while sw.ElapsedMilliseconds < 600L do
@@ -196,7 +196,7 @@ let ``renderWatchOn: a progress backlog coalesces — no post-run frame replay (
     console.Profile.Capabilities.Interactive <- true
     let sw = System.Diagnostics.Stopwatch.StartNew()
     let code =
-        Watch.renderWatchOn console Spines.pipeline 120L (fun () ->
+        Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 120L (fun () ->
             LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
             for i in 1 .. 10_000 do
                 LogSink.recordStageProgress "extract" i 10_000 (int64 i)
@@ -217,7 +217,7 @@ let ``renderWatchOn: a quiet progress-less stage renders stalled after the thres
     try
         let console = new TestConsole()
         console.Profile.Capabilities.Interactive <- true
-        Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+        Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () ->
             LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
             System.Threading.Thread.Sleep 400
             0)
@@ -238,10 +238,10 @@ let ``renderWatchOn detaches its subscriber on every exit path (#20 teardown)`` 
     try
         let console = new TestConsole()
         console.Profile.Capabilities.Interactive <- true
-        Watch.renderWatchOn console Spines.pipeline 0L (fun () -> 0) |> ignore
+        Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () -> 0) |> ignore
         Assert.Equal(0, LogSink.subscriberCount ())
         (try
-            Watch.renderWatchOn console Spines.pipeline 0L (fun () -> failwith "boom") |> ignore
+            Watch.renderWatchOn console (Watch.seededOf Spines.pipeline) 0L (fun () -> failwith "boom") |> ignore
          with _ -> ())
         Assert.Equal(0, LogSink.subscriberCount ())
     finally

--- a/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
@@ -156,3 +156,93 @@ let ``Watch board: an active stage breathes the phase's spinner frame (#20)`` ()
     let out = console.Output
     Assert.Contains(Theme.spinner 2, out)               // the active line wears the phase-2 frame
     Assert.DoesNotContain(Theme.spinner 3, out)         // and only that frame (phase is fixed per render)
+
+[<Fact>]
+let ``renderWatchOn: a flood of foreign envelopes never starves the spinner heartbeat (#20 rework)`` () =
+    // The starvation defect: the OLD loop only advanced the spinner on a TryTake
+    // TIMEOUT, so a pipeline chatting non-board envelopes faster than one per
+    // 100ms froze the board for the whole flood. The reworked loop heartbeats on
+    // wall clock. The body floods foreign envelopes for ~600ms — the output must
+    // carry spinner frames BEYOND the one painted by the stage transition
+    // (phase 1), i.e. heartbeat repaints happened DURING the flood.
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    try
+        let console = new TestConsole()
+        console.Profile.Capabilities.Interactive <- true
+        Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            while sw.ElapsedMilliseconds < 600L do
+                LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "transform.chatter" Map.empty)
+            0)
+        |> ignore
+        let out = console.Output
+        Assert.Contains(Theme.spinner 2, out)   // ≥1 heartbeat repaint during the flood
+        Assert.Contains(Theme.spinner 3, out)   // ≥2 — the spinner is breathing, not ticking once
+        // A chatty pipeline is ALIVE: liveness keys off dequeued envelopes, so the
+        // flood must never read as a stall.
+        Assert.DoesNotContain("stalled", out)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``renderWatchOn: a progress backlog coalesces — no post-run frame replay (#20 rework)`` () =
+    // The backlog defect: the OLD loop dwelled 120ms per renderable envelope with
+    // no coalescing, so 10,000 progress events queued ≈ 20 MINUTES of replay after
+    // the body had already returned. The reworked loop folds the whole backlog into
+    // coalesced frames and dwells on stage TRANSITIONS only — the run must complete
+    // in seconds, with the dwell floor left at a real value (120ms).
+    let console = new TestConsole()
+    console.Profile.Capabilities.Interactive <- true
+    let sw = System.Diagnostics.Stopwatch.StartNew()
+    let code =
+        Watch.renderWatchOn console Spines.pipeline 120L (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
+            for i in 1 .. 10_000 do
+                LogSink.recordStageProgress "extract" i 10_000 (int64 i)
+            0)
+    sw.Stop()
+    Assert.Equal(0, code)
+    Assert.True(
+        sw.ElapsedMilliseconds < 8_000L,
+        sprintf "10k progress envelopes took %dms — the backlog must coalesce, never replay one dwelled frame per envelope" sw.ElapsedMilliseconds)
+
+[<Fact>]
+let ``renderWatchOn: a quiet progress-less stage renders stalled after the threshold (#20 rework)`` () =
+    // The honesty half of the stall design: a stage with NO progress events (every
+    // full-export stage today) that goes quiet past the threshold must SAY stalled,
+    // not just freeze a dimmed spinner. Threshold pinned low via the env seam.
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_STALL_MS", "50")
+    try
+        let console = new TestConsole()
+        console.Profile.Capabilities.Interactive <- true
+        Watch.renderWatchOn console Spines.pipeline 0L (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Transform "extract.started" Map.empty)
+            System.Threading.Thread.Sleep 400
+            0)
+        |> ignore
+        Assert.Contains("stalled", console.Output)
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_STALL_MS", null)
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``renderWatchOn detaches its subscriber on every exit path (#20 teardown)`` () =
+    // The teardown law: the board's LogSink subscriber never outlives the render —
+    // a leaked subscriber would enqueue into a completed queue forever after. The
+    // witness is `LogSink.subscriberCount` (test-only accessor); asserted after a
+    // clean body AND after a throwing body.
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    LogSink.clearSubscribers ()
+    try
+        let console = new TestConsole()
+        console.Profile.Capabilities.Interactive <- true
+        Watch.renderWatchOn console Spines.pipeline 0L (fun () -> 0) |> ignore
+        Assert.Equal(0, LogSink.subscriberCount ())
+        (try
+            Watch.renderWatchOn console Spines.pipeline 0L (fun () -> failwith "boom") |> ignore
+         with _ -> ())
+        Assert.Equal(0, LogSink.subscriberCount ())
+    finally
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)

--- a/sidecar/projection/tests/Projection.Tests/WatchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchTests.fs
@@ -426,3 +426,83 @@ let ``Watch frame: the run frame clears the twelve-rule banned list`` () =
 let ``Watch frame: followOnAfter is total — every reachable terminal stage names a move`` () =
     for stage in [ "extract"; "profile"; "emit"; "deploy"; "canary"; "load"; "somethingNew" ] do
         Assert.False(System.String.IsNullOrWhiteSpace(Voice.followOnAfter stage))
+
+// ---------------------------------------------------------------------------
+// the fold weights (#20 rework — the drain loop paces on `Fold`, dwelling on
+// stage TRANSITIONS only; progress renders promptly; foreign envelopes never
+// starve the heartbeat)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Watch fold: a stage start weighs Transitioned`` () =
+    let _, fold = Watch.applyKind Watch.empty "extract.started" Map.empty
+    Assert.Equal(Watch.Fold.Transitioned, fold)
+
+[<Fact>]
+let ``Watch fold: a stage completion weighs Transitioned`` () =
+    let b, _ = Watch.applyKind Watch.empty "extract.started" Map.empty
+    let _, fold = Watch.applyKind b "summary.stageCompleted" (payload [ "stage", box "extract"; "durationMs", box 5L ])
+    Assert.Equal(Watch.Fold.Transitioned, fold)
+
+[<Fact>]
+let ``Watch fold: progress on an active stage weighs Progressed, never Transitioned`` () =
+    let b, _ = Watch.applyKind Watch.empty "extract.started" Map.empty
+    let _, fold = Watch.applyKind b "summary.stageProgress" (payload [ "stage", box "extract"; "done", box 3; "total", box 10; "elapsedMs", box 100L ])
+    Assert.Equal(Watch.Fold.Progressed, fold)
+
+[<Fact>]
+let ``Watch fold: a foreign envelope weighs NoChange`` () =
+    let _, fold = Watch.applyKind Watch.empty "transform.lineage" Map.empty
+    Assert.Equal(Watch.Fold.NoChange, fold)
+
+[<Fact>]
+let ``Watch fold: a repeated start weighs NoChange`` () =
+    let b, _ = Watch.applyKind Watch.empty "extract.started" Map.empty
+    let _, fold = Watch.applyKind b "extract.started" Map.empty
+    Assert.Equal(Watch.Fold.NoChange, fold)
+
+[<Fact>]
+let ``Watch fold: strongestFold ranks transition over progress over none`` () =
+    Assert.Equal(Watch.Fold.Transitioned, Watch.strongestFold Watch.Fold.Progressed Watch.Fold.Transitioned)
+    Assert.Equal(Watch.Fold.Transitioned, Watch.strongestFold Watch.Fold.Transitioned Watch.Fold.NoChange)
+    Assert.Equal(Watch.Fold.Progressed,   Watch.strongestFold Watch.Fold.NoChange Watch.Fold.Progressed)
+    Assert.Equal(Watch.Fold.NoChange,     Watch.strongestFold Watch.Fold.NoChange Watch.Fold.NoChange)
+
+[<Fact>]
+let ``Watch fold: apply is the did-it-change shim over applyKind`` () =
+    // The stored-run reconstruction folds on `apply`; the law is that its bool is
+    // exactly `applyKind <> NoChange` — one fold, two views, no drift.
+    let cases =
+        [ "extract.started", Map.empty
+          "transform.lineage", Map.empty
+          "summary.stageCompleted", payload [ "stage", box "extract"; "durationMs", box 5L ] ]
+    for code, p in cases do
+        let _, changed = Watch.apply Watch.empty code p
+        let _, fold = Watch.applyKind Watch.empty code p
+        Assert.Equal(changed, fold <> Watch.Fold.NoChange)
+
+// ---------------------------------------------------------------------------
+// the stalled line for a progress-less stage (#20 rework — a quiet Active None
+// stage says `stalled` in words; a frozen dimmed spinner alone explained nothing)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Watch line: a stalled progress-less stage reads stalled in words`` () =
+    let text = Watch.lineTextWith true { Key = "extract"; State = Watch.Active None }
+    Assert.Contains("Reading the model", text)
+    Assert.Contains("stalled", text)
+
+[<Fact>]
+let ``Watch line: a live progress-less stage carries no stall suffix`` () =
+    let text = Watch.lineTextWith false { Key = "extract"; State = Watch.Active None }
+    Assert.DoesNotContain("stalled", text)
+
+[<Fact>]
+let ``Watch line: the stalled suffix clears the twelve-rule banned list`` () =
+    let banned =
+        [ "your"; "you "; " i "; " we "; "that's real"; ", not "
+          "destroy"; "cleaned up"; "dig"; "oops"; "let's"; "refused" ]
+    let line = Watch.lineTextWith true { Key = "profile"; State = Watch.Active None }
+    let lowered = line.ToLowerInvariant()
+    for b in banned do
+        Assert.False(lowered.Contains b, sprintf "stalled line '%s' breaks the banned list: contains '%s'" line b)


### PR DESCRIPTION
Remediates the three operator complaints from real publish runs — `--pretty` not materializing on full-export/publish, the per-column nullability-notice flood, and the hung spinner — and unifies the four inconsistent channel-2 paths behind a single operator shell so the TTY presents every verb in one contained, fixed-perspective box. Rationale + amended laws in the consolidated `DECISIONS.md` entry (2026-07-03, "The operator-shell chapter"); forward notes in `HANDOFF.md` (sixth letter).

## The hang (fixed at the drain loop — `Watch.fs`)
- **Coalesce-to-latest**: queued envelopes fold into one frame per batch; the dwell floor paces stage **transitions** only. A 10k-progress backlog used to replay one dwelled frame per envelope (~20 minutes of post-run "hang"); now it folds in one pass.
- **Wall-clock heartbeat**: the spinner breathes regardless of queue traffic (the old timeout-branch-only heartbeat starved under envelope floods).
- **Honest stall**: liveness keys off *dequeued* envelopes (a chatty pipeline is alive), and a progress-less active stage says `stalled` in words instead of silently freezing a dimmed spinner. `PROJECTION_WATCH_STALL_MS` joins the dwell as a test seam.

## The flood (`LiveModelRead` → rollup + artifact)
- Model-read divergences (nullability / identity / primary-key) were printed raw to stderr — one line per finding, 2–3× per publish, over the Live region — then **discarded**. They now ride channel 1 at Debug, persist merged-deduped to `notices/model-read/<runId>.json` (`NoticeSink`, §10 artifact table), and condense to **one Warn rollup envelope** the board renders as a calm strip row with the artifact pointer. The §19-Q5 escalation deferral's re-open trigger fired and is resolved.
- Deploy's parallelism/warm-conn advisories become coded envelopes for the same reason.

## The one door (`Shell.fs`)
- `Shell.execute` routes **every PlanAction**: piped → run envelopes, byte-clean; pretty + spine → the live board inside a rounded Panel (fixed-viewport instrument box; no alternate screen, so the final frame + verdict stay in scrollback); pretty without a spine → a static preview frame ("nothing will be written") + scoped channel-1 null + the verdict panel.
- Full-export/publish gains verdict-panel + run-ledger parity; canary and synth-load finally get boards for the stage events they already emit; the previously-unbracketed verbs (preview/check/diff/compare/explain/seal/report/slice/capture) now emit `config.runStart`/`summary.runComplete` on pipes too (the A3 wire change, DECISIONS-recorded). ReadOnly registers never join the run ledger (the `check ready` no-append contract, now structural).
- The publish spine completes: `store` and `seed-load` become declared stages (`Spines.publishWith`, dispatch-chosen), so the board covers the whole run instead of showing its done-frame while the store/load legs still worked.

## Flows + polish
- A flow run presents in its own words — box title, verdict panel, and ledger record read "publish: cloud-dev → on-prem-dev — preview"; pre-run notes and the capability-survey advisory render voiced **before** the Live region; the no-arg flow menu is a `View` (pretty table / plain / `--json` / `--query`).
- Nice-to-haves: #19-lite extract progress (`OnRowsetComplete` → `summary.stageProgress`, so the extract line counts up "n of 23"), #6 echo-the-fix (live `suggestedConfig` teaser row), `--stat` (the run's §11 aggregates table on stdout).
- Pre-existing fix: `View.consoleFor` now strips color for any redirected sink — Spectre can't detect redirection through an injected `AnsiConsoleOutput`, so ANSI was spraying into pipes and files (`CLICOLOR_FORCE` still wins).

## Verification
- `scripts/test.sh fast` green after every phase (six independently-green commits). New suites: `ShellTests`, `NoticeRoutingTests`; new cases in `WatchTests`/`WatchInjectionTests` (flood-never-starves-heartbeat, 10k-backlog wall-time bound, dwell-on-transitions-only, stalled render, teardown scope), `FullExportStoreTests` (publish-spine wire + `boardOfStored` terminal), `LogSinkSubscriberTests` (null-writer law), `VoiceTotalityTests` (all new codes forced).
- PTY smoke (`script`-faked TTY): `projection publish` renders the framed run + boxed verdict panel; piped `diff`/`--stat` emit clean plain text + bracketed NDJSON.
- Known residuals recorded in HANDOFF: stdout narration inside watch bodies renders adjacent to teardown; adapter-layer one-shot warnings can't reach LogSink without cross-assembly plumbing; narrow-terminal Panel wrap is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6i8HzzcEnCiSBcBSqQwDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6i8HzzcEnCiSBcBSqQwDy)_