### PR TITLE
Partial cross-environment transfer: production readiness (peer QA→UAT, SsKey-aligned, differing physical names)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26685,3 +26685,25 @@ bodies renders adjacent to teardown rather than after the panel; adapter-layer
 one-shot `eprintfn` warnings (ReadSide / BatchSplitter / SqlPolicy) cannot
 reach LogSink without cross-assembly plumbing; narrow-terminal Panel wrap is
 known-cosmetic.
+
+## 2026-07-06 — `ConnectionRef.Raw`: the in-memory carrier for an already-resolved secret (D9 amendment)
+
+**Decision.** `ConnectionRef` gains a third case, `Raw of connStr: string`, and
+`ConnectionResolver.resolve` returns it verbatim (blank-guarded). `connSpecOf` /
+`connRefToSpec` map it to the openable `live:` spec form — never back into a
+config-persistable reference, so the D9 belt (config carries references, never
+secrets) is unchanged.
+
+**Why.** D9's intent is provenance: the secret is read at the resolver and only
+there — never logged, never persisted. Two legitimate call sites already HOLD the
+resolved string in memory (the go board's dry run, handed the resolved spec by the
+dispatch plane; the peer docker fixtures' ephemeral-database strings) and, lacking a
+carrier, both worked around the type by WRITING THE SECRET TO A TEMP FILE and
+minting `ConnectionRef.File` over it — an on-disk persistence strictly worse than
+the discipline the type was protecting. `Raw` removes the disk hop; the secret's
+lifetime shrinks to the process.
+
+**Bounds.** `Raw` is in-memory-only: it never round-trips into `projection.json`
+(the config parser continues to accept `env:`/`file:` references only, and
+`looksLikeSecret` still rejects pasted connection strings). Constructed only where
+the string is already lawfully resident.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -365,3 +365,29 @@ already holds by business key — nothing is inserted into them; FKs re-point.
   business-key fallback except via reconcile).
 - Streaming refuses `--tables` (subsets run materialized — memory scales with the
   largest table in the subset).
+
+## Entry 10 — 2026-07-06, FINAL VERDICT: every gate green; the program is complete
+
+- **Fast pool: PASSED** (4,100+ tests, 37s) — including the new `PeerTransferTests`,
+  the self-loop resolver rules, and the re-based composer parallelism pins (the
+  unresolvable-cycle fixture moved to the honest two-weak-edge 2-cycle; a NEW pin
+  proves a nullable self-FK no longer surrenders the estate's parallel levels).
+- **Docker pool: PASSED in full** (511s) — zero regressions from the cycle-resolver
+  change across the whole transfer/reverse-leg/migration/deploy canary estate, plus
+  the three new peer e2e scenarios green.
+- **Release builds: clean** (both test assemblies + transitively every src project) —
+  including the FS3511 fix from entry 4; production binaries build again.
+
+**What today's session delivered, end to end:**
+1. The blind-spot map (entries 3, 5) — four deep studies, all findings logged.
+2. The Release-build fix (entry 4).
+3. The peer (QA→UAT) SsKey-aligned partial-transfer leg: OSSYS contract acquisition
+   per side, shape gate, subset-FK gate with strategy proposals, dispatch wiring,
+   voice/exit-code axes (entries 6, 9).
+4. A REAL engine bug found by the new e2e canary and fixed in two halves (entries
+   7–8): self-FK 1-node SCCs no longer silently degrade the entire load order.
+5. The e2e proof: data moves between two genuinely differently-named environments,
+   SS_KEY-aligned, FKs re-pointed, reconcile-by-key for out-of-subset parents,
+   idempotent replace-subset re-runs.
+6. The operator runbook for today's live test (entry 9), incl. the named residuals
+   that remain (all pre-existing, none blocking the happy path).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -391,3 +391,32 @@ already holds by business key — nothing is inserted into them; FKs re-point.
    idempotent replace-subset re-runs.
 6. The operator runbook for today's live test (entry 9), incl. the named residuals
    that remain (all pre-existing, none blocking the happy path).
+
+## Entry 11 — 2026-07-06, PHASE 2 OPENED: adversarial hardening + mock-environment e2e program
+
+Operator directive: critical analysis to find remaining bugs, make the flow easier,
+and build much more robust end-to-end testing with mock OutSystems environments that
+confirm our understanding of the permissions and the tables we interact with.
+
+Four deep adversarial agents launched in parallel:
+1. **Peer-leg correctness hunt** — priority: physical COLUMN-name divergence between
+   environments (OutSystems keeps stale physical names after renames — does the
+   rename projection actually cover the column plane, or only tables?); shape-gate
+   blind spots; reconcile-resolution asymmetries; wipe-order hazards; second-order
+   effects of the self-loop resolver rule; face gate holes; metamodel-vs-deployed
+   type fidelity on the bulk write plane.
+2. **Permission-footprint inventory** — every SQL statement the peer path executes,
+   per phase, with its minimum permission and its behavior when denied (named
+   refusal / named descent / raw exception); the mock managed-grant recipe; the
+   mid-load-surprise list.
+3. **Flow ergonomics** — ranked proposals (J2 default User:Email reconcile,
+   reconcile-spec SsKey translation, preview closure sizing, config validation
+   notes, voice copy).
+4. **Mock-environment fixture + e2e matrix design** — parameterized espace prefixes
+   (not string-replace), the DML-only principal recipe, P0/P1/P2 scenario matrix.
+
+Known self-critique going in (to be verified by agent 1): today's peer e2e runs as
+an ADMIN principal — it proves identity alignment and FK re-pointing but NOT the
+managed-cloud grant envelope; the FK-retrust descent path
+(FkTrustNotRestoredOnBulkLoad) is unexercised on the peer leg; IDENTITY reseed
+mechanics differ under a real grant.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -563,3 +563,22 @@ subtlety found and absorbed: without VIEW DEFINITION the server hides check-cons
 bodies; those are now skipped as a named erasure (they never affect data transfer).
 The one true blind spot that remains: a table-level DENY is invisible to the
 preflight and surfaces mid-load (G1, pinned with a test).
+
+## Entry 15 — 2026-07-06, PHASE 2 CLOSED: every gate green
+
+- **Fast pool: PASSED** (45s) — all phase-2 fixes + updated pins + new pure suites.
+- **Docker pool: PASSED IN FULL** (536s; +25s over baseline = the five new
+  managed-grant scenarios, inside the predicted budget) — zero regressions from the
+  rename-map kind-scoping, the topo parallel-edge dedupe, the ordered-load gate, the
+  resumable capability gate, the cell-shaping sink-only omission, or the
+  check-definition optionality, across the entire transfer / reverse-leg / migration /
+  deploy / CDC canary estate.
+- Both peer suites green: identity/mechanics (admin) AND the managed-grant envelope
+  (restricted principals both sides).
+
+**Phase-2 ledger, summarized:** 2 critical + 3 high + 5 medium engine/gate bugs found
+by adversarial review and fixed with tests; 6 ergonomics improvements; the
+mock-OutSystems-environment fixture stack; 5 managed-grant e2e scenarios; 1
+live-test-killing extraction bug caught BY the new mock environments in their first
+hour (check-constraint definitions under VIEW-DEFINITION-less principals); the
+semantics walkthrough (entry 14) for operator validation.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -735,4 +735,6 @@ follow-on); streaming success-undo derives from the capture journal when needed
 so it sits outside the small-sample proving loop).
 
 Pure pins added (`subsetEscapeGate` semantics + exit-9 classification). Fast pool
-GREEN; the full docker pool running as the final arbiter (verdict appended below).
+GREEN; **the full docker pool PASSED IN FULL (519s)** — every leg's canaries
+(forward transfer, legacy reverse, streaming, peer, managed-grant, go-board,
+proving-loop) green through the new gates. The parity sweep is closed.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -619,3 +619,6 @@ stepwise end-to-end explanation.
 decision → green → preview → execute → idempotent re-run, with the axis table, the
 decision playbook, exit codes, troubleshooting, and the exact per-environment
 permission footprint.
+
+**Final verdict:** fast pool PASSED; the full docker pool PASSED IN FULL (536s) with
+the go-board e2e aboard. The preview-engine program is closed.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1,0 +1,50 @@
+# Partial-Transfer Production-Readiness Log — 2026-07-06
+
+> Append-only operator log for the partial-transfer readiness program: making the
+> verb/flow that moves a **subset of tables** between managed Cloud OutSystems
+> environments (e.g. QA → UAT, differing physical table names, SS_KEY-matched
+> schema shape) ready for a live operator test later today. Newest entries at the
+> bottom. Plain description only — findings, accomplishments, decisions taken.
+
+---
+
+## Entry 1 — 2026-07-06, session start: orientation
+
+- Session opened on branch `claude/fsharp-partial-transfer-production-1p4vpw` (clean tree,
+  based on `main` @ 4ba720a).
+- Read `CLAUDE.md`, the top `HANDOFF.md` letter (operator-shell chapter, 2026-07-03), and
+  `src/Projection.Cli/Faces/Transfer.fs` in full.
+- Confirmed the feature surface already exists in some depth:
+  - `runTransfer` — the forward `transfer` face: dry-run by default, `--execute` gated on
+    `PROJECTION_ALLOW_EXECUTE=1`, `--tables` subset selection, `--reconcile
+    <table>:<column>` + `--user-map` CSV re-keying, revert policy, resumable runs,
+    drop-set fail-loud exits.
+  - `runReverseLegTransfer` — the reverse (B→A) leg: takes a **logical source contract**
+    and a **physical sink contract** (two SsKey-aligned renditions of one authored
+    model) — this is precisely the "same schema shape, different physical table names"
+    cross-environment situation. Streaming vs materialized realization chosen by
+    `ReverseLegRealization.choose`; journal-gated execute.
+- Directly relevant docs identified for the deep study: `THE_USE_CASE_ONTOLOGY.md` (+ its
+  acceptance/fitness/obligations satellites), `PRESCOPE_TRANSFER.md`,
+  `CROSS_ENVIRONMENT_READINESS.md`, `TRANSFER_ISOMORPHISM_SUBSTANTIATION.md`,
+  `PREFLIGHT_CLOUD_INSERTION.md`, `J5_MANAGED_ENV_CAPABILITY_PLAYBOOK.md`,
+  `REVERSE_LEG_WORK_PLAN.md`, `AUDIT_2026_06_10_REVERSE_LEG_DML_PROOF.md`.
+- Next: four parallel deep-study sub-agents (engine, docs/ontology, test coverage, CLI
+  dispatch + contract acquisition) to map the current state and find blind spots.
+
+## Entry 2 — 2026-07-06, environment readiness + study fan-out
+
+- Launched four parallel deep-study agents:
+  1. **Engine** — Projection.Pipeline transfer flow, `--tables` subset semantics, SsKey
+     alignment, FK closure/cycle handling, sink insertion mechanics.
+  2. **Ontology/docs** — the use-case ontology + acceptance/obligations satellites,
+     transfer prescope, cross-environment readiness, cloud-insertion preflight,
+     reverse-leg program status, open backlog items.
+  3. **Test estate** — existing transfer/e2e docker tests, two-environment fixture
+     patterns, subset + schema-validation coverage, gap list with templates to copy.
+  4. **CLI/config** — exact command grammar, contract acquisition (CatalogRendition,
+     capture verbs), preflight/compare verbs, environment/connection story, worked
+     examples.
+- Local substrate verified ready for e2e work: dotnet SDK 9.0.314, Docker 29.3.1, and the
+  **warm SQL Server 2022 container is already up** (`projection-mssql-warm`, port 11433).
+  Full solution build kicked off in the background.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -503,3 +503,63 @@ definition-less check row is SKIPPED (a named erasure — ColumnChecks are
 physical-realization artifacts the shape verdict strips and the data plane never
 reads; privileged reads still carry them). Also: adapter-level extraction failures now
 classify onto the schema-read axis (exit 6) instead of unclassified-3.
+
+## Entry 14 — 2026-07-06, THE SEMANTICS WALKTHROUGH (plain shorthand, post-fix state)
+
+**The one-line model.** Every entity and attribute has a GUID (SS_KEY) that survives
+environments; names — logical and physical — are costumes over that GUID. The transfer
+moves rows by GUID and only touches names at two well-defined seams.
+
+**1. Contracts.** Run start: read each environment's OSSYS metamodel (plain SELECTs on
+ossys_* tables over that env's own connection). Result per side: a catalog where every
+kind/attribute carries its GUID + THAT environment's names (logical AND physical).
+Nothing is authored or assumed — each side describes itself.
+
+**2. Physical names never cross the wire.** Reads SELECT using the SOURCE catalog's
+physical table/column names; writes INSERT/MERGE using the SINK catalog's physical
+names; the two sides pair up per kind by GUID. So QA's `OSUSR_ABC_CUSTOMER` vs UAT's
+`OSUSR_XYZ_CUSTOMER` is a non-event — there is no mapping table, no convention, no
+string transform; each side just uses its own physicals.
+
+**3. Renames — the exact role, when, and where.** In flight, a row is a bag of values
+keyed by LOGICAL attribute name (not physical, not position). Normal case: both
+environments carry the same logical names (same model version) → the rename machinery
+is a no-op (empty map). It exists for ONE situation: the same attribute (same GUID)
+has DIFFERENT logical names in the two environments — e.g. you renamed
+`Customer.Email → ContactEmail` in QA and haven't promoted to UAT. WHEN: computed once
+at run start — diff the two contracts; every same-GUID/different-logical-name
+attribute yields a source-name → sink-name entry, grouped BY KIND (today's critical
+fix: one kind's rename can no longer touch another kind's same-named column). WHERE:
+applied exactly once per row, between ingest and plan-build (materialized: re-key the
+row's bag; streaming: re-key the stream's header once) — after that, everything
+downstream speaks sink vocabulary. Entity-level renames need nothing at all
+(everything is GUID-keyed); the only name-sensitive input is YOUR `tables:` list,
+which resolves against the SOURCE's logical names (`Module.Entity` if ambiguous).
+
+**4. Gates (before any write).** SHAPE: diff the two contracts by GUID with
+physical-realization artifacts stripped; blocks only what breaks insertability
+(missing kind/attribute in scope, type change, narrowing, NULL→NOT-NULL); everything
+else is a printed advisory. SUBSET-FK: every FK from a chosen table to an un-chosen,
+un-reconciled table must get a strategy — reconcile it against the sink's own rows
+(proposal printed as a paste-able `Module.Entity:Column`) or widen the subset. No
+bypass: those rows would otherwise land carrying QA's key values pointing at the
+wrong UAT rows.
+
+**5. The load.** Order = FK topology (parents first; verified, or the run refuses).
+The sink MINTS every identity (managed cloud forbids IDENTITY_INSERT): each parent
+row inserts via a MERGE that captures old-key → new-key; children's FK values re-point
+through that capture before their own insert. Nullable FKs inside a cycle load NULL
+first, then a phase-2 UPDATE re-points them. Reconciled kinds (Users, reference data)
+are never inserted — their source rows match sink rows by the business key you named,
+and FKs re-key to the SINK's existing identities.
+
+**6. Re-runs.** `strategy: replace` wipes the subset's sink rows child-first, then
+reloads — run it twice, same result.
+
+**7. Permissions (now proven, not assumed).** Everything above fits database-scope
+SELECT/INSERT/UPDATE/DELETE plus tempdb #staging — the whole flow runs green with
+that exact principal on BOTH sides, including the metamodel reads. One read-side
+subtlety found and absorbed: without VIEW DEFINITION the server hides check-constraint
+bodies; those are now skipped as a named erasure (they never affect data transfer).
+The one true blind spot that remains: a table-level DENY is invisible to the
+preflight and surfaces mid-load (G1, pinned with a test).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -622,3 +622,48 @@ permission footprint.
 
 **Final verdict:** fast pool PASSED; the full docker pool PASSED IN FULL (536s) with
 the go-board e2e aboard. The preview-engine program is closed.
+
+## Entry 17 — 2026-07-06, THE LIVE REHEARSAL: the runbook executed verbatim with the real CLI; two hotspots fixed
+
+Operator directive: identify likely-failure hotspots and course-correct; iterate the
+runbook critically, step by step.
+
+**What ran** (a mock QA/UAT pair on the warm container: espace-shifted physical names
+`OSUSR_*` vs `OSUSR_X*`, DML-only logins on BOTH sides, the operator's exact
+`projection.json` from the runbook, the REAL CLI binary — the first time the whole
+config-discovery → flow-parse → dispatch → engine path was driven end-to-end):
+
+1. `projection` (menu) — flows table with the tables tag. ✓
+2. `projection check go golden` — **RED exit 5**: both escapes named
+   (Customer.CityId→City, SalesOrder.CategoryId→Category) with paste-able remedies;
+   forecast "4 row(s) across 2 table(s)". ✓
+3. Reconcile entries pasted → **RED again, and rightly**: the identities forecast
+   caught that UAT held NO Category rows ("Category source '1'/'2' have no sink
+   match — a live run halts before any write") — the exact missing-reference-data
+   trap a live first run would hit, caught with zero writes. ✓
+4. Sink reference data fixed → **GREEN exit 0**. ✓
+5. `projection golden` (preview) → **HOTSPOT #1 FIXED**: the headline counted
+   RowsWritten (0 in a dry run) — "0 row(s) would move" over a 4-row forecast.
+   A DryRun headline now counts RowsIngested ("4 row(s) would move"). **HOTSPOT #2
+   FIXED**: the load plan printed all 15 modeled tables (13 all-zero noise); it now
+   shows the TOUCHED tables (moving or reconciled) + one collapse line for the rest.
+6. `--go` without PROJECTION_ALLOW_EXECUTE → named refusal exit 7 with remedy. ✓
+7. The live run → 4 rows moved; ground truth verified by SQL: customers minted
+   900/901 with CITYID re-pointed to the sink's OWN 501/502 (name-reconciled),
+   orders minted 9000/9001 pointing at the NEW customer keys with categories
+   name-matched to the right rows (Leaf→Leaf, not positional). ✓
+8. Re-run → idempotent (counts stable, zero dangling FKs); source untouched. ✓
+
+**Also fixed en route:** the seed needs QUOTED_IDENTIFIER ON under raw sqlcmd
+(test-infra only, engine unaffected).
+
+**Course-corrections written into the runbook** — a new "Live-environment hotspots"
+section covering what the rehearsal cannot prove: User-entity references (the gate
+cannot see an edge whose target kind is absent from the contract — check manually),
+materialized-subset memory at scale, wipe duration on large re-runs, Encrypt=True on
+real connections, command timeouts on slow links, the standing G1 DENY blind spot,
+and the cosmetic note-truncation. Plus the "Rehearsed end-to-end" section recording
+exactly what was validated.
+
+Fast pool + the peer/managed-grant/go-board docker sweep: GREEN after the narration
+fixes.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -667,3 +667,41 @@ exactly what was validated.
 
 Fast pool + the peer/managed-grant/go-board docker sweep: GREEN after the narration
 fixes.
+
+## Entry 18 — 2026-07-06, THE PROVING LOOP: success-undo artifacts + `projection revert`
+
+Operator directive: live revert commands AND written revert scripts, so a small
+declared subset can be transferred, proven, and deliberately reverted.
+
+**What existed:** revert was FAILURE-COMPENSATION only — `transfer-revert.sql` was
+written (or auto-executed) when a run crashed mid-load; a SUCCESSFUL run left no
+undo artifact, and no verb could execute one.
+
+**What landed:**
+1. **The success-undo artifact.** Every successful Execute now writes
+   `transfer-undo.sql` into the revert dir (default: cwd) — the same precise
+   child-first DELETE-by-captured-key script, targeting exactly the rows THIS run
+   minted; pre-existing/reconciled rows are never in it. Written by the engine's
+   success tail (`writeUndoArtifact` beside `writePlan`); distinct filename from the
+   failed-run compensation so the two never shadow each other. The run's closing
+   narration prints the path + the revert command.
+2. **`projection revert [--script <p>] --against <env> [--go]`** — the deliberate
+   undo verb (Intent → planRevert → face). Preview by default (tables + captured-key
+   counts, zero deletes); a live run needs the env gate + `--go` and executes in ONE
+   transaction (all deletes land or none — a failure rolls back and says so), with
+   per-table rows-deleted narration. Exit: 0 / 2 (script missing/args) / 6 (conn) /
+   7 (gate) / 3 (rolled back).
+3. **Proven live with the real CLI** (the rehearsal pair, DML-only principals):
+   transfer --go → `Undo script written: ./transfer-undo.sql` → revert preview
+   (2 statements over 2 tables, 2 keys each, no deletes) → revert --go →
+   "Reverted — 4 row(s) deleted" → sink counts back to zero, pre-existing cities +
+   categories untouched. And pinned durably: the `proving loop` docker e2e
+   (GoBoardDockerTests) runs transfer → artifact → face preview → face live revert →
+   pre-transfer state, under managed-grant principals.
+4. **Runbook Step 6½** documents the loop + the two honesty notes: a
+   replace-strategy WIPE is not undone (the undo removes what the run minted), and
+   the undo should run before new app activity references the minted rows (an FK
+   from a newer row rolls the transaction back, loudly).
+
+Fast pool + the transfer/revert docker sweep (GoBoard + both peer suites +
+ReverseLegCanary): GREEN.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -705,3 +705,34 @@ undo artifact, and no verb could execute one.
 
 Fast pool + the transfer/revert docker sweep (GoBoard + both peer suites +
 ReverseLegCanary): GREEN.
+
+## Entry 19 — 2026-07-06, THE PARITY SWEEP: every leg inherits this session's protections
+
+Operator directive: keep the other reverse-leg flows in feature parity.
+
+The audit (the full matrix is in the PR): most of the session's fixes were already
+engine-shared (kind-scoped renames, cell shaping, resolver semantics, narration,
+undo artifacts via the shared `writePlan`). Three genuine gaps found and closed:
+
+1. **The escaping-FK guard was FACE-only.** The legacy reverse leg and the forward
+   transfer accept `tables` subsets and reached the engine with the cross-wiring
+   hazard unguarded (the phase-2 CRITICAL-#2 class). New: `Transfer.subsetEscapeGate`
+   — a leg-neutral Execute pre-write gate (`transfer.subsetFkEscapes`, same exit-9
+   axis) in `runCore`'s chain, making the hazard unreachable from ANY entry point.
+   The peer face keeps its richer per-edge strategy narration in front of it.
+2. **The streaming arm lacked `orderedLoadGate`** — the one Execute path that could
+   still load on a degraded (alphabetical) order. Wired into its pre-write chain
+   (executeGate → orderedLoadGate → validateUserMap).
+3. **The forward transfer's `--resumable` had no capability gate** — the same raw
+   CREATE TABLE crash on a managed sink the reverse selector already refused. The
+   face now refuses by the same name (`transfer.reverseLeg.resumableSinkUnsupported`),
+   with the sink capability threaded from the flow's declared archetype.
+
+Named non-goals (documented, not silent): the go board stays env→env-scoped (legacy
+model-sourced flows keep their probe sheet; wiring the board there is clean
+follow-on); streaming success-undo derives from the capture journal when needed
+(estate-scale key lists don't belong in a .sql artifact; streaming has no `--tables`
+so it sits outside the small-sample proving loop).
+
+Pure pins added (`subsetEscapeGate` semantics + exit-9 classification). Fast pool
+GREEN; the full docker pool running as the final arbiter (verdict appended below).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -206,3 +206,162 @@ transfer with genuinely differing physical names there is **no wired path**:
 Release fix; stand up e2e #1 (the different-physical-names data-move witness); then
 either wire the peer-with-renames dispatch path or document the engine-level invocation;
 propose FK-closure strategies per table for the chosen subset.
+
+## Entry 6 — 2026-07-06, operator decisions received; the peer leg is WIRED
+
+Operator answered the four scoping questions: **full wiring** of the peer path;
+**reconcile-by-key** as the default strategy for out-of-subset FK parents; **OSSYS
+metamodel readable on both QA and UAT**; **replace-subset (WipeAndLoad)** re-run
+semantics for today.
+
+Landed since (all compiling, fast pool green):
+
+- **`PeerTransfer` module (Pipeline)** — the peer leg's support: `acquireContracts`
+  (both sides read from their own OSSYS metamodel → native GUID SsKeys, the identity
+  that aligns across environments); `shapeVerdict`/`shapeGate` (SS_KEY-keyed schema
+  compatibility scoped to the kinds the run touches: kind/attribute presence and
+  column-shape facets BLOCK by name; constraint/index drift and widenings surface as
+  advisories — nothing silent); `escapingFks` + `narrateEscapes` + `subsetFkGate`
+  (every FK edge escaping the declared subset detected, per-edge strategy proposed —
+  reconcile against the sink's own rows [candidate business-key columns derived from
+  the target's single-column unique indexes], widen the subset, or --allow-drops; a
+  live Execute with un-strategized escapes refuses by name, a preview narrates).
+- **Routing**: `MovementDirection.UpPeer` (a physical→physical env→env flow, i.e. the
+  `golden` QA→UAT shape) now routes to the new `PlanAction.TransferPeer` → the new
+  `runPeerTransfer` CLI face → gates → the SAME rename-aware contract-pair engine the
+  reverse leg proved (`runReverseLegThroughConnectionsWith` path). An env→env flow
+  with UNSET renditions keeps the old name-blind `Transfer` (the identical-rendition
+  escape hatch). Two new named refusal axes with distinct exits:
+  `transfer.peer.shapeDivergence` → exit 5 (matching `check shape`'s verdict class),
+  `transfer.peer.subsetFkEscapes` → exit 9 (drop-set class); unreadable OSSYS
+  metamodel → schema-read axis, exit 6.
+- **Routing tests updated** (the two pins that moved) + a new pin: unset-rendition
+  env→env still routes to plain `Transfer`.
+
+## Entry 7 — 2026-07-06, THE E2E TEST FOUND A REAL ENGINE BUG (the reason this test had to exist)
+
+Stood up `PeerAlignedTransferDockerTests` (Integration, Docker-SqlServer): two real
+databases on the warm container — cell A = the edge-case OSSYS estate (`OSUSR_*`),
+cell B = the same estate with every physical name shifted (`OSUSR_X*`), contracts
+OSSYS-read from each side, subset transfer executed through the contract-pair engine.
+
+**First run failed — and the failure is a genuine, previously-invisible engine defect,
+not a test bug:** the edge-case estate contains a self-referencing entity
+(`Category.ParentCategoryId`, nullable). The cycle resolver
+(`CycleResolution.asymmetric2CycleStrategy`) only handled 2-cycles; a 1-node SCC
+(self-FK) REFUSED resolution, and the topological-order pass then degraded the WHOLE
+catalog to its alphabetical fallback. Consequence: `Customer` (alphabetically before
+`City`) loaded BEFORE its FK parent, the sink-minted-key remap for City was empty at
+Customer's load time, and every Customer row's CityId FK missed → skip-and-diagnose
+dropped/diagnosed the rows (exit 9). **One nullable self-reference anywhere in the
+estate silently poisoned the load order of every unrelated table pair.** Real
+OutSystems estates are full of this shape (Category.Parent, Employee.Manager,
+Folder.Parent) — the operator's QA→UAT test today would almost certainly have hit it.
+
+**Fix (engine, minimal and targeted):** the resolver now treats a **Weak (nullable)
+self-edge** as breakable *for ordering* — the two-phase load's deferral machinery
+already re-points nullable self-FKs in phase 2 regardless of order (the F1 lift,
+2026-06-10), and the resolved SCC stays in `Cycles`, so `deferredFkColumns` still
+defers the column. A MANDATORY self-FK still refuses (honest — it genuinely cannot
+load in one pass). Pure resolver tests added for both arms.
+
+Also new pure coverage (`PeerTransferTests`): `resolveLoadSet` refusal semantics
+(previously untested anywhere), escaping-FK detection incl. nullable-edge softening +
+reconcile-candidate proposals + chain-stops-at-boundary, subset-FK gate
+refuse/downgrade contract, shape-gate blocking vs advisory classification (missing
+kind/attribute, type change, widening, nullability tightening/loosening, scoping), and
+the two new Preflight exits.
+
+## Entry 8 — 2026-07-06, the self-FK fix landed in two halves; ALL THREE e2e scenarios GREEN
+
+The resolver rule alone was not enough — a second, deeper defect sat beneath it:
+`internalEdgesOf` (the topo pass's SCC edge enumerator) explicitly excluded self-pairs
+(`if a <> b`), so a 1-member SCC's self-edge was invisible to ANY resolver by
+construction. Both halves are now fixed: self-pairs are enumerated, the resolver
+breaks a Weak (nullable) self-edge for ordering (deferral still re-points it in
+phase 2 — the resolved SCC stays in `Cycles`), and the 2-cycle arm explicitly ignores
+self-edges so its semantics are byte-preserved. A mandatory self-FK still refuses.
+
+One test-side correction along the way (the engine was right, the assertion wrong):
+`DBCC CHECKIDENT(…, RESEED, 500)` on a never-inserted table makes the NEXT minted
+value 500, not 501 — the verbatim-FK check now tests "not the source's surrogates +
+no dangling FK" instead of a numeric boundary.
+
+**The peer e2e suite is GREEN (real SQL Server, two espace-variant databases,
+`OSUSR_*` vs `OSUSR_X*`):**
+1. **A declared table subset lands in the differently-named sink** — contracts
+   OSSYS-read from each side, SsKeys align by native GUID, City loads before Customer
+   (topological, despite the estate's self-FK Category), sink mints keys, the
+   Customer→City FK re-points through the capture remap (source surrogates provably
+   absent), the (email → city-name) join identical source↔sink, zero drops.
+2. **Reconcile-by-key for an out-of-subset parent** — subset [Customer] only, City
+   reconciled `MatchByColumn NAME` against rows the sink already held under its own
+   surrogates (501/502): City written 0 rows, disposition re-keyed-by-rule, both
+   customers point at the sink's own city rows. This is the operator's chosen default
+   strategy for partial refresh, now witnessed end-to-end.
+3. **Replace-subset idempotency** — WipeAndLoad × 2 over the subset: counts stable,
+   join stable, no duplicates.
+
+Full fast + docker pools running for regression coverage of the resolver change.
+
+## Entry 9 — 2026-07-06, the operator runbook for today's QA→UAT partial-transfer test
+
+**Config (`projection.json`)** — both environments declared `rendition: physical`
+(this is what routes the flow onto the new SsKey-aligned peer leg; leaving renditions
+unset keeps the old name-blind transfer as an escape hatch):
+
+```jsonc
+{
+  "environments": {
+    "cloud-qa":  { "access": "direct", "conn": "env:CLOUD_QA_CONN",  "rendition": "physical" },
+    "cloud-uat": { "access": "direct", "conn": "env:CLOUD_UAT_CONN", "grant": "data",
+                   "rendition": "physical", "archetype": "managed-dml" }
+  },
+  "flows": {
+    "golden": { "from": "cloud-qa", "to": "cloud-uat", "scope": "data",
+                "tables": ["Customer", "Order"],
+                "reconcile": ["ServiceCenter.User:Email"],
+                "rekey": "file:./secrets/uat-users.csv",
+                "strategy": "replace" }
+  },
+  "readiness": { "schema": "cloud-qa", "confirm": ["cloud-uat"] }
+}
+```
+
+**The run sequence:**
+1. `projection check shape` — the espace-safe estate readiness gate (OSSYS-reads
+   both environments, SS_KEY-keyed, zero-delta-modulo-physical required). Exit 0 =
+   ready; 5 = real divergence/data dealbreaker; 6 = unreadable.
+2. `projection golden` — the PREVIEW (dry-run is the default): narrates the load
+   plan in dependency order, every escaping-FK edge with its proposed strategies
+   (reconcile candidates derived from the target's unique business keys), unmatched
+   identities, cycles. No writes.
+3. `PROJECTION_ALLOW_EXECUTE=1 projection golden --go` — the live run (both gates:
+   the env var authorizes the environment, `--go` states per-run intent).
+   `strategy: replace` = wipe-the-subset-then-load (the chosen idempotent re-run
+   semantics). Exit 0 clean; 9 = rows dropped or escapes un-strategized (add
+   reconcile entries or `--allow-drops` after reading the report); 5 = shape
+   divergence; 6/7 = connection/grant.
+
+**What the new gates do for you:** contract acquisition reads each side's OSSYS
+metamodel (native GUID SS_KEYs) — QA's and UAT's `OSUSR_*` names may differ freely;
+the shape gate refuses by name if the models genuinely diverge over the transferred
+set (attribute presence/type/nullability/length), with advisories for benign drift;
+the subset-FK gate refuses a live run while any relationship escapes the subset
+without a strategy. Reconciled kinds (`reconcile:` / `rekey:`) match rows the sink
+already holds by business key — nothing is inserted into them; FKs re-point.
+
+**Known residuals that could still bite today (all pre-existing, none new):**
+- Object-scope DENY is invisible to the DB-scope grant preflight (G1) — a per-table
+  DENY surfaces mid-load, not pre-flight.
+- Contract-vs-live drift: a model column missing from the deployed table is a raw
+  SqlException, not a named refusal (G2). `check shape` first mitigates.
+- Grant preflight demands INSERT over every model kind, not just the subset —
+  over-refusal possible on narrowly-granted sinks.
+- The G10 resume marker is subset-insensitive (irrelevant under `strategy: replace`).
+- `--user-map` CSV resolves tables by physical name (espace-unsafe); prefer the
+  `Module.Entity` reconcile form.
+- Composite-PK kinds refuse under sink-minted identity (named refusal, no
+  business-key fallback except via reconcile).
+- Streaming refuses `--tables` (subsets run materialized — memory scales with the
+  largest table in the subset).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -48,3 +48,161 @@
 - Local substrate verified ready for e2e work: dotnet SDK 9.0.314, Docker 29.3.1, and the
   **warm SQL Server 2022 container is already up** (`projection-mssql-warm`, port 11433).
   Full solution build kicked off in the background.
+
+## Entry 3 — 2026-07-06, ontology/docs study returned: the use case is named, and the sharpest gap is identified
+
+The docs deep-study came back. Plain-language summary of what the documentation establishes:
+
+- **This exact use case is a first-class, named flow.** `THE_CLI.md` §11–12 documents the
+  `golden` flow verbatim: `{ "from": "cloud-qa", "to": "cloud-uat", "scope": "data",
+  "tables": ["Customer","Order"], "rekey": "file:./secrets/uat-users.csv" }` — a subset of
+  a peer cell's data promoted into a cloud sink, listed as "fully backed today," with
+  `check` (canary/drift/data/ready) as the operator preflight. The ontology names it
+  protein **P-3 (Dev→UAT with user re-key)** generalized cloud→cloud; the producer
+  taxonomy calls QA→UAT the **`peer`** producer with the **`golden`** flow.
+- **Identity law:** entity/attribute identity is `SsKey` (OutSystems GUID), designation is
+  logical name, physical `OSUSR_*` name is a *disposition* — comparison always by SsKey,
+  never physical name. `CROSS_ENVIRONMENT_READINESS.md` designs `projection check shape`:
+  OSSYS-read both environments (recovering native GUIDs), `CatalogDiff` must report zero
+  delta modulo `Readiness.toLogicalShape` normalization (constraint names/triggers/column
+  checks derive from physical names and must be stripped). Espace-invariance is the law
+  (A45 candidate).
+- **Managed-cloud capability verdict (confirmed on a real managed environment
+  2026-06-15):** SELECT/INSERT/UPDATE/DELETE granted, **no ALTER, no IDENTITY_INSERT**
+  (error 1088) → `PreservedFromSource` is dead on managed cloud; **`AssignedBySink`
+  (sink mints keys + FK remap) is the live path**; MERGE…OUTPUT capture permitted;
+  rollback channel is plain SQL DELETE.
+- **THE SHARPEST GAP (blind spot #1):** the `peer`/`golden` mechanism as documented
+  *assumes matching `OSUSR_*` physical names between source and sink* — but real QA/UAT
+  espace naming makes prefixes differ. The cross-rendition write-target resolution that
+  handles differing names (`runWithRenames` / the reverse leg's two-contract mechanism)
+  was built and witnessed **only for the `legacy` (B→A) leg**, never wired or tested for
+  a peer (QA→UAT) transfer with two independently-named physical contracts. This is
+  precisely the scenario the operator will test today.
+- **Other open items pulled from the docs** (consolidated; engine/tests studies to
+  confirm which are still live at HEAD):
+  1. `golden` re-key against a real cloud pair unwitnessed (canaries are offline Docker
+     with matching names; user-directory probe P10 residual).
+  2. Live two-independently-read-DB identity alignment: `ReadSide` synthesizes SsKeys
+     from *physical* coordinates, so two live reads never align; the OSSYS-read fix
+     (`check shape` slices S1–S5) is a 2026-06-21 design whose shipped status must be
+     verified against code.
+  3. `golden` needs an explicit `--reconcile` tail (no default User:Email from config).
+  4. G1: object-scope DENY escapes the DB-scope grant preflight → mid-load partial write.
+  5. G2: live-source schema drift vs contract → raw unnamed SqlException.
+  6. No idempotent re-run: second Execute into a populated sink duplicates every
+     `AssignedBySink` row (honest modes today: WipeAndLoad or journal-gated resume).
+  7. Table-subset transfers force the materialized arm (not streaming) — throughput note.
+  8. Composite/multi-column-PK and non-IDENTITY-PK tables refuse under `AssignedBySink`;
+     no business-key fallback except the User kind.
+  9. CDC verdict on real managed environment still PARTIAL.
+- Also surfaced by the session's stop hook, independent of the docs: the **perf-gate
+  Release build currently fails** with FS3511 at `SyntheticLoadRun.fs:130` on an
+  untouched tree (markdown-only commit) — verifying now; if confirmed pre-existing it is
+  itself a production blocker (Release binaries won't build).
+
+## Entry 4 — 2026-07-06, Release build was broken at HEAD; fixed
+
+- Confirmed: `dotnet build src/Projection.Pipeline -c Release` fails at HEAD (clean tree)
+  with FS3511 in `SyntheticLoadRun.run` — the known Release-only state-machine
+  reducibility failure (survival rule 5). Production Release binaries could not build.
+- Fix applied (mechanical, per the house scars): the tuple-pattern `match` that headed
+  the `task { }` now resolves before the task opens, and the pure middle (module filter →
+  Faker-coordinate refusal → config fold → opt-in graph analytics) is hoisted to a
+  module-level `private prepareSynthesis`. The task body keeps the reducible
+  `match! → match → match! → match → return` spine. Zero behavior change intended;
+  fast pool + Release build of the Integration assembly running to verify.
+
+## Entry 5 — 2026-07-06, all four deep studies returned: the full blind-spot map
+
+All three code-facing studies **independently converge** on the same central finding.
+
+**What already exists and is genuinely strong:**
+- The use case is named end-to-end in the target docs: the `golden` flow
+  (`{ from: cloud-qa, to: cloud-uat, scope: data, tables: [...], reconcile:
+  [ServiceCenter.User:Email], rekey: file:… }` in `examples/projection.sample.json`),
+  invoked as `projection golden [--go]`, dry-run by default, double-gated
+  (`PROJECTION_ALLOW_EXECUTE=1` + `--go`).
+- **`projection check shape` is SHIPPED, not just designed** (verified directly in
+  `Faces/Diff.fs:122-168` + `Projection.Pipeline/Readiness.fs`): OSSYS-reads every
+  configured environment (native OutSystems GUID SsKeys — espace-safe), normalizes away
+  physical-realization artifacts (`Readiness.toLogicalShape`), and requires
+  `CatalogDiff` zero-delta ⇒ "one shape" across environments with different `OSUSR_*`
+  names. Exit 0 ready / 5 divergence-or-dealbreaker / 6 unreadable. This satisfies the
+  "SS_KEY tables+attributes must match to validate schema shape" core requirement — as a
+  *manual* preflight.
+- The engine's dual-catalog machinery (`runReverseLegThroughConnectionsWith`) is exactly
+  the right shape for "same schema, different physical names": two SsKey-aligned
+  contracts, `CatalogDiff.between` → rename map, reads with source names, writes with
+  sink names, all correspondence by SsKey. Proven live in docker canaries (M3/LE-1,
+  LE-2) including a genuinely differently-named table pair (`Customer` →
+  `OSUSR_XF_CUSTOMER`).
+- FK handling: whole-catalog topological order, two-phase deferred-FK loads, unbreakable
+  cycle refusal by name, three identity dispositions; managed-cloud reality (no
+  IDENTITY_INSERT, error 1088) handled via `AssignedBySink` (sink mints keys, MERGE…
+  OUTPUT captures source→assigned pairs, FKs re-pointed through the remap), business-key
+  reconciliation for shared kinds (Users), fail-loud drop accounting (exit 9,
+  `--allow-drops` downgrade), revert scripts/auto-revert of sink-minted rows.
+- Two-DB espace-invariance canary exists (`OssysComprehensiveFixtureTests`): two OSSYS
+  databases, same GUIDs, `OSUSR_` vs `OSUSR_X` names → readiness sees one shape.
+
+**THE central blind spot (all three studies, code-confirmed):** for a *peer* (QA→UAT)
+transfer with genuinely differing physical names there is **no wired path**:
+1. The forward `Transfer` path (which the `golden` flow routes to) reads its ONE
+   contract from the **source** (`ReadSide.readSchema source`,
+   `TransferRun.fs:2137`) and writes with the **source's physical names** into the sink
+   — object-not-found (or worse) if UAT's `OSUSR_*` names differ.
+2. The rename-capable reverse-leg path is dispatch-gated to `rendition: logical` →
+   `rendition: physical` (on-prem→cloud) and its contracts are two renditions of ONE
+   authored model — there is no "physical-as-deployed-at-QA" vs
+   "physical-as-deployed-at-UAT" rendition.
+3. Two independent `ReadSide` live reads can never align (SsKeys synthesized from
+   physical coordinates) — but **OSSYS reads do align** (native GUIDs), and `check
+   shape` already proves it. The missing piece is feeding two OSSYS-read,
+   SsKey-aligned per-environment contracts into the existing rename-aware engine.
+
+**Secondary blind spots (consolidated from the three code studies):**
+- No schema-compatibility gate on the transfer path itself: `CatalogDiff.Reshaped`
+  (type/length/nullability divergence) is computed and discarded; sink live schema
+  never verified against the contract → drift = mid-load SqlException, not a named
+  refusal. `check shape` exists but is not wired as a transfer precondition.
+- `--tables` subset has **no FK-closure story**: an in-subset child pointing at an
+  out-of-subset parent is (a) mass-dropped w/ exit 9 if the parent is IDENTITY-PK
+  (`AssignedBySink` remap has no captures), (b) copied verbatim w/ orphans surfacing
+  only at FK re-trust (or silently on ManagedDml) if business-PK, (c) correct only
+  under a manual `--reconcile`. The espace-aware closure machinery
+  (`Closure.fs`/`ClosureOracle.fs`) exists but is wired only to `slice-extract`/
+  `slice-apply`, not `transfer`.
+- G10 resume marker is subset-insensitive: a completed `--tables A` resumable run makes
+  a later `--tables B` run a silent no-op replay.
+- Grant preflight demands INSERT over the WHOLE estate even for a 2-table subset
+  (`plannedTransferWrites` ignores LoadSet) — over-refusal on narrowly-granted sinks.
+- `WipeAndLoad` + subset: out-of-subset children referencing wiped rows → unhandled 547
+  mid-wipe.
+- `--user-map` resolves tables by physical name only (espace-unsafe); `--reconcile` has
+  the espace-safe `Module.Entity` form.
+- Object-scope DENY invisible to the DB-scope grant probe (G1, pinned); contract-named
+  column missing from live source = raw unnamed SqlException (G2, pinned/reserved).
+- Streaming refuses `--tables` (named follow-on) — subsets always run materialized
+  (full per-kind rows in memory).
+- No argv surface for `--tables`/`--reconcile` — flow config (`projection.json`) is the
+  only expressible surface (by design, A44).
+- `transfer.tablesUnknown` exits 3 (unclassified) instead of the argument-error 2.
+- Composite-PK `AssignedBySink` kinds refuse by name (no business-key fallback outside
+  the User family) — must be surveyed per-table before a real run.
+
+**Test-estate gaps (docker e2e), with templates identified:**
+1. **No test moves DATA between two differently-named environments** — schema-shape
+   equivalence is proven, data movement is not. Template: two `WithEphemeralDatabase`
+   on `EphemeralContainerFixture` + the `OSUSR_`→`OSUSR_X` trick + OSSYS reads on both
+   sides + `CatalogDiff.between` rename map into the rename-aware engine.
+2. FK-outside-subset (`--tables` child w/ parent left behind, sink pre-populated with
+   parents) — never asserted.
+3. `--tables` × FK-cycle/deferred-FK combination — never asserted together.
+4. Pure unit test for `resolveLoadSet` — missing entirely (cheapest gap).
+5. Reserved stubs already in-tree for G1/G2 refusals (bodies empty).
+
+**Readiness plan for today's operator test** (pending operator answers): commit the
+Release fix; stand up e2e #1 (the different-physical-names data-move witness); then
+either wire the peer-with-renames dispatch path or document the engine-level invocation;
+propose FK-closure strategies per table for the chosen subset.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -420,3 +420,86 @@ an ADMIN principal — it proves identity alignment and FK re-pointing but NOT t
 managed-cloud grant envelope; the FK-retrust descent path
 (FkTrustNotRestoredOnBulkLoad) is unexercised on the peer leg; IDENTITY reseed
 mechanics differ under a real grant.
+
+## Entry 12 — 2026-07-06, phase-2 findings triaged and FIXED (two critical, three high, five medium)
+
+The four agents returned. Every confirmed finding fixed this session, each with tests:
+
+**CRITICAL (both confirmed, both fixed):**
+1. **The rename map was kind-BLIND.** `RenameProjection` flattened per-kind attribute
+   renames into ONE `Map<Name,Name>` applied to EVERY kind's rows: renaming
+   `Invoice.Status → State` silently re-keyed `Order.Status` too — Order's value became
+   unreachable at the sink getter and the column wrote NULL. Now KIND-SCOPED
+   (`renameMapByKind` / `forKind`) through the materialized repoint, the streaming
+   basis, phase-2 projections, and the reconcile ingest; the flat API is deleted;
+   regression pins added. (This poisoning existed on the REVERSE LEG too — pre-existing,
+   now dead everywhere.)
+2. **`--allow-drops` on escaping subset FKs did not drop — it cross-wired.** No engine
+   code drops/NULLs an FK to an out-of-subset un-reconciled kind; the rows landed
+   carrying the SOURCE environment's surrogate values, silently pointing at whatever
+   sink rows own those keys (exit 0, empty drop report). The bypass is REMOVED: a live
+   run refuses (`transfer.peer.subsetFkEscapes`) until the target is reconciled or the
+   subset widened; the narration now proposes the copy-pasteable
+   `Module.Entity:Column` reconcile form.
+
+**HIGH (fixed):** sink-only attributes are now OMITTED from the bulk column list (the
+sink's default genuinely applies; before, `KeepNulls` pinned an explicit NULL and a
+mandatory sink-only column crashed raw); the shape gate's Length arm blocks
+open-ended-source→bounded-sink (was misread as "wider"); Precision/Scale block only a
+narrowing (was a false refusal on widening); Nullability judges the COLUMN plane (the
+facet's own vocabulary).
+
+**MEDIUM (fixed):** materialized `--resumable` against a managed-DML sink now refuses
+BY NAME (`transfer.reverseLeg.resumableSinkUnsupported`) instead of dying raw on the
+progress table's CREATE TABLE (only the streaming arm was archetype-guarded);
+`resolveLoadSet` refuses duplicate logical names as ambiguous and accepts
+`Module.Entity` (was silent last-wins); the peer face refuses a bad reconcile spec
+BEFORE the gates (exit 2 — was mis-blamed as exit-9 escapes); parallel FK edges
+between one pair (Employee.Manager + Employee.Mentor) no longer wedge the topo order
+via a stale indegree (strength combines: breakable only if ALL parallel edges are
+weak); a live Execute on an ALPHABETICAL (degraded) load order refuses by name
+(`transfer.loadOrderUnproven`) instead of loading children before parents.
+
+**Ergonomics landed** (from the ranked list): peer refusals render through the GATE
+surface (statement + next move; was the flat GenericStop wall); shape advisories +
+escape proposals land on STDOUT (a redirected preview no longer silently loses the
+safety info); env→env data flows with UNSET renditions get a voiced note naming the
+name-blind assumption and the `rendition: physical` fix; `--user-map` accepts the
+espace-safe `Module.Entity` form; the flow menu shows `reconcile:` tags; refusal
+messages hint the logical form for peer transfers.
+
+## Entry 13 — 2026-07-06, THE MOCK-ENVIRONMENT PROGRAM: managed-grant e2e landed, and it caught a live-test-killing bug in hour one
+
+New fixtures: `OssysSeedBuilder` (espace-key parameterization — a named transform, not
+a string hack), `DmlPrincipal` (the managed-cloud principal: EXPLICIT db-scope
+SELECT/INSERT/UPDATE/DELETE — deliberately not db_datareader/writer, whose rights
+don't surface in `fn_my_permissions` and would false-trip the grant preflight), and
+`MockOutSystemsEnv` (metamodel + espace-prefixed physical tables + optional managed
+principal; single or paired cells).
+
+`PeerManagedGrantTransferDockerTests` — five scenarios, ALL GREEN:
+1. **Grant conformance probe** — the principal's permission evidence is exactly what
+   the engine's preflight reads; IDENTITY_INSERT/CREATE TABLE/ALTER fail in their
+   documented error classes; #temp staging and MERGE…OUTPUT succeed. (Also pinned: SQL
+   Server 2022 auto-grants two VIEW ANY COLUMN * KEY DEFINITION rows to every user —
+   presence/absence assertions, not set equality.)
+2. **The peer subset happy path with DML-only principals on BOTH sides** — including
+   contract acquisition through the restricted logins. Plus a genuine mechanics
+   finding: FK-targeted kinds ride the MERGE capture lane which validates constraints
+   INLINE — the sink FK ends enabled AND TRUSTED, no ALTER ever needed. (The
+   bulk-lane untrusted tolerance belongs to non-FK-targeted kinds.)
+3. **Reconcile-by-key under the grant.**
+4. **Unreadable sink metamodel → named schema-read refusal (exit 6).**
+5. **G1 pinned on the peer dispatch** — object-scope DENY INSERT is invisible to the
+   DB-scope preflight: raw permission exception mid-load, the parent kind already
+   landed (partial write). Cross-references the reserved promotion stub.
+
+**THE BIG CATCH (would have killed today's live test at step one):** the OSSYS
+metamodel extraction FAILED ENTIRELY under the managed grant —
+`sys.check_constraints.definition` is NULL without VIEW DEFINITION, and the
+`columnChecks` rowset reader treated it as required (`adapter.ossysSql.rowMapping`,
+whole read dead). Fixed: the definition is optional through the whole chain; a
+definition-less check row is SKIPPED (a named erasure — ColumnChecks are
+physical-realization artifacts the shape verdict strips and the data plane never
+reads; privileged reads still carry them). Also: adapter-level extraction failures now
+classify onto the schema-read axis (exit 6) instead of unclassified-3.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -738,3 +738,52 @@ Pure pins added (`subsetEscapeGate` semantics + exit-9 classification). Fast poo
 GREEN; **the full docker pool PASSED IN FULL (519s)** — every leg's canaries
 (forward transfer, legacy reverse, streaming, peer, managed-grant, go-board,
 proving-loop) green through the new gates. The parity sweep is closed.
+
+## Entry 20 — 2026-07-06, THE FINAL PASS: two Opus critiques applied (refactor + DX)
+
+Operator directive: identify duplication/refactoring needs and polish DX before
+moving on. Two Opus critics swept the session's ~4,400-line diff; every accepted
+finding applied, the explicit not-dos honored.
+
+**Refactoring (the duplication the session created, now paid down):**
+- `ConnectionRef.Raw` (with its DECISIONS amendment): the in-memory carrier for an
+  already-resolved secret. Kills the temp-file-secret dance at FOUR sites (the go
+  board's dry run + three test fixtures) — the workaround was persisting the secret
+  to disk, strictly worse than the D9 discipline it dodged. `Raw` never round-trips
+  into config (maps to the `live:` spec form only).
+- `TransferSubset.escapingEdges`: the ONE escaping-relationship traversal, consumed
+  by both the engine backstop and the peer face's rich detector — the two
+  predicates can no longer drift (board-green-while-engine-refuses is structurally
+  impossible).
+- `parseReconcileInputs`: four near-identical reconcile/user-map parse blocks in the
+  faces collapsed to one helper (the peer face's deliberate defer-missing-file
+  divergence preserved as a named flag).
+- The `DmlPrincipal` promotion FINISHED: `ReverseLegCanaryTests`' private duplicate
+  deleted, eight call sites swapped to the shared module.
+- `PeerAlignedTransferDockerTests`' blind `String.Replace` espace shift replaced
+  with `OssysSeedBuilder.withEspaceKey`; both peer suites' `throughConnections` ride
+  `Raw`.
+- Explicit NOT-DOs (per the critique, with reasons on record): no rename of
+  `transfer.reverseLeg.resumableSinkUnsupported` (operator-facing compat > cosmetic
+  accuracy); no `runCheckGo` preamble decomposition (the linear cascade IS the
+  clearest form); no View-ification of the board render (deliberate report format;
+  pure core already split).
+
+**DX (the operator-surface polish):**
+- **THE WRONG-SINK REVERT GUARD** (the critique's top finding): every undo/revert
+  artifact now carries a provenance header naming the database its keys were
+  captured against; `projection revert` refuses by name (`revert.sinkMismatch`,
+  exit 7) when `--against` resolves elsewhere — `--force` is the deliberate
+  override; a header-less (pre-stamp) artifact proceeds with a printed note.
+  Pinned in the proving-loop e2e (pointing the undo at the SOURCE refuses).
+- **`check go --format json`**: the board's typed structure serializes
+  (`{verdict, redCount, items:[{axis, status, headline, remedy, detail}]}`) — the
+  CI-able claim now has a machine-readable surface beyond the exit code. Pure pin
+  added; runbook notes the board's exit-5 vs the live run's 5/9 refinement.
+- Copy: "no reconcile rules declared yet" (the green-at-zero contradiction gone);
+  "modulo" de-jargoned; revert preview says "row(s) to delete" (not "captured
+  key(s)"); a second revert says "Nothing to revert" instead of feigning deletion;
+  escape proposals lead with the paste-able move (truncation-safe); ONE name — "the
+  go board" — everywhere.
+
+Fast pool + the full peer/managed/go-board/reverse-leg docker sweep: GREEN.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -582,3 +582,40 @@ mock-OutSystems-environment fixture stack; 5 managed-grant e2e scenarios; 1
 live-test-killing extraction bug caught BY the new mock environments in their first
 hour (check-constraint definitions under VIEW-DEFINITION-less principals); the
 semantics walkthrough (entry 14) for operator validation.
+
+## Entry 16 — 2026-07-06, THE PREVIEW ENGINE: the go board (red→green), the dry-run forecast, and the runbook
+
+Operator directive: all forecast capabilities in one place, a dry run, CLI-visible
+open-decision flagging, and a validateable red-until-configured → green model, plus a
+stepwise end-to-end explanation.
+
+**Landed — `projection check go <flow>` (THE GO BOARD):**
+- One typed checklist (`GoBoard`, Pipeline) judging every axis a live run hits:
+  routing, contracts, tables, reconcile, shape (+advisories), relationships
+  (escaping-FK open decisions with paste-able remedies), load order, **the engine
+  DRY RUN** (real reads, zero writes → exact per-table row forecast, unmatched
+  identities, drop forecast, unbreakable cycles), CDC posture, grant evidence
+  (+the standing G1 note), re-run semantics judged against the sink's ACTUAL state
+  (merge-into-populated duplicates; replace wipe-blockers probed), and the run-time
+  execute gates as a note.
+- Every red line carries the reason AND the exact remedy. Verdict is total:
+  GREEN ⇔ zero red. **Exit 0 green / 5 red — CI-able**: wire it red, fix the named
+  decisions, watch it turn green.
+- The check derives the flow through the SAME `planFlow` path a real run takes
+  (A44: the check and the run cannot drift); previews print a pointer to the board.
+
+**Proven:**
+- Pure: verdict algebra, render marks/remedy/detail/next-move.
+- Docker e2e (`GoBoardDockerTests`, managed-grant principals both sides): an
+  unconfigured flow (escaping FK) is RED exit 5 with the named decision; adding the
+  proposed reconcile turns it GREEN exit 0 (with the dry-run forecast: "Customer: 2
+  row(s) will transfer (assigned by the target)"); a real sink-metamodel divergence
+  turns it RED again; the sink stays byte-untouched throughout (the dry run never
+  writes).
+- Fast pool + the full peer/board docker sweep green.
+
+**The stepwise end-to-end guide** is now a first-class doc:
+`PARTIAL_TRANSFER_RUNBOOK.md` — configure → check go (red) → resolve each named
+decision → green → preview → execute → idempotent re-run, with the axis table, the
+decision playbook, exit codes, troubleshooting, and the exact per-environment
+permission footprint.

--- a/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
@@ -153,6 +153,33 @@ through the captured old→new key map → nullable cycle FKs re-pointed by
 phase-2 UPDATE → reconciled kinds' FKs re-keyed to the sink's existing rows →
 the run report printed (same vocabulary as the preview).
 
+## Step 6½ — The proving loop: revert what you just transferred
+
+Every successful `--go` writes **`transfer-undo.sql`** into the revert dir
+(default: the working directory) — the precise child-first
+`DELETE`-by-captured-key script for exactly the rows this run minted.
+Pre-existing sink rows (reconciled tables, anything already there) are never
+in it. The run's closing narration prints the path and the revert command.
+
+```
+projection revert --against cloud-uat                    # preview: tables + key counts, no deletes
+PROJECTION_ALLOW_EXECUTE=1 projection revert --against cloud-uat --go   # the undo, ONE transaction
+```
+
+- `--script <path>` points at a specific artifact (default `./transfer-undo.sql`;
+  a FAILED run's compensation script is `transfer-revert.sql` — same verb runs it).
+- The live revert runs in one transaction: all deletes land or none do (a
+  failure rolls back and says so).
+- So the small-sample proving loop is: declare a tiny `tables` subset → board
+  green → `--go` → verify in the target app/DB → `revert --go` → the sink is
+  back where it started. Iterate until confident, then widen the subset.
+- Two honesty notes: (1) a `replace`-strategy run's WIPE is not undone by the
+  script — the undo removes what the run MINTED; rows the wipe deleted are
+  gone (on a first load into empty tables this distinction is empty). (2) the
+  undo targets captured keys — run it BEFORE new app activity writes rows that
+  reference the minted ones (an FK from a newer row blocks the delete; the
+  transaction rolls back and tells you).
+
 ## Step 7 — Re-run whenever you need
 
 With `strategy: replace`, running step 6 again wipes the subset and reloads —

--- a/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
@@ -67,7 +67,12 @@ projection check go golden
 Read-only (plus a dry run — real reads, zero writes). It prints one line per
 axis with `[ GO ]` / `[STOP]` / `[note]` marks and a final verdict, and exits
 **5 while red, 0 when green** — so you can wire it into CI or a pre-flight
-script and literally watch it turn green.
+script and literally watch it turn green. `--format json` emits the whole
+board as structured data (`{verdict, redCount, items:[{axis, status,
+headline, remedy, detail}]}`) for pipelines that want more than the exit
+code. One note for CI authors: the board's not-ready verdict is always
+exit 5 (the `check shape` class); the live `--go` run refines that into 5
+(shape) vs 9 (relationships / identities / drops).
 
 The axes it judges, in order — the full forecast vocabulary:
 
@@ -173,12 +178,19 @@ PROJECTION_ALLOW_EXECUTE=1 projection revert --against cloud-uat --go   # the un
 - So the small-sample proving loop is: declare a tiny `tables` subset → board
   green → `--go` → verify in the target app/DB → `revert --go` → the sink is
   back where it started. Iterate until confident, then widen the subset.
+- **The wrong-sink guard**: every artifact carries a provenance header naming
+  the database the keys were captured against; `revert` refuses by name
+  (`revert.sinkMismatch`) if `--against` resolves to a different database.
+  `--force` is the deliberate override for a legitimately renamed/restored
+  copy. Never point a revert at any environment other than the one the
+  transfer wrote.
 - Two honesty notes: (1) a `replace`-strategy run's WIPE is not undone by the
   script — the undo removes what the run MINTED; rows the wipe deleted are
   gone (on a first load into empty tables this distinction is empty). (2) the
   undo targets captured keys — run it BEFORE new app activity writes rows that
   reference the minted ones (an FK from a newer row blocks the delete; the
-  transaction rolls back and tells you).
+  transaction rolls back and tells you). A second revert of the same artifact
+  reports "Nothing to revert" rather than pretending to delete again.
 
 ## Step 7 — Re-run whenever you need
 

--- a/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
@@ -1,0 +1,182 @@
+# The Partial-Transfer Runbook — QA → UAT, step by step
+
+> The end-to-end operating guide for moving a **subset of tables** between two
+> managed Cloud OutSystems environments whose physical `OSUSR_*` names differ.
+> Written 2026-07-06 (the preview-engine program). The companion narrative is
+> `PARTIAL_TRANSFER_READINESS_LOG.md` (entry 14 is the semantics walkthrough).
+>
+> The shape of the whole flow: **configure → check go (red) → resolve each
+> named decision → check go (green) → preview → execute → re-run at will.**
+> Nothing is written to the sink until step 6.
+
+---
+
+## Step 0 — What you need before starting
+
+- Connection strings for BOTH environments, supplied out-of-band (D9): either
+  an environment variable per side or a file per side. The principals need
+  database-scope `SELECT, INSERT, UPDATE, DELETE` — the managed-cloud default.
+  (`INSERT` etc. are only exercised on the sink; the source is read-only in
+  practice, but the same grant profile works for both.)
+- The principals must be able to `SELECT` the OSSYS metamodel tables
+  (`ossys_Espace`, `ossys_Entity`, `ossys_Entity_Attr`) — that is where the
+  SS_KEY-aligned contracts come from.
+- The `projection` CLI on a machine that can reach both databases.
+
+## Step 1 — Configure `projection.json`
+
+```jsonc
+{
+  "environments": {
+    "cloud-qa":  { "access": "direct", "conn": "env:CLOUD_QA_CONN",
+                   "rendition": "physical", "archetype": "managed-dml" },
+    "cloud-uat": { "access": "direct", "conn": "env:CLOUD_UAT_CONN",
+                   "rendition": "physical", "archetype": "managed-dml",
+                   "grant": "data" }
+  },
+  "flows": {
+    "golden": { "from": "cloud-qa", "to": "cloud-uat", "scope": "data",
+                "tables": ["Customer", "Order"],
+                "reconcile": [],
+                "strategy": "replace" }
+  }
+}
+```
+
+Load-bearing choices:
+- **`rendition: physical` on BOTH sides** — this is what routes the flow onto
+  the SsKey-aligned peer leg (per-side OSSYS contracts, the shape gate, the
+  relationship gate). Leave it unset and the flow rides the old name-blind
+  transfer, which assumes matching physical names — the plan will print a
+  voiced note warning you if you do.
+- **`tables`** — logical entity names (what you see in Service Studio), not
+  physical `OSUSR_*` names. Use `Module.Entity` if a name exists in more than
+  one module (the resolver refuses ambiguity by name).
+- **`strategy: replace`** — wipe-the-subset-then-reload; a re-run is
+  idempotent. `merge` appends and will duplicate sink-minted rows on a re-run
+  into a populated sink (the go board flags exactly this).
+- **`reconcile`** — start EMPTY. The go board will tell you which entries you
+  need (step 3).
+
+## Step 2 — Run the go board (expect RED the first time)
+
+```
+projection check go golden
+```
+
+Read-only (plus a dry run — real reads, zero writes). It prints one line per
+axis with `[ GO ]` / `[STOP]` / `[note]` marks and a final verdict, and exits
+**5 while red, 0 when green** — so you can wire it into CI or a pre-flight
+script and literally watch it turn green.
+
+The axes it judges, in order — the full forecast vocabulary:
+
+| Axis | What it proves | Red means |
+|---|---|---|
+| routing | the flow rides the SsKey-aligned peer leg | renditions unset → fix step 1 |
+| contracts | both OSSYS metamodels read; identities align | connection/grant problem — remedy printed |
+| tables | your subset resolves (unambiguously) | typo or ambiguous name — use `Module.Entity` |
+| reconcile | every reconcile entry resolves against the sink | bad entry — use `Module.Entity:Column` |
+| shape | the two models are ONE shape over the transferred set | real divergence — align model versions |
+| relationships | no FK escapes the subset un-strategized | **the main open decision — see step 3** |
+| load order | parents-before-children is proven | an unresolvable cycle — remedy printed |
+| forecast | the DRY RUN: exact row counts per table | the dry run refused — reason printed |
+| cycles / identities / drops | forecast of unbreakable cycles, unmatched identities, dropped rows | fix data / user-map, or accept with `--allow-drops` at run time |
+| cdc | the sink is not CDC-tracked | decide `--allow-cdc` or de-track |
+| grant | the sink principal carries db-scope DML | grant the missing permission |
+| re-run | your strategy is safe against the sink's ACTUAL state | duplicates (merge into populated) or wipe blockers — remedy printed |
+| execute gates | (note) the two run-time gates | never red — informational |
+
+## Step 3 — Resolve the open decisions (the usual one: escaping relationships)
+
+A `[STOP] relationships` line means a chosen table points at a table you did
+NOT choose. Every such edge needs one of two strategies:
+
+1. **Reconcile it** (the default recommendation): the sink already holds that
+   reference data under its own keys — tell the engine which business column
+   matches rows across environments. The board prints the paste-able entry,
+   e.g.:
+   ```jsonc
+   "reconcile": ["AppCore.City:Name"]
+   ```
+   Reconciled tables are never inserted into — source rows are matched to the
+   sink's existing rows by that column, and every FK re-keys to the sink's own
+   identities.
+2. **Widen the subset**: add the referenced table to `tables` — it transfers
+   too (the sink mints its keys; FKs re-point automatically).
+
+Re-run `projection check go golden` after each edit until the verdict is
+GREEN. Other common decisions the board can raise: unmatched identities (fix
+the reconcile data or accept the loss with `--allow-drops` at run time), a
+CDC-tracked sink (`--allow-cdc`), merge-into-populated-sink (switch to
+`strategy: replace`).
+
+## Step 4 — GREEN
+
+```
+  VERDICT — GREEN. Every gate passes. Execute with: PROJECTION_ALLOW_EXECUTE=1 projection golden --go
+```
+
+Exit code 0. The setup is validated: every gate the live run will hit has
+passed against the real environments, and the forecast tells you exactly how
+many rows will move per table.
+
+## Step 5 — Preview (the dry run, narrated)
+
+```
+projection golden
+```
+
+Preview is the DEFAULT (no flag). It runs the same engine with zero writes and
+narrates the load plan in dependency order: per-table row counts and identity
+dispositions ("assigned by the target" = sink mints keys; "re-keyed by rule" =
+reconciled), deferred FK columns, anything unmatched or droppable, plus the
+shape advisories. `projection golden > preview.txt` captures everything —
+the safety information prints on stdout.
+
+## Step 6 — Execute
+
+```
+PROJECTION_ALLOW_EXECUTE=1 projection golden --go
+```
+
+Two deliberate gates: the environment variable authorizes the environment; the
+flag states per-run intent. Exit codes: `0` clean · `5` shape divergence · `9`
+un-strategized relationships / unmatched identities / dropped rows (the report
+names them; `--allow-drops` downgrades identity/drop refusals you have
+deliberately accepted) · `6`/`7` connection/grant · `2` argument/spec errors.
+
+What happens inside, in order: contracts re-acquired → gates re-checked (the
+same ones the board ran) → subset wiped child-first (`strategy: replace`) →
+parents loaded first, sink minting every identity → children's FKs re-pointed
+through the captured old→new key map → nullable cycle FKs re-pointed by
+phase-2 UPDATE → reconciled kinds' FKs re-keyed to the sink's existing rows →
+the run report printed (same vocabulary as the preview).
+
+## Step 7 — Re-run whenever you need
+
+With `strategy: replace`, running step 6 again wipes the subset and reloads —
+same result every time (proven by the idempotency e2e). Refresh QA-side data,
+re-run, done. If the sink's reference data changed (reconciled tables), the
+board re-validates the matches — run `check go` again first when in doubt.
+
+---
+
+## Troubleshooting quick table
+
+| Symptom | Meaning | Move |
+|---|---|---|
+| board: `[STOP] contracts` | OSSYS metamodel unreadable | grant SELECT on `ossys_*` to the principal |
+| board: `[STOP] shape` | the two environments genuinely run different model versions | deploy the same version to both, or narrow the subset |
+| exit 9 at `--go` with drop lines | rows referenced identities that don't match | fix the reconcile data or accept with `--allow-drops` |
+| raw SQL permission error mid-load | a TABLE-level DENY (invisible to preflight — the pinned G1 gap) | remove the DENY; the revert script (`transfer-revert.sql`) undoes sink-minted rows |
+| board green but `--go` exits 7 | `PROJECTION_ALLOW_EXECUTE` not set | set it (the board's `[note]` line reminds you) |
+
+## What the tool touches, per environment
+
+Source: `SELECT` on `ossys_*` (contract) + `SELECT` on the subset's `OSUSR_*`
+tables (rows). Sink: the same reads, plus `INSERT`/`UPDATE` on the subset's
+tables (the load + FK re-point), `DELETE` on them (`replace` wipe / revert),
+`#temp` staging in tempdb, and `MERGE … OUTPUT` (key capture). Nothing needs
+ALTER, CREATE TABLE, or IDENTITY_INSERT — proven by the managed-grant e2e
+suite (`PeerManagedGrantTransferDockerTests`).

--- a/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_RUNBOOK.md
@@ -172,6 +172,53 @@ board re-validates the matches — run `check go` again first when in doubt.
 | raw SQL permission error mid-load | a TABLE-level DENY (invisible to preflight — the pinned G1 gap) | remove the DENY; the revert script (`transfer-revert.sql`) undoes sink-minted rows |
 | board green but `--go` exits 7 | `PROJECTION_ALLOW_EXECUTE` not set | set it (the board's `[note]` line reminds you) |
 
+## Rehearsed end-to-end (2026-07-06)
+
+Every step above was executed verbatim with the real CLI against a mock QA/UAT
+pair (espace-shifted physical names, DML-only principals on both sides):
+menu → board RED (2 escapes named) → reconcile entries pasted → board RED
+again (the identities forecast caught missing sink reference data BEFORE any
+write) → sink reference data fixed → GREEN → preview ("4 row(s) would move
+across 4 table(s)") → `--go` without the env var refused (exit 7, remedy
+printed) → live run (customers minted 900/901 with cities re-pointed to the
+sink's own 501/502; orders minted 9000/9001 pointing at the NEW customer keys
+and name-matched categories) → re-run idempotent (counts stable, zero dangling
+FKs, source untouched).
+
+## Live-environment hotspots (what the rehearsal CANNOT prove — read before your first real run)
+
+1. **User references.** Real estates carry `CreatedBy`/`UserId` columns
+   referencing the platform User entity (system espace). If the User kind is
+   IN the acquired contract, any such edge shows up on the board's
+   `relationships` line — reconcile it (`Users.User:Username` or by email).
+   If your subset tables carry user columns but NO such line appears, the
+   User entity may be OUTSIDE the contract — the gate cannot see a reference
+   whose target kind is absent, and user ids DIFFER between environments.
+   Check manually before trusting those columns.
+2. **Scale.** A `tables` subset runs MATERIALIZED: the subset's rows are
+   resident in memory on the machine running the CLI. Fine for thousands to
+   low millions of small rows; a very large table in the subset needs the
+   streaming realization, which does not yet support `--tables`. Start with
+   modest subsets.
+3. **Wipe duration on re-runs.** `strategy: replace` deletes with plain
+   `DELETE` (no TRUNCATE — the grant has no ALTER): a re-run over a very
+   large already-loaded subset holds a long transaction. First loads into an
+   empty sink are unaffected.
+4. **Connection strings.** Real managed environments typically require
+   `Encrypt=True` with a valid certificate chain (do not copy the
+   `TrustServerCertificate=True` from lab examples), plus VPN/IP-allowlist
+   network reach from the machine running the CLI to BOTH databases.
+5. **Command timeouts.** Contract acquisition is one metamodel batch (fast
+   even on large estates), but a multi-million-row ingest SELECT can exceed
+   default command timeouts on slow links — if you hit timeouts, narrow the
+   subset first.
+6. **The one standing preflight blind spot** — a TABLE-level DENY passes the
+   board's grant probe and surfaces mid-load (raw permission error). The
+   revert script (`transfer-revert.sql`) removes the partial rows; auto
+   revert is `--auto-revert`.
+7. **Cosmetic**: one narrow-terminal note line can render truncated with `…`
+   (a known display residual); the board and load plan are unaffected.
+
 ## What the tool touches, per environment
 
 Source: `SELECT` on `ossys_*` (contract) + `SELECT` on the subset's `OSUSR_*`

--- a/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
@@ -526,13 +526,14 @@ module OssysRowsetReader =
     let private parseColumnCheckRowFor
         (moduleName: string)
         (entityName: string)
+        (definition: string)
         (row: ColumnCheckRow)
         : Result<ColumnCheck> =
         let chkKey  = columnCheckSsKey moduleName entityName row.ConstraintName
         let chkName = Name.create row.ConstraintName
         match chkKey, chkName with
         | Ok k, Ok n ->
-            ColumnCheck.create k (Some n) row.Definition row.IsNotTrusted
+            ColumnCheck.create k (Some n) definition row.IsNotTrusted
         | _ ->
             propagateOrFallback
                 [ Result.errors chkKey
@@ -618,7 +619,16 @@ module OssysRowsetReader =
             // `Kind.ColumnChecks` is table-scoped (one entry per
             // unique constraint).
             |> List.distinctBy (fun row -> row.ConstraintName)
-            |> Bench.iterMap "adapter.osm.parse.rowsetColumnCheck" (parseColumnCheckRowFor moduleName kindRow.EntityName)
+            // A `Definition = None` row is the VIEW-DEFINITION-less read
+            // (the managed-cloud grant): the constraint exists but its
+            // body is unreadable, and `ColumnCheck` cannot represent a
+            // definition-less check — the row is SKIPPED (a named
+            // erasure: ColumnChecks are physical-realization artifacts
+            // the shape verdict strips (`Readiness.toLogicalShape`) and
+            // the data plane never consumes; a privileged read still
+            // carries them). 2026-07-06, the phase-2 mock-env program.
+            |> List.choose (fun row -> row.Definition |> Option.map (fun d -> row, d))
+            |> Bench.iterMap "adapter.osm.parse.rowsetColumnCheck" (fun (row, d) -> parseColumnCheckRowFor moduleName kindRow.EntityName d row)
         let foldedColumnChecks = Result.aggregate columnCheckResults
         // Slice 5 — TableId is typed (SchemaName / TableName).
         let physicalSchemaResult = SchemaName.create kindRow.DbSchema

--- a/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetTypes.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetTypes.fs
@@ -349,7 +349,13 @@ module OssysRowsetTypes =
         {
             AttrId         : int
             ConstraintName : string
-            Definition     : string
+            /// `None` when the reading principal lacks VIEW DEFINITION —
+            /// the managed-cloud grant (2026-07-06, the phase-2 mock-env
+            /// program): `sys.check_constraints.definition` NULLs out and
+            /// the constraint cannot be represented; the parse SKIPS it
+            /// (named in the parser's docstring) instead of failing the
+            /// whole extraction.
+            Definition     : string option
             IsNotTrusted   : bool
         }
 

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
@@ -241,7 +241,10 @@ module MetadataSnapshotRunner =
     type OssysColumnCheckRow =
         { AttrId         : int
           ConstraintName : string
-          Definition     : string
+          /// `None` when the principal lacks VIEW DEFINITION (the
+          /// managed-cloud grant) — `sys.check_constraints.definition`
+          /// NULLs out; the read must not fail on it (2026-07-06).
+          Definition     : string option
           IsNotTrusted   : bool }
 
     /// `#PhysColsPresent` rowset (matrix row 14). Set of `AttrId` whose
@@ -551,10 +554,10 @@ module MetadataSnapshotRunner =
 
     let private mapColumnCheckRow (r: SqlDataReader) : OssysColumnCheckRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1042-1048
-        { AttrId         = readInt    r 0
-          ConstraintName = readString r 1
-          Definition     = readString r 2
-          IsNotTrusted   = readBool   r 3 }
+        { AttrId         = readInt       r 0
+          ConstraintName = readString    r 1
+          Definition     = readStringOpt r 2
+          IsNotTrusted   = readBool      r 3 }
 
     let private mapPhysColsPresentRow (r: SqlDataReader) : OssysPhysColsPresentRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1056-1059

--- a/sidecar/projection/src/Projection.Adapters.Sql/ConnectionResolver.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ConnectionResolver.fs
@@ -38,6 +38,11 @@ module ConnectionResolver =
                 let value = (File.ReadAllText path).Trim()
                 if String.IsNullOrWhiteSpace value then Result.failureOf (blank label (sprintf "file '%s'" path))
                 else Result.success value
+        | ConnectionRef.Raw connStr ->
+            // The already-in-memory secret (D9 amendment 2026-07-06): the
+            // caller resolved it upstream; never logged, never persisted.
+            if String.IsNullOrWhiteSpace connStr then Result.failureOf (blank label "raw connection string")
+            else Result.success connStr
 
     /// A diagnostic label for a substrate — `Role:ENVIRONMENT` — so a
     /// resolution / open failure names which substrate failed.

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -148,6 +148,39 @@ let private narrateUndoPointer (mode: Transfer.Mode) (revertOut: string option) 
             printfn "  Revert this run with: PROJECTION_ALLOW_EXECUTE=1 projection revert --script %s --against <sink-environment> --go" path
     | _ -> ()
 
+/// The ONE reconcile/user-map input parse (final-pass consolidation,
+/// 2026-07-06: four near-identical copies collapsed). Parses the
+/// `--reconcile` specs and the optional `--user-map` CSV, aggregating every
+/// spec error. `deferMissingUserMap` preserves the peer face's gate-scoping
+/// contract: a missing file parses as EMPTY there (the delegate re-parses
+/// and refuses `transfer.userMap.fileMissing` byte-identically); every
+/// other caller refuses the missing file here.
+let private parseReconcileInputs
+    (reconcileSpecs: string list)
+    (userMapPath: string option)
+    (deferMissingUserMap: bool)
+    : Result<TransferSpec.ReconcileEntry list * TransferSpec.UserMapEntry list> =
+    let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
+    let parsedUserMap : Result<TransferSpec.UserMapEntry list> =
+        match userMapPath with
+        | None -> Result.success []
+        | Some path ->
+            if not (System.IO.File.Exists path) then
+                if deferMissingUserMap then Result.success []
+                else
+                    Result.failureOf
+                        (ValidationError.create "transfer.userMap.fileMissing"
+                            (sprintf "user-map file '%s' not found." path))
+            else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+    let errors =
+        (parsedReconciles |> List.collect (function Ok _ -> [] | Error es -> es))
+        @ (match parsedUserMap with Ok _ -> [] | Error es -> es)
+    if not (List.isEmpty errors) then Result.failure errors
+    else
+        Result.success
+            (parsedReconciles |> List.choose (function Ok e -> Some e | _ -> None),
+             (match parsedUserMap with Ok es -> es | _ -> []))
+
 /// 6.A.1 — the drop-set is fail-loud, not exit-0. A successful write that
 /// dropped FK-orphan rows or left reconciled-kind sources unmatched surfaces
 /// a distinct non-zero exit unless the operator declared the drops
@@ -202,22 +235,11 @@ let runTransfer
     let collect = function Ok _ -> [] | Error es -> es
     let parsedSource    = TransferSpec.parseConnectionSpec sourceSpec
     let parsedSink      = TransferSpec.parseConnectionSpec sinkSpec
-    let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
-    // Slice 4.2 — read + parse the optional --user-map CSV (boundary I/O).
-    let parsedUserMap : Result<TransferSpec.UserMapEntry list> =
-        match userMapPath with
-        | None -> Result.success []
-        | Some path ->
-            if not (System.IO.File.Exists path) then
-                Result.failureOf
-                    (ValidationError.create "transfer.userMap.fileMissing"
-                        (sprintf "user-map file '%s' not found." path))
-            else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+    let parsedInputs    = parseReconcileInputs reconcileSpecs userMapPath false
     let specErrors =
         collect parsedSource
         @ collect parsedSink
-        @ (parsedReconciles |> List.collect collect)
-        @ collect parsedUserMap
+        @ (match parsedInputs with Ok _ -> [] | Error es -> es)
     if not (List.isEmpty specErrors) then
         Console.Error.WriteLine "projection transfer: argument error:"
         printErrors Console.Error specErrors
@@ -237,8 +259,7 @@ let runTransfer
 
     let sourceRef    = Result.value parsedSource
     let sinkRef      = Result.value parsedSink
-    let entries      = parsedReconciles |> List.map Result.value
-    let userMapEntries = Result.value parsedUserMap
+    let entries, userMapEntries = Result.value parsedInputs
     let reconcile    = not (List.isEmpty entries) || not (List.isEmpty userMapEntries)
 
     // Bind the apparatus and DRIVE the run through it (D9: openSubstrate
@@ -344,20 +365,10 @@ let runContractPairTransfer
     // refused — the User family re-keys by business key on the up-leg. The
     // specs parse exactly as the forward face's; the named refusal that stood
     // here is lifted (DECISIONS 2026-06-15 — reconcile ∘ reverse leg).
-    let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
-    let parsedUserMap : Result<TransferSpec.UserMapEntry list> =
-        match userMapPath with
-        | None -> Result.success []
-        | Some path ->
-            if not (System.IO.File.Exists path) then
-                Result.failureOf
-                    (ValidationError.create "transfer.userMap.fileMissing"
-                        (sprintf "user-map file '%s' not found." path))
-            else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+    let parsedInputs = parseReconcileInputs reconcileSpecs userMapPath false
     let specErrors =
         collect parsedSource @ collect parsedSink
-        @ (parsedReconciles |> List.collect collect)
-        @ collect parsedUserMap
+        @ (match parsedInputs with Ok _ -> [] | Error es -> es)
     if not (List.isEmpty specErrors) then
         Console.Error.WriteLine (faceLabel + ": argument error:")
         printErrors Console.Error specErrors
@@ -369,8 +380,7 @@ let runContractPairTransfer
     // contract (the rendition the reverse leg writes into; `findKindByTable`
     // matches physical names, consistent with the forward face's live-read
     // contract). A bad spec refuses by name before any connection opens.
-    let entries        = parsedReconciles |> List.map Result.value
-    let userMapEntries = Result.value parsedUserMap
+    let entries, userMapEntries = Result.value parsedInputs
     let reconcile      = not (List.isEmpty entries) || not (List.isEmpty userMapEntries)
     match TransferSpec.resolveAllReconciliation physicalSinkContract entries userMapEntries with
     | Error es ->
@@ -547,22 +557,11 @@ let runPeerTransfer
     // (correctly-written but typo'd) strategy as a missing one, refusing
     // exit 9 "escapes" where the true problem was the bad spec (exit 2).
     let reconciledResolution : Result<Set<SsKey>> =
-        let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
-        let parsedUserMap =
-            match userMapPath with
-            | None -> Result.success []
-            | Some path ->
-                if not (System.IO.File.Exists path) then Result.success []   // the delegate refuses fileMissing byte-identically
-                else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
-        let specErrors =
-            (parsedReconciles |> List.collect (function Ok _ -> [] | Error es -> es))
-            @ (match parsedUserMap with Ok _ -> [] | Error es -> es)
-        if not (List.isEmpty specErrors) then Result.failure specErrors
-        else
-            let entries = parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None)
-            let userMapEntries = match parsedUserMap with Ok es -> es | Error _ -> []
+        // deferMissingUserMap: the delegate refuses fileMissing byte-identically.
+        parseReconcileInputs reconcileSpecs userMapPath true
+        |> Result.bind (fun (entries, userMapEntries) ->
             TransferSpec.resolveAllReconciliation sinkContract entries userMapEntries
-            |> Result.map (fun reconciliation -> reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+            |> Result.map (fun reconciliation -> reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq))
     match reconciledResolution with
     | Error errors ->
         Console.Error.WriteLine "projection transfer (peer): reconcile resolution error:"
@@ -625,7 +624,7 @@ let runPeerTransfer
     // forecast, with the red/green verdict).
     if not executeRequested then
         printfn ""
-        printfn "The decision board (open decisions + row forecast + red/green verdict): projection check go <flow>"
+        printfn "The go board (open decisions + row forecast + red/green verdict): projection check go <flow>"
 
     // The shared contract-pair body: realization selector, execute/journal
     // gates, apparatus, engine run, narration — identical to the reverse leg,
@@ -647,17 +646,32 @@ let runPeerTransfer
 // runs in ONE transaction (all deletes land or none do).
 // ---------------------------------------------------------------------------
 
-let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (goRequested: bool) : int =
+let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (goRequested: bool) (force: bool) : int =
     if not (System.IO.File.Exists scriptPath) then
         TtyRenderer.renderVoicedError
             (ValidationError.create "revert.scriptMissing"
                 (sprintf "revert script '%s' not found. A successful transfer writes transfer-undo.sql (a failed one transfer-revert.sql) into its --revert-dir (default: the working directory); point --script at it." scriptPath))
         2
     else
-    let statements =
+    let allLines =
         System.IO.File.ReadAllLines scriptPath
         |> Array.map (fun l -> l.Trim())
-        |> Array.filter (fun l -> l <> "" && not (l.Equals("GO", System.StringComparison.OrdinalIgnoreCase)))
+    // The provenance header the artifact writer stamps (the wrong-sink
+    // guard): `-- projection:<kind> server=<s> database=<db> generated=<t>`.
+    let stampedDatabase =
+        allLines
+        |> Array.tryPick (fun l ->
+            if l.StartsWith "-- projection:" then
+                l.Split(' ')
+                |> Array.tryPick (fun tok ->
+                    if tok.StartsWith "database=" then Some (tok.Substring 9) else None)
+            else None)
+    let statements =
+        allLines
+        |> Array.filter (fun l ->
+            l <> ""
+            && not (l.StartsWith "--")
+            && not (l.Equals("GO", System.StringComparison.OrdinalIgnoreCase)))
         |> Array.toList
     if List.isEmpty statements then
         printfn "revert: '%s' carries no statements — nothing to undo." scriptPath
@@ -689,7 +703,7 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
         |> List.map (fun (t, ss) -> t, ss |> List.sumBy keyCountOf)
     printfn "Revert '%s' against %s — %d statement(s) over %d table(s):" scriptPath envLabel statements.Length summary.Length
     for (t, keys) in summary do
-        printfn "  %-60s %d captured key(s)" t keys
+        printfn "  %-60s %d row(s) to delete" t keys
     let executeGated =
         goRequested && System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE" = "1"
     if goRequested && not executeGated then
@@ -708,6 +722,23 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
             6
         | Ok sink ->
             use sink = sink
+            // THE WRONG-SINK GUARD (2026-07-06, the final-pass critique's
+            // top finding): the artifact deletes BY KEY in whatever database
+            // --against resolves to. The header stamped at capture time
+            // names the database the keys belong to; a mismatch refuses by
+            // name (--force is the deliberate override — e.g. a restored
+            // copy under a new name). A header-less artifact (pre-stamp)
+            // proceeds with a printed note, never a refusal.
+            match stampedDatabase with
+            | Some stamped when not (System.String.Equals(stamped, sink.Database, System.StringComparison.OrdinalIgnoreCase)) && not force ->
+                TtyRenderer.renderVoicedError
+                    (ValidationError.create "revert.sinkMismatch"
+                        (sprintf "this undo was captured against database '%s', but --against resolves to '%s'. Re-point --against at the environment the transfer wrote, or pass --force if the database was deliberately renamed/restored." stamped sink.Database))
+                dumpBench "revert"
+                7
+            | _ ->
+            if Option.isNone stampedDatabase then
+                printfn "  (note: the script carries no provenance header — cannot verify it matches this sink.)"
             // ONE transaction: the undo lands whole or not at all (the
             // child-first order means FKs never block; a mid-script failure
             // rolls the earlier deletes back rather than leaving a
@@ -726,9 +757,12 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
                     perTable.[t] <- (match perTable.TryGetValue t with | true, n -> n | _ -> 0) + affected
                 tx.Commit()
                 printfn ""
-                printfn "Reverted — %d row(s) deleted:" total
-                for KeyValue (t, n) in perTable do
-                    printfn "  %-60s %d row(s)" t n
+                if total = 0 then
+                    printfn "Nothing to revert — the captured rows are already absent (a prior revert, or the sink was cleared)."
+                else
+                    printfn "Reverted — %d row(s) deleted:" total
+                    for KeyValue (t, n) in perTable do
+                        printfn "  %-60s %d row(s)" t n
                 dumpBench "revert"
                 0
             with ex ->
@@ -756,10 +790,11 @@ let private probeCount (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: strin
     cmd.CommandText <- sql
     System.Convert.ToInt32 (cmd.ExecuteScalar())
 
-let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned: PlanAction) : int =
+let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (planned: PlanAction) : int =
     let finish (items: GoBoard.Item list) : int =
         let board : GoBoard.Board = { Flow = flowName; From = fromLabel; To = toLabel; Items = items }
-        GoBoard.render board |> List.iter (printfn "%s")
+        if asJson then printfn "%s" (GoBoard.toJsonString board)
+        else GoBoard.render board |> List.iter (printfn "%s")
         GoBoard.exitCode board
     match planned with
     | PlanAction.Refused (_, e) ->
@@ -798,23 +833,10 @@ let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned
                  | Some s -> sprintf "%d table(s) declared; all resolve." (Set.count s)
                  | None -> "no subset declared — the whole modeled estate transfers.")))
         // -- reconcile strategy resolution ----------------------------------
-        let parsedReconciles = opts.Reconcile |> List.map TransferSpec.parseReconcileSpec
-        let parsedUserMap =
-            match opts.Rekey with
-            | None -> Result.success []
-            | Some path ->
-                if not (System.IO.File.Exists path) then
-                    Result.failureOf (ValidationError.create "transfer.userMap.fileMissing" (sprintf "user-map file '%s' not found." path))
-                else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
         let reconcileResolution =
-            let specErrors =
-                (parsedReconciles |> List.collect (function Ok _ -> [] | Error es -> es))
-                @ (match parsedUserMap with Ok _ -> [] | Error es -> es)
-            if not (List.isEmpty specErrors) then Result.failure specErrors
-            else
-                TransferSpec.resolveAllReconciliation sinkContract
-                    (parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None))
-                    (match parsedUserMap with Ok es -> es | Error _ -> [])
+            parseReconcileInputs opts.Reconcile opts.Rekey false
+            |> Result.bind (fun (entries, userMapEntries) ->
+                TransferSpec.resolveAllReconciliation sinkContract entries userMapEntries)
         match reconcileResolution with
         | Error errors ->
             items.Add (GoBoard.itemWith "reconcile"
@@ -824,7 +846,10 @@ let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned
         | Ok reconciliation ->
         let reconciledKeys = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
         items.Add (GoBoard.item "reconcile"
-            (GoBoard.Status.Green (sprintf "%d reconcile strateg(ies) resolve against the sink." (Map.count reconciliation))))
+            (GoBoard.Status.Green
+                (match Map.count reconciliation with
+                 | 0 -> "no reconcile rules declared yet."
+                 | n -> sprintf "%d reconcile rule(s) resolve against the sink." n)))
         // -- schema shape ----------------------------------------------------
         let gateScope = loadSet |> Option.map (Set.union reconciledKeys)
         let shape = PeerTransfer.shapeVerdict gateScope sourceContract sinkContract
@@ -834,7 +859,7 @@ let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned
                 shape.Blocking)
         elif not (List.isEmpty shape.Advisory) then
             items.Add (GoBoard.itemWith "shape"
-                (GoBoard.Status.Advisory (sprintf "one shape modulo %d advisory divergence(s) — none blocks a data load." shape.Advisory.Length))
+                (GoBoard.Status.Advisory (sprintf "the two models are one shape over the transferred set, with %d advisory difference(s) that do not block a data load." shape.Advisory.Length))
                 shape.Advisory)
         else
             items.Add (GoBoard.item "shape" (GoBoard.Status.Green "the two models are one shape over the transferred set."))
@@ -864,27 +889,21 @@ let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned
             items.Add (GoBoard.item "forecast" (GoBoard.Status.Red ("not run — the shape divergence above would make the read/write plan unreliable.", "resolve the shape line, then re-run for the row forecast.")))
         else
             let dryRun () =
-                let srcFile = System.IO.Path.GetTempFileName()
-                let sinkFile = System.IO.Path.GetTempFileName()
-                try
-                    let refOf (spec: string) (file: string) =
-                        match TransferSpec.parseConnectionSpec spec with
-                        | Ok r -> r
-                        | Error _ ->
-                            System.IO.File.WriteAllText(file, spec)
-                            ConnectionRef.File file
-                    let srcSub : Substrate = { Environment = parseEnvironment "Source" (Some fromLabel); Role = SubstrateRole.Source; ConnectionRef = refOf sourceSpec srcFile }
-                    let sinkSub : Substrate = { Environment = parseEnvironment "Sink" (Some toLabel); Role = SubstrateRole.Sink; ConnectionRef = refOf sinkSpec sinkFile }
-                    match TransferConnections.create srcSub sinkSub (not (Map.isEmpty reconciliation)) with
-                    | Error es -> Error es
-                    | Ok connections ->
-                        (Transfer.runReverseLegThroughConnections
-                            Transfer.DryRun opts.Emission false true false
-                            opts.Tables connections sourceContract sinkContract reconciliation)
-                            .GetAwaiter().GetResult()
-                finally
-                    try System.IO.File.Delete srcFile with _ -> ()
-                    try System.IO.File.Delete sinkFile with _ -> ()
+                // `ConnectionRef.Raw` (DECISIONS 2026-07-06): the resolved
+                // spec is already in memory — no temp-file round trip.
+                let refOf (spec: string) =
+                    match TransferSpec.parseConnectionSpec spec with
+                    | Ok r -> r
+                    | Error _ -> ConnectionRef.Raw spec
+                let srcSub : Substrate = { Environment = parseEnvironment "Source" (Some fromLabel); Role = SubstrateRole.Source; ConnectionRef = refOf sourceSpec }
+                let sinkSub : Substrate = { Environment = parseEnvironment "Sink" (Some toLabel); Role = SubstrateRole.Sink; ConnectionRef = refOf sinkSpec }
+                match TransferConnections.create srcSub sinkSub (not (Map.isEmpty reconciliation)) with
+                | Error es -> Error es
+                | Ok connections ->
+                    (Transfer.runReverseLegThroughConnections
+                        Transfer.DryRun opts.Emission false true false
+                        opts.Tables connections sourceContract sinkContract reconciliation)
+                        .GetAwaiter().GetResult()
             match dryRun () with
             | Error errors ->
                 items.Add (GoBoard.itemWith "forecast"

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -135,6 +135,19 @@ let narrateTransferReport (report: Transfer.TransferReport) : unit =
             n
     | _ -> ()
 
+/// After a successful EXECUTE, the undo artifact (`transfer-undo.sql`,
+/// written by the engine's success tail into the revert dir) is the
+/// deliberate-revert half of the proving loop — point the operator at it.
+let private narrateUndoPointer (mode: Transfer.Mode) (revertOut: string option) : unit =
+    match mode, revertOut with
+    | Transfer.Execute, Some dir ->
+        let path = System.IO.Path.Combine(dir, "transfer-undo.sql")
+        if System.IO.File.Exists path then
+            printfn ""
+            printfn "Undo script written: %s" path
+            printfn "  Revert this run with: PROJECTION_ALLOW_EXECUTE=1 projection revert --script %s --against <sink-environment> --go" path
+    | _ -> ()
+
 /// 6.A.1 — the drop-set is fail-loud, not exit-0. A successful write that
 /// dropped FK-orphan rows or left reconciled-kind sources unmatched surfaces
 /// a distinct non-zero exit unless the operator declared the drops
@@ -248,6 +261,7 @@ let runTransfer
         match result with
         | Ok report ->
             narrateTransferReport report
+            narrateUndoPointer mode revertOut
             narrateDropExit allowDrops report
         | Error errors ->
             printErrors Console.Error errors
@@ -428,6 +442,7 @@ let runContractPairTransfer
         match result with
         | Ok report ->
             narrateTransferReport report
+            narrateUndoPointer mode revertOut
             narrateDropExit allowDrops report
         | Error errors ->
             printErrors Console.Error errors
@@ -608,6 +623,109 @@ let runPeerTransfer
         reconcileSpecs userMapPath executeRequested allowCdc allowDrops
         emission resumable streaming journalDirectory tables
         revertPolicy revertDir sinkCapability
+
+// ---------------------------------------------------------------------------
+// `projection revert` (2026-07-06, the proving-loop program) — the DELIBERATE
+// UNDO. A successful transfer writes `transfer-undo.sql` (the precise
+// DELETE-by-captured-key script, children first, pre-existing rows never
+// touched); a failed run writes `transfer-revert.sql`. This verb previews
+// (default) or executes either artifact against a configured environment —
+// so a small declared subset can be transferred, verified, and reverted as
+// one proving loop. A live run needs PROJECTION_ALLOW_EXECUTE=1 + --go and
+// runs in ONE transaction (all deletes land or none do).
+// ---------------------------------------------------------------------------
+
+let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (goRequested: bool) : int =
+    if not (System.IO.File.Exists scriptPath) then
+        TtyRenderer.renderVoicedError
+            (ValidationError.create "revert.scriptMissing"
+                (sprintf "revert script '%s' not found. A successful transfer writes transfer-undo.sql (a failed one transfer-revert.sql) into its --revert-dir (default: the working directory); point --script at it." scriptPath))
+        2
+    else
+    let statements =
+        System.IO.File.ReadAllLines scriptPath
+        |> Array.map (fun l -> l.Trim())
+        |> Array.filter (fun l -> l <> "" && not (l.Equals("GO", System.StringComparison.OrdinalIgnoreCase)))
+        |> Array.toList
+    if List.isEmpty statements then
+        printfn "revert: '%s' carries no statements — nothing to undo." scriptPath
+        0
+    else
+    // The per-table summary: each statement is one chunked
+    // `DELETE FROM <table> WHERE <pk> IN (k, k, …);` — table from the text,
+    // key count from the IN list's commas (display only; execution runs the
+    // statements verbatim).
+    let tableOf (stmt: string) : string =
+        let afterFrom = stmt.IndexOf "DELETE FROM "
+        if afterFrom < 0 then "(statement)"
+        else
+            let rest = stmt.Substring(afterFrom + 12)
+            match rest.IndexOf " WHERE " with
+            | -1 -> rest.Trim()
+            | i -> rest.Substring(0, i).Trim()
+    let keyCountOf (stmt: string) : int =
+        match stmt.IndexOf " IN (" with
+        | -1 -> 0
+        | i ->
+            let inner = stmt.Substring(i + 5)
+            match inner.LastIndexOf ')' with
+            | -1 -> 0
+            | j -> (inner.Substring(0, j).Split(',')).Length
+    let summary =
+        statements
+        |> List.groupBy tableOf
+        |> List.map (fun (t, ss) -> t, ss |> List.sumBy keyCountOf)
+    printfn "Revert '%s' against %s — %d statement(s) over %d table(s):" scriptPath envLabel statements.Length summary.Length
+    for (t, keys) in summary do
+        printfn "  %-60s %d captured key(s)" t keys
+    let executeGated =
+        goRequested && System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE" = "1"
+    if goRequested && not executeGated then
+        TtyRenderer.renderVoicedError (ValidationError.create "gate.intent" "PROJECTION_ALLOW_EXECUTE is not set in the environment.")
+        dumpBench "revert"
+        7
+    elif not goRequested then
+        printfn ""
+        printfn "Preview only — no rows deleted. Execute with: PROJECTION_ALLOW_EXECUTE=1 projection revert --script %s --against %s --go" scriptPath envLabel
+        0
+    else
+        match (ConnectionSpec.openSpec SubstrateRole.Sink "revert-sink" connSpec).GetAwaiter().GetResult() with
+        | Error errors ->
+            printErrors Console.Error errors
+            dumpBench "revert"
+            6
+        | Ok sink ->
+            use sink = sink
+            // ONE transaction: the undo lands whole or not at all (the
+            // child-first order means FKs never block; a mid-script failure
+            // rolls the earlier deletes back rather than leaving a
+            // half-undone sink).
+            use tx = sink.BeginTransaction()
+            try
+                let mutable total = 0
+                let perTable = System.Collections.Generic.Dictionary<string, int>()
+                for stmt in statements do
+                    use cmd = sink.CreateCommand()
+                    cmd.Transaction <- tx
+                    cmd.CommandText <- stmt
+                    let affected = cmd.ExecuteNonQuery()
+                    total <- total + affected
+                    let t = tableOf stmt
+                    perTable.[t] <- (match perTable.TryGetValue t with | true, n -> n | _ -> 0) + affected
+                tx.Commit()
+                printfn ""
+                printfn "Reverted — %d row(s) deleted:" total
+                for KeyValue (t, n) in perTable do
+                    printfn "  %-60s %d row(s)" t n
+                dumpBench "revert"
+                0
+            with ex ->
+                (try tx.Rollback() with _ -> ())
+                TtyRenderer.renderVoicedError
+                    (ValidationError.create "revert.failed"
+                        (sprintf "revert failed and ROLLED BACK (no rows deleted): %s" ex.Message))
+                dumpBench "revert"
+                3
 
 // ---------------------------------------------------------------------------
 // THE GO BOARD (2026-07-06, the preview-engine program) — `projection check

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -46,19 +46,39 @@ let narrateTransferReport (report: Transfer.TransferReport) : unit =
     // §4 Move — lead with the finding (rows moved, in dependency order); the
     // load plan rides beneath. Dependency order is the engine's guarantee that
     // a row never lands before the rows it points to.
+    //
+    // 2026-07-06 (the live rehearsal): a DRY RUN's headline counts the rows
+    // that WOULD move (`RowsIngested` — a preview writes nothing by
+    // definition, so the written sum read "0 rows would move" over a
+    // 4-row forecast — actively misleading). An Execute's headline stays the
+    // written sum (the actual outcome).
     let totalWritten = report.Kinds |> List.sumBy (fun k -> k.RowsWritten)
+    let headlineCount =
+        match report.Mode with
+        | Transfer.DryRun  -> report.Kinds |> List.sumBy (fun k -> k.RowsIngested)
+        | Transfer.Execute -> totalWritten
     let verdictCode = match report.Mode with Transfer.DryRun -> "transfer.previewPlan" | Transfer.Execute -> "transfer.applied"
-    let verdictPayload : Voice.Payload = Map.ofList [ "rowCount", box totalWritten; "tableCount", box report.Kinds.Length ]
+    // The plan narration shows the tables the run TOUCHES (rows in flight or
+    // a reconcile rule); the untouched remainder collapses to one line — 13
+    // all-zero rows around the 2 that matter was noise, not information.
+    let touched, untouched =
+        report.Kinds
+        |> List.partition (fun k ->
+            k.RowsIngested > 0 || k.RowsWritten > 0
+            || k.Disposition = IdentityDisposition.ReconciledByRule)
+    let verdictPayload : Voice.Payload = Map.ofList [ "rowCount", box headlineCount; "tableCount", box touched.Length ]
     TtyRenderer.renderVoicedTo Console.Out verdictCode verdictPayload
     printfn ""
-    printfn "The load plan (%d table(s)):" report.Kinds.Length
-    for k in report.Kinds do
+    printfn "The load plan (%d table(s) touched):" touched.Length
+    for k in touched do
         printfn "  %-40s %-22s ingested=%d written=%d deferred-fk-columns=%d"
             (nm k.Kind)
             (dispositionName k.Disposition)
             k.RowsIngested
             k.RowsWritten
             (Set.count k.DeferredFkColumns)
+    if not (List.isEmpty untouched) then
+        printfn "  (%d other modeled table(s): no rows to move, not reconciled — untouched.)" untouched.Length
     if not (List.isEmpty report.UnbreakableCycleFks) then
         printfn ""
         printfn

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -186,7 +186,19 @@ let runTransfer
     (tables: string list)
     (revertPolicy: RevertPolicy)
     (revertDir: string option)
+    (sinkResidentResume: bool)
     : int =
+    // 2026-07-06 (the parity sweep): the FORWARD leg's --resumable rides the
+    // same G10 sink-resident progress table the reverse leg's does — and had
+    // the same unguarded raw CREATE TABLE crash on a managed sink. The same
+    // named refusal, before any connection opens.
+    if resumable && not sinkResidentResume then
+        TtyRenderer.renderVoicedError
+            (ValidationError.create "transfer.reverseLeg.resumableSinkUnsupported"
+                "--resumable keeps its G10 marker in a sink-resident progress table, which needs CREATE TABLE the sink's data grant forbids (archetype managed-dml/undeclared). Drop --resumable (a wipe-and-load re-run is idempotent by construction), or declare the sink archetype full-rights if it truly can host the table.")
+        dumpBench "transfer"
+        2
+    else
     let collect = function Ok _ -> [] | Error es -> es
     let parsedSource    = TransferSpec.parseConnectionSpec sourceSpec
     let parsedSink      = TransferSpec.parseConnectionSpec sinkSpec

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -265,7 +265,14 @@ let runTransfer
 // and drives `Transfer.runReverseLegThroughConnections` through the apparatus.
 // ---------------------------------------------------------------------------
 
-let runReverseLegTransfer
+/// The shared two-contract face body: the reverse leg (`legacy`, logical→
+/// physical renditions of ONE authored model) and the peer leg (A→A, two
+/// OSSYS-read per-environment contracts) drive the SAME engine path — two
+/// SsKey-aligned contracts, reads with source names, writes with sink names.
+/// `faceLabel` owns the operator-facing error prefix (THE_VOICE: the verb
+/// presents in its own words).
+let runContractPairTransfer
+    (faceLabel: string)
     (sourceSpec: string)
     (sinkSpec: string)
     (logicalSourceContract: Catalog)
@@ -306,7 +313,7 @@ let runReverseLegTransfer
         @ (parsedReconciles |> List.collect collect)
         @ collect parsedUserMap
     if not (List.isEmpty specErrors) then
-        Console.Error.WriteLine "projection move (reverse leg): argument error:"
+        Console.Error.WriteLine (faceLabel + ": argument error:")
         printErrors Console.Error specErrors
         dumpBench "transfer"
         2
@@ -321,7 +328,7 @@ let runReverseLegTransfer
     let reconcile      = not (List.isEmpty entries) || not (List.isEmpty userMapEntries)
     match TransferSpec.resolveAllReconciliation physicalSinkContract entries userMapEntries with
     | Error es ->
-        Console.Error.WriteLine "projection move (reverse leg): reconcile resolution error:"
+        Console.Error.WriteLine (faceLabel + ": reconcile resolution error:")
         printErrors Console.Error es
         dumpBench "transfer"
         2
@@ -370,7 +377,7 @@ let runReverseLegTransfer
           ConnectionRef = Result.value parsedSink }
     match TransferConnections.create sourceSub sinkSub reconcile with
     | Error es ->
-        Console.Error.WriteLine "projection move (reverse leg): apparatus invariant violation:"
+        Console.Error.WriteLine (faceLabel + ": apparatus invariant violation:")
         printErrors Console.Error es
         dumpBench "transfer"
         3
@@ -408,5 +415,150 @@ let runReverseLegTransfer
     // G0c — the advisory capability survey renders in the dispatch prologue
     // (voiced, pre-Live) since 2026-07-02; same posture as the peer transfer.
     Face.staged "transfer" executeGated Spines.transfer runBody
+
+/// The reverse-leg face under its own name — the pre-2026-07-06 signature,
+/// byte-identical behavior; the body is the shared `runContractPairTransfer`.
+let runReverseLegTransfer
+    (sourceSpec: string)
+    (sinkSpec: string)
+    (logicalSourceContract: Catalog)
+    (physicalSinkContract: Catalog)
+    (reconcileSpecs: string list)
+    (userMapPath: string option)
+    (executeRequested: bool)
+    (allowCdc: bool)
+    (allowDrops: bool)
+    (emission: EmissionMode)
+    (resumable: bool)
+    (streaming: bool)
+    (journalDirectory: string option)
+    (tables: string list)
+    (revertPolicy: RevertPolicy)
+    (revertDir: string option)
+    (sinkCapability: SinkLoadCapability)
+    : int =
+    runContractPairTransfer "projection move (reverse leg)"
+        sourceSpec sinkSpec logicalSourceContract physicalSinkContract
+        reconcileSpecs userMapPath executeRequested allowCdc allowDrops
+        emission resumable streaming journalDirectory tables
+        revertPolicy revertDir sinkCapability
+
+// ---------------------------------------------------------------------------
+// The peer (A→A) face — the QA→UAT partial transfer with differing physical
+// names (the 2026-07-06 partial-transfer readiness program). Two deployed
+// cells of ONE model: each side's contract is read from its OWN OSSYS
+// metamodel (`PeerTransfer.acquireContracts` — native GUID SsKeys, the
+// espace-invariance law), so the pair aligns by identity without an authored
+// model in the loop. Two pre-write gates ride the pair before the shared
+// contract-pair body runs:
+//   - the SHAPE gate — SS_KEY-keyed schema compatibility over the kinds this
+//     run touches (`transfer.peer.shapeDivergence`, exit 5; advisories
+//     surface, never silent), and
+//   - the SUBSET-FK gate — FK edges escaping a declared `tables` subset each
+//     get a proposed strategy (reconcile against rows the sink already holds;
+//     widen the subset; --allow-drops); a live Execute with un-strategized
+//     escapes refuses by name (`transfer.peer.subsetFkEscapes`, exit 9), a
+//     preview narrates the proposals instead.
+// ---------------------------------------------------------------------------
+
+let runPeerTransfer
+    (sourceSpec: string)
+    (sinkSpec: string)
+    (reconcileSpecs: string list)
+    (userMapPath: string option)
+    (executeRequested: bool)
+    (allowCdc: bool)
+    (allowDrops: bool)
+    (emission: EmissionMode)
+    (resumable: bool)
+    (streaming: bool)
+    (journalDirectory: string option)
+    (tables: string list)
+    (revertPolicy: RevertPolicy)
+    (revertDir: string option)
+    (sinkCapability: SinkLoadCapability)
+    : int =
+    // Acquire the two SsKey-aligned contracts (the one I/O seam this face
+    // adds). An unreadable OSSYS metamodel refuses on the schema-read axis
+    // (exit 6) before any gate or connection-opening work.
+    match (PeerTransfer.acquireContracts sourceSpec sinkSpec).GetAwaiter().GetResult() with
+    | Error errors ->
+        Console.Error.WriteLine "projection transfer (peer): contract acquisition error:"
+        printErrors Console.Error errors
+        dumpBench "transfer"
+        (Preflight.refusalOf errors).ExitCode
+    | Ok (sourceContract, sinkContract) ->
+
+    // Resolve the gate inputs: the declared subset (against the SOURCE
+    // contract — the same resolver the engine uses) and the reconciled kind
+    // set (against the SINK contract — the same resolution the shared body
+    // performs). A spec that fails to parse/resolve here is NOT refused here:
+    // the shared body reproduces the refusal byte-identically, so the gates
+    // simply step aside (empty reconciled set / no subset) and delegate.
+    let reconciledKeys : Set<SsKey> =
+        let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
+        let parsedUserMap =
+            match userMapPath with
+            | None -> Result.success []
+            | Some path ->
+                if not (System.IO.File.Exists path) then Result.success []
+                else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+        let entries = parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None)
+        match parsedUserMap with
+        | Error _ -> Set.empty
+        | Ok userMapEntries ->
+            match TransferSpec.resolveAllReconciliation sinkContract entries userMapEntries with
+            | Ok reconciliation -> reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+            | Error _ -> Set.empty
+    match Transfer.resolveLoadSet sourceContract tables with
+    | Error errors ->
+        // The subset itself failed to resolve — same refusal the engine
+        // would give; surface it now, before any connection opens.
+        Console.Error.WriteLine "projection transfer (peer): table subset error:"
+        printErrors Console.Error errors
+        dumpBench "transfer"
+        (Preflight.refusalOf errors).ExitCode
+    | Ok loadSet ->
+
+    // Gate 1 — SS_KEY-keyed shape compatibility over the kinds this run
+    // touches (the subset + its reconciled kinds; the whole estate when no
+    // subset is declared). Blocking divergence refuses by name (exit 5);
+    // advisories print to stderr and the run proceeds.
+    let gateScope = loadSet |> Option.map (Set.union reconciledKeys)
+    match PeerTransfer.shapeGate gateScope sourceContract sinkContract with
+    | Error errors ->
+        errors |> List.iter TtyRenderer.renderVoicedError
+        dumpBench "transfer"
+        (Preflight.refusalOf errors).ExitCode
+    | Ok advisories ->
+    if not (List.isEmpty advisories) then
+        Console.Error.WriteLine (sprintf "projection transfer (peer): %d shape advisory(ies) — real divergence that does not block a data load:" advisories.Length)
+        advisories |> List.iter (fun line -> Console.Error.WriteLine ("  " + line))
+
+    // Gate 2 — FK edges escaping the declared subset. A preview narrates the
+    // per-edge strategy proposals; a live Execute with un-strategized escapes
+    // refuses by name unless the operator declared the drop-set acceptable.
+    let escapes =
+        match loadSet with
+        | Some s -> PeerTransfer.escapingFks sourceContract s reconciledKeys
+        | None -> []
+    if not (List.isEmpty escapes) then
+        printfn "%d relationship(s) escape the declared table subset:" escapes.Length
+        PeerTransfer.narrateEscapes escapes |> List.iter (fun line -> printfn "  %s" line)
+    match PeerTransfer.subsetFkGate executeRequested allowDrops escapes with
+    | Error errors ->
+        errors |> List.iter TtyRenderer.renderVoicedError
+        dumpBench "transfer"
+        (Preflight.refusalOf errors).ExitCode
+    | Ok () ->
+
+    // The shared contract-pair body: realization selector, execute/journal
+    // gates, apparatus, engine run, narration — identical to the reverse leg,
+    // with the peer pair as the contracts and the peer label on the prose.
+    runContractPairTransfer "projection transfer (peer)"
+        sourceSpec sinkSpec sourceContract sinkContract
+        reconcileSpecs userMapPath executeRequested allowCdc allowDrops
+        emission resumable streaming journalDirectory tables
+        revertPolicy revertDir sinkCapability
 
 // ---------------------------------------------------------------------------

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -573,6 +573,13 @@ let runPeerTransfer
         (Preflight.refusalOf errors).ExitCode
     | Ok () ->
 
+    // The decision board is one verb away — point every preview at it (the
+    // board re-derives the same gates PLUS the live probes and the row
+    // forecast, with the red/green verdict).
+    if not executeRequested then
+        printfn ""
+        printfn "The decision board (open decisions + row forecast + red/green verdict): projection check go <flow>"
+
     // The shared contract-pair body: realization selector, execute/journal
     // gates, apparatus, engine run, narration — identical to the reverse leg,
     // with the peer pair as the contracts and the peer label on the prose.
@@ -581,5 +588,261 @@ let runPeerTransfer
         reconcileSpecs userMapPath executeRequested allowCdc allowDrops
         emission resumable streaming journalDirectory tables
         revertPolicy revertDir sinkCapability
+
+// ---------------------------------------------------------------------------
+// THE GO BOARD (2026-07-06, the preview-engine program) — `projection check
+// go <flow>`: the ONE surface that forecasts a live run and flags every OPEN
+// DECISION, red until each is resolved, green when the flow is genuinely
+// executable. The runner: acquire the two contracts, run every pure gate the
+// live run would hit, run the ENGINE DRY RUN (real reads, zero writes — the
+// row-count forecast, the unmatched-identity forecast, the drop forecast),
+// probe the sink (CDC posture, grant evidence, re-run hazards), and render
+// the checklist with a total red/green verdict. Exit 0 green / 5 red — the
+// board is CI-able.
+// ---------------------------------------------------------------------------
+
+let private probeCount (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : int =
+    use cmd = cnn.CreateCommand()
+    cmd.CommandText <- sql
+    System.Convert.ToInt32 (cmd.ExecuteScalar())
+
+let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (planned: PlanAction) : int =
+    let finish (items: GoBoard.Item list) : int =
+        let board : GoBoard.Board = { Flow = flowName; From = fromLabel; To = toLabel; Items = items }
+        GoBoard.render board |> List.iter (printfn "%s")
+        GoBoard.exitCode board
+    match planned with
+    | PlanAction.Refused (_, e) ->
+        finish [ GoBoard.item "routing" (GoBoard.Status.Red (sprintf "the flow does not plan: %s" e.Message, "fix projection.json (the flow/environment definition) and re-run.")) ]
+    | PlanAction.Transfer (_, _, _, _) ->
+        finish
+            [ GoBoard.item "routing"
+                (GoBoard.Status.Red
+                    ("this env->env data flow rides the NAME-BLIND transfer (renditions unset) — it assumes matching physical table names on both sides.",
+                     "set \"rendition\": \"physical\" on BOTH environments in projection.json to run the SsKey-aligned peer leg (shape + relationship gates), then re-run.")) ]
+    | PlanAction.TransferPeer (sourceSpec, sinkSpec, opts, _) ->
+        let items = ResizeArray<GoBoard.Item>()
+        items.Add (GoBoard.item "routing" (GoBoard.Status.Green "the SsKey-aligned peer leg (both renditions physical)."))
+        // -- contracts (the two OSSYS metamodel reads) ---------------------
+        match (PeerTransfer.acquireContracts sourceSpec sinkSpec).GetAwaiter().GetResult() with
+        | Error errors ->
+            items.Add (GoBoard.itemWith "contracts"
+                (GoBoard.Status.Red
+                    ("a metamodel could not be read — the run has no contract to align on.",
+                     "check the connection reference and the principal's SELECT on the ossys_* tables; then re-run."))
+                (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
+            finish (List.ofSeq items)
+        | Ok (sourceContract, sinkContract) ->
+        items.Add (GoBoard.item "contracts" (GoBoard.Status.Green "both metamodels read; identities align by SS_KEY."))
+        // -- the declared subset -------------------------------------------
+        match Transfer.resolveLoadSet sourceContract opts.Tables with
+        | Error errors ->
+            items.Add (GoBoard.itemWith "tables"
+                (GoBoard.Status.Red ("the declared table subset does not resolve.", "fix the flow's `tables` list (use Module.Entity for ambiguous names); then re-run."))
+                (errors |> List.map (fun e -> e.Message)))
+            finish (List.ofSeq items)
+        | Ok loadSet ->
+        items.Add (GoBoard.item "tables"
+            (GoBoard.Status.Green
+                (match loadSet with
+                 | Some s -> sprintf "%d table(s) declared; all resolve." (Set.count s)
+                 | None -> "no subset declared — the whole modeled estate transfers.")))
+        // -- reconcile strategy resolution ----------------------------------
+        let parsedReconciles = opts.Reconcile |> List.map TransferSpec.parseReconcileSpec
+        let parsedUserMap =
+            match opts.Rekey with
+            | None -> Result.success []
+            | Some path ->
+                if not (System.IO.File.Exists path) then
+                    Result.failureOf (ValidationError.create "transfer.userMap.fileMissing" (sprintf "user-map file '%s' not found." path))
+                else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
+        let reconcileResolution =
+            let specErrors =
+                (parsedReconciles |> List.collect (function Ok _ -> [] | Error es -> es))
+                @ (match parsedUserMap with Ok _ -> [] | Error es -> es)
+            if not (List.isEmpty specErrors) then Result.failure specErrors
+            else
+                TransferSpec.resolveAllReconciliation sinkContract
+                    (parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None))
+                    (match parsedUserMap with Ok es -> es | Error _ -> [])
+        match reconcileResolution with
+        | Error errors ->
+            items.Add (GoBoard.itemWith "reconcile"
+                (GoBoard.Status.Red ("a reconcile/user-map entry does not resolve against the sink.", "fix the entry (Module.Entity:Column is the espace-safe form) or the user-map file; then re-run."))
+                (errors |> List.map (fun e -> e.Message)))
+            finish (List.ofSeq items)
+        | Ok reconciliation ->
+        let reconciledKeys = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+        items.Add (GoBoard.item "reconcile"
+            (GoBoard.Status.Green (sprintf "%d reconcile strateg(ies) resolve against the sink." (Map.count reconciliation))))
+        // -- schema shape ----------------------------------------------------
+        let gateScope = loadSet |> Option.map (Set.union reconciledKeys)
+        let shape = PeerTransfer.shapeVerdict gateScope sourceContract sinkContract
+        if not (List.isEmpty shape.Blocking) then
+            items.Add (GoBoard.itemWith "shape"
+                (GoBoard.Status.Red (sprintf "%d blocking schema divergence(s) over the transferred set." shape.Blocking.Length, "align the models (deploy the same version to both environments) or narrow the subset; then re-run."))
+                shape.Blocking)
+        elif not (List.isEmpty shape.Advisory) then
+            items.Add (GoBoard.itemWith "shape"
+                (GoBoard.Status.Advisory (sprintf "one shape modulo %d advisory divergence(s) — none blocks a data load." shape.Advisory.Length))
+                shape.Advisory)
+        else
+            items.Add (GoBoard.item "shape" (GoBoard.Status.Green "the two models are one shape over the transferred set."))
+        // -- escaping relationships (the OPEN-DECISION axis) ----------------
+        let escapes =
+            match loadSet with
+            | Some s -> PeerTransfer.escapingFks sourceContract s reconciledKeys
+            | None -> []
+        if not (List.isEmpty escapes) then
+            items.Add (GoBoard.itemWith "relationships"
+                (GoBoard.Status.Red (sprintf "%d relationship(s) escape the subset — each needs a decision." escapes.Length, "add the proposed reconcile entr(ies) to the flow, or widen `tables`; then re-run."))
+                (PeerTransfer.narrateEscapes escapes))
+        else
+            items.Add (GoBoard.item "relationships" (GoBoard.Status.Green "every relationship the subset touches is inside it or reconciled."))
+        // -- load order (the whole-estate topology) --------------------------
+        let topo = (Projection.Core.Passes.TopologicalOrderPass.runWith Projection.Core.TreatAsCycle sinkContract).Value
+        (match Transfer.orderedLoadGate topo with
+         | Some refusal ->
+             items.Add (GoBoard.itemWith "load order"
+                 (GoBoard.Status.Red ("the load order degraded to the alphabetical fallback — a live run refuses.", "make the named cycle's FK columns nullable (they then defer automatically), or transfer without the affected kinds."))
+                 [ refusal.Message ])
+         | None ->
+             items.Add (GoBoard.item "load order" (GoBoard.Status.Green "parents before children, proven (topological).")))
+        // -- THE DRY RUN (real reads, zero writes): the row/identity forecast -
+        let shapeClean = List.isEmpty shape.Blocking
+        if not shapeClean then
+            items.Add (GoBoard.item "forecast" (GoBoard.Status.Red ("not run — the shape divergence above would make the read/write plan unreliable.", "resolve the shape line, then re-run for the row forecast.")))
+        else
+            let dryRun () =
+                let srcFile = System.IO.Path.GetTempFileName()
+                let sinkFile = System.IO.Path.GetTempFileName()
+                try
+                    let refOf (spec: string) (file: string) =
+                        match TransferSpec.parseConnectionSpec spec with
+                        | Ok r -> r
+                        | Error _ ->
+                            System.IO.File.WriteAllText(file, spec)
+                            ConnectionRef.File file
+                    let srcSub : Substrate = { Environment = parseEnvironment "Source" (Some fromLabel); Role = SubstrateRole.Source; ConnectionRef = refOf sourceSpec srcFile }
+                    let sinkSub : Substrate = { Environment = parseEnvironment "Sink" (Some toLabel); Role = SubstrateRole.Sink; ConnectionRef = refOf sinkSpec sinkFile }
+                    match TransferConnections.create srcSub sinkSub (not (Map.isEmpty reconciliation)) with
+                    | Error es -> Error es
+                    | Ok connections ->
+                        (Transfer.runReverseLegThroughConnections
+                            Transfer.DryRun opts.Emission false true false
+                            opts.Tables connections sourceContract sinkContract reconciliation)
+                            .GetAwaiter().GetResult()
+                finally
+                    try System.IO.File.Delete srcFile with _ -> ()
+                    try System.IO.File.Delete sinkFile with _ -> ()
+            match dryRun () with
+            | Error errors ->
+                items.Add (GoBoard.itemWith "forecast"
+                    (GoBoard.Status.Red ("the dry run refused.", "resolve the named refusal; then re-run."))
+                    (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
+            | Ok report ->
+                let nm = nameOf report.Names
+                let forecastLines =
+                    report.Kinds
+                    |> List.filter (fun k -> k.RowsIngested > 0 || k.Disposition = IdentityDisposition.ReconciledByRule)
+                    |> List.map (fun k -> sprintf "%s: %d row(s) will transfer (%s)" (nm k.Kind) k.RowsIngested (dispositionName k.Disposition))
+                items.Add (GoBoard.itemWith "forecast"
+                    (GoBoard.Status.Green (sprintf "dry run complete — %d row(s) across %d table(s) would transfer." (report.Kinds |> List.sumBy (fun k -> k.RowsIngested)) (report.Kinds |> List.filter (fun k -> k.RowsIngested > 0) |> List.length)))
+                    forecastLines)
+                if not (List.isEmpty report.UnbreakableCycleFks) then
+                    items.Add (GoBoard.itemWith "cycles"
+                        (GoBoard.Status.Red (sprintf "%d relationship cycle(s) cannot be broken — the load cannot run as planned." report.UnbreakableCycleFks.Length, "make the cycle's FK columns nullable, or exclude the affected kinds."))
+                        (report.UnbreakableCycleFks |> List.map (fun u -> sprintf "%s.%s -> %s" (nm u.Kind) (Name.value u.Column) (nm u.Target))))
+                if not (List.isEmpty report.UnmatchedIdentities) then
+                    items.Add (GoBoard.itemWith "identities"
+                        (GoBoard.Status.Red (sprintf "%d source identit(ies) have no sink match — a live run halts before any write." report.UnmatchedIdentities.Length, "remediate the user-map / reconcile data, or accept the loss with --allow-drops at run time."))
+                        (report.UnmatchedIdentities |> List.map (fun (k, s) -> sprintf "%s source '%s'" (nm k) (SourceKey.value s))))
+                elif not (Map.isEmpty reconciliation) then
+                    items.Add (GoBoard.item "identities" (GoBoard.Status.Green "every reconciled source identity matches a sink row."))
+                if not (List.isEmpty report.SkippedReferences) then
+                    items.Add (GoBoard.itemWith "drops"
+                        (GoBoard.Status.Red (sprintf "%d row(s) would drop — a relationship points at an unmatched record." report.SkippedReferences.Length, "fix the referenced data, or accept with --allow-drops at run time."))
+                        (report.SkippedReferences |> List.truncate 10 |> List.map (fun (owner, r) -> sprintf "%s.%s -> %s (source '%s')" (nm owner) (Name.value r.Column) (nm r.Target) (SourceKey.value r.UnresolvedSource))))
+        // -- sink probes: CDC posture, grant evidence, re-run semantics ------
+        match (ConnectionSpec.openSpec SubstrateRole.Sink "check-go-sink" sinkSpec).GetAwaiter().GetResult() with
+        | Error errors ->
+            items.Add (GoBoard.itemWith "sink probes"
+                (GoBoard.Status.Red ("the sink connection could not open for the CDC/grant/re-run probes.", "check the connection reference; then re-run."))
+                (errors |> List.map (fun e -> e.Message)))
+        | Ok sink ->
+            use sink = sink
+            (match (ReadSide.cdcTrackedTables sink).GetAwaiter().GetResult() with
+             | Error errors ->
+                 items.Add (GoBoard.itemWith "cdc" (GoBoard.Status.Red ("the CDC probe failed — a live run refuses rather than proceed blind.", "grant the probe's reads or resolve the error; then re-run.")) (errors |> List.map (fun e -> e.Message)))
+             | Ok [] ->
+                 items.Add (GoBoard.item "cdc" (GoBoard.Status.Green "the sink tracks no tables with CDC."))
+             | Ok tracked ->
+                 items.Add (GoBoard.itemWith "cdc"
+                     (GoBoard.Status.Red (sprintf "the sink is CDC-tracked (%d table(s)) — a live run refuses without consent." tracked.Length, "run --go with --allow-cdc (the capture will see the load), or disable capture on the sink."))
+                     (tracked |> List.truncate 5)))
+            (match (Preflight.captureGrantEvidence sink).GetAwaiter().GetResult() with
+             | Error errors ->
+                 items.Add (GoBoard.itemWith "grant" (GoBoard.Status.Red ("the grant probe failed.", "check the sink connection/principal; then re-run.")) (errors |> List.map (fun e -> e.Message)))
+             | Ok evidence ->
+                 let missing =
+                     [ "SELECT"; "INSERT"; "UPDATE"; "DELETE" ]
+                     |> List.filter (fun p -> not (Preflight.coversPermissionAtDatabaseScope p evidence))
+                 if List.isEmpty missing then
+                     items.Add (GoBoard.itemWith "grant"
+                         (GoBoard.Status.Green "the sink principal carries database-scope SELECT/INSERT/UPDATE/DELETE.")
+                         [ "standing note: a TABLE-level DENY is invisible to this probe and would surface mid-load (the pinned G1 gap)." ])
+                 else
+                     items.Add (GoBoard.item "grant"
+                         (GoBoard.Status.Red (sprintf "the sink principal lacks database-scope %s." (String.concat ", " missing), "grant the missing permission(s) to the sink principal; then re-run."))))
+            // Re-run semantics over the ACTUAL sink state.
+            let subsetKinds =
+                match loadSet with
+                | Some s -> Catalog.allKinds sinkContract |> List.filter (fun k -> Set.contains k.SsKey s)
+                | None -> Catalog.allKinds sinkContract |> List.filter (fun k -> not (Set.contains k.SsKey reconciledKeys))
+            let populated =
+                subsetKinds
+                |> List.choose (fun k ->
+                    let n = probeCount sink (sprintf "SELECT COUNT_BIG(*) FROM [%s].[%s];" (TableId.schemaText k.Physical) (TableId.tableText k.Physical))
+                    if n > 0 then Some (sprintf "%s: %d row(s)" (Name.value k.Name) n) else None)
+            (match opts.Emission, populated with
+             | EmissionMode.Incremental, (_ :: _) ->
+                 items.Add (GoBoard.itemWith "re-run"
+                     (GoBoard.Status.Red ("the sink already holds rows in the transferred set and the strategy is merge/incremental — a re-run would DUPLICATE sink-minted rows.", "set \"strategy\": \"replace\" on the flow (wipe-the-subset-then-load, idempotent), or clear the subset first."))
+                     populated)
+             | EmissionMode.WipeAndLoad, _ ->
+                 // The wipe-blocker probe: out-of-subset sink children holding
+                 // rows that reference an in-subset parent block the child-first
+                 // DELETE with a raw 547 (the pinned wipe hazard).
+                 let subsetSet = subsetKinds |> List.map (fun k -> k.SsKey) |> Set.ofList
+                 let blockers =
+                     Catalog.allKinds sinkContract
+                     |> List.filter (fun k -> not (Set.contains k.SsKey subsetSet))
+                     |> List.collect (fun child ->
+                         child.References
+                         |> List.filter (fun r -> Set.contains r.TargetKind subsetSet)
+                         |> List.choose (fun r ->
+                             child.Attributes
+                             |> List.tryFind (fun a -> a.SsKey = r.SourceAttribute)
+                             |> Option.bind (fun a ->
+                                 let n = probeCount sink (sprintf "SELECT COUNT_BIG(*) FROM [%s].[%s] WHERE [%s] IS NOT NULL;" (TableId.schemaText child.Physical) (TableId.tableText child.Physical) (ColumnRealization.columnNameText a.Column))
+                                 if n > 0 then Some (sprintf "%s.%s -> in-subset parent (%d referencing row(s))" (Name.value child.Name) (Name.value a.Name) n) else None)))
+                 if List.isEmpty blockers then
+                     items.Add (GoBoard.item "re-run" (GoBoard.Status.Green "strategy replace: the subset wipes child-first and reloads — idempotent; no out-of-subset rows block the wipe."))
+                 else
+                     items.Add (GoBoard.itemWith "re-run"
+                         (GoBoard.Status.Red ("out-of-subset sink rows reference the tables the wipe would delete — the wipe would fail mid-way (FK 547).", "widen `tables` to include the referencing table(s), or clear those rows first."))
+                         blockers)
+             | _ ->
+                 items.Add (GoBoard.item "re-run" (GoBoard.Status.Green "the transferred set is empty on the sink — first load; both strategies behave identically.")))
+        // -- the run-time gates (never red here: they are per-run intent) ----
+        let envGate = System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE" = "1"
+        items.Add (GoBoard.item "execute gates"
+            (GoBoard.Status.Advisory
+                (if envGate then "PROJECTION_ALLOW_EXECUTE is set; the live run still needs the per-run intent flag --go."
+                 else "two gates at run time: PROJECTION_ALLOW_EXECUTE=1 (environment authorization) + --go (per-run intent).")))
+        finish (List.ofSeq items)
+    | _ ->
+        Console.Error.WriteLine (sprintf "projection check go: flow '%s' is not a live data-transfer flow (the go board covers env->env data flows)." flowName)
+        2
 
 // ---------------------------------------------------------------------------

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -483,8 +483,10 @@ let runPeerTransfer
     // (exit 6) before any gate or connection-opening work.
     match (PeerTransfer.acquireContracts sourceSpec sinkSpec).GetAwaiter().GetResult() with
     | Error errors ->
-        Console.Error.WriteLine "projection transfer (peer): contract acquisition error:"
-        printErrors Console.Error errors
+        // The gate surface owns the copy (§5): `source.ossys.*` classifies
+        // onto the schema-read axis, so the operator gets the statement +
+        // the next move, never the flat GenericStop wall.
+        TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
         dumpBench "transfer"
         (Preflight.refusalOf errors).ExitCode
     | Ok (sourceContract, sinkContract) ->
@@ -492,24 +494,35 @@ let runPeerTransfer
     // Resolve the gate inputs: the declared subset (against the SOURCE
     // contract — the same resolver the engine uses) and the reconciled kind
     // set (against the SINK contract — the same resolution the shared body
-    // performs). A spec that fails to parse/resolve here is NOT refused here:
-    // the shared body reproduces the refusal byte-identically, so the gates
-    // simply step aside (empty reconciled set / no subset) and delegate.
-    let reconciledKeys : Set<SsKey> =
+    // performs). 2026-07-06 (adversarial MEDIUM #7): a reconcile spec that
+    // fails to parse/resolve REFUSES HERE, before the gates — the prior
+    // swallow-to-empty let the subset-FK gate blame the operator's
+    // (correctly-written but typo'd) strategy as a missing one, refusing
+    // exit 9 "escapes" where the true problem was the bad spec (exit 2).
+    let reconciledResolution : Result<Set<SsKey>> =
         let parsedReconciles = reconcileSpecs |> List.map TransferSpec.parseReconcileSpec
         let parsedUserMap =
             match userMapPath with
             | None -> Result.success []
             | Some path ->
-                if not (System.IO.File.Exists path) then Result.success []
+                if not (System.IO.File.Exists path) then Result.success []   // the delegate refuses fileMissing byte-identically
                 else TransferSpec.parseUserMapCsv (System.IO.File.ReadAllText path)
-        let entries = parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None)
-        match parsedUserMap with
-        | Error _ -> Set.empty
-        | Ok userMapEntries ->
-            match TransferSpec.resolveAllReconciliation sinkContract entries userMapEntries with
-            | Ok reconciliation -> reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
-            | Error _ -> Set.empty
+        let specErrors =
+            (parsedReconciles |> List.collect (function Ok _ -> [] | Error es -> es))
+            @ (match parsedUserMap with Ok _ -> [] | Error es -> es)
+        if not (List.isEmpty specErrors) then Result.failure specErrors
+        else
+            let entries = parsedReconciles |> List.choose (function Ok e -> Some e | Error _ -> None)
+            let userMapEntries = match parsedUserMap with Ok es -> es | Error _ -> []
+            TransferSpec.resolveAllReconciliation sinkContract entries userMapEntries
+            |> Result.map (fun reconciliation -> reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+    match reconciledResolution with
+    | Error errors ->
+        Console.Error.WriteLine "projection transfer (peer): reconcile resolution error:"
+        printErrors Console.Error errors
+        dumpBench "transfer"
+        2
+    | Ok reconciledKeys ->
     match Transfer.resolveLoadSet sourceContract tables with
     | Error errors ->
         // The subset itself failed to resolve — same refusal the engine
@@ -527,13 +540,19 @@ let runPeerTransfer
     let gateScope = loadSet |> Option.map (Set.union reconciledKeys)
     match PeerTransfer.shapeGate gateScope sourceContract sinkContract with
     | Error errors ->
-        errors |> List.iter TtyRenderer.renderVoicedError
+        // §5 gate surface — `transfer.peer.shapeDivergence` carries its own
+        // axis (ShapeDivergence, exit 5) and copy; never the GenericStop wall.
+        TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
         dumpBench "transfer"
         (Preflight.refusalOf errors).ExitCode
     | Ok advisories ->
+    // Advisories land on STDOUT with the rest of the preview (the answer
+    // channel): `projection golden > preview.txt` must capture the safety
+    // information the operator reviews before authorizing a live write —
+    // stderr-only advisories silently vanish from a redirected preview.
     if not (List.isEmpty advisories) then
-        Console.Error.WriteLine (sprintf "projection transfer (peer): %d shape advisory(ies) — real divergence that does not block a data load:" advisories.Length)
-        advisories |> List.iter (fun line -> Console.Error.WriteLine ("  " + line))
+        printfn "%d shape advisory(ies) — real divergence that does not block a data load:" advisories.Length
+        advisories |> List.iter (fun line -> printfn "  %s" line)
 
     // Gate 2 — FK edges escaping the declared subset. A preview narrates the
     // per-edge strategy proposals; a live Execute with un-strategized escapes
@@ -545,9 +564,11 @@ let runPeerTransfer
     if not (List.isEmpty escapes) then
         printfn "%d relationship(s) escape the declared table subset:" escapes.Length
         PeerTransfer.narrateEscapes escapes |> List.iter (fun line -> printfn "  %s" line)
-    match PeerTransfer.subsetFkGate executeRequested allowDrops escapes with
+    match PeerTransfer.subsetFkGate executeRequested escapes with
     | Error errors ->
-        errors |> List.iter TtyRenderer.renderVoicedError
+        // §5 gate surface — `transfer.peer.subsetFkEscapes` (SubsetFkEscape,
+        // exit 9) with the reconcile/widen/allow-drops next move.
+        TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
         dumpBench "transfer"
         (Preflight.refusalOf errors).ExitCode
     | Ok () ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -43,9 +43,12 @@ let private usageLines : string list =
         "    projection <flow> [--go] [--fresh] [--allow-drops] [--allow-cdc] [--resumable] [--atomic] [--auto-revert]   the daily surface"
         "    projection                                           list flows (name: from → to)"
         "    projection check  ( <source.sql> [--cdc-silence] | drift --model <m> --to <t>"
-        "                      | data --before <t> --after <t> | ready | shape )"
+        "                      | data --before <t> --after <t> | ready | shape | go <flow> )"
         "                      shape = the cross-environment readiness gate (the `readiness` set"
         "                      resolves to one espace-safe shape + zero data dealbreakers)"
+        "                      go    = THE GO BOARD for a data flow: every open decision +"
+        "                      the dry-run row forecast, red (exit 5) until each decision is"
+        "                      resolved, green (exit 0) when --go would execute cleanly"
         "    projection diff <a> <b> [--format json] [--depth N] [--only <channel>] [--module <name>]"
         "                      change between two refs (--only columns|relationships|indexes|"
         "                      sequences|tables scopes the display; --module scopes the diff)"
@@ -109,7 +112,7 @@ let private usageLines : string list =
         "    2  parse error (model JSON / spec / config-parse)"
         "    3  execution error (SQL rejected the change; connection open; unbreakable cycle)"
         "    4  Docker unavailable (a docker target; check fidelity)"
-        "    5  fidelity divergence (check canary / check drift; check shape not-ready)"
+        "    5  fidelity divergence (check canary / check drift; check shape / check go not-ready)"
         "    6  config error (file missing / unparseable / D9; connection-ref resolve; check shape env unreadable)"
         "    7  gate refusal (--go without PROJECTION_ALLOW_EXECUTE=1; permission pre-flight)"
         "    8  data divergence (check data row / null)"
@@ -288,6 +291,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
+    | PlanAction.CheckGo (flowName, fromLabel, toLabel, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo flowName fromLabel toLabel planned)
     // explain ------------------------------------------------------------
     | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->
         shellRun "projection diff" Shell.ReadOnly (fun () -> runDiff a b asJson (defaultArg depthOpt View.defaultDepth) channel onlyModule)

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -64,6 +64,10 @@ let private usageLines : string list =
         "    projection synth-correct --out <path>   propose a blessed-correction artifact (review/edit/bless)"
         "    projection inspect [<runId> [<runId>]]  a stored run (no id = latest; arrows dig, PgUp/PgDn walk runs)"
         "    projection init                 scaffold a projection.json"
+        "    projection revert [--script <p>] --against <env> [--go]   undo a transfer: run the"
+        "                      transfer-undo.sql a successful run wrote (or a failed run's"
+        "                      transfer-revert.sql) — preview by default; --go deletes the"
+        "                      captured rows in ONE transaction (pre-existing rows untouched)"
         "    projection setup [--conn <ref>] read back what is configured (history, writes, board);"
         "                                    --conn also probes a target (reachable + ALTER grant)"
         ""
@@ -292,6 +296,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
     | PlanAction.CheckGo (flowName, fromLabel, toLabel, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo flowName fromLabel toLabel planned)
+    | PlanAction.RevertScript (script, envLabel, connSpec, go) -> shellRun "projection revert" (if go then Shell.Go else Shell.ReadOnly) (fun () -> runRevertScript script envLabel connSpec go)
     // explain ------------------------------------------------------------
     | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->
         shellRun "projection diff" Shell.ReadOnly (fun () -> runDiff a b asJson (defaultArg depthOpt View.defaultDepth) channel onlyModule)

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -221,7 +221,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // events, so their streams now open with `config.runStart` and
         // close with the §10 terminal — and the run is capturable.
         withRun "projection transfer" (fun () ->
-            runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables opts.RevertPolicy opts.RevertDir)
+            runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability.SinkResidentResume)
     | PlanAction.TransferPeer (src, sink, opts, execute) ->
         // The peer (A→A) leg (2026-07-06): two cells of one model, physical
         // `OSUSR_*` names differing per espace. NO model rides the action —

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -215,6 +215,14 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // close with the §10 terminal — and the run is capturable.
         withRun "projection transfer" (fun () ->
             runTransfer src sink None None opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Tables opts.RevertPolicy opts.RevertDir)
+    | PlanAction.TransferPeer (src, sink, opts, execute) ->
+        // The peer (A→A) leg (2026-07-06): two cells of one model, physical
+        // `OSUSR_*` names differing per espace. NO model rides the action —
+        // the face reads a contract from EACH side's OSSYS metamodel (native
+        // GUID identity), gates the pair (shape / subset-FK), and drives the
+        // same contract-pair engine path the reverse leg proved.
+        withRun "projection transfer" (fun () ->
+            runPeerTransfer src sink opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -465,7 +465,11 @@ let private runList (asJson: bool) : int =
                 [ for KeyValue (name, f) in cfg.Flows ->
                     let extra =
                         [ if Option.isSome f.Rekey then yield "rekey"
-                          if not (List.isEmpty f.Tables) then yield sprintf "tables: %s" (String.concat "," f.Tables) ]
+                          if not (List.isEmpty f.Tables) then yield sprintf "tables: %s" (String.concat "," f.Tables)
+                          // `reconcile` is as load-bearing as `rekey` on the
+                          // golden shape (the re-key contract) — surface it so
+                          // the menu scan shows which flows carry a strategy.
+                          if not (List.isEmpty f.Reconcile) then yield sprintf "reconcile: %s" (String.concat "," f.Reconcile) ]
                     name, flowSourceText f.From, f.To, String.concat "; " extra ]
             TtyRenderer.renderAnswer asJson View.defaultDepth (TtyRenderer.buildFlowMenuView rows)
         0

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -64,10 +64,12 @@ let private usageLines : string list =
         "    projection synth-correct --out <path>   propose a blessed-correction artifact (review/edit/bless)"
         "    projection inspect [<runId> [<runId>]]  a stored run (no id = latest; arrows dig, PgUp/PgDn walk runs)"
         "    projection init                 scaffold a projection.json"
-        "    projection revert [--script <p>] --against <env> [--go]   undo a transfer: run the"
-        "                      transfer-undo.sql a successful run wrote (or a failed run's"
+        "    projection revert [--script <p>] --against <env> [--go] [--force]   undo a transfer: run"
+        "                      the transfer-undo.sql a successful run wrote (or a failed run's"
         "                      transfer-revert.sql) — preview by default; --go deletes the"
-        "                      captured rows in ONE transaction (pre-existing rows untouched)"
+        "                      captured rows in ONE transaction (pre-existing rows untouched);"
+        "                      the artifact's provenance header must match the --against"
+        "                      database (--force overrides a deliberate rename/restore)"
         "    projection setup [--conn <ref>] read back what is configured (history, writes, board);"
         "                                    --conn also probes a target (reachable + ALTER grant)"
         ""
@@ -295,8 +297,8 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
-    | PlanAction.CheckGo (flowName, fromLabel, toLabel, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo flowName fromLabel toLabel planned)
-    | PlanAction.RevertScript (script, envLabel, connSpec, go) -> shellRun "projection revert" (if go then Shell.Go else Shell.ReadOnly) (fun () -> runRevertScript script envLabel connSpec go)
+    | PlanAction.CheckGo (flowName, fromLabel, toLabel, asJson, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo flowName fromLabel toLabel asJson planned)
+    | PlanAction.RevertScript (script, envLabel, connSpec, go, force) -> shellRun "projection revert" (if go then Shell.Go else Shell.ReadOnly) (fun () -> runRevertScript script envLabel connSpec go force)
     // explain ------------------------------------------------------------
     | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->
         shellRun "projection diff" Shell.ReadOnly (fun () -> runDiff a b asJson (defaultArg depthOpt View.defaultDepth) channel onlyModule)

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -1244,6 +1244,12 @@ module Voice =
         | Preflight.CdcTrackedSink ->
             View.Warn, "The sink is CDC-tracked. Allow the capture, or halt.",
             Some(View.Action "Allow CDC capture, or halt.")
+        | Preflight.ShapeDivergence ->
+            View.Bad, "The source and sink schemas are not one shape over the transferred set. Align the models, narrow the subset, or halt.",
+            Some(View.Action "Align the models (deploy the same version to both), narrow the table subset, or halt.")
+        | Preflight.SubsetFkEscape ->
+            View.Warn, "Some relationships point outside the chosen tables. Reconcile each against the target's rows, widen the subset, or accept the drops.",
+            Some(View.Action "Reconcile each named table against the target's rows, widen the subset, or accept the drops: --allow-drops.")
         | Preflight.UnclassifiedRefusal ->
             View.Bad, "Stopped before any change was applied. The cause is shown below.", None
 

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -1248,8 +1248,8 @@ module Voice =
             View.Bad, "The source and sink schemas are not one shape over the transferred set. Align the models, narrow the subset, or halt.",
             Some(View.Action "Align the models (deploy the same version to both), narrow the table subset, or halt.")
         | Preflight.SubsetFkEscape ->
-            View.Warn, "Some relationships point outside the chosen tables. Reconcile each against the target's rows, widen the subset, or accept the drops.",
-            Some(View.Action "Reconcile each named table against the target's rows, widen the subset, or accept the drops: --allow-drops.")
+            View.Warn, "Some relationships point outside the chosen tables — their rows would keep the source environment's references. Reconcile each against the target's rows, or widen the subset.",
+            Some(View.Action "Reconcile each named table against the target's rows (Module.Entity:Column), or widen the subset.")
         | Preflight.UnclassifiedRefusal ->
             View.Bad, "Stopped before any change was applied. The cause is shown below.", None
 

--- a/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
@@ -110,6 +110,20 @@ module TopologicalOrderPass =
         let initialIndegree =
             nodes |> List.map (fun n -> n, 0) |> Map.ofList
 
+        // PARALLEL edges (two references between the same (child, parent)
+        // pair — e.g. Employee.ManagerId + Employee.MentorId → Employee)
+        // contribute ONE precedence edge (2026-07-06, adversarial MEDIUM
+        // #9): the prior per-reference adjacency/indegree increments left a
+        // stale indegree after the resolver broke the (deduped) classified
+        // edge — Kahn residue, whole-catalog alphabetical degrade. Strength
+        // COMBINES across the parallel set: the pair is breakable only if
+        // EVERY parallel reference is Weak (a Cascade or non-nullable
+        // sibling still binds the dependency).
+        let strongerOf (a: EdgeStrength) (b: EdgeStrength) : EdgeStrength =
+            match a, b with
+            | EdgeStrength.Cascade, _ | _, EdgeStrength.Cascade -> EdgeStrength.Cascade
+            | EdgeStrength.Other, _ | _, EdgeStrength.Other -> EdgeStrength.Other
+            | _ -> EdgeStrength.Weak
         let folder (state: Graph) (k: Kind) : Graph =
             // Sort references by SsKey too — same invariance commitment
             // at the inner level.
@@ -127,20 +141,27 @@ module TopologicalOrderPass =
                     // dependency).
                     st
                 elif Set.contains r.TargetKind presentKeys then
-                    let children =
-                        Map.tryFind r.TargetKind st.Adjacency
-                        |> Option.defaultValue []
-                    let updatedAdjacency =
-                        st.Adjacency |> Map.add r.TargetKind (k.SsKey :: children)
-                    let currentIndegree =
-                        Map.tryFind k.SsKey st.Indegree |> Option.defaultValue 0
-                    let updatedIndegree =
-                        st.Indegree |> Map.add k.SsKey (currentIndegree + 1)
-                    { st with
-                        Adjacency       = updatedAdjacency
-                        Indegree        = updatedIndegree
-                        Edges           = edge :: st.Edges
-                        ClassifiedEdges = Map.add edge strength st.ClassifiedEdges }
+                    match Map.tryFind edge st.ClassifiedEdges with
+                    | Some existing ->
+                        // A parallel reference over an already-tracked pair:
+                        // combine strength only — adjacency/indegree/Edges
+                        // stay single-entry so break/reduce stays coherent.
+                        { st with ClassifiedEdges = Map.add edge (strongerOf existing strength) st.ClassifiedEdges }
+                    | None ->
+                        let children =
+                            Map.tryFind r.TargetKind st.Adjacency
+                            |> Option.defaultValue []
+                        let updatedAdjacency =
+                            st.Adjacency |> Map.add r.TargetKind (k.SsKey :: children)
+                        let currentIndegree =
+                            Map.tryFind k.SsKey st.Indegree |> Option.defaultValue 0
+                        let updatedIndegree =
+                            st.Indegree |> Map.add k.SsKey (currentIndegree + 1)
+                        { st with
+                            Adjacency       = updatedAdjacency
+                            Indegree        = updatedIndegree
+                            Edges           = edge :: st.Edges
+                            ClassifiedEdges = Map.add edge strength st.ClassifiedEdges }
                 else
                     { st with MissingEdges = edge :: st.MissingEdges }) state
 

--- a/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
@@ -324,13 +324,18 @@ module TopologicalOrderPass =
         (classified: Map<(SsKey * SsKey), EdgeStrength>)
         : ((SsKey * SsKey) * EdgeStrength) list =
         // All (source, target) pairs where both endpoints are in the
-        // SCC. Sorted by edge tuple for deterministic output.
+        // SCC. Sorted by edge tuple for deterministic output. Self-pairs
+        // (a = b) are REAL internal edges — a 1-member SCC's self-reference
+        // is exactly the (k, k) pair, and excluding it made every self-loop
+        // SCC unresolvable by construction (the resolver saw an empty edge
+        // list; found 2026-07-06 by the peer-aligned two-environment
+        // canary). The 2-cycle arm of the resolver ignores self-edges, so
+        // its semantics are unchanged.
         [ for a in members do
             for b in members do
-                if a <> b then
-                    match Map.tryFind (a, b) classified with
-                    | Some s -> yield (a, b), s
-                    | None   -> () ]
+                match Map.tryFind (a, b) classified with
+                | Some s -> yield (a, b), s
+                | None   -> () ]
         |> List.sortBy fst
 
     let private applyResolver

--- a/sidecar/projection/src/Projection.Core/Strategies/CycleResolution.fs
+++ b/sidecar/projection/src/Projection.Core/Strategies/CycleResolution.fs
@@ -78,17 +78,49 @@ module CycleResolution =
     type Resolver =
         SsKey list -> ((SsKey * SsKey) * EdgeStrength) list -> ResolutionStep
 
-    /// V1's asymmetric-2-cycle strategy. For SCCs of size 2 with
-    /// exactly one Weak edge, returns that edge as breakable. Refuses
-    /// to resolve any other shape — 0 Weak, multiple Weak, or larger
-    /// SCCs — leaving the cycle for the alphabetical fallback.
+    /// V1's asymmetric-2-cycle strategy, extended (2026-07-06) with the
+    /// self-loop rule. For SCCs of size 2 with exactly one Weak edge,
+    /// returns that edge as breakable. For SCCs of size 1 (a
+    /// self-referencing kind), a Weak self-edge is breakable FOR
+    /// ORDERING: the two-phase load's deferral machinery re-points a
+    /// nullable self-FK in phase 2 regardless of order (the F1 lift,
+    /// DECISIONS 2026-06-10), and a RESOLVED SCC stays in `Cycles`, so
+    /// `cycleMembers`/`deferredFkColumns` still defer the column — only
+    /// the ORDER stops degrading. Before this rule, one nullable
+    /// self-reference anywhere (Category.Parent, Employee.Manager — the
+    /// common OutSystems shapes) refused resolution and dropped the
+    /// WHOLE catalog to the alphabetical fallback, re-ordering every
+    /// unrelated parent/child pair; a subset transfer then loaded
+    /// children before their parents and mass-dropped FK rows (found
+    /// 2026-07-06 by the peer-aligned two-environment canary). Still
+    /// refuses every other shape — 0 Weak, multiple-Weak 2-cycles,
+    /// non-Weak self-edges, larger SCCs — leaving those for the
+    /// alphabetical fallback.
     let asymmetric2CycleStrategy : Resolver =
         fun members internalEdges ->
             match members with
+            | [ single ] ->
+                let weakSelfEdges =
+                    internalEdges
+                    |> List.filter (fun ((s, t), strength) ->
+                        s = single && t = single && strength = EdgeStrength.Weak)
+                    |> List.map fst
+                match weakSelfEdges with
+                | [] ->
+                    { EdgesToBreak = []
+                      Reason       = "self-referencing SCC has no Weak (nullable) self-edge to defer" }
+                | edges ->
+                    { EdgesToBreak = edges
+                      Reason       = "auto-resolved by deferring the nullable self-reference to phase 2" }
             | [_; _] ->
+                // Self-edges are not the 2-cycle's business — a member's
+                // self-reference rides its own deferral; only the two
+                // INTER-member edges decide asymmetry here (the pre-2026-07-06
+                // semantics, preserved now that `internalEdgesOf` reports
+                // self-pairs).
                 let weakEdges =
                     internalEdges
-                    |> List.filter (fun (_, s) -> s = EdgeStrength.Weak)
+                    |> List.filter (fun ((s, t), strength) -> s <> t && strength = EdgeStrength.Weak)
                 match weakEdges with
                 | [ (edge, _) ] ->
                     { EdgesToBreak = [ edge ]

--- a/sidecar/projection/src/Projection.Core/Transfer.fs
+++ b/sidecar/projection/src/Projection.Core/Transfer.fs
@@ -66,11 +66,18 @@ module Environment =
 
 /// A *reference* to where a substrate's credentials live — never the
 /// secret (D9). Either an environment-variable name or a file path the
-/// operator supplies out of band.
+/// operator supplies out of band — or, since 2026-07-06, the already-
+/// resolved string held IN MEMORY (`Raw`): the carrier for a caller that
+/// legitimately holds the secret (a face handed the resolved spec by the
+/// dispatch plane; a test fixture's ephemeral database). Before `Raw`,
+/// those sites wrote the secret to a TEMP FILE and read it back — an
+/// on-disk persistence strictly worse than D9's provenance intent
+/// (DECISIONS 2026-07-06, the ConnectionRef.Raw amendment).
 [<RequireQualifiedAccess>]
 type ConnectionRef =
     | EnvVar of name: string
     | File of path: string
+    | Raw of connStr: string
 
 /// An `Environment` bound to the `SubstrateRole` it plays in a Transfer,
 /// with its out-of-band `ConnectionRef`. The thing you open.

--- a/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
+++ b/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
@@ -1,0 +1,90 @@
+namespace Projection.Pipeline
+
+// LINT-ALLOW-FILE: the board renderer composes operator-facing report prose
+//   (THE_VOICE register: verdict on top, proof beneath, the next move named)
+//   at a terminal reporting boundary. The assembly core is pure — every probe
+//   result arrives as data; I/O lives one layer up (the CLI run face),
+//   exactly as `Readiness`/`Compare` split.
+
+open Projection.Core
+
+/// THE GO BOARD (2026-07-06, the preview-engine program): the ONE surface
+/// that forecasts a flow's live run and flags every OPEN DECISION — red
+/// until each is resolved, green when the flow is genuinely executable.
+///
+///   - Every "amino acid" of the forecast is an `Item` on one axis:
+///     routing, contract acquisition, table subset, reconcile strategy,
+///     schema shape, escaping relationships, load order, plan structure,
+///     identity matching, CDC posture, grant evidence, re-run semantics,
+///     and the execute gates.
+///   - `Status.Red` carries the reason AND the exact remedy — the operator
+///     never has to derive the next move.
+///   - The verdict is total: GREEN ⇔ zero red items. `check go` exits 0 on
+///     green and 5 (the not-ready class, same as `check shape`) on red, so
+///     the board is CI-able: wire it red, fix the named decisions, watch it
+///     turn green.
+[<RequireQualifiedAccess>]
+module GoBoard =
+
+    [<RequireQualifiedAccess>]
+    type Status =
+        /// The axis passes — the note says what was proven.
+        | Green of note: string
+        /// Real information that does not block a live run — surfaced,
+        /// never silent.
+        | Advisory of note: string
+        /// An open decision or blocking fault: what is wrong + the exact
+        /// remedy that turns the line green.
+        | Red of reason: string * remedy: string
+
+    type Item =
+        { /// The axis label (short, stable — the operator scans these).
+          Axis   : string
+          Status : Status
+          /// Optional per-line proof/detail beneath the headline (escaping
+          /// edges, divergence lines, unmatched identities…).
+          Detail : string list }
+
+    type Board =
+        { Flow  : string
+          From  : string
+          To    : string
+          Items : Item list }
+
+    let item (axis: string) (status: Status) : Item = { Axis = axis; Status = status; Detail = [] }
+    let itemWith (axis: string) (status: Status) (detail: string list) : Item = { Axis = axis; Status = status; Detail = detail }
+
+    let private isRed (i: Item) = match i.Status with Status.Red _ -> true | _ -> false
+
+    /// GREEN ⇔ zero red items (advisories never block).
+    let isGreen (b: Board) : bool = b.Items |> List.forall (fun i -> not (isRed i))
+
+    let redCount (b: Board) : int = b.Items |> List.filter isRed |> List.length
+
+    /// The CI-able exit: 0 green; 5 (the not-ready verdict class `check
+    /// shape` also uses) on red.
+    let exitCode (b: Board) : int = if isGreen b then 0 else 5
+
+    /// Render the board as operator-facing lines: the mark column, the axis,
+    /// the headline; detail lines indented beneath; the verdict at the close
+    /// with the next move named.
+    let render (b: Board) : string list =
+        [ yield sprintf "THE GO BOARD — flow '%s' (%s -> %s)" b.Flow b.From b.To
+          yield ""
+          for i in b.Items do
+              let mark, headline =
+                  match i.Status with
+                  | Status.Green note          -> "[ GO ]", note
+                  | Status.Advisory note       -> "[note]", note
+                  | Status.Red (reason, _)     -> "[STOP]", reason
+              yield sprintf "  %s %-18s %s" mark i.Axis headline
+              match i.Status with
+              | Status.Red (_, remedy) -> yield sprintf "         %-18s -> %s" "" remedy
+              | _ -> ()
+              for d in i.Detail do
+                  yield sprintf "         %-18s    %s" "" d
+          yield ""
+          if isGreen b then
+              yield sprintf "  VERDICT — GREEN. Every gate passes. Execute with: PROJECTION_ALLOW_EXECUTE=1 projection %s --go" b.Flow
+          else
+              yield sprintf "  VERDICT — RED. %d open decision(s) / blocking fault(s) — resolve every [STOP] line above, then re-run `projection check go %s` until green." (redCount b) b.Flow ]

--- a/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
+++ b/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
@@ -65,6 +65,43 @@ module GoBoard =
     /// shape` also uses) on red.
     let exitCode (b: Board) : int = if isGreen b then 0 else 5
 
+    /// The machine-readable projection (`--format json`) — the CI-consumable
+    /// twin of the exit code: `{flow, from, to, verdict, redCount, items:[
+    /// {axis, status, headline, remedy?, detail[]}]}`. Typed writer, never
+    /// string concatenation (the house JSON discipline).
+    let toJsonString (b: Board) : string =
+        use ms = new System.IO.MemoryStream()
+        use w = new System.Text.Json.Utf8JsonWriter(ms, System.Text.Json.JsonWriterOptions(Indented = true))
+        w.WriteStartObject()
+        w.WriteString("flow", b.Flow)
+        w.WriteString("from", b.From)
+        w.WriteString("to", b.To)
+        w.WriteString("verdict", (if isGreen b then "green" else "red"))
+        w.WriteNumber("redCount", redCount b)
+        w.WriteStartArray "items"
+        for i in b.Items do
+            w.WriteStartObject()
+            w.WriteString("axis", i.Axis)
+            (match i.Status with
+             | Status.Green note ->
+                 w.WriteString("status", "green")
+                 w.WriteString("headline", note)
+             | Status.Advisory note ->
+                 w.WriteString("status", "advisory")
+                 w.WriteString("headline", note)
+             | Status.Red (reason, remedy) ->
+                 w.WriteString("status", "red")
+                 w.WriteString("headline", reason)
+                 w.WriteString("remedy", remedy))
+            w.WriteStartArray "detail"
+            for d in i.Detail do w.WriteStringValue d
+            w.WriteEndArray()
+            w.WriteEndObject()
+        w.WriteEndArray()
+        w.WriteEndObject()
+        w.Flush()
+        System.Text.Encoding.UTF8.GetString(ms.ToArray())
+
     /// Render the board as operator-facing lines: the mark column, the axis,
     /// the headline; detail lines indented beneath; the verdict at the close
     /// with the next move named.

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -515,6 +515,12 @@ type PlanAction =
     /// and the confirm set, each as (label, D9 conn-ref); the runner reads every
     /// env via OSSYS (native GUID identity) and rolls a `ReadinessReport`.
     | CheckShape of agreedLabel: string * agreedRef: string * confirm: (string * string) list * asJson: bool
+    /// `check go <flow>` — THE GO BOARD (2026-07-06, the preview-engine
+    /// program): the red/green go-readiness checklist for a data flow. The
+    /// action carries the flow's coordinates + the PLANNED action the flow
+    /// would run (the same `planFlow` derivation a real run takes, under
+    /// preview opts), so the board judges exactly what `--go` would execute.
+    | CheckGo of flow: string * fromLabel: string * toLabel: string * planned: PlanAction
     // explain ------------------------------------------------------------
     | ExplainDiff of refA: string * refB: string * asJson: bool * depth: int option * channel: string option * onlyModule: string option
     | Compare of refA: string * refB: string * asJson: bool

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -384,6 +384,12 @@ type Intent =
     /// `compare <A> <B>` — NM-71/WP9: the read-only multi-environment readiness
     /// check (schema delta + data dealbreakers). Advisory; no writes.
     | Compare of args: string list
+    /// `revert [--script <path>] --against <env> [--go]` — execute (or
+    /// preview) a transfer undo/revert artifact (`transfer-undo.sql` /
+    /// `transfer-revert.sql`) against a configured environment: the
+    /// deliberate-undo half of the proving loop (2026-07-06). Preview is the
+    /// default; a live run needs PROJECTION_ALLOW_EXECUTE=1 + --go.
+    | Revert of args: string list
     /// `slice-extract` / `slice-apply` / `slice-reset` / `slice-run` — the
     /// data-portability verbs (Slice 3/7). Lifted onto the typed `Intent` surface
     /// (recon #3) so the CLI runs ONE dispatcher; the bespoke flag parsing stays
@@ -515,6 +521,12 @@ type PlanAction =
     /// and the confirm set, each as (label, D9 conn-ref); the runner reads every
     /// env via OSSYS (native GUID identity) and rolls a `ReadinessReport`.
     | CheckShape of agreedLabel: string * agreedRef: string * confirm: (string * string) list * asJson: bool
+    /// `revert [--script <path>] --against <env> [--go]` — execute (or
+    /// preview) a transfer undo/revert artifact against a configured live
+    /// environment (2026-07-06, the proving-loop program). Carries the
+    /// script path, the environment label (display), the RESOLVED conn
+    /// spec, and the per-run intent flag.
+    | RevertScript of script: string * envLabel: string * connSpec: string * go: bool
     /// `check go <flow>` — THE GO BOARD (2026-07-06, the preview-engine
     /// program): the red/green go-readiness checklist for a data flow. The
     /// action carries the flow's coordinates + the PLANNED action the flow

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -526,13 +526,13 @@ type PlanAction =
     /// environment (2026-07-06, the proving-loop program). Carries the
     /// script path, the environment label (display), the RESOLVED conn
     /// spec, and the per-run intent flag.
-    | RevertScript of script: string * envLabel: string * connSpec: string * go: bool
+    | RevertScript of script: string * envLabel: string * connSpec: string * go: bool * force: bool
     /// `check go <flow>` — THE GO BOARD (2026-07-06, the preview-engine
     /// program): the red/green go-readiness checklist for a data flow. The
     /// action carries the flow's coordinates + the PLANNED action the flow
     /// would run (the same `planFlow` derivation a real run takes, under
     /// preview opts), so the board judges exactly what `--go` would execute.
-    | CheckGo of flow: string * fromLabel: string * toLabel: string * planned: PlanAction
+    | CheckGo of flow: string * fromLabel: string * toLabel: string * asJson: bool * planned: PlanAction
     // explain ------------------------------------------------------------
     | ExplainDiff of refA: string * refB: string * asJson: bool * depth: int option * channel: string option * onlyModule: string option
     | Compare of refA: string * refB: string * asJson: bool

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -461,6 +461,20 @@ type PlanAction =
     /// live + data source → transfer (DryRun preview when execute=false; the
     /// DML-only load when execute=true under --scope data).
     | Transfer of source: string * sink: string * opts: LoadOpts * execute: bool
+    /// live + data source whose DERIVED direction is `UpPeer` (A→A: two
+    /// deployed cells of ONE model, e.g. cloud-qa → cloud-uat, whose physical
+    /// `OSUSR_*` names differ per espace) → the peer SsKey-aligned transfer.
+    /// Unlike the bare `Transfer` (ONE `ReadSide` contract from the source,
+    /// physical names assumed identical on the sink), the peer runner reads a
+    /// contract from EACH side's OSSYS metamodel (`Source.ofOssys` — native
+    /// GUID identity, the espace-invariance law), gates the pair on SS_KEY-
+    /// keyed shape compatibility (`transfer.peer.shapeDivergence`, exit 5) and
+    /// on subset-escaping FK edges (`transfer.peer.subsetFkEscapes`, exit 9),
+    /// then rides the SAME rename-aware engine the reverse leg proved
+    /// (`Transfer.runReverseLegThroughConnectionsWith`) — reads with the
+    /// source's physical names, writes with the sink's. 2026-07-06, the
+    /// partial-transfer readiness program.
+    | TransferPeer of source: string * sink: string * opts: LoadOpts * execute: bool
     /// live + data source whose DERIVED direction is `UpLegacy` (B→A) → the
     /// reverse-leg runner (`Transfer.runReverseLeg` / the M3.b face). The engine
     /// distinguishes this from an A→A peer `Transfer` — which it cannot do by

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -1319,59 +1319,7 @@ module Command =
             | _ -> []
         { Notes = unhonoredNotes spec @ freshNote @ resumableNote @ synthesisNote @ streamingNote @ journalNote @ correctionNote @ renditionNote; Action = action }
 
-    /// Route a `check` verb tail to its proof-plane action — purely.
-    let planCheck (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
-        let valueOf = flagValue args
-        let connOf (raw: string) : Result<string> = resolveLiveConn cfg raw
-        let action =
-            match args with
-            | "drift" :: _ ->
-                match valueOf "--model", valueOf "--to" with
-                | Some m, Some toRaw -> (match connOf toRaw with Ok c -> PlanAction.CheckDrift (m, c) | Error es -> PlanAction.Refused (6, List.head es))
-                | _ -> PlanAction.Refused (2, err "cli.check.driftArgs" "projection check drift: requires --model <model.json> --to <environment>.")
-            | "data" :: _ ->
-                match valueOf "--before", valueOf "--after" with
-                | Some b, Some a -> (match connOf b, connOf a with | Ok bc, Ok ac -> PlanAction.CheckData (bc, ac) | (Error es, _) | (_, Error es) -> PlanAction.Refused (6, List.head es))
-                | _ -> PlanAction.Refused (2, err "cli.check.dataArgs" "projection check data: requires --before <environment> --after <environment>.")
-            | "ready" :: _ -> PlanAction.CheckReady
-            | "shape" :: _ ->
-                match cfg.Readiness with
-                | None ->
-                    PlanAction.Refused (2, err "cli.check.shapeNoBlock" "projection check shape: no `readiness` block in projection.json (set readiness.schema + readiness.confirm).")
-                | Some rs ->
-                    // Resolve each env name to (label, D9 conn-ref) for the OSSYS
-                    // read; a non-direct or unknown env is a NAMED refusal.
-                    let refOf (envName: string) : Result<string * string> =
-                        match Map.tryFind envName cfg.Environments with
-                        | Some env ->
-                            match env.Access with
-                            | Access.Direct r -> Result.success (envName, connSpecOf r)
-                            | _ -> Result.failureOf (err "cli.check.shapeNotDirect" (sprintf "readiness environment '%s' is not access:direct (no live OSSYS connection to read)." envName))
-                        | None -> Result.failureOf (err "cli.check.shapeUnknownEnv" (sprintf "readiness environment '%s' is not defined." envName))
-                    let agreedR = refOf rs.Schema
-                    let confirmRs = rs.Confirm |> List.map refOf
-                    let errors =
-                        (match agreedR with Error es -> es | Ok _ -> [])
-                        @ (confirmRs |> List.collect (function Error es -> es | Ok _ -> []))
-                    match errors with
-                    | e :: _ -> PlanAction.Refused (6, e)
-                    | [] ->
-                        let agreed = match agreedR with Ok v -> v | Error _ -> (rs.Schema, "")
-                        let confirm = confirmRs |> List.choose (function Ok v -> Some v | Error _ -> None)
-                        PlanAction.CheckShape (fst agreed, snd agreed, confirm, (valueOf "--format" = Some "json"))
-            | _ ->
-                match args |> List.tryFind (fun a -> not (a.StartsWith "--") && a <> "fidelity") with
-                | Some path -> PlanAction.CheckCanary (path, List.contains "--cdc-silence" args)
-                | None -> PlanAction.Refused (1, err "cli.check.noDdl" "projection check: the fidelity canary needs a source DDL path (check <source.sql>).")
-        { Notes = []; Action = action }
 
-    /// Route an `explain` verb tail to its understanding action — purely.
-    /// `explain <flow>` is the live preview: what publishing the flow would
-    /// change against its target's last sealed episode (B = the flow's model,
-    /// A_prior = the target store) — the preview sibling to `report`'s history.
-    /// `compare <A> <B>` — NM-71/WP9: resolve two operand refs and run the
-    /// read-only readiness compare (schema delta + data dealbreakers). The face
-    /// writes `compare.json` + prints the roll-up. Two refs are required.
     let planCompare (_cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
         let valueOf = flagValue args
         let action =
@@ -1731,6 +1679,78 @@ module Command =
     /// ChangeManifest series — what changed since the last sealed episode. An
     /// explicit `--store <path>` overrides; a target with no store is refused
     /// (named, never silent). The bundle itself is built by the runner.
+    /// Route a `check` verb tail to its proof-plane action — purely.
+    let planCheck (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
+        let valueOf = flagValue args
+        let connOf (raw: string) : Result<string> = resolveLiveConn cfg raw
+        let action =
+            match args with
+            | "drift" :: _ ->
+                match valueOf "--model", valueOf "--to" with
+                | Some m, Some toRaw -> (match connOf toRaw with Ok c -> PlanAction.CheckDrift (m, c) | Error es -> PlanAction.Refused (6, List.head es))
+                | _ -> PlanAction.Refused (2, err "cli.check.driftArgs" "projection check drift: requires --model <model.json> --to <environment>.")
+            | "data" :: _ ->
+                match valueOf "--before", valueOf "--after" with
+                | Some b, Some a -> (match connOf b, connOf a with | Ok bc, Ok ac -> PlanAction.CheckData (bc, ac) | (Error es, _) | (_, Error es) -> PlanAction.Refused (6, List.head es))
+                | _ -> PlanAction.Refused (2, err "cli.check.dataArgs" "projection check data: requires --before <environment> --after <environment>.")
+            | "ready" :: _ -> PlanAction.CheckReady
+            | "go" :: rest ->
+                // THE GO BOARD — resolve the named flow through the SAME
+                // planning path a real run takes (preview opts), so the board
+                // judges exactly what `--go` would execute (A44: the check
+                // and the run cannot drift).
+                match rest |> List.filter (fun a -> not (a.StartsWith "--")) with
+                | [ flowName ] ->
+                    match Map.tryFind flowName cfg.Flows with
+                    | None ->
+                        PlanAction.Refused (2, err "cli.check.goUnknownFlow" (sprintf "projection check go: flow '%s' is not defined in projection.json." flowName))
+                    | Some flow ->
+                        let previewOpts : FlowRunOpts =
+                            { Go = false; Fresh = false; AllowDrops = false; AllowCdc = false
+                              Resumable = false; Streaming = false; Journal = None; NoAtomic = false
+                              AutoRevert = false; RevertDir = None; Seed = None; Scale = None; Correction = None }
+                        let fromLabel = match flow.From with FlowSource.Env e -> e | FlowSource.Model -> "model" | FlowSource.Synthetic _ -> "synthetic" | FlowSource.NoData -> "none"
+                        PlanAction.CheckGo (flowName, fromLabel, flow.To, (planFlow cfg flow previewOpts).Action)
+                | _ ->
+                    PlanAction.Refused (2, err "cli.check.goArgs" "projection check go: requires exactly one flow name (projection check go <flow>).")
+            | "shape" :: _ ->
+                match cfg.Readiness with
+                | None ->
+                    PlanAction.Refused (2, err "cli.check.shapeNoBlock" "projection check shape: no `readiness` block in projection.json (set readiness.schema + readiness.confirm).")
+                | Some rs ->
+                    // Resolve each env name to (label, D9 conn-ref) for the OSSYS
+                    // read; a non-direct or unknown env is a NAMED refusal.
+                    let refOf (envName: string) : Result<string * string> =
+                        match Map.tryFind envName cfg.Environments with
+                        | Some env ->
+                            match env.Access with
+                            | Access.Direct r -> Result.success (envName, connSpecOf r)
+                            | _ -> Result.failureOf (err "cli.check.shapeNotDirect" (sprintf "readiness environment '%s' is not access:direct (no live OSSYS connection to read)." envName))
+                        | None -> Result.failureOf (err "cli.check.shapeUnknownEnv" (sprintf "readiness environment '%s' is not defined." envName))
+                    let agreedR = refOf rs.Schema
+                    let confirmRs = rs.Confirm |> List.map refOf
+                    let errors =
+                        (match agreedR with Error es -> es | Ok _ -> [])
+                        @ (confirmRs |> List.collect (function Error es -> es | Ok _ -> []))
+                    match errors with
+                    | e :: _ -> PlanAction.Refused (6, e)
+                    | [] ->
+                        let agreed = match agreedR with Ok v -> v | Error _ -> (rs.Schema, "")
+                        let confirm = confirmRs |> List.choose (function Ok v -> Some v | Error _ -> None)
+                        PlanAction.CheckShape (fst agreed, snd agreed, confirm, (valueOf "--format" = Some "json"))
+            | _ ->
+                match args |> List.tryFind (fun a -> not (a.StartsWith "--") && a <> "fidelity") with
+                | Some path -> PlanAction.CheckCanary (path, List.contains "--cdc-silence" args)
+                | None -> PlanAction.Refused (1, err "cli.check.noDdl" "projection check: the fidelity canary needs a source DDL path (check <source.sql>).")
+        { Notes = []; Action = action }
+
+    /// Route an `explain` verb tail to its understanding action — purely.
+    /// `explain <flow>` is the live preview: what publishing the flow would
+    /// change against its target's last sealed episode (B = the flow's model,
+    /// A_prior = the target store) — the preview sibling to `report`'s history.
+    /// `compare <A> <B>` — NM-71/WP9: resolve two operand refs and run the
+    /// read-only readiness compare (schema delta + data dealbreakers). The face
+    /// writes `compare.json` + prints the roll-up. Two refs are required.
     let planReport (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
         // The flow target's bundle `out` folder, when one is configured — the
         // directory the full-export feeding this timeline wrote `fidelity.json`

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -334,6 +334,10 @@ module ProjectionConfig =
         match r with
         | ConnectionRef.EnvVar n -> "env:" + n
         | ConnectionRef.File p   -> "file:" + p
+        // Raw never comes FROM config parsing (D9 belt: the config carries
+        // references, never secrets); round-tripping one would re-embed the
+        // secret, so it maps to the openable `live:` spec form instead.
+        | ConnectionRef.Raw c    -> "live:" + c
 
     /// D9 belt: reject a value that looks like an inline secret rather than
     /// a reference (a connection string pasted into the config).
@@ -1077,6 +1081,7 @@ module Command =
         match r with
         | ConnectionRef.EnvVar n -> "env:" + n
         | ConnectionRef.File p   -> "file:" + p
+        | ConnectionRef.Raw c    -> "live:" + c
 
     /// Resolve a live-connection reference: a scheme-prefixed ref (env:/file:)
     /// or a named `direct` environment → its out-of-band connection spec.
@@ -1340,6 +1345,7 @@ module Command =
         let valueOf = flagValue args
         let script = valueOf "--script" |> Option.defaultValue "transfer-undo.sql"
         let go = List.contains "--go" args
+        let force = List.contains "--force" args
         let action =
             match valueOf "--against" with
             | None ->
@@ -1347,7 +1353,7 @@ module Command =
             | Some envLabel ->
                 match resolveLiveConn cfg envLabel with
                 | Error es -> PlanAction.Refused (6, List.head es)
-                | Ok conn -> PlanAction.RevertScript (script, envLabel, conn, go)
+                | Ok conn -> PlanAction.RevertScript (script, envLabel, conn, go, force)
         { Notes = []; Action = action }
 
     let planExplain (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
@@ -1729,7 +1735,11 @@ module Command =
                               Resumable = false; Streaming = false; Journal = None; NoAtomic = false
                               AutoRevert = false; RevertDir = None; Seed = None; Scale = None; Correction = None }
                         let fromLabel = match flow.From with FlowSource.Env e -> e | FlowSource.Model -> "model" | FlowSource.Synthetic _ -> "synthetic" | FlowSource.NoData -> "none"
-                        PlanAction.CheckGo (flowName, fromLabel, flow.To, (planFlow cfg flow previewOpts).Action)
+                        let asJson =
+                            match rest |> List.pairwise |> List.tryFind (fun (a, _) -> a = "--format") with
+                            | Some (_, v) -> v = "json"
+                            | None -> false
+                        PlanAction.CheckGo (flowName, fromLabel, flow.To, asJson, (planFlow cfg flow previewOpts).Action)
                 | _ ->
                     PlanAction.Refused (2, err "cli.check.goArgs" "projection check go: requires exactly one flow name (projection check go <flow>).")
             | "shape" :: _ ->

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -696,7 +696,7 @@ module ProjectionConfig =
     /// expressible ⇔ reachable). THE_CLI.md §3.
     let reservedFlowVerbs : Set<string> =
         set [ "check"; "explain"; "seal"; "report"; "profile"; "synth-correct"; "init"; "diff"; "compare"
-              "slice-extract"; "slice-apply"; "slice-reset"; "slice-run" ]
+              "revert"; "slice-extract"; "slice-apply"; "slice-reset"; "slice-run" ]
 
     let parse (json: string) : Result<ProjectionConfig> =
         if String.IsNullOrWhiteSpace json then Result.success empty
@@ -1331,6 +1331,25 @@ module Command =
                     err "cli.compare.args" "projection compare: needs two references — projection compare <A> <B>.")
         { Notes = []; Action = action }
 
+    /// `revert [--script <path>] --against <env> [--go]` — the deliberate
+    /// undo (2026-07-06): run the DELETE-by-captured-key artifact a
+    /// successful transfer wrote (`transfer-undo.sql`) — or a failed run's
+    /// `transfer-revert.sql` — against the named environment. Preview is
+    /// the default; `--go` (+ the env gate) executes.
+    let planRevert (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
+        let valueOf = flagValue args
+        let script = valueOf "--script" |> Option.defaultValue "transfer-undo.sql"
+        let go = List.contains "--go" args
+        let action =
+            match valueOf "--against" with
+            | None ->
+                PlanAction.Refused (2, err "cli.revert.args" "projection revert: needs --against <environment> (the sink the undo runs against). Optional: --script <path> (default ./transfer-undo.sql), --go.")
+            | Some envLabel ->
+                match resolveLiveConn cfg envLabel with
+                | Error es -> PlanAction.Refused (6, List.head es)
+                | Ok conn -> PlanAction.RevertScript (script, envLabel, conn, go)
+        { Notes = []; Action = action }
+
     let planExplain (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =
         let valueOf = flagValue args
         let depthOpt =
@@ -1848,6 +1867,7 @@ module Command =
         | "seal" :: rest    -> Result.success (Intent.Seal rest)
         | "report" :: rest  -> Result.success (Intent.Report rest)
         | "compare" :: rest -> Result.success (Intent.Compare rest)
+        | "revert" :: rest  -> Result.success (Intent.Revert rest)
         | "profile" :: rest -> Result.success (Intent.Profile rest)
         | "synth-correct" :: rest -> Result.success (Intent.SynthCorrect rest)
         // Slice data-portability verbs (recon #3) — formerly dispatched on a raw
@@ -1914,6 +1934,7 @@ module Command =
         | Intent.Seal args         -> planSeal args
         | Intent.Report args       -> planReport cfg args
         | Intent.Compare args      -> planCompare cfg args
+        | Intent.Revert args       -> planRevert cfg args
         | Intent.Profile args      -> planProfile cfg args
         | Intent.SynthCorrect args -> planSynthCorrect cfg args
         | Intent.SliceExtract args         -> { Notes = []; Action = PlanAction.RunSliceExtract args }

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -1209,6 +1209,16 @@ module Command =
                         // to render, so the refusal is at PLAN time, named.
                         if hasModel then PlanAction.RunReverseLeg (spec.Model, modelOssys, src, conn, opts, execute)
                         else modelMissing "projection (reverse leg): the B→A reverse leg renders its contracts from the authored model. "
+                    | MovementDirection.UpPeer ->
+                        // The peer (A→A) move — two deployed cells of one model
+                        // whose physical `OSUSR_*` names differ per espace. The
+                        // peer runner reads a contract from EACH side's OSSYS
+                        // metamodel (native GUID identity), so no authored model
+                        // rides the action; the shape gate + subset-FK gate own
+                        // the pre-write refusals. 2026-07-06. (An env→env flow
+                        // with UNSET renditions keeps the name-blind `Transfer`
+                        // below — the identical-rendition escape hatch.)
+                        PlanAction.TransferPeer (src, conn, opts, execute)
                     | _ -> PlanAction.Transfer (src, conn, opts, execute)
                 if not spec.Commit then
                     match spec.Data with
@@ -1247,6 +1257,7 @@ module Command =
             match spec.Strategy, action with
             | Strategy.Merge, _ -> []
             | _, PlanAction.Transfer _ -> []
+            | _, PlanAction.TransferPeer _ -> []
             | _, PlanAction.RunReverseLeg _ -> []
             | _, PlanAction.SynthesizeAndLoad _ -> []
             | _ -> [ "--fresh accepted; this action has no selectable data-load strategy (incremental applied)." ]
@@ -1257,6 +1268,7 @@ module Command =
             match spec.Resumable, action with
             | false, _ -> []
             | true, PlanAction.Transfer _ -> []
+            | true, PlanAction.TransferPeer _ -> []
             | true, PlanAction.RunReverseLeg _ -> []
             | true, _ -> [ "--resumable accepted; this action has no resumable data-load seam (standard write applied)." ]
         // D8 — seed/scale are honored on the synthetic load only; on any other
@@ -1274,11 +1286,16 @@ module Command =
             match spec.Streaming, action with
             | false, _ -> []
             | true, PlanAction.RunReverseLeg _ -> []
+            // The peer leg rides the reverse-leg realization selector, so an
+            // explicit --streaming is honored (or refused BY NAME on an
+            // inadmissible combination — never silently dropped).
+            | true, PlanAction.TransferPeer _ -> []
             | true, _ -> [ "--streaming accepted; this action has no streaming write seam (materialized write applied)." ]
         let journalNote =
             match spec.Journal, action with
             | None, _ -> []
             | Some _, PlanAction.RunReverseLeg _ -> []
+            | Some _, PlanAction.TransferPeer _ -> []
             | Some _, _ -> [ "--journal accepted; this action has no journaled write seam (unjournaled write applied)." ]
         // F0c-I/O — the blessed correction is consumed only by the synthetic load
         // (it threads `Profile ⊕ Correction` into σ + drives Faker realization);

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -1305,7 +1305,19 @@ module Command =
             | None, _ -> []
             | Some _, PlanAction.SynthesizeAndLoad _ -> []
             | Some _, _ -> [ "correction accepted; this action has no synthesis leg (no correction applied)." ]
-        { Notes = unhonoredNotes spec @ freshNote @ resumableNote @ synthesisNote @ streamingNote @ journalNote @ correctionNote; Action = action }
+        // The name-blind fallback is a silent assumption worth NAMING (the
+        // no-silent-downgrade discipline): an env→env DATA move whose
+        // renditions are unset rides the generic `Transfer`, which reads ONE
+        // contract from the source and writes with the SOURCE's physical
+        // names — correct only when the sink's names match. The peer leg
+        // (`rendition: physical` on both sides) carries the SsKey-aligned
+        // shape + subset-FK gates. 2026-07-06 (ergonomics pass, proposal 2).
+        let renditionNote =
+            match spec.Direction, spec.Data, action with
+            | MovementDirection.Down, DataOrigin.FromTarget _, PlanAction.Transfer _ ->
+                [ "this flow moves data between two live environments with `rendition` unset — the transfer assumes MATCHING physical table names on both sides. Set `rendition: physical` on both environments to run the SsKey-aligned peer leg (shape + subset-FK gates) instead." ]
+            | _ -> []
+        { Notes = unhonoredNotes spec @ freshNote @ resumableNote @ synthesisNote @ streamingNote @ journalNote @ correctionNote @ renditionNote; Action = action }
 
     /// Route a `check` verb tail to its proof-plane action — purely.
     let planCheck (cfg: ProjectionConfig) (args: string list) : ExecutionPlan =

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -256,26 +256,20 @@ module PeerTransfer =
             Catalog.allModulesKinds contract
             |> List.map (fun (m, k) -> k.SsKey, m.Name)
             |> Map.ofList
-        Catalog.allKinds contract
-        |> List.filter (fun k -> Set.contains k.SsKey loadSet)
-        |> List.collect (fun kind ->
-            kind.References
-            |> List.choose (fun r ->
-                if Set.contains r.TargetKind loadSet || Set.contains r.TargetKind reconciled then None
-                else
-                    match Catalog.tryFindKind r.TargetKind contract with
-                    | None -> None // a dangling model edge is the model's own diagnostic, not this gate's
-                    | Some target ->
-                        let sourceAttr = attrIn kind r.SourceAttribute
-                        Some
-                            { Kind       = kind.SsKey
-                              KindName   = kind.Name
-                              Column     = sourceAttr |> Option.map (fun a -> a.Name) |> Option.defaultValue r.Name
-                              Nullable   = sourceAttr |> Option.map (fun a -> not a.IsMandatory) |> Option.defaultValue false
-                              Target     = r.TargetKind
-                              TargetName = target.Name
-                              TargetModule = moduleOf |> Map.tryFind r.TargetKind |> Option.defaultValue target.Name
-                              CandidateReconcileColumns = candidateKeysOf target }))
+        // The ONE traversal (`TransferSubset.escapingEdges`, shared with the
+        // engine backstop `Transfer.subsetEscapeGate`) — this detector only
+        // ENRICHES each edge for the operator narration.
+        TransferSubset.escapingEdges contract loadSet reconciled
+        |> List.map (fun (kind, r, target) ->
+            let sourceAttr = attrIn kind r.SourceAttribute
+            { Kind       = kind.SsKey
+              KindName   = kind.Name
+              Column     = sourceAttr |> Option.map (fun a -> a.Name) |> Option.defaultValue r.Name
+              Nullable   = sourceAttr |> Option.map (fun a -> not a.IsMandatory) |> Option.defaultValue false
+              Target     = r.TargetKind
+              TargetName = target.Name
+              TargetModule = moduleOf |> Map.tryFind r.TargetKind |> Option.defaultValue target.Name
+              CandidateReconcileColumns = candidateKeysOf target })
         |> List.sortBy (fun e -> Name.value e.KindName, Name.value e.Column)
 
     /// The per-edge strategy proposal lines (operator-facing; one line per
@@ -293,7 +287,9 @@ module PeerTransfer =
                     |> List.map (fun c -> sprintf "reconcile '%s:%s'" targetRef (Name.value c))
                     |> String.concat " or "
             let softening = if e.Nullable then " (optional — rows with no reference pass untouched)" else ""
-            sprintf "%s.%s -> %s is outside the subset%s. Strategies: reconcile against the rows the sink already holds (%s); or add '%s' to the subset."
+            // Lead with the paste-able move (narrow terminals truncate the
+            // tail; the remedy must survive).
+            sprintf "%s.%s -> %s escapes the subset%s. %s; or add '%s' to tables."
                 (Name.value e.KindName) (Name.value e.Column) (Name.value e.TargetName)
                 softening
                 candidates (Name.value e.TargetName))

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -287,7 +287,7 @@ module PeerTransfer =
             let targetRef = sprintf "%s.%s" (Name.value e.TargetModule) (Name.value e.TargetName)
             let candidates =
                 match e.CandidateReconcileColumns with
-                | [] -> "no unique non-key column found — widen the subset"
+                | [] -> sprintf "no unique non-key column detected — reconcile '%s:<a column you know is unique>' still works" targetRef
                 | cs ->
                     cs
                     |> List.map (fun c -> sprintf "reconcile '%s:%s'" targetRef (Name.value c))

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -147,21 +147,41 @@ module PeerTransfer =
                         | AttributeFacet.Computed ->
                             line blocking "the computed-column definition differs between source and sink"
                         | AttributeFacet.Nullability ->
+                            // Judge on `ColumnRealization.IsNullable` — the
+                            // SAME plane the facet fires on (adversarial LOW
+                            // #12: `IsMandatory` can disagree with the column
+                            // reality, letting a sink-NOT-NULL divergence pass
+                            // as permissive).
                             match srcAttr, snkAttr with
-                            | Some s, Some t when (not s.IsMandatory) && t.IsMandatory ->
-                                line blocking "nullable in the source but mandatory in the sink — NULL values cannot land"
+                            | Some s, Some t when s.Column.IsNullable && not t.Column.IsNullable ->
+                                line blocking "nullable in the source but NOT NULL in the sink — NULL values cannot land"
                             | _ ->
                                 line advisory "the sink is more permissive on nullability (no value is refused)"
                         | AttributeFacet.Length ->
                             match srcAttr |> Option.bind (fun a -> a.Length), snkAttr |> Option.bind (fun a -> a.Length) with
                             | Some s, Some t when t < s ->
                                 line blocking (sprintf "the sink length (%d) is narrower than the source (%d) — values can overflow" t s)
+                            | None, Some t ->
+                                // 2026-07-06 (adversarial HIGH #4): source
+                                // open-ended (MAX) into a bounded sink was
+                                // misread as "wider" — it truncates.
+                                line blocking (sprintf "the source length is open-ended but the sink is bounded (%d) — values can overflow" t)
                             | _, None ->
                                 line advisory "the sink length is open-ended (no value is refused)"
                             | _ ->
                                 line advisory "the sink length is wider (no value is refused)"
                         | AttributeFacet.Precision | AttributeFacet.Scale ->
-                            line blocking "the decimal precision/scale differs between source and sink"
+                            // Block only a NARROWING (adversarial LOW #11 —
+                            // a sink-wider DECIMAL is loadable; refusing it
+                            // was a false refusal).
+                            let narrower (f: Attribute -> int option) =
+                                match srcAttr |> Option.bind f, snkAttr |> Option.bind f with
+                                | Some s, Some t when t < s -> true
+                                | _ -> false
+                            if narrower (fun a -> a.Precision) || narrower (fun a -> a.Scale) then
+                                line blocking "the sink decimal precision/scale is narrower than the source — values can overflow"
+                            else
+                                line advisory "the sink decimal precision/scale is wider (no value is refused)"
                         | AttributeFacet.DefaultValue ->
                             line advisory "the default value differs (defaults never rewrite transferred values)"
         // Constraint / index / kind-own drift: real divergence, but none of it
@@ -205,9 +225,14 @@ module PeerTransfer =
           Nullable   : bool
           Target     : SsKey
           TargetName : Name
+          /// The target's owning MODULE name — the proposal narrates the
+          /// resolvable `Module.Entity:Column` reconcile form (a bare
+          /// logical name resolves by PHYSICAL table only, which differs
+          /// per environment; adversarial MEDIUM #8).
+          TargetModule : Name
           /// Candidate reconcile columns on the target: its single-column
           /// UNIQUE indexes over non-PK attributes (the business keys a
-          /// `reconcile <Target>:<Column>` can match sink rows by).
+          /// `reconcile Module.Entity:Column` can match sink rows by).
           CandidateReconcileColumns : Name list }
 
     /// Detect every FK edge that escapes the declared subset: source kind in
@@ -227,6 +252,10 @@ module PeerTransfer =
                     |> Option.map (fun a -> a.Name)
                 | _ -> None)
             |> List.sortBy Name.value
+        let moduleOf : Map<SsKey, Name> =
+            Catalog.allModulesKinds contract
+            |> List.map (fun (m, k) -> k.SsKey, m.Name)
+            |> Map.ofList
         Catalog.allKinds contract
         |> List.filter (fun k -> Set.contains k.SsKey loadSet)
         |> List.collect (fun kind ->
@@ -245,33 +274,49 @@ module PeerTransfer =
                               Nullable   = sourceAttr |> Option.map (fun a -> not a.IsMandatory) |> Option.defaultValue false
                               Target     = r.TargetKind
                               TargetName = target.Name
+                              TargetModule = moduleOf |> Map.tryFind r.TargetKind |> Option.defaultValue target.Name
                               CandidateReconcileColumns = candidateKeysOf target }))
         |> List.sortBy (fun e -> Name.value e.KindName, Name.value e.Column)
 
     /// The per-edge strategy proposal lines (operator-facing; one line per
-    /// escaping edge, the recommended move first).
+    /// escaping edge, the recommended move first, in the RESOLVABLE
+    /// `Module.Entity:Column` reconcile form).
     let narrateEscapes (escapes: EscapingFk list) : string list =
         escapes
         |> List.map (fun e ->
+            let targetRef = sprintf "%s.%s" (Name.value e.TargetModule) (Name.value e.TargetName)
             let candidates =
                 match e.CandidateReconcileColumns with
-                | [] -> "no unique non-key column found — widen the subset or accept drops"
-                | cs -> sprintf "reconcile candidates: %s" (cs |> List.map Name.value |> String.concat ", ")
+                | [] -> "no unique non-key column found — widen the subset"
+                | cs ->
+                    cs
+                    |> List.map (fun c -> sprintf "reconcile '%s:%s'" targetRef (Name.value c))
+                    |> String.concat " or "
             let softening = if e.Nullable then " (optional — rows with no reference pass untouched)" else ""
-            sprintf "%s.%s -> %s is outside the subset%s. Strategies: reconcile '%s' against the rows the sink already holds (%s); or add '%s' to the subset; or accept the drop-set with --allow-drops."
+            sprintf "%s.%s -> %s is outside the subset%s. Strategies: reconcile against the rows the sink already holds (%s); or add '%s' to the subset."
                 (Name.value e.KindName) (Name.value e.Column) (Name.value e.TargetName)
                 softening
-                (Name.value e.TargetName) candidates (Name.value e.TargetName))
+                candidates (Name.value e.TargetName))
 
     /// The gate form: a live Execute with un-strategized escaping edges
     /// refuses by name (`transfer.peer.subsetFkEscapes` — the drop-set axis,
-    /// exit 9) unless the operator declared the drops acceptable. A DryRun
-    /// never refuses here — the preview narrates the proposals instead.
-    let subsetFkGate (execute: bool) (allowDrops: bool) (escapes: EscapingFk list) : Result<unit> =
-        if execute && not allowDrops && not (List.isEmpty escapes) then
+    /// exit 9). A DryRun never refuses here — the preview narrates the
+    /// proposals instead.
+    ///
+    /// 2026-07-06 (the phase-2 adversarial review, CRITICAL #2): the
+    /// `--allow-drops` bypass is GONE. Nothing on the engine's write plane
+    /// drops or NULLs an escaping FK — the rows would land carrying the
+    /// SOURCE environment's surrogate values, silently cross-wired to
+    /// whatever sink rows happen to own those keys (`--allow-drops` covers
+    /// the REPORTED drop-set of reconciled/remapped kinds, which these
+    /// columns never enter). Until the engine can genuinely drop/NULL
+    /// escaping references, the honest gate refuses: reconcile the target
+    /// or widen the subset.
+    let subsetFkGate (execute: bool) (escapes: EscapingFk list) : Result<unit> =
+        if execute && not (List.isEmpty escapes) then
             Result.failureOf
                 (ValidationError.create "transfer.peer.subsetFkEscapes"
-                    (sprintf "%d relationship(s) escape the declared table subset; each needs a strategy before a live run: %s"
+                    (sprintf "%d relationship(s) escape the declared table subset; each needs a strategy before a live run (their rows would keep SOURCE-environment references — --allow-drops does not cover this): %s"
                         escapes.Length
                         (String.concat " " (narrateEscapes escapes))))
         else Result.success ()

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -1,0 +1,277 @@
+namespace Projection.Pipeline
+
+// LINT-ALLOW-FILE: the gate/proposal renderers compose operator-facing report
+//   prose (THE_VOICE register) at a terminal reporting boundary; the detection
+//   core is pure and carries no I/O — contract acquisition (the two OSSYS
+//   reads) is the one Task-returning seam, mirroring `Readiness`/`Compare`'s
+//   pure-core / I/O-one-layer-up split.
+
+open System.Threading.Tasks
+open Projection.Core
+
+/// The peer (A→A) transfer's contract + gate support: two cloud cells of ONE
+/// model whose physical `OSUSR_*` names differ per espace (the QA→UAT partial
+/// transfer, `PARTIAL_TRANSFER_READINESS_LOG.md` 2026-07-06).
+///
+/// The identity precondition the rename-aware engine needs (`TransferRun.fs`,
+/// `runCore` with an ingestion pair) is SsKey ALIGNMENT between the two
+/// contracts. `ReadSide` cannot supply it (SsKeys synthesized from physical
+/// coordinates — two live reads never align); the ONE authored model rendered
+/// twice (`CatalogRendition`) covers only the logical↔physical reverse leg.
+/// The peer pair aligns the third way: EACH side's contract is read from its
+/// own OSSYS metamodel (`Source.ofOssys` → `LiveModelRead`), whose `SsKey`s
+/// are the native OutSystems GUIDs — stable across environments (LifeTime
+/// preserves SS_KEY; the espace-invariance law, `CROSS_ENVIRONMENT_READINESS`
+/// / `Readiness`). Same identity, two physical realizations — exactly the
+/// precondition, without an authored model in the loop.
+///
+/// Two pre-transfer gates ride the acquired pair:
+///   - the SHAPE gate — the SS_KEY-keyed schema-compatibility verdict
+///     (insertability-blocking divergences refuse by name; real-but-benign
+///     divergences surface as advisories, never silently), and
+///   - the SUBSET-FK gate — every FK edge escaping a declared `tables` subset
+///     is detected and a per-edge strategy is proposed (reconcile-by-key
+///     against rows the sink already holds — the default recommendation;
+///     widen the subset; or accept the drop-set with --allow-drops).
+[<RequireQualifiedAccess>]
+module PeerTransfer =
+
+    // ------------------------------------------------------------------
+    // Contract acquisition — the one I/O seam.
+    // ------------------------------------------------------------------
+
+    /// Read the two SsKey-aligned contracts from the two environments' OSSYS
+    /// metamodels (D9 conn refs: `env:<var>` / `file:<path>` / raw). A failed
+    /// read is the named `source.ossys.readFailed` refusal from the `Source`
+    /// port, classified onto the schema-read axis (exit 6) by `Preflight`.
+    let acquireContracts (sourceConn: string) (sinkConn: string) : Task<Result<Catalog * Catalog>> =
+        task {
+            match! Source.read (Source.ofOssys sourceConn) with
+            | Error es -> return Result.failure es
+            | Ok sourceContract ->
+                match! Source.read (Source.ofOssys sinkConn) with
+                | Error es -> return Result.failure es
+                | Ok sinkContract -> return Result.success (sourceContract, sinkContract)
+        }
+
+    // ------------------------------------------------------------------
+    // The shape gate — SS_KEY-keyed schema compatibility, scoped to the
+    // kinds the run will touch.
+    // ------------------------------------------------------------------
+
+    /// The shape verdict over the pair: `Blocking` divergences prevent correct
+    /// row insertion (kind presence, attribute presence, column-shape facets);
+    /// `Advisory` divergences are real but do not block a data load
+    /// (constraint/index/kind-facet drift, logical renames, widenings) — they
+    /// surface so nothing is silent.
+    type ShapeVerdict =
+        { Blocking : string list
+          Advisory : string list }
+
+    let private kindNameIn (c: Catalog) (key: SsKey) : string =
+        match Catalog.tryFindKind key c with
+        | Some k -> Name.value k.Name
+        | None -> SsKey.rootOriginal key
+
+    let private attrIn (k: Kind) (key: SsKey) : Attribute option =
+        k.Attributes |> List.tryFind (fun a -> a.SsKey = key)
+
+    let private attrNameIn (k: Kind option) (key: SsKey) : string =
+        k
+        |> Option.bind (fun k -> attrIn k key)
+        |> Option.map (fun a -> Name.value a.Name)
+        |> Option.defaultValue (SsKey.rootOriginal key)
+
+    /// Compute the shape verdict for the pair, scoped: `Some keys` restricts
+    /// the verdict to the kinds a partial run touches (the subset + its
+    /// reconciled kinds); `None` judges the whole estate (a full transfer).
+    /// Both catalogs are normalized to their espace-invariant logical shape
+    /// first (`Readiness.toLogicalShape` — physical-realization artifacts
+    /// stripped), so only REAL model divergence registers; the physical
+    /// `OSUSR_*` naming difference this leg exists for never does.
+    let shapeVerdict (scope: Set<SsKey> option) (sourceContract: Catalog) (sinkContract: Catalog) : ShapeVerdict =
+        let src = Readiness.toLogicalShape sourceContract
+        let snk = Readiness.toLogicalShape sinkContract
+        let diff = CatalogDiff.between src snk
+        let inScope (k: SsKey) =
+            match scope with
+            | None -> true
+            | Some s -> Set.contains k s
+        let blocking = ResizeArray<string>()
+        let advisory = ResizeArray<string>()
+        // Kind presence: a source kind absent from the sink model blocks — the
+        // rows have no landing table. (Sink-only kinds never block a load OUT
+        // of the source; they surface only on an unscoped, whole-estate check.)
+        for key in CatalogDiff.removed diff |> Set.filter inScope do
+            blocking.Add (sprintf "entity '%s' is not in the sink model — its rows have no landing table." (kindNameIn src key))
+        if Option.isNone scope then
+            for key in CatalogDiff.added diff do
+                advisory.Add (sprintf "entity '%s' exists only in the sink model (no source rows will touch it)." (kindNameIn snk key))
+        // Same-identity logical renames: identity (SS_KEY) holds, so the load
+        // is unaffected; surfaced because the operator's table lists are
+        // name-keyed.
+        for KeyValue (key, r) in CatalogDiff.renamed diff do
+            if inScope key then
+                advisory.Add (sprintf "entity '%s' is named '%s' in the sink — same identity (SS_KEY); the load keys on identity." (Name.value r.OldName) (Name.value r.NewName))
+        // Attribute grain, per in-scope kind present in both models.
+        for KeyValue (kindKey, ad) in CatalogDiff.attributeDiffs diff do
+            if inScope kindKey then
+                let srcKind = Catalog.tryFindKind kindKey src
+                let snkKind = Catalog.tryFindKind kindKey snk
+                let kindLabel = kindNameIn src kindKey
+                for attrKey in ad.Removed do
+                    blocking.Add (sprintf "%s.%s exists only in the source model — its values have no landing column." kindLabel (attrNameIn srcKind attrKey))
+                for attrKey in ad.Added do
+                    match snkKind |> Option.bind (fun k -> attrIn k attrKey) with
+                    | Some a when a.IsMandatory && not a.IsIdentity && Option.isNone a.DefaultValue ->
+                        blocking.Add (sprintf "%s.%s is sink-only, mandatory, and carries no default — inserted rows cannot satisfy it." kindLabel (Name.value a.Name))
+                    | Some a ->
+                        advisory.Add (sprintf "%s.%s exists only in the sink model (inserted rows leave it to its default)." kindLabel (Name.value a.Name))
+                    | None -> ()
+                for KeyValue (attrKey, r) in ad.Renamed do
+                    advisory.Add (sprintf "%s.%s is named '%s' in the sink — same identity; the rename map re-points it." kindLabel (Name.value r.OldName) (Name.value r.NewName))
+                for change in ad.Reshaped do
+                    let srcAttr = srcKind |> Option.bind (fun k -> attrIn k change.AttributeKey)
+                    let snkAttr = snkKind |> Option.bind (fun k -> attrIn k change.AttributeKey)
+                    let attrLabel = attrNameIn srcKind change.AttributeKey
+                    for facet in change.Facets do
+                        let line (verdict: ResizeArray<string>) (detail: string) =
+                            verdict.Add (sprintf "%s.%s: %s." kindLabel attrLabel detail)
+                        match facet with
+                        | AttributeFacet.DataType ->
+                            line blocking "the data type differs between source and sink"
+                        | AttributeFacet.PrimaryKey ->
+                            line blocking "the primary-key marking differs between source and sink"
+                        | AttributeFacet.Identity ->
+                            line blocking "the IDENTITY marking differs between source and sink"
+                        | AttributeFacet.Computed ->
+                            line blocking "the computed-column definition differs between source and sink"
+                        | AttributeFacet.Nullability ->
+                            match srcAttr, snkAttr with
+                            | Some s, Some t when (not s.IsMandatory) && t.IsMandatory ->
+                                line blocking "nullable in the source but mandatory in the sink — NULL values cannot land"
+                            | _ ->
+                                line advisory "the sink is more permissive on nullability (no value is refused)"
+                        | AttributeFacet.Length ->
+                            match srcAttr |> Option.bind (fun a -> a.Length), snkAttr |> Option.bind (fun a -> a.Length) with
+                            | Some s, Some t when t < s ->
+                                line blocking (sprintf "the sink length (%d) is narrower than the source (%d) — values can overflow" t s)
+                            | _, None ->
+                                line advisory "the sink length is open-ended (no value is refused)"
+                            | _ ->
+                                line advisory "the sink length is wider (no value is refused)"
+                        | AttributeFacet.Precision | AttributeFacet.Scale ->
+                            line blocking "the decimal precision/scale differs between source and sink"
+                        | AttributeFacet.DefaultValue ->
+                            line advisory "the default value differs (defaults never rewrite transferred values)"
+        // Constraint / index / kind-own drift: real divergence, but none of it
+        // refuses a row — advisory by design (the migrate verb owns schema).
+        let advisoryCount (label: string) (keys: Set<SsKey>) =
+            if not (Set.isEmpty keys) then
+                let names = keys |> Set.toList |> List.map (kindNameIn src) |> String.concat ", "
+                advisory.Add (sprintf "%s differ(s) on: %s (schema drift — does not block a data load)." label names)
+        advisoryCount "foreign-key constraints" (CatalogDiff.referenceDiffs diff |> Map.filter (fun k _ -> inScope k) |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+        advisoryCount "indexes" (CatalogDiff.indexDiffs diff |> Map.filter (fun k _ -> inScope k) |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+        advisoryCount "entity-level facets (modality/triggers/checks/activation)" (CatalogDiff.kindFacetDiffs diff |> Map.filter (fun k _ -> inScope k) |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+        { Blocking = List.ofSeq blocking; Advisory = List.ofSeq advisory }
+
+    /// The gate form of the verdict: blocking divergence refuses by name
+    /// (`transfer.peer.shapeDivergence` — the shape-divergence axis, exit 5,
+    /// the same verdict class `check shape` reports). Advisory lines ride in
+    /// the `Ok` so the caller surfaces them regardless.
+    let shapeGate (scope: Set<SsKey> option) (sourceContract: Catalog) (sinkContract: Catalog) : Result<string list> =
+        let verdict = shapeVerdict scope sourceContract sinkContract
+        if List.isEmpty verdict.Blocking then Result.success verdict.Advisory
+        else
+            Result.failureOf
+                (ValidationError.create "transfer.peer.shapeDivergence"
+                    (sprintf "the source and sink models are not one shape over the transferred set (%d blocking divergence(s)): %s"
+                        verdict.Blocking.Length
+                        (String.concat " " verdict.Blocking)))
+
+    // ------------------------------------------------------------------
+    // The subset-FK gate — every relationship escaping the declared subset,
+    // detected, with a strategy proposed per edge.
+    // ------------------------------------------------------------------
+
+    /// One FK edge from an in-subset kind to an out-of-subset, un-reconciled
+    /// kind — the edge a partial transfer must decide a strategy for.
+    type EscapingFk =
+        { Kind       : SsKey
+          KindName   : Name
+          /// The FK attribute's logical name (espace-safe).
+          Column     : Name
+          /// The FK column is optional — rows carrying NULL pass untouched.
+          Nullable   : bool
+          Target     : SsKey
+          TargetName : Name
+          /// Candidate reconcile columns on the target: its single-column
+          /// UNIQUE indexes over non-PK attributes (the business keys a
+          /// `reconcile <Target>:<Column>` can match sink rows by).
+          CandidateReconcileColumns : Name list }
+
+    /// Detect every FK edge that escapes the declared subset: source kind in
+    /// the load-set, target kind neither in the load-set nor reconciled.
+    /// Deterministic (sorted by kind name, then column name). Empty load-set
+    /// semantics ride the caller: pass the RESOLVED subset (a full transfer
+    /// has no escaping edges by definition — pass `Set.empty` mapped over
+    /// `None` upstream and skip the call).
+    let escapingFks (contract: Catalog) (loadSet: Set<SsKey>) (reconciled: Set<SsKey>) : EscapingFk list =
+        let candidateKeysOf (target: Kind) : Name list =
+            target.Indexes
+            |> List.choose (fun ix ->
+                match ix.Uniqueness, ix.Columns with
+                | IndexUniqueness.Unique, [ col ] ->
+                    attrIn target col.Attribute
+                    |> Option.filter (fun a -> not a.IsPrimaryKey)
+                    |> Option.map (fun a -> a.Name)
+                | _ -> None)
+            |> List.sortBy Name.value
+        Catalog.allKinds contract
+        |> List.filter (fun k -> Set.contains k.SsKey loadSet)
+        |> List.collect (fun kind ->
+            kind.References
+            |> List.choose (fun r ->
+                if Set.contains r.TargetKind loadSet || Set.contains r.TargetKind reconciled then None
+                else
+                    match Catalog.tryFindKind r.TargetKind contract with
+                    | None -> None // a dangling model edge is the model's own diagnostic, not this gate's
+                    | Some target ->
+                        let sourceAttr = attrIn kind r.SourceAttribute
+                        Some
+                            { Kind       = kind.SsKey
+                              KindName   = kind.Name
+                              Column     = sourceAttr |> Option.map (fun a -> a.Name) |> Option.defaultValue r.Name
+                              Nullable   = sourceAttr |> Option.map (fun a -> not a.IsMandatory) |> Option.defaultValue false
+                              Target     = r.TargetKind
+                              TargetName = target.Name
+                              CandidateReconcileColumns = candidateKeysOf target }))
+        |> List.sortBy (fun e -> Name.value e.KindName, Name.value e.Column)
+
+    /// The per-edge strategy proposal lines (operator-facing; one line per
+    /// escaping edge, the recommended move first).
+    let narrateEscapes (escapes: EscapingFk list) : string list =
+        escapes
+        |> List.map (fun e ->
+            let candidates =
+                match e.CandidateReconcileColumns with
+                | [] -> "no unique non-key column found — widen the subset or accept drops"
+                | cs -> sprintf "reconcile candidates: %s" (cs |> List.map Name.value |> String.concat ", ")
+            let softening = if e.Nullable then " (optional — rows with no reference pass untouched)" else ""
+            sprintf "%s.%s -> %s is outside the subset%s. Strategies: reconcile '%s' against the rows the sink already holds (%s); or add '%s' to the subset; or accept the drop-set with --allow-drops."
+                (Name.value e.KindName) (Name.value e.Column) (Name.value e.TargetName)
+                softening
+                (Name.value e.TargetName) candidates (Name.value e.TargetName))
+
+    /// The gate form: a live Execute with un-strategized escaping edges
+    /// refuses by name (`transfer.peer.subsetFkEscapes` — the drop-set axis,
+    /// exit 9) unless the operator declared the drops acceptable. A DryRun
+    /// never refuses here — the preview narrates the proposals instead.
+    let subsetFkGate (execute: bool) (allowDrops: bool) (escapes: EscapingFk list) : Result<unit> =
+        if execute && not allowDrops && not (List.isEmpty escapes) then
+            Result.failureOf
+                (ValidationError.create "transfer.peer.subsetFkEscapes"
+                    (sprintf "%d relationship(s) escape the declared table subset; each needs a strategy before a live run: %s"
+                        escapes.Length
+                        (String.concat " " (narrateEscapes escapes))))
+        else Result.success ()

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -650,7 +650,10 @@ module Preflight =
             MidWriteNotProtected
         elif code = "transfer.peer.shapeDivergence" then
             ShapeDivergence
-        elif code = "transfer.peer.subsetFkEscapes" then
+        elif code = "transfer.peer.subsetFkEscapes" || code = "transfer.subsetFkEscapes" then
+            // The peer face's rich-narration refusal AND the engine-level
+            // backstop (the parity sweep — legacy/forward legs) ride ONE
+            // axis: exit 9, the drop-set class.
             SubsetFkEscape
         elif code.StartsWith "source.ossys." then
             // The peer leg's contract acquisition — an unreadable OSSYS

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -657,6 +657,16 @@ module Preflight =
             // metamodel is the schema-read failure class (exit 6), same axis
             // the migrate verb's schema read reports under its own name.
             SchemaReadFailed
+        elif code.StartsWith "adapter.ossysSql." || code.StartsWith "adapter.osm." then
+            // 2026-07-06 (the phase-2 mock-env program): a metamodel
+            // extraction that fails INSIDE the adapter (a rowset shape /
+            // row-mapping failure — e.g. a VIEW-DEFINITION-less principal
+            // NULLing a definition column) carries its own adapter code
+            // through the Result plane, so it never hits the
+            // `source.ossys.readFailed` exception wrapper. It is the SAME
+            // operator situation — the schema could not be read — so it
+            // rides the same axis (exit 6), never the unclassified 3.
+            SchemaReadFailed
         else
             UnclassifiedRefusal
 

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -560,6 +560,17 @@ module Preflight =
         /// the live atomic `BEGIN TRAN` wrapper stays survey-gated (see the A3
         /// scaffold above) — this is the classification half only.
         | MidWriteNotProtected
+        /// The peer leg's SS_KEY-keyed schema-compatibility gate: the source
+        /// and sink models are not one shape over the transferred set
+        /// (`PeerTransfer.shapeGate`). The same verdict class `check shape`
+        /// reports, so it carries the same exit (5) — a schema divergence, not
+        /// a connection/grant/argument failure.
+        | ShapeDivergence
+        /// The peer leg's subset-FK gate: a declared table subset carries FK
+        /// edges to kinds outside it with no strategy chosen (reconcile /
+        /// widen / --allow-drops). The drop-set class — a live run would lose
+        /// or dangle rows — so it rides the destructive-failure exit (9).
+        | SubsetFkEscape
         /// The named default for a code outside the known gate vocabulary — a
         /// generic refusal. NOT a silent pass: it still carries the generic
         /// non-zero refusal exit (3), so an unmapped gate fails loud.
@@ -577,6 +588,8 @@ module Preflight =
         | SchemaReadFailed            -> "schema read failed"
         | UndeclaredDestructiveChange -> "undeclared destructive change"
         | MidWriteNotProtected        -> "mid-write not protected"
+        | ShapeDivergence             -> "schema shapes diverge"
+        | SubsetFkEscape              -> "relationships escape the subset"
         | UnclassifiedRefusal         -> "unclassified refusal"
 
     /// The distinct CLI exit code for each gate axis — TOTAL over the closed
@@ -596,6 +609,8 @@ module Preflight =
         | SchemaReadFailed            -> 6
         | UndeclaredDestructiveChange -> 9
         | MidWriteNotProtected        -> 9
+        | ShapeDivergence             -> 5
+        | SubsetFkEscape              -> 9
         | UnclassifiedRefusal         -> 3
 
     /// Route a refusal code onto its gate axis (`GateLabel`). The explicit
@@ -633,6 +648,15 @@ module Preflight =
             // other exit-9 axes — a half-populated target is a destructive
             // outcome, not a generic refusal.
             MidWriteNotProtected
+        elif code = "transfer.peer.shapeDivergence" then
+            ShapeDivergence
+        elif code = "transfer.peer.subsetFkEscapes" then
+            SubsetFkEscape
+        elif code.StartsWith "source.ossys." then
+            // The peer leg's contract acquisition — an unreadable OSSYS
+            // metamodel is the schema-read failure class (exit 6), same axis
+            // the migrate verb's schema read reports under its own name.
+            SchemaReadFailed
         else
             UnclassifiedRefusal
 

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -62,6 +62,7 @@
     <Compile Include="TransferFkTrust.fs" />
     <Compile Include="TransferRevert.fs" />
     <Compile Include="TransferResume.fs" />
+    <Compile Include="TransferSubset.fs" />
     <Compile Include="TransferRun.fs" />
     <Compile Include="MigrationRun.fs" />
     <Compile Include="DriftRun.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -69,6 +69,7 @@
     <Compile Include="ReportRun.fs" />
     <Compile Include="TransferSpec.fs" />
     <Compile Include="PeerTransfer.fs" />
+    <Compile Include="GoBoard.fs" />
     <Compile Include="ModelResolution.fs" />
     <Compile Include="FakerRealization.fs" />
     <Compile Include="SyntheticLoadRun.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -68,6 +68,7 @@
     <Compile Include="EjectRun.fs" />
     <Compile Include="ReportRun.fs" />
     <Compile Include="TransferSpec.fs" />
+    <Compile Include="PeerTransfer.fs" />
     <Compile Include="ModelResolution.fs" />
     <Compile Include="FakerRealization.fs" />
     <Compile Include="SyntheticLoadRun.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/RenameProjection.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RenameProjection.fs
@@ -16,10 +16,11 @@ open Projection.Core
 module RenameProjection =
 
     /// One attribute renamed between the source (A) and the sink (B): the
-    /// stable SsKey (A1) and the source/sink logical names — the keys
-    /// `StaticRow.Values` is indexed by on each side.
+    /// OWNING kind, the stable attribute SsKey (A1), and the source/sink
+    /// logical names — the keys `StaticRow.Values` is indexed by on each side.
     type ColumnRename =
         {
+            Kind       : SsKey
             Attribute  : SsKey
             SourceName : Name
             SinkName   : Name
@@ -31,16 +32,35 @@ module RenameProjection =
     let renames (diff: CatalogDiff) : ColumnRename list =
         CatalogDiff.attributeDiffs diff
         |> Map.toList
-        |> List.collect (fun (_, ad) ->
+        |> List.collect (fun (kindKey, ad) ->
             ad.Renamed
             |> Map.toList
             |> List.map (fun (attrKey, record) ->
-                { Attribute = attrKey; SourceName = record.OldName; SinkName = record.NewName }))
+                { Kind = kindKey; Attribute = attrKey; SourceName = record.OldName; SinkName = record.NewName }))
         |> List.sortBy (fun r -> SsKey.rootOriginal r.Attribute)
 
-    /// The source-Name → sink-Name re-key map the row projection consumes.
-    let renameMap (cols: ColumnRename list) : Map<Name, Name> =
-        cols |> List.map (fun c -> c.SourceName, c.SinkName) |> Map.ofList
+    /// The KIND-SCOPED source-Name → sink-Name re-key maps the row projection
+    /// consumes: one map per kind, applied ONLY to that kind's rows.
+    ///
+    /// 2026-07-06 (the phase-2 adversarial review, CRITICAL #1): the prior
+    /// flat `Map<Name, Name>` was kind-BLIND — a rename recorded for one
+    /// kind's attribute re-keyed the same NAME in every other kind's rows,
+    /// so `Invoice.Status → State` silently emptied `Order.Status` (the
+    /// re-keyed source value became unreachable at the sink getter and the
+    /// column wrote NULL). Kind-scoping makes the poisoning structurally
+    /// impossible; the flat form is deliberately GONE (a dangerous API with
+    /// zero legitimate consumers).
+    let renameMapByKind (cols: ColumnRename list) : Map<SsKey, Map<Name, Name>> =
+        cols
+        |> List.groupBy (fun c -> c.Kind)
+        |> List.map (fun (k, cs) ->
+            k, cs |> List.map (fun c -> c.SourceName, c.SinkName) |> Map.ofList)
+        |> Map.ofList
+
+    /// The one kind's re-key map (empty when the kind carries no renames —
+    /// `repointRow`/`RowBasis.rename` are identity on the empty map).
+    let forKind (kind: SsKey) (byKind: Map<SsKey, Map<Name, Name>>) : Map<Name, Name> =
+        Map.tryFind kind byKind |> Option.defaultValue Map.empty
 
     /// Re-point one source row's values onto the sink's names: every key in the
     /// rename map is re-keyed to its sink name; un-renamed keys pass through

--- a/sidecar/projection/src/Projection.Pipeline/SyntheticLoadRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SyntheticLoadRun.fs
@@ -112,6 +112,82 @@ module SyntheticLoadRun =
     /// the FULL estate, silently ignoring `model.modules`. An empty
     /// `model.modules` is the all-permissive identity, so the default synthetic
     /// load stays byte-identical.
+    /// The pure post-catalog preparation (module filter → Faker-coordinate
+    /// refusal → `Profile ⊕ Correction` config fold → opt-in graph analytics →
+    /// boundary realization), hoisted to module level so `run`'s `task { }`
+    /// keeps the statically-compilable `match! → match → match! → return`
+    /// spine (FS3511, survival rule 5).
+    ///
+    /// NM-08/09 — narrow the resolved estate by `model.modules` through the
+    /// shared seam BEFORE synthesis (identity when `model.modules` is empty),
+    /// so a `from: synthetic` flow honors the scope every sibling action
+    /// applies.
+    ///
+    /// F-Faker — refuse BY NAME any blessed Faker coordinate that does NOT
+    /// resolve against the model (a rename / typo), before generating: a
+    /// hand-authored binding that points nowhere is an operator error to
+    /// surface, never a silent no-op (the hand-authored-coordinate analogue of
+    /// "refuse rather than corrupt").
+    ///
+    /// F0c-I/O — fold the blessed corrections onto the config (the PURE
+    /// `Profile ⊕ Correction` hinge: Pii ⇒ Synthesize, fidelity overrides,
+    /// per-kind volume) AND build the boundary realization (Faker over the σ
+    /// tokens / preserved values, seeded per row). Both are identity when the
+    /// correction is empty, so an uncorrected load is byte-identical to the
+    /// pre-F0c flow.
+    ///
+    /// H-071 / H-072 consumers (both opt-in) — the two graph analytics reach
+    /// the synthetic path here. Both read the SAME FK-graph topology the load
+    /// already computes for its write order, so it is derived at most once.
+    /// Each is OFF by default and byte-identical when off — the whole branch
+    /// is skipped, so no analytics run.
+    ///   H-071 — weight per-kind volume by centrality (central kinds get more
+    ///           rows); operator `volume` corrections win the merge.
+    ///   H-072 — cluster FK locality by discovered bounded context (an
+    ///           intra-context reference set reads as a self-consistent
+    ///           slice). Threaded as a generic cluster map (Core stays
+    ///           decoupled from BoundedContextDiscovery).
+    let private prepareSynthesis
+        (modelSection: Config.ModelSection)
+        (correction: Correction)
+        (config: SyntheticConfig)
+        (weightVolumeByCentrality: bool)
+        (clusterFksByContext: bool)
+        (rawCatalog: Catalog) =
+        let filtered =
+            ModuleFilterBinding.fromConfig modelSection
+            |> Result.bind (fun opts -> ModuleFilter.apply opts rawCatalog)
+        match filtered with
+        | Error es -> Result.failure es
+        | Ok catalog ->
+            match Correction.unresolvedFakerCoordinates catalog correction with
+            | (bad :: _) as unresolved ->
+                Result.failureOf
+                    (ValidationError.create "synthetic.correction.unresolvedCoordinate"
+                        (sprintf "%d blessed Faker coordinate(s) name a location not in the model (e.g. %s/%s/%s); re-point them or update the artifact." (List.length unresolved) bad.Module bad.Entity bad.Attribute))
+            | [] ->
+                let baseConfig = Correction.applyToConfig catalog correction config
+                let effectiveConfig =
+                    if not (weightVolumeByCentrality || clusterFksByContext) then baseConfig
+                    else
+                        let topo = (Projection.Core.Passes.TopologicalOrderPass.runWith Projection.Core.TreatAsCycle catalog).Value
+                        let withVolume =
+                            if weightVolumeByCentrality then
+                                let ranking = (Projection.Core.Passes.CentralityPass.registered.Run topo).Value.Value
+                                let derived = SyntheticVolume.byCentrality centralityWeightStrength centralityWeightMaxFactor baseConfig.Scale ranking
+                                { baseConfig with VolumeByKind = SyntheticVolume.mergeUnderOperator baseConfig.VolumeByKind derived }
+                            else baseConfig
+                        if clusterFksByContext then
+                            let discovery = (Projection.Core.Passes.BoundedContextPass.registered.Run topo).Value.Value
+                            let clusters =
+                                discovery.Candidates
+                                |> List.collect (fun c -> c.Members |> List.map (fun m -> m, c.AnchorKey))
+                                |> Map.ofList
+                            { withVolume with FkLocalityClusters = clusters }
+                        else withVolume
+                let realize = FakerRealization.realize catalog correction
+                Result.success (catalog, effectiveConfig, realize)
+
     let run
         (modelOssys: string option)
         (modelFile: string option)
@@ -127,79 +203,30 @@ module SyntheticLoadRun =
         (weightVolumeByCentrality: bool)
         (clusterFksByContext: bool)
         : Task<Result<Transfer.TransferReport>> =
-        task {
-            match resolveProfile profileRef, resolveCorrection correctionRef with
-            | Error es, _ -> return Result.failure es
-            | _, Error es -> return Result.failure es
-            | Ok profile, Ok correction ->
+        // FS3511 (survival rule 5): the tuple-pattern `match` that headed the
+        // `task { }` and the deep pure middle both defeated static state-machine
+        // reduction in Release. The profile / correction resolution is
+        // synchronous boundary I/O, so it resolves BEFORE the task opens; the
+        // pure middle lives in `prepareSynthesis`; the task body keeps the
+        // reducible `match! → match → match! → match → return` spine.
+        match resolveProfile profileRef, resolveCorrection correctionRef with
+        | Error es, _ -> Task.FromResult (Result.failure es)
+        | _, Error es -> Task.FromResult (Result.failure es)
+        | Ok profile, Ok correction ->
+            task {
                 match! ModelResolution.resolveCatalog modelOssys modelFile with
                 | Error es -> return Result.failure es
                 | Ok rawCatalog ->
-                    // NM-08/09 — narrow the resolved estate by `model.modules`
-                    // through the shared seam BEFORE synthesis (identity when
-                    // `model.modules` is empty), so a `from: synthetic` flow honors
-                    // the scope every sibling action applies.
-                    let filtered =
-                        ModuleFilterBinding.fromConfig modelSection
-                        |> Result.bind (fun opts -> ModuleFilter.apply opts rawCatalog)
-                    match filtered with
+                    match prepareSynthesis modelSection correction config weightVolumeByCentrality clusterFksByContext rawCatalog with
                     | Error es -> return Result.failure es
-                    | Ok catalog ->
-                    // F-Faker — refuse BY NAME any blessed Faker coordinate that
-                    // does NOT resolve against the model (a rename / typo), before
-                    // generating: a hand-authored binding that points nowhere is an
-                    // operator error to surface, never a silent no-op (the
-                    // hand-authored-coordinate analogue of "refuse rather than corrupt").
-                    match Correction.unresolvedFakerCoordinates catalog correction with
-                    | (bad :: _) as unresolved ->
-                        return Result.failureOf
-                            (ValidationError.create "synthetic.correction.unresolvedCoordinate"
-                                (sprintf "%d blessed Faker coordinate(s) name a location not in the model (e.g. %s/%s/%s); re-point them or update the artifact." (List.length unresolved) bad.Module bad.Entity bad.Attribute))
-                    | [] ->
-                    // F0c-I/O — fold the blessed corrections onto the config (the
-                    // PURE `Profile ⊕ Correction` hinge: Pii ⇒ Synthesize, fidelity
-                    // overrides, per-kind volume) AND build the boundary realization
-                    // (Faker over the σ tokens / preserved values, seeded per row).
-                    // Both are identity when the correction is empty, so an
-                    // uncorrected load is byte-identical to the pre-F0c flow.
-                    let baseConfig = Correction.applyToConfig catalog correction config
-                    // H-071 / H-072 consumers (both opt-in) — the two graph analytics
-                    // reach the synthetic path here. Both read the SAME FK-graph
-                    // topology the load already computes for its write order, so it is
-                    // derived at most once. Each is OFF by default and byte-identical
-                    // when off — the whole branch is skipped, so no analytics run.
-                    //   H-071 — weight per-kind volume by centrality (central kinds get
-                    //           more rows); operator `volume` corrections win the merge.
-                    //   H-072 — cluster FK locality by discovered bounded context (an
-                    //           intra-context reference set reads as a self-consistent
-                    //           slice). Threaded as a generic cluster map (Core stays
-                    //           decoupled from BoundedContextDiscovery).
-                    let effectiveConfig =
-                        if not (weightVolumeByCentrality || clusterFksByContext) then baseConfig
-                        else
-                            let topo = (Projection.Core.Passes.TopologicalOrderPass.runWith Projection.Core.TreatAsCycle catalog).Value
-                            let withVolume =
-                                if weightVolumeByCentrality then
-                                    let ranking = (Projection.Core.Passes.CentralityPass.registered.Run topo).Value.Value
-                                    let derived = SyntheticVolume.byCentrality centralityWeightStrength centralityWeightMaxFactor baseConfig.Scale ranking
-                                    { baseConfig with VolumeByKind = SyntheticVolume.mergeUnderOperator baseConfig.VolumeByKind derived }
-                                else baseConfig
-                            if clusterFksByContext then
-                                let discovery = (Projection.Core.Passes.BoundedContextPass.registered.Run topo).Value.Value
-                                let clusters =
-                                    discovery.Candidates
-                                    |> List.collect (fun c -> c.Members |> List.map (fun m -> m, c.AnchorKey))
-                                    |> Map.ofList
-                                { withVolume with FkLocalityClusters = clusters }
-                            else withVolume
-                    let realize = FakerRealization.realize catalog correction
-                    // The sink opens through the one `ConnectionSpec.openSpec`
-                    // opener (recon #13 — `env:` / `file:` / `live:` / bare,
-                    // uniform with `transfer` / `slice`).
-                    match! ConnectionSpec.openSpec SubstrateRole.Sink "synthetic-sink" connSpec with
-                    | Error es -> return Result.failure es
-                    | Ok sink ->
-                        use sink = sink
-                        let mode = if execute then Transfer.Execute else Transfer.DryRun
-                        return! Transfer.runSynthetic mode emission allowCdc sink catalog profile effectiveConfig seed realize
-        }
+                    | Ok (catalog, effectiveConfig, realize) ->
+                        // The sink opens through the one `ConnectionSpec.openSpec`
+                        // opener (recon #13 — `env:` / `file:` / `live:` / bare,
+                        // uniform with `transfer` / `slice`).
+                        match! ConnectionSpec.openSpec SubstrateRole.Sink "synthetic-sink" connSpec with
+                        | Error es -> return Result.failure es
+                        | Ok sink ->
+                            use sink = sink
+                            let mode = if execute then Transfer.Execute else Transfer.DryRun
+                            return! Transfer.runSynthetic mode emission allowCdc sink catalog profile effectiveConfig seed realize
+            }

--- a/sidecar/projection/src/Projection.Pipeline/TransferCellShaping.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferCellShaping.fs
@@ -16,15 +16,31 @@ module TransferCellShaping =
     /// cell rows. Deferred FK columns are emitted as the empty raw —
     /// `KeepNulls` maps that to SQL NULL — so Phase 1 satisfies a cycle;
     /// Phase 2 re-points them.
+    ///
+    /// 2026-07-06 (the phase-2 adversarial review, HIGH #3): a SINK-ONLY
+    /// attribute (present in the sink contract, absent from the ingested
+    /// rows) is now OMITTED from the column list entirely — the sink's own
+    /// DEFAULT applies at insert. Before, it emitted the empty raw →
+    /// explicit NULL, which `KeepNulls` pinned in place: the default the
+    /// shape gate promised never fired, and a mandatory sink-only column
+    /// crashed the bulk load raw. The availability set derives from the
+    /// first row's key set (the ingest SELECT's column list is uniform per
+    /// kind) ∪ the deferred set (deferred columns are deliberately NULLed).
     let private toCellsOver (attrs: Attribute list) (deferred: Set<Name>) (rows: StaticRow list) : CellValue list list =
-        rows
-        |> List.map (fun row ->
-            attrs
-            |> List.map (fun a ->
-                let raw =
-                    if Set.contains a.Name deferred then ""
-                    else Map.tryFind a.Name row.Values |> Option.defaultValue ""
-                { Column = ColumnRealization.columnNameText a.Column; Type = a.Type; Raw = raw }))
+        match rows with
+        | [] -> []
+        | first :: _ ->
+            let available =
+                Set.union deferred (first.Values |> Map.toSeq |> Seq.map fst |> Set.ofSeq)
+            let carried = attrs |> List.filter (fun a -> Set.contains a.Name available)
+            rows
+            |> List.map (fun row ->
+                carried
+                |> List.map (fun a ->
+                    let raw =
+                        if Set.contains a.Name deferred then ""
+                        else Map.tryFind a.Name row.Values |> Option.defaultValue ""
+                    { Column = ColumnRealization.columnNameText a.Column; Type = a.Type; Raw = raw }))
 
     let toCellRows (kind: Kind) (deferred: Set<Name>) (rows: StaticRow list) : CellValue list list =
         toCellsOver kind.Attributes deferred rows
@@ -48,8 +64,12 @@ module TransferCellShaping =
     /// per-attribute basis scans once — the docstring's "once per kind"
     /// made true. The row application is unchanged.
     let private quantumCellsOverStaged (basis: RowBasis) (attrs: Attribute list) (deferred: Set<Name>) : RowQuantum list -> CellValue list list =
+        // HIGH #3 (see `toCellsOver`): a sink-only attribute — absent from
+        // the stream's basis — is omitted, so the sink default applies.
         let cols =
             attrs
+            |> List.filter (fun a ->
+                Set.contains a.Name deferred || Option.isSome (RowBasis.tryOrdinal a.Name basis))
             |> List.map (fun a ->
                 let get =
                     if Set.contains a.Name deferred then (fun _ -> "")

--- a/sidecar/projection/src/Projection.Pipeline/TransferRevert.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRevert.fs
@@ -15,6 +15,15 @@ open Projection.Targets.SSDT
 [<RequireQualifiedAccess>]
 module TransferRevert =
 
+    /// The provenance header stamped into every revert/undo artifact
+    /// (2026-07-06, the wrong-sink guard): the SINK the keys were captured
+    /// against, so `projection revert` can refuse a script pointed at a
+    /// DIFFERENT database (deleting by key in the wrong environment). A
+    /// comment line — harmless to any SQL consumer.
+    let artifactHeader (artifactKind: string) (sink: SqlConnection) : string =
+        sprintf "-- projection:%s server=%s database=%s generated=%s"
+            artifactKind sink.DataSource sink.Database (System.DateTime.UtcNow.ToString "o") // LINT-ALLOW: terminal artifact-header text; DataSource/Database are SqlClient-provided identifiers at this terminal file boundary
+
     /// Build A — the child-first `DELETE`-by-captured-key revert script for a
     /// failed load. For each `AssignedBySink` kind, in the REVERSE of the
     /// parent-first insert order (children first, so an FK never blocks a delete),
@@ -60,7 +69,7 @@ module TransferRevert =
                 | Some dir ->
                     try
                         System.IO.Directory.CreateDirectory dir |> ignore
-                        System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "transfer-revert.sql"), String.concat "\n" script) // LINT-ALLOW: terminal file-write boundary; each script entry is already terminal SQL text, String.concat is the irreducible primitive for newline-joining the artifact
+                        System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "transfer-revert.sql"), String.concat "\n" (artifactHeader "transfer-revert" sink :: script)) // LINT-ALLOW: terminal file-write boundary; each script entry is already terminal SQL text, String.concat is the irreducible primitive for newline-joining the artifact
                     with _ -> ()
                 | None -> ()
                 if autoRevert then

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -89,6 +89,18 @@ module ReverseLegRealization =
             Result.failureOf
                 (ValidationError.create "transfer.reverseLeg.journalRequiresStreaming"
                     "--journal is the streaming realization's chunk-resume ledger; the request's table subset / --resumable / wipe forces the materialized path. Remove those to stream, or drop --journal.")
+        elif resumable && not sinkResidentResumeAvailable then
+            // 2026-07-06 (the phase-2 permission audit): the MATERIALIZED
+            // resumable envelope hosts its G10 marker in a sink-resident
+            // progress table (`TransferResume.progressTableSql` — CREATE
+            // TABLE), which the ManagedDml data grant forbids. Only the
+            // streaming∧resumable arm consulted the archetype before; a plain
+            // `--resumable` against a managed sink sailed past the selector
+            // and died RAW on error 262 mid-run. Refuse BY NAME instead —
+            // the same capability-honesty the streaming arm already had.
+            Result.failureOf
+                (ValidationError.create "transfer.reverseLeg.resumableSinkUnsupported"
+                    "--resumable keeps its G10 marker in a sink-resident progress table, which needs CREATE TABLE the sink's data grant forbids (archetype managed-dml/undeclared). Use --streaming --journal <dir> for a resumable estate-scale run, drop --resumable (a wipe-and-load subset re-run is idempotent by construction), or declare the sink archetype full-rights if it truly can host the table.")
         elif admissible then Result.success (ReverseLegRealization.Streaming journalDirectory)
         else Result.success ReverseLegRealization.Materialized
 
@@ -535,6 +547,30 @@ module Transfer =
                             (SsKey.rootOriginal k)))
             | [] -> None
 
+    /// 2026-07-06 (the phase-2 adversarial review, MEDIUM #10): an Execute
+    /// whose load order fell back to the ALPHABETICAL degrade (an
+    /// unresolvable dependency cycle anywhere in the estate) would load
+    /// children before their parents estate-wide — mass FK-remap drops for
+    /// `AssignedBySink` kinds, silent cross-environment orphans for
+    /// preserved-key loads. Refuse a live run by name; a DryRun still
+    /// previews the degraded plan (the operator sees the order and the
+    /// cycle diagnostics without a write).
+    let orderedLoadGate (topo: TopologicalOrder) : ValidationError option =
+        match topo.Mode with
+        | Topological -> None
+        | _ ->
+            let cycleText =
+                topo.Cycles
+                |> List.truncate 3
+                |> List.map (fun c ->
+                    sprintf "[%s]" (c.Members |> List.map SsKey.rootOriginal |> String.concat ", "))
+                |> String.concat "; "
+            Some (ValidationError.create
+                    "transfer.loadOrderUnproven"
+                    (sprintf
+                        "the load order degraded to the alphabetical fallback (%d unresolved dependency cycle(s): %s) — a live load would land children before their parents. Make the cycle's FK columns nullable (they then defer to phase 2 automatically), or transfer without the affected kinds."
+                        topo.Cycles.Length cycleText))
+
     /// AC-I5 — pre-write validate-user-map. A reconciling Transfer whose
     /// user-map leaves Source identities unmatched would, post-write, surface
     /// them via `exitCodeForReport` (exit 9) — *after* the rows landed. This
@@ -733,7 +769,7 @@ module Transfer =
         (sink: SqlConnection)
         (catalog: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
-        (ingestion: (Catalog * Map<Name, Name>) option)
+        (ingestion: (Catalog * Map<SsKey, Map<Name, Name>>) option)
         (writeOpts: WriteOptions)
         : Task<Result<TransferReport>> =
         task {
@@ -812,8 +848,12 @@ module Transfer =
             let! rawRows = Ingestion.collectInOrderFor ingestScope source ingestCatalog topo
             let rows =
                 match ingestion with
-                | Some (_, renameMap) when not (Map.isEmpty renameMap) ->
-                    rawRows |> Map.map (fun _ rs -> RenameProjection.repointRows renameMap rs)
+                | Some (_, renamesByKind) when not (Map.isEmpty renamesByKind) ->
+                    // KIND-SCOPED re-key (2026-07-06, adversarial CRITICAL #1):
+                    // each kind's rows re-point through ITS OWN rename map only
+                    // — a rename in one kind can no longer poison a same-named
+                    // column in an unrelated kind.
+                    rawRows |> Map.map (fun k rs -> RenameProjection.repointRows (RenameProjection.forKind k renamesByKind) rs)
                 | _ -> rawRows
             let! reconciled = reconcileAgainstSink sink catalog reconciliation rows
             // The plan-build is the ONE OperatorIntent Insertion site —
@@ -830,7 +870,10 @@ module Transfer =
                 if mode = Execute then
                     match executeGate catalog plan with
                     | Some refusal -> Some refusal
-                    | None         -> validateUserMap allowDrops reconciled
+                    | None ->
+                        match orderedLoadGate topo with
+                        | Some refusal -> Some refusal
+                        | None         -> validateUserMap allowDrops reconciled
                 else None
             match preWrite with
             | Some refusal -> return Result.failureOf refusal
@@ -1048,7 +1091,12 @@ module Transfer =
                 // correction is empty (byte-identical to the pre-F0c load).
                 let realizedRows = realize rows
                 let plan = DataLoadPlan.build catalog topo realizedRows SurrogateRemapContext.empty
-                let preWrite = if mode = Execute then executeGate catalog plan else None
+                let preWrite =
+                    if mode = Execute then
+                        match executeGate catalog plan with
+                        | Some r -> Some r
+                        | None -> orderedLoadGate topo
+                    else None
                 match preWrite with
                 | Some refusal -> return Result.failureOf refusal
                 | None ->
@@ -1145,7 +1193,12 @@ module Transfer =
             | Ok () ->
                 let topo = (TopologicalOrderPass.runWith TreatAsCycle catalog).Value
                 let plan = DataLoadPlan.build catalog topo rows SurrogateRemapContext.empty
-                let preWrite = if mode = Execute then executeGate catalog plan else None
+                let preWrite =
+                    if mode = Execute then
+                        match executeGate catalog plan with
+                        | Some r -> Some r
+                        | None -> orderedLoadGate topo
+                    else None
                 match preWrite with
                 | Some refusal -> return Result.failureOf refusal
                 | None ->
@@ -1198,9 +1251,9 @@ module Transfer =
         (sourceContract: Catalog)
         (sinkContract: Catalog)
         : Task<Result<TransferReport>> =
-        let renameMap =
-            RenameProjection.renames diff |> RenameProjection.renameMap
-        runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
+        let renamesByKind =
+            RenameProjection.renames diff |> RenameProjection.renameMapByKind
+        runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renamesByKind)) { WriteOptions.def with IdentityPolicy = identityPolicy }
 
     let runWithRenamesWith
         (identityPolicy: IdentityPolicy)
@@ -1325,7 +1378,7 @@ module Transfer =
         (source: SqlConnection)
         (sink: SqlConnection)
         (ingestCatalog: Catalog)
-        (renameMap: Map<Name, Name>)
+        (renamesByKind: Map<SsKey, Map<Name, Name>>)
         (catalog: Catalog)
         (plan: DataLoadPlan)
         (journal: CaptureJournal option)
@@ -1371,12 +1424,12 @@ module Transfer =
 
         // PL-9 (S22): each load-kind's renamed row basis derives ONCE and
         // threads to BOTH phases — phase 2 recomputed it from the same
-        // (renameMap, ingestKind) inputs in the same run.
+        // (per-kind rename map, ingestKind) inputs in the same run.
         let basisByKind : Map<SsKey, RowBasis> =
             plan.Loads
             |> List.choose (fun l ->
                 Catalog.tryFindKind l.Kind ingestCatalog
-                |> Option.map (fun ik -> l.Kind, RowBasis.rename renameMap (Kind.rowBasis ik)))
+                |> Option.map (fun ik -> l.Kind, RowBasis.rename (RenameProjection.forKind l.Kind renamesByKind) (Kind.rowBasis ik)))
             |> Map.ofList
 
         // Q3 + PL-9 (S16): the re-point at the quantum grain, STAGED per
@@ -1629,12 +1682,13 @@ module Transfer =
                                 |> List.map (fun a -> a.Name)
                                 |> Set.ofList
                                 |> Set.union load.DeferredFkColumns
+                            let kindRenames = RenameProjection.forKind kind.SsKey renamesByKind
                             let projectedIngest =
                                 match
                                     ingestKind.Attributes
                                     |> List.filter (fun a ->
                                         Set.contains
-                                            (Map.tryFind a.Name renameMap |> Option.defaultValue a.Name)
+                                            (Map.tryFind a.Name kindRenames |> Option.defaultValue a.Name)
                                             neededSinkNames)
                                 with
                                 | [] -> ingestKind
@@ -1644,7 +1698,7 @@ module Transfer =
                             // stream; phase 2's basis is the projection's own
                             // — a DIFFERENT fact once S11 narrows the pull,
                             // derived once per kind here.)
-                            let basis = RowBasis.rename renameMap (Kind.rowBasis projectedIngest)
+                            let basis = RowBasis.rename kindRenames (Kind.rowBasis projectedIngest)
                             let renderUpdate = TransferCellShaping.phase2UpdateSqlQuantum basis kind load.DeferredFkColumns
                             // PL-9 (S16): re-point + PK re-key staged once per
                             // kind. The re-key: the PK cell re-keys to the
@@ -1747,7 +1801,7 @@ module Transfer =
         : Task<Result<TransferReport>> =
         task {
             let diff = CatalogDiff.between sourceContract sinkContract
-            let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
+            let renamesByKind = RenameProjection.renames diff |> RenameProjection.renameMapByKind
             let cdcGate : Task<Result<unit>> =
                 task {
                     if mode = Execute && not allowCdc then
@@ -1791,7 +1845,7 @@ module Transfer =
                             match Catalog.tryFindKind kind sourceContract with
                             | Some ingestKind ->
                                 let! rows = AsyncStream.toList (Ingestion.streamKindRows source ingestKind)
-                                acc <- Map.add kind (RenameProjection.repointRows renameMap rows) acc
+                                acc <- Map.add kind (RenameProjection.repointRows (RenameProjection.forKind kind renamesByKind) rows) acc
                             | None -> ()
                         return acc
                     }
@@ -1897,7 +1951,7 @@ module Transfer =
                         let! streamed =
                             task {
                                 try
-                                    let! r = writePlanStreaming source sink sourceContract renameMap sinkContract plan journal reconciled.Remap reconciledKinds
+                                    let! r = writePlanStreaming source sink sourceContract renamesByKind sinkContract plan journal reconciled.Remap reconciledKinds
                                     return r
                                 with ex ->
                                     do! TransferRevert.runRevertFromJournal sink sinkContract plan journal autoRevert revertDir
@@ -2041,9 +2095,9 @@ module Transfer =
         (sinkContract: Catalog)
         (reconciliation: Map<SsKey, ReconciliationStrategy>)
         : Task<Result<TransferReport>> =
-        let renameMap =
-            RenameProjection.renames diff |> RenameProjection.renameMap
-        runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renameMap)) { WriteOptions.def with IdentityPolicy = identityPolicy }
+        let renamesByKind =
+            RenameProjection.renames diff |> RenameProjection.renameMapByKind
+        runCore mode allowCdc false source sink sinkContract reconciliation (Some (sourceContract, renamesByKind)) { WriteOptions.def with IdentityPolicy = identityPolicy }
 
     let runReconcilingWithRenamesWith
         (identityPolicy: IdentityPolicy)
@@ -2085,25 +2139,61 @@ module Transfer =
     /// `resolveReconciliation` is a function of the reconstructed contract
     /// so the contract is read exactly once (the Source open is not
     /// duplicated to resolve reconciliation specs).
-    /// Resolve the declared table subset (logical entity names) to a load-set
-    /// of `SsKey`s against the source contract — refusing any name the schema
-    /// does not carry (total decisions, named skips). Empty list → `None` (all).
-    /// Public since the peer leg (2026-07-06): the peer face resolves the SAME
-    /// subset ahead of its shape / subset-FK gates, one vocabulary, one resolver.
+    /// Resolve the declared table subset (logical entity names, or the
+    /// module-qualified `Module.Entity` form) to a load-set of `SsKey`s
+    /// against the source contract — refusing any name the schema does not
+    /// carry, AND any bare name that resolves to more than one kind (total
+    /// decisions, named skips; 2026-07-06, adversarial MEDIUM #6 — the prior
+    /// `Map.ofList` silently last-won a duplicate logical name across
+    /// modules, transferring whichever kind sorted last). Empty list →
+    /// `None` (all). Public since the peer leg: the peer face resolves the
+    /// SAME subset ahead of its shape / subset-FK gates, one vocabulary,
+    /// one resolver.
     let resolveLoadSet (contract: Catalog) (tables: string list) : Result<Set<SsKey> option> =
         if List.isEmpty tables then Result.success None
         else
-            let byName =
-                Catalog.allKinds contract
-                |> List.map (fun k -> (Name.value k.Name).ToLowerInvariant(), k.SsKey)
-                |> Map.ofList
-            let resolved = tables |> List.map (fun t -> t, Map.tryFind (t.ToLowerInvariant()) byName)
-            match resolved |> List.choose (fun (t, o) -> if Option.isNone o then Some t else None) with
-            | [] -> Result.success (Some (resolved |> List.choose snd |> Set.ofList))
-            | missing ->
+            let all = Catalog.allModulesKinds contract
+            let resolveOne (t: string) : Choice<SsKey, string, string> =
+                let byBareName () =
+                    all
+                    |> List.filter (fun (_, k) -> System.String.Equals(Name.value k.Name, t, System.StringComparison.OrdinalIgnoreCase))
+                match t.IndexOf '.' with
+                | dot when dot > 0 ->
+                    let moduleName = t.Substring(0, dot)
+                    let entityName = t.Substring(dot + 1)
+                    match CatalogResolution.tryKindByLogical contract moduleName entityName with
+                    | Some key -> Choice1Of3 key
+                    | None ->
+                        // A dotted string may be a bare entity name that
+                        // happens to carry a '.'; fall through to the bare
+                        // lookup before refusing.
+                        match byBareName () with
+                        | [ (_, k) ] -> Choice1Of3 k.SsKey
+                        | [] -> Choice2Of3 t
+                        | _ -> Choice3Of3 t
+                | _ ->
+                    match byBareName () with
+                    | [ (_, k) ] -> Choice1Of3 k.SsKey
+                    | [] -> Choice2Of3 t
+                    | many ->
+                        let qualified =
+                            many
+                            |> List.map (fun (m, k) -> sprintf "%s.%s" (Name.value m.Name) (Name.value k.Name))
+                            |> String.concat ", "
+                        Choice3Of3 (sprintf "%s (matches %s)" t qualified)
+            let resolved  = tables |> List.map resolveOne
+            let missing   = resolved |> List.choose (function Choice2Of3 t -> Some t | _ -> None)
+            let ambiguous = resolved |> List.choose (function Choice3Of3 t -> Some t | _ -> None)
+            if not (List.isEmpty missing) then
                 Result.failureOf
                     (ValidationError.create "transfer.tablesUnknown"
                         (sprintf "table subset names not found in the source schema: %s" (String.concat ", " missing)))
+            elif not (List.isEmpty ambiguous) then
+                Result.failureOf
+                    (ValidationError.create "transfer.tablesAmbiguous"
+                        (sprintf "table subset names match more than one entity — qualify them as Module.Entity: %s" (String.concat "; " ambiguous)))
+            else
+                Result.success (Some (resolved |> List.choose (function Choice1Of3 k -> Some k | _ -> None) |> Set.ofList))
 
     /// The full apparatus-driven entry: the emission mode, the G10 resumable
     /// flag, and the declared table subset, threaded onto the `WriteOptions` the
@@ -2209,8 +2299,8 @@ module Transfer =
         : Task<Result<TransferReport>> =
         task {
             let diff = CatalogDiff.between logicalSourceContract physicalSinkContract
-            let renameMap =
-                RenameProjection.renames diff |> RenameProjection.renameMap
+            let renamesByKind =
+                RenameProjection.renames diff |> RenameProjection.renameMapByKind
             match resolveLoadSet logicalSourceContract tables with
             | Error es -> return Result.failure es
             | Ok loadSet ->
@@ -2222,7 +2312,7 @@ module Transfer =
                     | Error es -> return Result.failure es
                     | Ok sink ->
                         use sink = sink
-                        return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renameMap)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy; AutoRevert = autoRevert; RevertArtifactDir = revertDir }
+                        return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renamesByKind)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy; AutoRevert = autoRevert; RevertArtifactDir = revertDir }
         }
 
     /// The structural-policy reverse leg (byte-identical; the ManagedDml cloud

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -298,12 +298,12 @@ module Transfer =
     /// — the deliberate-revert sibling of `TransferRevert.runRevert`'s
     /// failed-run `transfer-revert.sql`. Empty script / no dir → no-op;
     /// a write failure never fails the (successful) load.
-    let private writeUndoArtifact (artifactDir: string option) (undo: string list) : unit =
+    let private writeUndoArtifact (sink: SqlConnection) (artifactDir: string option) (undo: string list) : unit =
         match artifactDir with
         | Some dir when not (List.isEmpty undo) ->
             try
                 System.IO.Directory.CreateDirectory dir |> ignore
-                System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "transfer-undo.sql"), String.concat "\n" undo) // LINT-ALLOW: terminal file-write boundary; each entry is terminal SQL text (same convention as TransferRevert.runRevert's artifact write)
+                System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "transfer-undo.sql"), String.concat "\n" (TransferRevert.artifactHeader "transfer-undo" sink :: undo)) // LINT-ALLOW: terminal file-write boundary; each entry is terminal SQL text (same convention as TransferRevert.runRevert's artifact write)
             with _ -> ()
         | _ -> ()
 
@@ -460,7 +460,7 @@ module Transfer =
                 // NOTE: a WipeAndLoad's wipe is NOT undone by this script —
                 // the undo removes what this run MINTED; rows the wipe
                 // deleted are gone (named in the runbook).
-                writeUndoArtifact revertArtifactDir (TransferRevert.buildRevertScript catalog plan remap)
+                writeUndoArtifact sink revertArtifactDir (TransferRevert.buildRevertScript catalog plan remap)
                 return writeSkips.Value, laneDescents.Value
             | RunStopped _ ->
                 // The body never returns Error; total match, named.
@@ -586,17 +586,9 @@ module Transfer =
         | None -> None
         | Some set ->
             let escapes =
-                Catalog.allKinds catalog
-                |> List.filter (fun k -> Set.contains k.SsKey set)
-                |> List.collect (fun kind ->
-                    kind.References
-                    |> List.choose (fun r ->
-                        if Set.contains r.TargetKind set || Set.contains r.TargetKind reconciled then None
-                        else
-                            Catalog.tryFindKind r.TargetKind catalog
-                            |> Option.map (fun target ->
-                                sprintf "%s.%s -> %s" (Name.value kind.Name) (Name.value r.Name) (Name.value target.Name))))
-                |> List.sort
+                TransferSubset.escapingEdges catalog set reconciled
+                |> List.map (fun (kind, r, target) ->
+                    sprintf "%s.%s -> %s" (Name.value kind.Name) (Name.value r.Name) (Name.value target.Name))
             if List.isEmpty escapes then None
             else
                 Some (ValidationError.create

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -294,6 +294,19 @@ module Transfer =
     /// `ReconciledByRule` loads are byte-identical to the pre-§5.2 path —
     /// the re-point is a no-op when no `AssignedBySink` kind is in scope.
 
+    /// Best-effort write of the SUCCESS-undo artifact (`transfer-undo.sql`)
+    /// — the deliberate-revert sibling of `TransferRevert.runRevert`'s
+    /// failed-run `transfer-revert.sql`. Empty script / no dir → no-op;
+    /// a write failure never fails the (successful) load.
+    let private writeUndoArtifact (artifactDir: string option) (undo: string list) : unit =
+        match artifactDir with
+        | Some dir when not (List.isEmpty undo) ->
+            try
+                System.IO.Directory.CreateDirectory dir |> ignore
+                System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "transfer-undo.sql"), String.concat "\n" undo) // LINT-ALLOW: terminal file-write boundary; each entry is terminal SQL text (same convention as TransferRevert.runRevert's artifact write)
+            with _ -> ()
+        | _ -> ()
+
     let private writePlan (sink: SqlConnection) (catalog: Catalog) (plan: DataLoadPlan) (autoRevert: bool) (revertArtifactDir: string option) : Task<(SsKey * UnresolvedReference) list * LaneDescent list> =
         task {
             let assignedBySinkKinds =
@@ -436,7 +449,19 @@ module Transfer =
                     return ()
                 }
             match verdict.Disposition with
-            | RunCompleted () -> return writeSkips.Value, laneDescents.Value
+            | RunCompleted () ->
+                // 2026-07-06 (the proving-loop program): the undo script is
+                // written on SUCCESS too — `transfer-undo.sql`, the precise
+                // DELETE-by-captured-key script (children first; pre-existing
+                // rows untouched). A small-subset transfer can be proven and
+                // then deliberately reverted (`projection revert`). Distinct
+                // file from `transfer-revert.sql` (the FAILED-run
+                // compensation) so the two artifacts never shadow each other.
+                // NOTE: a WipeAndLoad's wipe is NOT undone by this script —
+                // the undo removes what this run MINTED; rows the wipe
+                // deleted are gone (named in the runbook).
+                writeUndoArtifact revertArtifactDir (TransferRevert.buildRevertScript catalog plan remap)
+                return writeSkips.Value, laneDescents.Value
             | RunStopped _ ->
                 // The body never returns Error; total match, named.
                 return invalidOp "writePlan: the load body cannot stop"

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -2088,7 +2088,9 @@ module Transfer =
     /// Resolve the declared table subset (logical entity names) to a load-set
     /// of `SsKey`s against the source contract — refusing any name the schema
     /// does not carry (total decisions, named skips). Empty list → `None` (all).
-    let private resolveLoadSet (contract: Catalog) (tables: string list) : Result<Set<SsKey> option> =
+    /// Public since the peer leg (2026-07-06): the peer face resolves the SAME
+    /// subset ahead of its shape / subset-FK gates, one vocabulary, one resolver.
+    let resolveLoadSet (contract: Catalog) (tables: string list) : Result<Set<SsKey> option> =
         if List.isEmpty tables then Result.success None
         else
             let byName =

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -572,6 +572,39 @@ module Transfer =
                             (SsKey.rootOriginal k)))
             | [] -> None
 
+    /// 2026-07-06 (the parity sweep): the ESCAPING-RELATIONSHIP gate at the
+    /// ENGINE level — every leg (peer, legacy reverse, forward) inherits it.
+    /// A declared subset whose FK targets an out-of-subset, un-reconciled
+    /// kind would land rows carrying the SOURCE environment's surrogate
+    /// values (silent cross-wiring; the phase-2 CRITICAL #2 class). The
+    /// peer FACE narrates rich per-edge strategy proposals before this
+    /// fires; here is the backstop that makes the hazard unreachable from
+    /// ANY entry point. `None` load-set (a full transfer) has no escapes
+    /// by definition.
+    let subsetEscapeGate (catalog: Catalog) (loadSet: Set<SsKey> option) (reconciled: Set<SsKey>) : ValidationError option =
+        match loadSet with
+        | None -> None
+        | Some set ->
+            let escapes =
+                Catalog.allKinds catalog
+                |> List.filter (fun k -> Set.contains k.SsKey set)
+                |> List.collect (fun kind ->
+                    kind.References
+                    |> List.choose (fun r ->
+                        if Set.contains r.TargetKind set || Set.contains r.TargetKind reconciled then None
+                        else
+                            Catalog.tryFindKind r.TargetKind catalog
+                            |> Option.map (fun target ->
+                                sprintf "%s.%s -> %s" (Name.value kind.Name) (Name.value r.Name) (Name.value target.Name))))
+                |> List.sort
+            if List.isEmpty escapes then None
+            else
+                Some (ValidationError.create
+                        "transfer.subsetFkEscapes"
+                        (sprintf
+                            "%d relationship(s) escape the declared table subset (their rows would keep SOURCE-environment references): %s. Reconcile each target against the sink's rows, or widen the subset."
+                            escapes.Length (String.concat "; " escapes)))
+
     /// 2026-07-06 (the phase-2 adversarial review, MEDIUM #10): an Execute
     /// whose load order fell back to the ALPHABETICAL degrade (an
     /// unresolvable dependency cycle anywhere in the estate) would load
@@ -898,7 +931,10 @@ module Transfer =
                     | None ->
                         match orderedLoadGate topo with
                         | Some refusal -> Some refusal
-                        | None         -> validateUserMap allowDrops reconciled
+                        | None ->
+                            match subsetEscapeGate catalog writeOpts.LoadSet reconciledKinds with
+                            | Some refusal -> Some refusal
+                            | None         -> validateUserMap allowDrops reconciled
                 else None
             match preWrite with
             | Some refusal -> return Result.failureOf refusal
@@ -1883,13 +1919,20 @@ module Transfer =
                     DataLoadPlan.build sinkContract topo Map.empty SurrogateRemapContext.empty
                     |> DataLoadPlan.reclassifyReconciled reconciledKinds
                 // Pre-write gates (Execute only), precedence-ordered:
-                // structural unsatisfiability first, then the validate-
+                // structural unsatisfiability first, then the load-order
+                // proof (2026-07-06 parity sweep — the streaming arm was
+                // the one Execute path without it), then the validate-
                 // user-map orphan halt (AC-I5 / NM-31 — now ON streaming).
+                // (No subset gate: streaming refuses --tables at the
+                // realization selector, so no load-set reaches here.)
                 let preWrite =
                     if mode = Execute then
                         match executeGate sinkContract plan with
                         | Some refusal -> Some refusal
-                        | None         -> validateUserMap allowDrops reconciled
+                        | None ->
+                            match orderedLoadGate topo with
+                            | Some refusal -> Some refusal
+                            | None         -> validateUserMap allowDrops reconciled
                     else None
                 match preWrite with
                 | Some refusal -> return Result.failureOf refusal

--- a/sidecar/projection/src/Projection.Pipeline/TransferSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferSpec.fs
@@ -112,7 +112,7 @@ module TransferSpec =
             | None ->
                 Result.failureOf
                     (specInvalid "transfer.reconcile.tableNotFound"
-                        (sprintf "reconcile: no kind found for '%s' (tried logical Module.Entity and physical table name)." e.Table))
+                        (sprintf "reconcile: no kind found for '%s' (tried logical Module.Entity and physical table name). For a peer transfer between differently-named environments, use the logical 'Module.Entity:Column' form — a physical name written against the source will not resolve against the sink." e.Table))
             | Some k ->
                 let attrOpt =
                     match findAttributeByName e.MatchColumn k with
@@ -197,11 +197,25 @@ module TransferSpec =
         (entries: UserMapEntry list)
         : Result<Map<SsKey, ReconciliationStrategy>> =
         let resolveTable (table: string, rows: UserMapEntry list) : Result<SsKey * ReconciliationStrategy> =
-            match findKindByTable table catalog with
+            // The table ref resolves LOGICALLY ("Module.Entity", espace-safe)
+            // when it carries a '.', else by PHYSICAL table name — the SAME
+            // two-form lookup `resolveReconciliation.resolveOne` performs.
+            // Physical-only resolution was espace-UNSAFE for the peer leg
+            // (source and sink physical names differ per environment;
+            // PARTIAL_TRANSFER_READINESS_LOG entry 5's named gap, closed
+            // 2026-07-06).
+            let kindOpt =
+                match table.IndexOf '.' with
+                | dot when dot > 0 ->
+                    match findKindByLogical (table.Substring(0, dot)) (table.Substring(dot + 1)) catalog with
+                    | Some _ as k -> k
+                    | None -> findKindByTable table catalog
+                | _ -> findKindByTable table catalog
+            match kindOpt with
             | None ->
                 Result.failureOf
                     (specInvalid "transfer.userMap.tableNotFound"
-                        (sprintf "user-map: no kind found for table '%s' in the contract." table))
+                        (sprintf "user-map: no kind found for '%s' (tried logical Module.Entity and physical table name). For a peer transfer between differently-named environments, use the logical 'Module.Entity' form." table))
             | Some k ->
                 let dupSources =
                     rows

--- a/sidecar/projection/src/Projection.Pipeline/TransferSubset.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferSubset.fs
@@ -1,0 +1,34 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// The ONE escaping-relationship traversal (2026-07-06, the final-pass
+/// consolidation): every FK edge from an in-subset kind to an out-of-subset,
+/// un-reconciled target. Two consumers project it — the engine backstop
+/// (`Transfer.subsetEscapeGate`, the compact leg-neutral refusal) and the
+/// peer face's rich detector (`PeerTransfer.escapingFks`, which enriches
+/// each edge with module names, nullability softening, and reconcile
+/// candidates). One traversal means the board can never show green while
+/// the engine refuses (or vice versa) — the predicates cannot drift.
+[<RequireQualifiedAccess>]
+module TransferSubset =
+
+    /// `(owning kind, the reference, the target kind)` for every escaping
+    /// edge. A dangling model edge (target kind absent from the contract) is
+    /// the model's own diagnostic, not this traversal's — skipped, as both
+    /// prior copies did. Deterministic: sorted by (kind name, reference name).
+    let escapingEdges
+        (contract: Catalog)
+        (loadSet: Set<SsKey>)
+        (reconciled: Set<SsKey>)
+        : (Kind * Reference * Kind) list =
+        Catalog.allKinds contract
+        |> List.filter (fun k -> Set.contains k.SsKey loadSet)
+        |> List.collect (fun kind ->
+            kind.References
+            |> List.choose (fun r ->
+                if Set.contains r.TargetKind loadSet || Set.contains r.TargetKind reconciled then None
+                else
+                    Catalog.tryFindKind r.TargetKind contract
+                    |> Option.map (fun target -> (kind, r, target))))
+        |> List.sortBy (fun (k, r, _) -> Name.value k.Name, Name.value r.Name)

--- a/sidecar/projection/tests/Projection.Tests.Integration/ComprehensiveCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ComprehensiveCanaryTests.fs
@@ -492,7 +492,7 @@ module ComprehensiveCanaryTests =
             let checkRow : OssysRowsetTypes.ColumnCheckRow =
                 { AttrId = suppAttrId
                   ConstraintName = "CHK_SUPP"
-                  Definition = "[ID] > 0"
+                  Definition = Some "[ID] > 0"
                   IsNotTrusted = false }
             let suppBundle : OssysRowsetTypes.RowsetBundle =
                 { OssysRowsetTypes.RowsetBundle.empty with

--- a/sidecar/projection/tests/Projection.Tests.Integration/DmlPrincipal.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/DmlPrincipal.fs
@@ -1,0 +1,88 @@
+namespace Projection.Tests
+
+open Microsoft.Data.SqlClient
+open Projection.Pipeline
+
+/// The ONE shared managed-grant principal helper (2026-07-06, promoted from
+/// `ReverseLegFixtures.createDmlPrincipal` so the reverse-leg canaries, the
+/// peer managed-grant suite, and future consumers share one login-naming /
+/// grant-string / cleanup implementation).
+///
+/// The managed-cloud profile is reproduced with EXPLICIT database-scope
+/// grants, never `db_datareader`/`db_datawriter`: fixed-role rights do NOT
+/// surface in `sys.fn_my_permissions(NULL,'DATABASE')` — the probe
+/// `Preflight.captureGrantEvidence` reads — so a role-based mock would
+/// false-trip `transfer.insufficientGrant` (exit 7) on a sink that could
+/// take the writes (and `db_datawriter` carries no SELECT, which the
+/// reconcile leg and capture staging need). What is deliberately ABSENT
+/// (absence, not DENY — the faithful cloud reproduction): ALTER, CREATE
+/// TABLE, REFERENCES, EXECUTE, VIEW DEFINITION, CONTROL. Consequences the
+/// engine relies on: `SET IDENTITY_INSERT` fails (1088-class), `CREATE
+/// TABLE` fails (262), `ALTER TABLE … CHECK CONSTRAINT` fails (descends to
+/// the named FK-trust tolerance), while `#temp` creation and `MERGE …
+/// OUTPUT` succeed.
+[<RequireQualifiedAccess>]
+module DmlPrincipal =
+
+    [<Literal>]
+    let ManagedGrants = "SELECT, INSERT, UPDATE, DELETE"
+
+    /// Create a login + database user carrying `grants` at database scope on
+    /// the admin connection's database; returns `(login, connection string
+    /// re-pointed at the restricted login)`. Caller drops via `dropLogin`.
+    let create
+        (admin: SqlConnection)
+        (adminConnStr: string)
+        (grants: string)
+        : System.Threading.Tasks.Task<string * string> =
+        task {
+            let login = "mockdml_" + System.Guid.NewGuid().ToString("N").Substring(0, 8)
+            let password = "Mock!dml#" + System.Guid.NewGuid().ToString("N").Substring(0, 12)
+            do! Deploy.executeBatch admin
+                    (sprintf "CREATE LOGIN [%s] WITH PASSWORD = N'%s'; CREATE USER [%s] FOR LOGIN [%s]; GRANT %s TO [%s];"
+                        login password login login grants login)
+            let builder = SqlConnectionStringBuilder(adminConnStr)
+            builder.UserID <- login
+            builder.Password <- password
+            return login, builder.ConnectionString
+        }
+
+    /// The managed-cloud profile (`ManagedGrants` at database scope).
+    let createManaged (admin: SqlConnection) (adminConnStr: string) =
+        create admin adminConnStr ManagedGrants
+
+    /// Best-effort login cleanup (the per-run database drops with the
+    /// ephemeral fixture; the LOGIN is instance-scoped and must go too).
+    let dropLogin (admin: SqlConnection) (login: string) : unit =
+        try
+            (Deploy.executeBatch admin (sprintf "DROP LOGIN [%s];" login)).GetAwaiter().GetResult()
+        with _ -> ()
+
+    /// The database-scope permission names `fn_my_permissions` reports for
+    /// the CURRENT principal — the exact evidence `Preflight.captureGrantEvidence`
+    /// reads. Run over a connection opened AS the principal under test.
+    let selfPermissions (cnn: SqlConnection) : System.Threading.Tasks.Task<Set<string>> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- "SELECT permission_name FROM sys.fn_my_permissions(NULL, 'DATABASE');"
+            let acc = System.Collections.Generic.List<string>()
+            use! reader = cmd.ExecuteReaderAsync()
+            let mutable go = true
+            while go do
+                let! more = reader.ReadAsync()
+                if more then acc.Add(reader.GetString 0) else go <- false
+            return Set.ofSeq acc
+        }
+
+    /// True when the exception is the SQL permission-denied class (229 /
+    /// 262 / 1088 / 297 / 4902) — the classifier the permission-matrix
+    /// assertions key on, so a test asserts WHICH capability was refused
+    /// rather than "some SqlException happened".
+    let isPermissionDenied (ex: exn) : bool =
+        match ex with
+        | :? SqlException as se ->
+            se.Errors
+            |> Seq.cast<SqlError>
+            |> Seq.exists (fun e -> List.contains e.Number [ 229; 262; 297; 1088; 4902 ])
+            || se.Message.ToLowerInvariant().Contains "permission"
+        | _ -> false

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -94,11 +94,11 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
 
                         // 1. RED — subset [Customer], City escapes, no strategy.
-                        let red1 = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
+                        let red1 = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
                         Assert.Equal(5, red1)
 
                         // 2. GREEN — the SAME flow with the proposed reconcile.
-                        let green = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let green = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(0, green)
 
                         // The board's dry run NEVER writes: the sink customer
@@ -113,7 +113,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         // attribute = blocking).
                         do! GoBoardFixtures.exec snk.Admin
                                 "DELETE FROM [dbo].[ossys_Entity_Attr] WHERE [Name] = N'LastName' AND [Entity_Id] = 1000;"
-                        let red2 = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let red2 = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(5, red2)
                         return ()
                     }))
@@ -133,7 +133,6 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                 (fun src snk ->
                     task {
                         let undoDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "prove-" + System.Guid.NewGuid().ToString("N").Substring(0, 8))
-                        let sinkFile = System.IO.Path.GetTempFileName()
                         try
                             let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
                             let (srcContract, sinkContract) = Result.value contractsR
@@ -145,13 +144,9 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
 
                             // 1. TRANSFER the subset (revert dir threaded so the
                             //    success tail writes transfer-undo.sql).
-                            let srcSub : Substrate = { Environment = Projection.Core.Environment.Qa; Role = SubstrateRole.Source; ConnectionRef = ConnectionRef.File sinkFile }
-                            // (the source ref file carries the SOURCE conn; reuse one temp file per side)
-                            let srcFile = System.IO.Path.GetTempFileName()
-                            System.IO.File.WriteAllText(srcFile, src.EngineConnStr)
-                            System.IO.File.WriteAllText(sinkFile, snk.EngineConnStr)
-                            let srcSub = { srcSub with ConnectionRef = ConnectionRef.File srcFile }
-                            let sinkSub : Substrate = { Environment = Projection.Core.Environment.Uat; Role = SubstrateRole.Sink; ConnectionRef = ConnectionRef.File sinkFile }
+                            //    `ConnectionRef.Raw` (DECISIONS 2026-07-06).
+                            let srcSub : Substrate = { Environment = Projection.Core.Environment.Qa; Role = SubstrateRole.Source; ConnectionRef = ConnectionRef.Raw src.EngineConnStr }
+                            let sinkSub : Substrate = { Environment = Projection.Core.Environment.Uat; Role = SubstrateRole.Sink; ConnectionRef = ConnectionRef.Raw snk.EngineConnStr }
                             let connections = TransferConnections.create srcSub sinkSub true |> Result.value
                             let! runR =
                                 Transfer.runReverseLegThroughConnectionsWith
@@ -168,16 +163,23 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                             Assert.True(System.IO.File.Exists undoPath, "the success tail must write transfer-undo.sql")
 
                             // 3. REVERT through the face: preview (no deletes), then live.
-                            let preview = Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("file:" + sinkFile) false
+                            let preview = Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("live:" + snk.EngineConnStr) false false
                             Assert.Equal(0, preview)
                             let! stillThere = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
                             Assert.Equal(2, stillThere)
                             let prior = System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE"
                             System.Environment.SetEnvironmentVariable("PROJECTION_ALLOW_EXECUTE", "1")
                             let live =
-                                try Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("file:" + sinkFile) true
+                                try Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("live:" + snk.EngineConnStr) true false
                                 finally System.Environment.SetEnvironmentVariable("PROJECTION_ALLOW_EXECUTE", prior)
                             Assert.Equal(0, live)
+
+                            // 4a. THE WRONG-SINK GUARD: the artifact's
+                            //     provenance header names the sink database;
+                            //     pointing --against at the SOURCE refuses by
+                            //     name (exit 7) before any delete.
+                            let mismatch = Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-qa" ("live:" + src.EngineConnStr) true false
+                            Assert.Equal(7, mismatch)
 
                             // 4. The sink is back to its pre-transfer state:
                             //    minted rows gone, pre-existing city rows intact.
@@ -185,9 +187,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                             Assert.Equal(0, customersReverted)
                             let! cities = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
                             Assert.Equal(2, cities)
-                            try System.IO.File.Delete srcFile with _ -> ()
                             return ()
                         finally
-                            try System.IO.File.Delete sinkFile with _ -> ()
                             try System.IO.Directory.Delete(undoDir, true) with _ -> ()
                     }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -1,0 +1,119 @@
+namespace Projection.Tests
+
+// THE GO BOARD, end-to-end against two real mock OutSystems environments
+// (2026-07-06, the preview-engine program): the red→green→red story the
+// operator validates their setup against.
+//
+//   1. RED — an unconfigured flow (a subset whose FK escapes, no reconcile):
+//      the board exits 5 and names the open decision with the paste-able
+//      remedy.
+//   2. GREEN — the SAME flow with the proposed reconcile added: every gate
+//      passes, the dry-run forecast carries the row counts, exit 0.
+//   3. RED AGAIN — a real schema divergence appears on the sink (a metamodel
+//      attribute removed): the shape axis stops the board, exit 5.
+//
+// The board runs the ENGINE DRY RUN (real reads, zero writes) — asserted by
+// the sink staying empty throughout. Managed-grant principals on both sides,
+// so the forecast itself is proven inside the cloud envelope. Serial via
+// Docker-SqlServer; blocking wait via TaskSync.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Cli.Faces.Transfer
+
+module private GoBoardFixtures =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let sourceRows =
+        [ "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON; \
+           INSERT INTO [dbo].[OSUSR_DEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (1, N'Lisbon', 1), (2, N'Porto', 1); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] OFF; \
+           SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] ON; \
+           INSERT INTO [dbo].[OSUSR_ABC_CUSTOMER] ([ID],[EMAIL],[FIRSTNAME],[LASTNAME],[CITYID]) VALUES \
+               (10, N'alice@x', N'Alice', N'Almeida', 1), (11, N'bob@x', N'Bob', N'Barbosa', 2); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] OFF;" ]
+
+    let sinkCityRows =
+        [ "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; \
+           INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1), (502, N'Porto', 1); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF;" ]
+
+    let optsWith (tables: string list) (reconcile: string list) : LoadOpts =
+        { Declaration = DeclareNone
+          Emission    = EmissionMode.Incremental
+          Reconcile   = reconcile
+          Rekey       = None
+          AllowCdc    = false
+          Resumable   = false
+          Streaming   = false
+          Journal     = None
+          Atomic      = false
+          RevertPolicy = RevertPolicy.Script
+          RevertDir   = None
+          Store       = None
+          Env         = None
+          Tables      = tables
+          Seed        = None
+          Scale       = None
+          Correction  = None
+          SinkCapability = SinkLoadCapability.structural }
+
+    let countRows (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) : System.Threading.Tasks.Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT COUNT_BIG(*) FROM %s;" table
+            let! scalar = cmd.ExecuteScalarAsync()
+            return int (unbox<int64> scalar)
+        }
+
+    let exec (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : System.Threading.Tasks.Task =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! _ = cmd.ExecuteNonQueryAsync()
+            return ()
+        }
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``go board: RED on the open decision, GREEN with the reconcile, RED again on shape divergence — and the dry run never writes`` () =
+        if not (GoBoardFixtures.skipIfNoDocker "GoBoardRedGreen") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "GoBoard"
+                "" GoBoardFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" GoBoardFixtures.sinkCityRows MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
+
+                        // 1. RED — subset [Customer], City escapes, no strategy.
+                        let red1 = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
+                        Assert.Equal(5, red1)
+
+                        // 2. GREEN — the SAME flow with the proposed reconcile.
+                        let green = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        Assert.Equal(0, green)
+
+                        // The board's dry run NEVER writes: the sink customer
+                        // table is still empty after both boards.
+                        let! customers = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                        Assert.Equal(0, customers)
+                        let! cities = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                        Assert.Equal(2, cities)   // the pre-seeded reconcile targets, untouched
+
+                        // 3. RED again — a REAL shape divergence: the sink
+                        // metamodel loses Customer.LastName (source-only
+                        // attribute = blocking).
+                        do! GoBoardFixtures.exec snk.Admin
+                                "DELETE FROM [dbo].[ossys_Entity_Attr] WHERE [Name] = N'LastName' AND [Entity_Id] = 1000;"
+                        let red2 = runCheckGo "golden" "cloud-qa" "cloud-uat" (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        Assert.Equal(5, red2)
+                        return ()
+                    }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -117,3 +117,77 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         Assert.Equal(5, red2)
                         return ()
                     }))
+
+    /// THE PROVING LOOP (2026-07-06): transfer a small declared subset, prove
+    /// it landed, then DELIBERATELY REVERT it — the success-undo artifact
+    /// (`transfer-undo.sql`, written by the engine's success tail) executed
+    /// through the `projection revert` face restores the sink to its
+    /// pre-transfer state; pre-existing rows are never touched.
+    [<Fact>]
+    member _.``proving loop: transfer a subset, then revert it from the success-undo artifact — the sink returns to its pre-transfer state`` () =
+        if not (GoBoardFixtures.skipIfNoDocker "ProvingLoop") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "ProveRevert"
+                "" GoBoardFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" GoBoardFixtures.sinkCityRows MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        let undoDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "prove-" + System.Guid.NewGuid().ToString("N").Substring(0, 8))
+                        let sinkFile = System.IO.Path.GetTempFileName()
+                        try
+                            let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                            let (srcContract, sinkContract) = Result.value contractsR
+                            let cityKind =
+                                Catalog.allKinds sinkContract
+                                |> List.find (fun k -> Name.value k.Name = "City")
+                            let cityName = cityKind.Attributes |> List.find (fun a -> Name.value a.Name = "Name")
+                            let reconciliation = Map.ofList [ cityKind.SsKey, ReconciliationStrategy.MatchByColumn cityName.Name ]
+
+                            // 1. TRANSFER the subset (revert dir threaded so the
+                            //    success tail writes transfer-undo.sql).
+                            let srcSub : Substrate = { Environment = Projection.Core.Environment.Qa; Role = SubstrateRole.Source; ConnectionRef = ConnectionRef.File sinkFile }
+                            // (the source ref file carries the SOURCE conn; reuse one temp file per side)
+                            let srcFile = System.IO.Path.GetTempFileName()
+                            System.IO.File.WriteAllText(srcFile, src.EngineConnStr)
+                            System.IO.File.WriteAllText(sinkFile, snk.EngineConnStr)
+                            let srcSub = { srcSub with ConnectionRef = ConnectionRef.File srcFile }
+                            let sinkSub : Substrate = { Environment = Projection.Core.Environment.Uat; Role = SubstrateRole.Sink; ConnectionRef = ConnectionRef.File sinkFile }
+                            let connections = TransferConnections.create srcSub sinkSub true |> Result.value
+                            let! runR =
+                                Transfer.runReverseLegThroughConnectionsWith
+                                    IdentityPolicy.Structural Transfer.Execute EmissionMode.Incremental false true false
+                                    [ "Customer" ] connections srcContract sinkContract reconciliation
+                                    false (Some undoDir)
+                            let report = Result.value runR
+                            Assert.Equal(2, report.Kinds |> List.sumBy (fun k -> k.RowsWritten))
+                            let! customersAfter = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                            Assert.Equal(2, customersAfter)
+
+                            // 2. The undo artifact exists and names the minted keys.
+                            let undoPath = System.IO.Path.Combine(undoDir, "transfer-undo.sql")
+                            Assert.True(System.IO.File.Exists undoPath, "the success tail must write transfer-undo.sql")
+
+                            // 3. REVERT through the face: preview (no deletes), then live.
+                            let preview = Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("file:" + sinkFile) false
+                            Assert.Equal(0, preview)
+                            let! stillThere = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                            Assert.Equal(2, stillThere)
+                            let prior = System.Environment.GetEnvironmentVariable "PROJECTION_ALLOW_EXECUTE"
+                            System.Environment.SetEnvironmentVariable("PROJECTION_ALLOW_EXECUTE", "1")
+                            let live =
+                                try Projection.Cli.Faces.Transfer.runRevertScript undoPath "cloud-uat" ("file:" + sinkFile) true
+                                finally System.Environment.SetEnvironmentVariable("PROJECTION_ALLOW_EXECUTE", prior)
+                            Assert.Equal(0, live)
+
+                            // 4. The sink is back to its pre-transfer state:
+                            //    minted rows gone, pre-existing city rows intact.
+                            let! customersReverted = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                            Assert.Equal(0, customersReverted)
+                            let! cities = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                            Assert.Equal(2, cities)
+                            try System.IO.File.Delete srcFile with _ -> ()
+                            return ()
+                        finally
+                            try System.IO.File.Delete sinkFile with _ -> ()
+                            try System.IO.Directory.Delete(undoDir, true) with _ -> ()
+                    }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/MockOutSystemsEnv.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/MockOutSystemsEnv.fs
@@ -1,0 +1,79 @@
+namespace Projection.Tests
+
+open Microsoft.Data.SqlClient
+open System.Threading.Tasks
+open Projection.Pipeline
+
+/// A MOCK OUTSYSTEMS ENVIRONMENT (2026-07-06, the phase-2 program): one
+/// ephemeral database carrying (a) the OSSYS metamodel + espace-prefixed
+/// `OSUSR_*` physical tables (the edge-case estate, espace-parameterized via
+/// `OssysSeedBuilder`), optionally (b) test-local row batches, and
+/// optionally (c) a MANAGED-GRANT principal (`DmlPrincipal.createManaged`)
+/// whose connection string is what the ENGINE drives — so a test proves the
+/// transfer under the real cloud permission envelope, not as admin.
+///
+/// CPS form (the `WithEphemeralDatabase` idiom): the body receives the full
+/// surface; login + database cleanup happen in `finally` regardless of
+/// outcome. Two environments compose via `withMockEnvPair` — the peer shape.
+[<RequireQualifiedAccess>]
+module MockOutSystemsEnv =
+
+    type GrantProfile =
+        /// The fixture's admin connection drives the engine (the pre-phase-2
+        /// posture — identity/mechanics tests that deliberately ignore grants).
+        | AdminFullRights
+        /// A `DmlPrincipal.ManagedGrants` login drives the engine — the
+        /// managed-cloud envelope (no ALTER / CREATE TABLE / IDENTITY_INSERT).
+        | ManagedDml
+
+    type MockEnv =
+        { /// Admin-scope connection (setup, DENY injection, assertions).
+          Admin        : SqlConnection
+          AdminConnStr : string
+          /// What the ENGINE connects as (the restricted login under
+          /// `ManagedDml`; the admin string under `AdminFullRights`).
+          EngineConnStr : string
+          Login        : string option
+          EspaceKey    : string }
+
+    /// One mock cell: deploy the espace-shifted edge-case estate + the given
+    /// row batches, mint the grant profile, run the body, clean up.
+    let withMockEnv
+        (fixture: EphemeralContainerFixture)
+        (label: string)
+        (espaceKey: string)
+        (rowBatches: string list)
+        (grant: GrantProfile)
+        (body: MockEnv -> Task<'a>)
+        : Task<'a> =
+        fixture.WithEphemeralDatabase label (fun admin adminConnStr ->
+            task {
+                let seed =
+                    Projection.Adapters.OssysSql.MetadataExtractionSql.readEdgeCaseSeed ()
+                    |> (if espaceKey = "" then OssysSeedBuilder.sameEspace else OssysSeedBuilder.withEspaceKey espaceKey)
+                do! Deploy.executeBatch admin seed
+                for batch in rowBatches do
+                    do! Deploy.executeBatch admin batch
+                match grant with
+                | AdminFullRights ->
+                    return! body { Admin = admin; AdminConnStr = adminConnStr; EngineConnStr = adminConnStr; Login = None; EspaceKey = espaceKey }
+                | ManagedDml ->
+                    let! login, restricted = DmlPrincipal.createManaged admin adminConnStr
+                    try
+                        return! body { Admin = admin; AdminConnStr = adminConnStr; EngineConnStr = restricted; Login = Some login; EspaceKey = espaceKey }
+                    finally
+                        DmlPrincipal.dropLogin admin login
+            })
+
+    /// Two mock cells in one test — the peer (A→A) shape. Nested lifecycles;
+    /// the sink drops first (inner), then the source.
+    let withMockEnvPair
+        (fixture: EphemeralContainerFixture)
+        (label: string)
+        (sourceKey: string) (sourceRows: string list) (sourceGrant: GrantProfile)
+        (sinkKey: string)   (sinkRows: string list)   (sinkGrant: GrantProfile)
+        (body: MockEnv -> MockEnv -> Task<'a>)
+        : Task<'a> =
+        withMockEnv fixture (label + "Src") sourceKey sourceRows sourceGrant (fun src ->
+            withMockEnv fixture (label + "Snk") sinkKey sinkRows sinkGrant (fun snk ->
+                body src snk))

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerAlignedTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerAlignedTransferDockerTests.fs
@@ -45,7 +45,7 @@ module private PeerAlignedFixtures =
     /// physical DDL move together; GUIDs / logical names / structure held
     /// fixed). The same transform the espace-invariance canary proved reads
     /// as ONE shape.
-    let seedB () : string = (seedA ()).Replace("OSUSR_", "OSUSR_X")
+    let seedB () : string = (seedA ()) |> OssysSeedBuilder.withEspaceKey "X"
 
     /// Deterministic source rows: two cities (known surrogates 1/2 via
     /// IDENTITY_INSERT) and two customers pointing at them. LEGACYCODE is
@@ -118,24 +118,18 @@ module private PeerAlignedFixtures =
         (body: TransferConnections -> System.Threading.Tasks.Task<'a>)
         : System.Threading.Tasks.Task<'a> =
         task {
-            let srcFile = System.IO.Path.GetTempFileName()
-            let sinkFile = System.IO.Path.GetTempFileName()
-            System.IO.File.WriteAllText(srcFile, srcConnStr)
-            System.IO.File.WriteAllText(sinkFile, sinkConnStr)
-            try
-                let srcSub : Substrate =
-                    { Environment = Projection.Core.Environment.Qa
-                      Role = SubstrateRole.Source
-                      ConnectionRef = ConnectionRef.File srcFile }
-                let sinkSub : Substrate =
-                    { Environment = Projection.Core.Environment.Uat
-                      Role = SubstrateRole.Sink
-                      ConnectionRef = ConnectionRef.File sinkFile }
-                let connections = TransferConnections.create srcSub sinkSub reconcile |> value
-                return! body connections
-            finally
-                try System.IO.File.Delete srcFile with _ -> ()
-                try System.IO.File.Delete sinkFile with _ -> ()
+            // `ConnectionRef.Raw` (DECISIONS 2026-07-06): the ephemeral-DB
+            // string is already in memory — no temp-file round trip.
+            let srcSub : Substrate =
+                { Environment = Projection.Core.Environment.Qa
+                  Role = SubstrateRole.Source
+                  ConnectionRef = ConnectionRef.Raw srcConnStr }
+            let sinkSub : Substrate =
+                { Environment = Projection.Core.Environment.Uat
+                  Role = SubstrateRole.Sink
+                  ConnectionRef = ConnectionRef.Raw sinkConnStr }
+            let connections = TransferConnections.create srcSub sinkSub reconcile |> value
+            return! body connections
         }
 
 [<Xunit.Collection("Docker-SqlServer")>]

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerAlignedTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerAlignedTransferDockerTests.fs
@@ -1,0 +1,343 @@
+namespace Projection.Tests
+
+// The peer (A→A) SsKey-aligned transfer, end-to-end against two REAL
+// espace-variant databases (the 2026-07-06 partial-transfer readiness
+// program; PARTIAL_TRANSFER_READINESS_LOG.md). This closes the estate's
+// headline gap: the espace-invariance canary (`OssysComprehensiveFixtureTests`)
+// proved two `OSUSR_`-variant OSSYS cells READ as one shape — no test MOVED
+// DATA between them. Here: cell A = the edge-case OSSYS estate (`OSUSR_*`),
+// cell B = the same estate with every physical `OSUSR_*` name shifted
+// (`OSUSR_X*` — the espace-key shift), contracts read from EACH side's OSSYS
+// metamodel (`LiveModelRead` — native GUID SsKeys, the identity that aligns
+// across environments), and the contract-pair engine
+// (`Transfer.runReverseLegThroughConnections` — the same runCore path the
+// peer face drives) executes a declared TABLE SUBSET into the
+// differently-named sink:
+//   1. subset [City; Customer] — rows land in the `OSUSR_X*` tables, the
+//      Customer→City FK re-pointed through the sink-minted keys (the sink's
+//      identity is reseeded so a verbatim FK copy CANNOT pass);
+//   2. subset [Customer] + City reconciled by NAME — the out-of-subset
+//      parent matches rows the sink ALREADY holds (the reconcile-by-key
+//      strategy for partial refresh); no city row is written;
+//   3. subset replace re-run — WipeAndLoad × 2 is idempotent (counts and
+//      the FK join stable; no duplicate rows).
+// Serial via Docker-SqlServer; blocking wait via TaskSync.
+
+open Xunit
+open Projection.Core
+open Projection.Adapters.OssysSql
+open Projection.Pipeline
+
+module private PeerAlignedFixtures =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let value (r: Result<'a>) : 'a = Result.value r
+
+    /// Cell A: the edge-case OSSYS estate as shipped (metamodel + physical
+    /// `OSUSR_*` tables, physical tables empty — rows are seeded test-locally).
+    let seedA () : string = MetadataExtractionSql.readEdgeCaseSeed ()
+
+    /// Cell B: the sibling espace cell — every `OSUSR_*` physical name
+    /// shifted to `OSUSR_X*` (metamodel `Physical_Table_Name` AND the
+    /// physical DDL move together; GUIDs / logical names / structure held
+    /// fixed). The same transform the espace-invariance canary proved reads
+    /// as ONE shape.
+    let seedB () : string = (seedA ()).Replace("OSUSR_", "OSUSR_X")
+
+    /// Deterministic source rows: two cities (known surrogates 1/2 via
+    /// IDENTITY_INSERT) and two customers pointing at them. LEGACYCODE is
+    /// deliberately unset (the attribute is Is_Active=0 in the metamodel, so
+    /// the OSSYS contract may not carry it).
+    let sourceRows =
+        "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON; \
+         INSERT INTO [dbo].[OSUSR_DEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (1, N'Lisbon', 1), (2, N'Porto', 1); \
+         SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] OFF; \
+         SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] ON; \
+         INSERT INTO [dbo].[OSUSR_ABC_CUSTOMER] ([ID],[EMAIL],[FIRSTNAME],[LASTNAME],[CITYID]) VALUES \
+             (10, N'alice@x', N'Alice', N'Almeida', 1), (11, N'bob@x', N'Bob', N'Barbosa', 2); \
+         SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] OFF;"
+
+    /// Shift the sink's identity ranges away from the source's surrogates so
+    /// a VERBATIM FK copy cannot accidentally satisfy the join assertions —
+    /// only a genuine remap through the sink-minted keys passes.
+    let reseedSinkIdentities =
+        "DBCC CHECKIDENT ('[dbo].[OSUSR_XDEF_CITY]', RESEED, 500); \
+         DBCC CHECKIDENT ('[dbo].[OSUSR_XABC_CUSTOMER]', RESEED, 900);"
+
+    /// Sink cities the reconcile scenario matches against — same NAMEs as the
+    /// source's, deliberately different surrogates (501/502 vs 1/2).
+    let sinkCityRows =
+        "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; \
+         INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1), (502, N'Porto', 1); \
+         SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF;"
+
+    /// The OSSYS-read contract for one cell — the production acquisition path
+    /// (`PeerTransfer.acquireContracts` is this, via the conn-spec form).
+    let contractOf (cnn: Microsoft.Data.SqlClient.SqlConnection) : System.Threading.Tasks.Task<Result<Catalog>> =
+        LiveModelRead.fromConnection cnn
+
+    let countRows (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) : System.Threading.Tasks.Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT COUNT_BIG(*) FROM %s;" table
+            let! scalar = cmd.ExecuteScalarAsync()
+            return int (unbox<int64> scalar)
+        }
+
+    /// The identity-independent relationship the transfer must preserve: the
+    /// (customer EMAIL → city NAME) join, sorted by email.
+    let customerCityJoin (cnn: Microsoft.Data.SqlClient.SqlConnection) (customerTable: string) (cityTable: string) : System.Threading.Tasks.Task<(string * string) list> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <-
+                sprintf
+                    "SELECT c.[EMAIL], ci.[NAME] FROM [dbo].[%s] c JOIN [dbo].[%s] ci ON ci.[ID] = c.[CITYID] ORDER BY c.[EMAIL];"
+                    customerTable cityTable
+            let acc = System.Collections.Generic.List<string * string>()
+            use! reader = cmd.ExecuteReaderAsync()
+            let mutable go = true
+            while go do
+                let! more = reader.ReadAsync()
+                if more then acc.Add(reader.GetString 0, reader.GetString 1) else go <- false
+            return List.ofSeq acc
+        }
+
+    let kindByLogicalName (contract: Catalog) (name: string) : Kind =
+        Catalog.allKinds contract
+        |> List.find (fun k -> System.String.Equals(Name.value k.Name, name, System.StringComparison.OrdinalIgnoreCase))
+
+    /// Build the apparatus over the two ephemeral databases (the D9 file-ref
+    /// pattern the PE-3 golden canary uses), run the body, clean up.
+    let throughConnections
+        (srcConnStr: string)
+        (sinkConnStr: string)
+        (reconcile: bool)
+        (body: TransferConnections -> System.Threading.Tasks.Task<'a>)
+        : System.Threading.Tasks.Task<'a> =
+        task {
+            let srcFile = System.IO.Path.GetTempFileName()
+            let sinkFile = System.IO.Path.GetTempFileName()
+            System.IO.File.WriteAllText(srcFile, srcConnStr)
+            System.IO.File.WriteAllText(sinkFile, sinkConnStr)
+            try
+                let srcSub : Substrate =
+                    { Environment = Projection.Core.Environment.Qa
+                      Role = SubstrateRole.Source
+                      ConnectionRef = ConnectionRef.File srcFile }
+                let sinkSub : Substrate =
+                    { Environment = Projection.Core.Environment.Uat
+                      Role = SubstrateRole.Sink
+                      ConnectionRef = ConnectionRef.File sinkFile }
+                let connections = TransferConnections.create srcSub sinkSub reconcile |> value
+                return! body connections
+            finally
+                try System.IO.File.Delete srcFile with _ -> ()
+                try System.IO.File.Delete sinkFile with _ -> ()
+        }
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type PeerAlignedTransferDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    /// The headline: a declared table subset moves between two espace-variant
+    /// cells — the sink's physical names differ (`OSUSR_X*`), identity aligns
+    /// by native GUID SsKey, and the Customer→City FK re-points through the
+    /// sink-minted city keys (verbatim copy CANNOT pass — the sink identity
+    /// range is reseeded away from the source surrogates).
+    [<Fact>]
+    member _.``peer A→A: a table subset lands in a differently-named sink with FKs re-pointed (SsKey-aligned contracts)`` () =
+        if not (PeerAlignedFixtures.skipIfNoDocker "PeerSubset") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "PeerSubsetSrc" (fun src srcConnStr ->
+                task {
+                    do! Deploy.executeBatch src (PeerAlignedFixtures.seedA ())
+                    do! Deploy.executeBatch src PeerAlignedFixtures.sourceRows
+                    return!
+                        fixture.WithEphemeralDatabase "PeerSubsetSink" (fun sink sinkConnStr ->
+                            task {
+                                do! Deploy.executeBatch sink (PeerAlignedFixtures.seedB ())
+                                do! Deploy.executeBatch sink PeerAlignedFixtures.reseedSinkIdentities
+
+                                // Contracts from EACH side's OSSYS metamodel — the
+                                // production acquisition (native GUID identity).
+                                let! srcContractR = PeerAlignedFixtures.contractOf src
+                                let! sinkContractR = PeerAlignedFixtures.contractOf sink
+                                let srcContract = PeerAlignedFixtures.value srcContractR
+                                let sinkContract = PeerAlignedFixtures.value sinkContractR
+
+                                // The identity precondition, asserted where it is
+                                // load-bearing: same SsKeys, different physical names.
+                                let srcCustomer = PeerAlignedFixtures.kindByLogicalName srcContract "Customer"
+                                let sinkCustomer = PeerAlignedFixtures.kindByLogicalName sinkContract "Customer"
+                                Assert.Equal(srcCustomer.SsKey, sinkCustomer.SsKey)
+                                Assert.Equal("OSUSR_ABC_CUSTOMER", TableId.tableText srcCustomer.Physical)
+                                Assert.Equal("OSUSR_XABC_CUSTOMER", TableId.tableText sinkCustomer.Physical)
+
+                                // The shape gate the peer face runs — the pair must
+                                // judge as one shape over the subset.
+                                let scope = Set.ofList [ srcCustomer.SsKey; (PeerAlignedFixtures.kindByLogicalName srcContract "City").SsKey ]
+                                match PeerTransfer.shapeGate (Some scope) srcContract sinkContract with
+                                | Error es -> Assert.Fail(sprintf "espace-variant cells must pass the shape gate; got %A" es)
+                                | Ok _ -> ()
+
+                                let! report =
+                                    PeerAlignedFixtures.throughConnections srcConnStr sinkConnStr false (fun connections ->
+                                        task {
+                                            let! r =
+                                                Transfer.runReverseLegThroughConnections
+                                                    Transfer.Execute EmissionMode.Incremental false true false
+                                                    [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
+                                            return PeerAlignedFixtures.value r
+                                        })
+
+                                // Every ingested row landed; nothing dropped.
+                                Assert.Empty(report.SkippedReferences)
+                                Assert.Empty(report.UnmatchedIdentities)
+                                let written (name: string) =
+                                    report.Kinds
+                                    |> List.find (fun k -> k.Kind = (PeerAlignedFixtures.kindByLogicalName srcContract name).SsKey)
+                                    |> fun k -> k.RowsWritten
+                                Assert.Equal(2, written "City")
+                                Assert.Equal(2, written "Customer")
+
+                                // Rows are IN THE DIFFERENTLY-NAMED tables, and the
+                                // FK re-pointed through sink-minted keys (the reseed
+                                // puts them in the 500s — a verbatim copy of the
+                                // source surrogates 1/2 cannot pass). Note the DBCC
+                                // CHECKIDENT quirk: on a never-inserted table the
+                                // reseed value IS the next minted value (500), not
+                                // 500+1 — so the check is "not the source's keys",
+                                // not a >500 boundary.
+                                let! cities = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XDEF_CITY]"
+                                let! customers = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
+                                Assert.Equal(2, cities)
+                                Assert.Equal(2, customers)
+                                let! verbatimFks = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XABC_CUSTOMER] WHERE [CITYID] IN (1, 2)"
+                                Assert.Equal(0, verbatimFks)
+                                let! danglingFks = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XABC_CUSTOMER] c WHERE NOT EXISTS (SELECT 1 FROM [dbo].[OSUSR_XDEF_CITY] ci WHERE ci.[ID] = c.[CITYID])"
+                                Assert.Equal(0, danglingFks)
+                                let! srcJoin = PeerAlignedFixtures.customerCityJoin src "OSUSR_ABC_CUSTOMER" "OSUSR_DEF_CITY"
+                                let! sinkJoin = PeerAlignedFixtures.customerCityJoin sink "OSUSR_XABC_CUSTOMER" "OSUSR_XDEF_CITY"
+                                Assert.Equal<(string * string) list>(srcJoin, sinkJoin)
+                                Assert.Equal<(string * string) list>([ ("alice@x", "Lisbon"); ("bob@x", "Porto") ], sinkJoin)
+                            })
+                }))
+
+    /// The reconcile-by-key strategy for an out-of-subset parent: only
+    /// Customer transfers; City — outside the subset — reconciles by NAME
+    /// against the rows the sink ALREADY holds (the partial-refresh shape:
+    /// reference data pre-exists in the target under its own surrogates).
+    [<Fact>]
+    member _.``peer A→A: an out-of-subset FK parent reconciles by business key against the sink's own rows`` () =
+        if not (PeerAlignedFixtures.skipIfNoDocker "PeerReconcile") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "PeerReconSrc" (fun src srcConnStr ->
+                task {
+                    do! Deploy.executeBatch src (PeerAlignedFixtures.seedA ())
+                    do! Deploy.executeBatch src PeerAlignedFixtures.sourceRows
+                    return!
+                        fixture.WithEphemeralDatabase "PeerReconSink" (fun sink sinkConnStr ->
+                            task {
+                                do! Deploy.executeBatch sink (PeerAlignedFixtures.seedB ())
+                                do! Deploy.executeBatch sink PeerAlignedFixtures.reseedSinkIdentities
+                                do! Deploy.executeBatch sink PeerAlignedFixtures.sinkCityRows
+
+                                let! srcContractR = PeerAlignedFixtures.contractOf src
+                                let! sinkContractR = PeerAlignedFixtures.contractOf sink
+                                let srcContract = PeerAlignedFixtures.value srcContractR
+                                let sinkContract = PeerAlignedFixtures.value sinkContractR
+
+                                let cityKind = PeerAlignedFixtures.kindByLogicalName sinkContract "City"
+                                let cityNameAttr =
+                                    cityKind.Attributes
+                                    |> List.find (fun a -> ColumnRealization.columnNameText a.Column = "NAME")
+                                let reconciliation =
+                                    Map.ofList [ cityKind.SsKey, ReconciliationStrategy.MatchByColumn cityNameAttr.Name ]
+
+                                // The escaping-FK detector names exactly this edge —
+                                // and the reconcile strategy silences it (the gate's
+                                // contract: reconciled targets are strategized).
+                                let subsetKeys = Set.ofList [ (PeerAlignedFixtures.kindByLogicalName srcContract "Customer").SsKey ]
+                                let bare = PeerTransfer.escapingFks srcContract subsetKeys Set.empty
+                                Assert.Equal(1, bare.Length)
+                                Assert.Equal("City", Name.value bare.Head.TargetName)
+                                let strategized = PeerTransfer.escapingFks srcContract subsetKeys (Set.ofList [ cityKind.SsKey ])
+                                Assert.Empty(strategized)
+
+                                let! report =
+                                    PeerAlignedFixtures.throughConnections srcConnStr sinkConnStr true (fun connections ->
+                                        task {
+                                            let! r =
+                                                Transfer.runReverseLegThroughConnections
+                                                    Transfer.Execute EmissionMode.Incremental false true false
+                                                    [ "Customer" ] connections srcContract sinkContract reconciliation
+                                            return PeerAlignedFixtures.value r
+                                        })
+
+                                // City is re-keyed, never written; every source city
+                                // matched a sink row by NAME.
+                                let cityOutcome = report.Kinds |> List.find (fun k -> k.Kind = cityKind.SsKey)
+                                Assert.Equal(IdentityDisposition.ReconciledByRule, cityOutcome.Disposition)
+                                Assert.Equal(0, cityOutcome.RowsWritten)
+                                Assert.Empty(report.UnmatchedIdentities)
+                                Assert.Empty(report.SkippedReferences)
+
+                                // The sink keeps ITS OWN two cities (501/502) — and
+                                // the transferred customers point at THEM.
+                                let! cities = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XDEF_CITY]"
+                                Assert.Equal(2, cities)
+                                let! reKeyed = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XABC_CUSTOMER] WHERE [CITYID] IN (501, 502)"
+                                Assert.Equal(2, reKeyed)
+                                let! sinkJoin = PeerAlignedFixtures.customerCityJoin sink "OSUSR_XABC_CUSTOMER" "OSUSR_XDEF_CITY"
+                                Assert.Equal<(string * string) list>([ ("alice@x", "Lisbon"); ("bob@x", "Porto") ], sinkJoin)
+                            })
+                }))
+
+    /// The replace-subset re-run: WipeAndLoad over the declared subset is
+    /// idempotent — a second Execute wipes the subset's sink rows child-first
+    /// and reloads, so counts and the FK join are stable (no duplicates, the
+    /// operator's chosen re-run semantics for today's partial refresh).
+    [<Fact>]
+    member _.``peer A→A: a WipeAndLoad subset re-run is idempotent (no duplicate rows; the join stable)`` () =
+        if not (PeerAlignedFixtures.skipIfNoDocker "PeerReplay") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "PeerReplaySrc" (fun src srcConnStr ->
+                task {
+                    do! Deploy.executeBatch src (PeerAlignedFixtures.seedA ())
+                    do! Deploy.executeBatch src PeerAlignedFixtures.sourceRows
+                    return!
+                        fixture.WithEphemeralDatabase "PeerReplaySink" (fun sink sinkConnStr ->
+                            task {
+                                do! Deploy.executeBatch sink (PeerAlignedFixtures.seedB ())
+                                do! Deploy.executeBatch sink PeerAlignedFixtures.reseedSinkIdentities
+
+                                let! srcContractR = PeerAlignedFixtures.contractOf src
+                                let! sinkContractR = PeerAlignedFixtures.contractOf sink
+                                let srcContract = PeerAlignedFixtures.value srcContractR
+                                let sinkContract = PeerAlignedFixtures.value sinkContractR
+
+                                let runOnce () =
+                                    PeerAlignedFixtures.throughConnections srcConnStr sinkConnStr false (fun connections ->
+                                        task {
+                                            let! r =
+                                                Transfer.runReverseLegThroughConnections
+                                                    Transfer.Execute EmissionMode.WipeAndLoad false true false
+                                                    [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
+                                            return PeerAlignedFixtures.value r
+                                        })
+
+                                let! _first = runOnce ()
+                                let! firstJoin = PeerAlignedFixtures.customerCityJoin sink "OSUSR_XABC_CUSTOMER" "OSUSR_XDEF_CITY"
+                                let! _second = runOnce ()
+                                let! cities = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XDEF_CITY]"
+                                let! customers = PeerAlignedFixtures.countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
+                                Assert.Equal(2, cities)
+                                Assert.Equal(2, customers)
+                                let! secondJoin = PeerAlignedFixtures.customerCityJoin sink "OSUSR_XABC_CUSTOMER" "OSUSR_XDEF_CITY"
+                                Assert.Equal<(string * string) list>(firstJoin, secondJoin)
+                                Assert.Equal<(string * string) list>([ ("alice@x", "Lisbon"); ("bob@x", "Porto") ], secondJoin)
+                            })
+                }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
@@ -1,0 +1,370 @@
+namespace Projection.Tests
+
+// The peer (A→A) transfer UNDER THE MANAGED-CLOUD GRANT (2026-07-06, the
+// phase-2 mock-environment program). The first peer suite proved identity
+// alignment and FK re-pointing AS ADMIN; this suite proves the same engine
+// path — and the permission model itself — under the REAL cloud envelope:
+// a principal carrying exactly database-scope SELECT/INSERT/UPDATE/DELETE
+// (no ALTER, no CREATE TABLE, no IDENTITY_INSERT), on BOTH sides.
+//
+//   1. The GRANT-CONFORMANCE PROBE: the mock principal's fn_my_permissions
+//      evidence is exactly what the engine's preflight reads; the denied
+//      capabilities fail with the documented error classes; #temp + MERGE
+//      succeed — "confirm our understanding of the permissions."
+//   2. The peer subset happy path, DML-only both sides: rows land in the
+//      differently-named sink, FKs re-point through sink-minted keys, and
+//      the load needs NO ALTER at all — FK-targeted kinds ride the MERGE
+//      capture lane, which validates constraints INLINE (the FK ends
+//      enabled AND trusted; the bulk-lane untrusted/descend tolerance
+//      belongs to non-FK-targeted kinds — the reverse-leg DML-only
+//      canaries own that witness).
+//   3. Reconcile-by-key under the grant (SELECT-only touch on the target).
+//   4. OSSYS metamodel unreadable on the sink → the NAMED contract
+//      acquisition refusal (schema-read axis, exit 6) — never a raw crash.
+//   5. Object-scope DENY INSERT mid-subset: the DB-scope preflight is blind
+//      to it (G1, PINNED) — raw permission exception mid-load, upstream
+//      kinds already landed. The named-gap witness on the peer dispatch,
+//      cross-referencing the reserved promotion stub in
+//      ReverseLegBoundaryTests.
+//
+// Serial via Docker-SqlServer; blocking wait via TaskSync.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+module private ManagedGrantFixtures =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let value (r: Result<'a>) : 'a = Result.value r
+
+    /// Deterministic source rows (cell A carries the unshifted `OSUSR_*`
+    /// names): two cities, two customers pointing at them.
+    let sourceRows =
+        [ "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON; \
+           INSERT INTO [dbo].[OSUSR_DEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (1, N'Lisbon', 1), (2, N'Porto', 1); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] OFF; \
+           SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] ON; \
+           INSERT INTO [dbo].[OSUSR_ABC_CUSTOMER] ([ID],[EMAIL],[FIRSTNAME],[LASTNAME],[CITYID]) VALUES \
+               (10, N'alice@x', N'Alice', N'Almeida', 1), (11, N'bob@x', N'Bob', N'Barbosa', 2); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] OFF;" ]
+
+    /// Sink identity ranges shifted away from the source surrogates so a
+    /// verbatim FK copy cannot pass the join assertions.
+    let sinkReseed =
+        [ "DBCC CHECKIDENT ('[dbo].[OSUSR_XDEF_CITY]', RESEED, 500); \
+           DBCC CHECKIDENT ('[dbo].[OSUSR_XABC_CUSTOMER]', RESEED, 900);" ]
+
+    /// Pre-seeded sink cities under the sink's OWN surrogates — the
+    /// reconcile scenario's match targets.
+    let sinkCityRows =
+        [ "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; \
+           INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1), (502, N'Porto', 1); \
+           SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF;" ]
+
+    let countRows (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) : System.Threading.Tasks.Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT COUNT_BIG(*) FROM %s;" table
+            let! scalar = cmd.ExecuteScalarAsync()
+            return int (unbox<int64> scalar)
+        }
+
+    let scalarInt (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : System.Threading.Tasks.Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! scalar = cmd.ExecuteScalarAsync()
+            return System.Convert.ToInt32 scalar
+        }
+
+    let exec (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : System.Threading.Tasks.Task =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! _ = cmd.ExecuteNonQueryAsync()
+            return ()
+        }
+
+    /// Open a raw connection (the restricted engine string).
+    let openConn (connStr: string) : System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlConnection> =
+        task {
+            let c = new Microsoft.Data.SqlClient.SqlConnection(connStr)
+            do! c.OpenAsync()
+            return c
+        }
+
+    /// The engine apparatus over two ENGINE connection strings (the D9
+    /// file-ref pattern) — under `ManagedDml` these are the restricted
+    /// logins, so the whole run pays the cloud envelope.
+    let throughConnections
+        (srcConnStr: string)
+        (sinkConnStr: string)
+        (reconcile: bool)
+        (body: TransferConnections -> System.Threading.Tasks.Task<'a>)
+        : System.Threading.Tasks.Task<'a> =
+        task {
+            let srcFile = System.IO.Path.GetTempFileName()
+            let sinkFile = System.IO.Path.GetTempFileName()
+            System.IO.File.WriteAllText(srcFile, srcConnStr)
+            System.IO.File.WriteAllText(sinkFile, sinkConnStr)
+            try
+                let srcSub : Substrate =
+                    { Environment = Projection.Core.Environment.Qa
+                      Role = SubstrateRole.Source
+                      ConnectionRef = ConnectionRef.File srcFile }
+                let sinkSub : Substrate =
+                    { Environment = Projection.Core.Environment.Uat
+                      Role = SubstrateRole.Sink
+                      ConnectionRef = ConnectionRef.File sinkFile }
+                let connections = TransferConnections.create srcSub sinkSub reconcile |> value
+                return! body connections
+            finally
+                try System.IO.File.Delete srcFile with _ -> ()
+                try System.IO.File.Delete sinkFile with _ -> ()
+        }
+
+    let kindByLogicalName (contract: Catalog) (name: string) : Kind =
+        Catalog.allKinds contract
+        |> List.find (fun k -> System.String.Equals(Name.value k.Name, name, System.StringComparison.OrdinalIgnoreCase))
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type PeerManagedGrantTransferDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    /// The permission-understanding probe: the mock managed principal's
+    /// grant evidence and denial classes are EXACTLY the documented cloud
+    /// profile — pinning the harness itself so every other test's premise
+    /// is verified, not assumed.
+    [<Fact>]
+    member _.``managed grant conformance: fn_my_permissions is exactly the DML set; denied capabilities fail in their documented classes; tempdb and MERGE succeed`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "GrantConformance") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnv fixture "GrantConf" "" [] MockOutSystemsEnv.ManagedDml (fun env ->
+                task {
+                    use! cnn = ManagedGrantFixtures.openConn env.EngineConnStr
+                    // (a) The evidence the engine's preflight reads: exactly
+                    // CONNECT + the four DML grants (explicit grants — a
+                    // role-based principal would report NONE of these and
+                    // false-trip the insufficient-grant refusal).
+                    let! perms = DmlPrincipal.selfPermissions cnn
+                    // The DML set is PRESENT as database-scope grants (what
+                    // `Preflight.captureGrantEvidence` needs to see)…
+                    for required in [ "CONNECT"; "SELECT"; "INSERT"; "UPDATE"; "DELETE" ] do
+                        Assert.Contains(required, perms)
+                    // …and the write-plane-relevant elevated rights are ABSENT.
+                    // (SQL Server 2022 also reports two always-granted
+                    // VIEW ANY COLUMN * KEY DEFINITION rows to every user —
+                    // irrelevant to the engine; the assertion is
+                    // presence/absence, not set equality.)
+                    for forbidden in [ "ALTER"; "CREATE TABLE"; "CONTROL"; "VIEW DEFINITION"; "REFERENCES"; "EXECUTE" ] do
+                        Assert.DoesNotContain(forbidden, perms)
+                    // (b) IDENTITY_INSERT is structurally unavailable (the
+                    // 1088/8104 class) — the engine must never need it.
+                    let! identityInsert =
+                        task {
+                            try
+                                do! ManagedGrantFixtures.exec cnn "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON;"
+                                return false
+                            with ex -> return DmlPrincipal.isPermissionDenied ex
+                        }
+                    Assert.True(identityInsert, "SET IDENTITY_INSERT must be denied under the managed grant")
+                    // (c) CREATE TABLE denied (error 262) — the G10
+                    // sink-resident progress table can never exist here.
+                    let! createTable =
+                        task {
+                            try
+                                do! ManagedGrantFixtures.exec cnn "CREATE TABLE dbo.__probe_ct (Id INT);"
+                                return false
+                            with ex -> return DmlPrincipal.isPermissionDenied ex
+                        }
+                    Assert.True(createTable, "CREATE TABLE must be denied under the managed grant")
+                    // (d) ALTER denied — the FK re-trust must descend, never succeed.
+                    let! alter =
+                        task {
+                            try
+                                do! ManagedGrantFixtures.exec cnn "ALTER TABLE [dbo].[OSUSR_ABC_CUSTOMER] WITH CHECK CHECK CONSTRAINT ALL;"
+                                return false
+                            with ex -> return DmlPrincipal.isPermissionDenied ex
+                        }
+                    Assert.True(alter, "ALTER must be denied under the managed grant")
+                    // (e) The capture lane's transport fits the grant: #temp
+                    // SELECT INTO + MERGE…OUTPUT INTO #keymap succeed.
+                    do! ManagedGrantFixtures.exec cnn
+                            "SELECT TOP 0 [ID] AS [__SRC_KEY], [NAME], [ISACTIVE] INTO #probe_stage FROM [dbo].[OSUSR_DEF_CITY]; \
+                             CREATE TABLE #probe_keymap ([__SRC_KEY] BIGINT, [ASSIGNED] BIGINT); \
+                             MERGE INTO [dbo].[OSUSR_DEF_CITY] AS T \
+                             USING (SELECT [__SRC_KEY], [NAME], [ISACTIVE] FROM #probe_stage) AS S ON 1 = 0 \
+                             WHEN NOT MATCHED THEN INSERT ([NAME],[ISACTIVE]) VALUES (S.[NAME], S.[ISACTIVE]) \
+                             OUTPUT S.[__SRC_KEY], INSERTED.[ID] INTO #probe_keymap ([__SRC_KEY],[ASSIGNED]); \
+                             DROP TABLE #probe_stage; DROP TABLE #probe_keymap;"
+                    return ()
+                }))
+
+    /// The headline under the grant: subset [City; Customer] between two
+    /// espace-variant cells, engine driven by DML-only logins on BOTH sides.
+    /// A finding worth its own pin: BOTH kinds here are FK-targeted, so they
+    /// ride the MERGE capture lane, which validates constraints INLINE —
+    /// the sink FK ends VALID AND TRUSTED with no ALTER ever needed (the
+    /// bulk-lane untrusted/descend path belongs to non-FK-targeted kinds;
+    /// the reverse-leg DML-only canaries own that witness).
+    [<Fact>]
+    member _.``peer under managed grant: the subset lands, FKs re-point, and the capture lane needs no ALTER (FK stays enabled and trusted)`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "PeerManagedHappy") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "PeerMg"
+                "" ManagedGrantFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" ManagedGrantFixtures.sinkReseed MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        // Contracts acquired OVER THE RESTRICTED LOGINS — the
+                        // OSSYS metamodel read itself is proven inside the grant.
+                        let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                        let (srcContract, sinkContract) = ManagedGrantFixtures.value contractsR
+
+                        let! report =
+                            ManagedGrantFixtures.throughConnections src.EngineConnStr snk.EngineConnStr false (fun connections ->
+                                task {
+                                    let! r =
+                                        Transfer.runReverseLegThroughConnections
+                                            Transfer.Execute EmissionMode.Incremental false true false
+                                            [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
+                                    return ManagedGrantFixtures.value r
+                                })
+
+                        Assert.Empty(report.SkippedReferences)
+                        Assert.Empty(report.UnmatchedIdentities)
+                        let! cities = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                        let! customers = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                        Assert.Equal(2, cities)
+                        Assert.Equal(2, customers)
+                        let! verbatim = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER] WHERE [CITYID] IN (1, 2)"
+                        Assert.Equal(0, verbatim)
+                        // The FK survived the load VALID: enabled, TRUSTED
+                        // (the MERGE lane validated it inline — no bulk
+                        // bypass, no ALTER needed), and zero dangling rows.
+                        let! fkState =
+                            ManagedGrantFixtures.scalarInt snk.Admin
+                                "SELECT COUNT(*) FROM sys.foreign_keys WHERE name = 'FK_OSUSR_XABC_CUSTOMER_OSUSR_XDEF_CITY' AND is_disabled = 0 AND is_not_trusted = 0;"
+                        Assert.Equal(1, fkState)
+                        let! dangling =
+                            ManagedGrantFixtures.countRows snk.Admin
+                                "[dbo].[OSUSR_XABC_CUSTOMER] c WHERE NOT EXISTS (SELECT 1 FROM [dbo].[OSUSR_XDEF_CITY] ci WHERE ci.[ID] = c.[CITYID])"
+                        Assert.Equal(0, dangling)
+                        return ()
+                    }))
+
+    /// Reconcile-by-key under the grant: the out-of-subset parent matches
+    /// rows the sink already holds; the reconcile leg's sink reads and the
+    /// FK re-key fit SELECT/INSERT/UPDATE/DELETE.
+    [<Fact>]
+    member _.``peer under managed grant: an out-of-subset parent reconciles by business key`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "PeerManagedRecon") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "PeerMgRec"
+                "" ManagedGrantFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" (ManagedGrantFixtures.sinkReseed @ ManagedGrantFixtures.sinkCityRows) MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                        let (srcContract, sinkContract) = ManagedGrantFixtures.value contractsR
+                        let cityKind = ManagedGrantFixtures.kindByLogicalName sinkContract "City"
+                        let cityName =
+                            cityKind.Attributes
+                            |> List.find (fun a -> ColumnRealization.columnNameText a.Column = "NAME")
+                        let reconciliation = Map.ofList [ cityKind.SsKey, ReconciliationStrategy.MatchByColumn cityName.Name ]
+
+                        let! report =
+                            ManagedGrantFixtures.throughConnections src.EngineConnStr snk.EngineConnStr true (fun connections ->
+                                task {
+                                    let! r =
+                                        Transfer.runReverseLegThroughConnections
+                                            Transfer.Execute EmissionMode.Incremental false true false
+                                            [ "Customer" ] connections srcContract sinkContract reconciliation
+                                    return ManagedGrantFixtures.value r
+                                })
+
+                        Assert.Empty(report.UnmatchedIdentities)
+                        Assert.Empty(report.SkippedReferences)
+                        let! cities = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                        Assert.Equal(2, cities)   // the sink's OWN rows; none inserted
+                        let! reKeyed = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER] WHERE [CITYID] IN (501, 502)"
+                        Assert.Equal(2, reKeyed)
+                        return ()
+                    }))
+
+    /// The contract-acquisition refusal: the sink's OSSYS metamodel is
+    /// unreadable (object-scope DENY SELECT on `ossys_Entity_Attr`) — the
+    /// NAMED schema-read refusal (exit 6 class), never a raw crash, and the
+    /// sink data untouched.
+    [<Fact>]
+    member _.``peer under managed grant: an unreadable sink metamodel refuses by name on the schema-read axis`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "PeerManagedOssysDeny") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "PeerMgDeny"
+                "" ManagedGrantFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" [] MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        do! ManagedGrantFixtures.exec snk.Admin
+                                (sprintf "DENY SELECT ON [dbo].[ossys_Entity_Attr] TO [%s];" (Option.get snk.Login))
+                        match! PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr with
+                        | Ok _ -> Assert.Fail "expected the sink metamodel read to refuse"
+                        | Error errors ->
+                            // The exact code depends on WHERE the read died
+                            // (a thrown SqlException wraps as
+                            // `source.ossys.readFailed`; an adapter-level
+                            // extraction failure carries its own
+                            // `adapter.*` code) — the CONTRACT is the axis:
+                            // every acquisition failure classifies onto
+                            // schema-read, exit 6, never the unclassified 3.
+                            let e = List.head errors
+                            Assert.Equal((6, Preflight.SchemaReadFailed), Preflight.classify e.Code)
+                        return ()
+                    }))
+
+    /// G1 PINNED on the peer dispatch: an object-scope DENY INSERT is
+    /// invisible to the DB-scope grant preflight — the load crashes RAW
+    /// mid-subset with the parent kind already landed (the partial-write
+    /// surprise). The promotion trigger lives with the reserved stub in
+    /// ReverseLegBoundaryTests (`object-scope DENY`); when an object-scope
+    /// probe lands, flip this to a named pre-write refusal.
+    [<Fact>]
+    member _.``peer under managed grant PINNED GAP: object-scope DENY INSERT crashes raw mid-load with a partial write (G1)`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "PeerManagedG1") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "PeerMgG1"
+                "" ManagedGrantFixtures.sourceRows MockOutSystemsEnv.ManagedDml
+                "X" ManagedGrantFixtures.sinkReseed MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        do! ManagedGrantFixtures.exec snk.Admin
+                                (sprintf "DENY INSERT ON [dbo].[OSUSR_XABC_CUSTOMER] TO [%s];" (Option.get snk.Login))
+                        let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                        let (srcContract, sinkContract) = ManagedGrantFixtures.value contractsR
+                        let! outcome =
+                            ManagedGrantFixtures.throughConnections src.EngineConnStr snk.EngineConnStr false (fun connections ->
+                                task {
+                                    try
+                                        let! r =
+                                            Transfer.runReverseLegThroughConnections
+                                                Transfer.Execute EmissionMode.Incremental false true false
+                                                [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
+                                        return Choice1Of2 r
+                                    with ex -> return Choice2Of2 ex
+                                })
+                        match outcome with
+                        | Choice1Of2 _ -> Assert.Fail "expected the object-scope DENY to crash the load (the pinned G1 gap)"
+                        | Choice2Of2 ex ->
+                            Assert.True(DmlPrincipal.isPermissionDenied ex, sprintf "expected the permission class, got: %s" ex.Message)
+                        // The partial write, pinned: the parent kind (City,
+                        // topologically first) already landed.
+                        let! cities = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                        Assert.Equal(2, cities)
+                        let! customers = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                        Assert.Equal(0, customers)
+                        return ()
+                    }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
@@ -107,24 +107,18 @@ module private ManagedGrantFixtures =
         (body: TransferConnections -> System.Threading.Tasks.Task<'a>)
         : System.Threading.Tasks.Task<'a> =
         task {
-            let srcFile = System.IO.Path.GetTempFileName()
-            let sinkFile = System.IO.Path.GetTempFileName()
-            System.IO.File.WriteAllText(srcFile, srcConnStr)
-            System.IO.File.WriteAllText(sinkFile, sinkConnStr)
-            try
-                let srcSub : Substrate =
-                    { Environment = Projection.Core.Environment.Qa
-                      Role = SubstrateRole.Source
-                      ConnectionRef = ConnectionRef.File srcFile }
-                let sinkSub : Substrate =
-                    { Environment = Projection.Core.Environment.Uat
-                      Role = SubstrateRole.Sink
-                      ConnectionRef = ConnectionRef.File sinkFile }
-                let connections = TransferConnections.create srcSub sinkSub reconcile |> value
-                return! body connections
-            finally
-                try System.IO.File.Delete srcFile with _ -> ()
-                try System.IO.File.Delete sinkFile with _ -> ()
+            // `ConnectionRef.Raw` (DECISIONS 2026-07-06): the ephemeral-DB
+            // string is already in memory — no temp-file round trip.
+            let srcSub : Substrate =
+                { Environment = Projection.Core.Environment.Qa
+                  Role = SubstrateRole.Source
+                  ConnectionRef = ConnectionRef.Raw srcConnStr }
+            let sinkSub : Substrate =
+                { Environment = Projection.Core.Environment.Uat
+                  Role = SubstrateRole.Sink
+                  ConnectionRef = ConnectionRef.Raw sinkConnStr }
+            let connections = TransferConnections.create srcSub sinkSub reconcile |> value
+            return! body connections
         }
 
     let kindByLogicalName (contract: Catalog) (name: string) : Kind =

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -34,6 +34,7 @@
     <Compile Include="VerifyDataIntegrationTests.fs" />
     <Compile Include="IngestionIntegrationTests.fs" />
     <Compile Include="TransferCanaryTests.fs" />
+    <Compile Include="PeerAlignedTransferDockerTests.fs" />
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />
     <Compile Include="ReverseLegStreamingTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="TransferCanaryTests.fs" />
     <Compile Include="PeerAlignedTransferDockerTests.fs" />
     <Compile Include="PeerManagedGrantTransferDockerTests.fs" />
+    <Compile Include="GoBoardDockerTests.fs" />
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />
     <Compile Include="ReverseLegStreamingTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <Compile Include="IntegrationCollections.fs" />
     <Compile Include="EphemeralContainerFixture.fs" />
+    <Compile Include="DmlPrincipal.fs" />
+    <Compile Include="MockOutSystemsEnv.fs" />
     <Compile Include="LiveSourceDockerTests.fs" />
     <Compile Include="PayOnceCombinedVerbDockerTests.fs" />
     <Compile Include="PayOnceSchemaReadDockerTests.fs" />
@@ -35,6 +37,7 @@
     <Compile Include="IngestionIntegrationTests.fs" />
     <Compile Include="TransferCanaryTests.fs" />
     <Compile Include="PeerAlignedTransferDockerTests.fs" />
+    <Compile Include="PeerManagedGrantTransferDockerTests.fs" />
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />
     <Compile Include="ReverseLegStreamingTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
@@ -246,34 +246,6 @@ module internal ReverseLegFixtures =
         "(1000,N'VP',1002),(1001,N'Mgr',1000),(1002,N'CEO',NULL),(1003,N'Ghost',9999); " +
         "SET IDENTITY_INSERT [dbo].[Employee] OFF;"
 
-    /// A login + db-user carrying EXACTLY the cloud sink's `grant: data`
-    /// envelope (database-scope SELECT, INSERT, UPDATE, DELETE — no ALTER,
-    /// no ddl_admin), created by the fixture's admin connection. Returns
-    /// (loginName, restricted connection string). The caller drops the
-    /// login in `finally` (the user dies with the ephemeral DB).
-    let createDmlPrincipal
-        (adminSink: Microsoft.Data.SqlClient.SqlConnection)
-        (sinkConnStr: string)
-        (grants: string)
-        : System.Threading.Tasks.Task<string * string> =
-        task {
-            let login = "l3dml_" + System.Guid.NewGuid().ToString("N").Substring(0, 8)
-            let password = "L3!dml#" + System.Guid.NewGuid().ToString("N").Substring(0, 12)
-            do! Deploy.executeBatch adminSink
-                    (sprintf "CREATE LOGIN [%s] WITH PASSWORD = N'%s'; CREATE USER [%s] FOR LOGIN [%s]; GRANT %s TO [%s];"
-                        login password login login grants login)
-            let builder = Microsoft.Data.SqlClient.SqlConnectionStringBuilder(sinkConnStr)
-            builder.UserID <- login
-            builder.Password <- password
-            return login, builder.ConnectionString
-        }
-
-    let dropLogin (adminSink: Microsoft.Data.SqlClient.SqlConnection) (login: string) : unit =
-        try
-            (Deploy.executeBatch adminSink (sprintf "DROP LOGIN [%s];" login)).GetAwaiter().GetResult()
-        with _ -> ()
-
-
 [<Xunit.Collection("Docker-SqlServer")>]
 type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
     interface IClassFixture<EphemeralContainerFixture>
@@ -640,7 +612,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
             (fun src _ adminSink sinkConnStr logicalContract physicalContract ->
                 task {
                     let! (login, restrictedConnStr) =
-                        ReverseLegFixtures.createDmlPrincipal adminSink sinkConnStr "SELECT, INSERT, UPDATE, DELETE"
+                        DmlPrincipal.createManaged adminSink sinkConnStr
                     try
                         use sink = new Microsoft.Data.SqlClient.SqlConnection(restrictedConnStr)
                         do! sink.OpenAsync()
@@ -660,7 +632,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                             [ ("acc-a1", Some "alice@x"); ("acc-a2", Some "alice@x"); ("acc-b1", Some "bob@x") ], aAccCust)
                         Assert.Equal(4, aPayInv.Length)
                     finally
-                        ReverseLegFixtures.dropLogin adminSink login
+                        DmlPrincipal.dropLogin adminSink login
                 })
 
     [<Fact>]
@@ -670,7 +642,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
             (fun _ _ adminSink sinkConnStr _ _ ->
                 task {
                     let! (login, restrictedConnStr) =
-                        ReverseLegFixtures.createDmlPrincipal adminSink sinkConnStr "SELECT, INSERT, UPDATE, DELETE"
+                        DmlPrincipal.createManaged adminSink sinkConnStr
                     try
                         use restricted = new Microsoft.Data.SqlClient.SqlConnection(restrictedConnStr)
                         do! restricted.OpenAsync()
@@ -682,7 +654,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                                     "SET IDENTITY_INSERT [dbo].[OSUSR_L3_CUSTOMER] ON;" :> System.Threading.Tasks.Task)
                         Assert.Contains("permission", ex.Message.ToLowerInvariant())
                     finally
-                        ReverseLegFixtures.dropLogin adminSink login
+                        DmlPrincipal.dropLogin adminSink login
                 })
 
     [<Fact>]
@@ -692,7 +664,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
             (fun src _ adminSink sinkConnStr logicalContract physicalContract ->
                 task {
                     let! (login, restrictedConnStr) =
-                        ReverseLegFixtures.createDmlPrincipal adminSink sinkConnStr "SELECT"
+                        DmlPrincipal.create adminSink sinkConnStr "SELECT"
                     try
                         use sink = new Microsoft.Data.SqlClient.SqlConnection(restrictedConnStr)
                         do! sink.OpenAsync()
@@ -708,7 +680,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         let! customers = ReverseLegFixtures.countRows adminSink "[dbo].[OSUSR_L3_CUSTOMER]"
                         Assert.Equal(0, customers)
                     finally
-                        ReverseLegFixtures.dropLogin adminSink login
+                        DmlPrincipal.dropLogin adminSink login
                 })
 
     [<Fact>]
@@ -723,7 +695,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
             (fun src _ adminSink sinkConnStr logicalContract physicalContract ->
                 task {
                     let! (login, restrictedConnStr) =
-                        ReverseLegFixtures.createDmlPrincipal adminSink sinkConnStr "SELECT, INSERT, UPDATE, DELETE"
+                        DmlPrincipal.createManaged adminSink sinkConnStr
                     try
                         do! Deploy.executeBatch adminSink
                                 (sprintf "DENY INSERT ON [dbo].[OSUSR_L3_INVOICE] TO [%s];" login)
@@ -740,7 +712,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         Assert.Equal(2, customers)
                         Assert.Equal(0, invoices)
                     finally
-                        ReverseLegFixtures.dropLogin adminSink login
+                        DmlPrincipal.dropLogin adminSink login
                 })
 
     // ------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests.Support/OssysSeedBuilder.fs
+++ b/sidecar/projection/tests/Projection.Tests.Support/OssysSeedBuilder.fs
@@ -1,0 +1,28 @@
+namespace Projection.Tests
+
+/// Espace-key parameterization of an OSSYS seed script (Tier 1 of the
+/// mock-environment fixture design, 2026-07-06). Real OutSystems espacing
+/// gives the SAME logical model DIFFERENT physical `OSUSR_<espace>_<name>`
+/// prefixes per environment; the transform shifts every `OSUSR_*` physical
+/// name — table names in DDL, `ossys_Entity.Physical_Table_Name` metamodel
+/// rows, and the constraint/default/check names OutSystems derives from the
+/// physical table — while GUID SS_Keys, logical names, and structure stay
+/// fixed. Anchored regex, not a blind `String.Replace`: the transform is a
+/// named, deliberate operation.
+[<RequireQualifiedAccess>]
+module OssysSeedBuilder =
+
+    /// Shift every `OSUSR_<KEY>_` physical prefix by prepending `newKey` to
+    /// the espace key (`withEspaceKey "X"` turns `OSUSR_ABC_CUSTOMER` into
+    /// `OSUSR_XABC_CUSTOMER` — byte-compatible with the espace-invariance
+    /// canary's historical transform).
+    let withEspaceKey (newKey: string) (seed: string) : string =
+        System.Text.RegularExpressions.Regex.Replace(
+            seed,
+            @"OSUSR_([A-Za-z0-9]+)_",
+            fun m -> "OSUSR_" + newKey + m.Groups.[1].Value + "_")
+
+    /// The identity transform — the COMMON QA→UAT case: LifeTime promotion
+    /// preserves the espace key, so both cells carry the SAME physical
+    /// names. (Deliberately named so a test declares which case it proves.)
+    let sameEspace (seed: string) : string = seed

--- a/sidecar/projection/tests/Projection.Tests.Support/Projection.Tests.Support.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Support/Projection.Tests.Support.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="TaskSync.fs" />
+    <Compile Include="OssysSeedBuilder.fs" />
     <Compile Include="TotalityFunctor.fs" />
     <Compile Include="IRBuilders.fs" />
     <Compile Include="Fixtures.fs" />

--- a/sidecar/projection/tests/Projection.Tests/CycleResolutionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CycleResolutionTests.fs
@@ -86,6 +86,24 @@ let private bKey = testKey "B"
 let private cKey = testKey "C"
 
 [<Fact>]
+let ``resolver: a Weak self-edge (nullable self-FK) is broken for ordering — phase 2 re-points it`` () =
+    // The 2026-07-06 self-loop rule (the peer-canary finding): a nullable
+    // self-reference (Category.Parent / Employee.Manager) must not degrade
+    // the whole catalog to the alphabetical fallback — the deferral
+    // machinery re-points it in phase 2 regardless of order.
+    let step =
+        CycleResolution.asymmetric2CycleStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Weak ]
+    Assert.Equal<(SsKey * SsKey) list>([ (aKey, aKey) ], step.EdgesToBreak)
+    Assert.Contains("auto-resolved", step.Reason)
+
+[<Fact>]
+let ``resolver: a non-Weak self-edge still refuses (a mandatory self-FK cannot defer)`` () =
+    let step =
+        CycleResolution.asymmetric2CycleStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Other ]
+    Assert.Empty(step.EdgesToBreak)
+    Assert.Contains("no Weak (nullable) self-edge", step.Reason)
+
+[<Fact>]
 let ``resolver: 2-cycle with exactly one Weak edge returns that edge`` () =
     let edges =
         [ (aKey, bKey), EdgeStrength.Weak

--- a/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
@@ -780,12 +780,53 @@ let private mkAcyclicLeveledCatalog () : Kind list =
     let indep = mkStaticLevelKind "LvlIndep" "OSUSR_TEST_LVL_INDEP" None [ "1" ]
     [ root; mid; leaf; indep ]
 
-/// The same graph PLUS a self-cycle kind. The unresolved 1-node SCC puts
-/// the WHOLE order into `Mode = Alphabetical` — the mint's degraded arm
+/// A pair of static kinds forming a genuinely UNRESOLVABLE cycle: each
+/// holds a NULLABLE FK to the other — a 2-SCC with TWO Weak edges, which
+/// the asymmetric resolver refuses by name ("multiple Weak edges; resolver
+/// refuses to choose"). Both FK columns are nullable + same-cycle, so both
+/// defer to Phase 2 (the partition law covers both phases).
+let private mkStaticMutualCycleKind (name: string) (table: string) (otherName: string) : Kind =
+    let kindKey = mkKey ["TestModule"; name]
+    let idKey = mkKey ["TestModule"; name; "Id"]
+    let peerKey = mkKey ["TestModule"; name; "PeerId"]
+    let row =
+        { Identifier = mkKey ["TestModule"; name; "Row"; "1"]
+          Values = Map.ofList [ mkName "Id", "1"; mkName "PeerId", "1" ] }
+    {
+        SsKey    = kindKey
+        Name     = mkName name
+        Origin   = Native
+        Modality = [ Static [ row ] ]
+        Physical = mkTableId "dbo" table
+        Attributes =
+            [
+                { Attribute.create idKey (mkName "Id") Integer with Column = ColumnRealization.create ("ID") (false) |> Result.value; IsPrimaryKey = true; IsMandatory = true }
+                { Attribute.create peerKey (mkName "PeerId") Integer with Column = ColumnRealization.create ("PEERID") (true) |> Result.value }
+            ]
+        References =
+            [ Reference.create (mkKey ["TestModule"; name; "RefPeer"]) (mkName "RefPeer") peerKey (mkKey ["TestModule"; otherName]) ]
+        Indexes    = []
+        Description = None
+        IsActive = true
+        Triggers = []
+        ColumnChecks = []
+        ExtendedProperties = []
+        }
+
+/// The same graph PLUS an unresolvable cycle. The unresolved SCC puts the
+/// WHOLE order into `Mode = Alphabetical` — the mint's degraded arm
 /// (singleton groups; no parallelism licensed) and the Phase-2 surface
-/// (the deferred self-FK re-points by UPDATE).
+/// (the deferred cycle FKs re-point by UPDATE).
+///
+/// Until 2026-07-06 the fixture was ONE nullable self-FK kind — the
+/// self-loop resolver rule (the peer-canary finding) now RESOLVES that
+/// shape, so the unresolvable premise needs the honest two-weak-edge
+/// 2-cycle instead. The self-FK kind stays in the partition-law sweep via
+/// `mkStaticSelfCycleKind` where its Phase-2 shape is what matters.
 let private mkCycleBearingCatalog () : Kind list =
-    mkAcyclicLeveledCatalog () @ [ mkStaticSelfCycleKind "LvlCyc" "OSUSR_TEST_LVL_CYC" ]
+    mkAcyclicLeveledCatalog ()
+    @ [ mkStaticMutualCycleKind "LvlCycA" "OSUSR_TEST_LVL_CYCA" "LvlCycB"
+        mkStaticMutualCycleKind "LvlCycB" "OSUSR_TEST_LVL_CYCB" "LvlCycA" ]
 
 let private composeBoth (kinds: Kind list) =
     let catalog = mkCatalog kinds
@@ -812,9 +853,14 @@ let private leveledSegmentsOf (leveled: DataEmissionComposer.LeveledDeploymentTe
 
 [<Fact>]
 let ``P2: composeRenderedLeveled PARTITIONS composeRenderedFull — segment multiset equality (faithful split, never a re-render)`` () =
-    // The law holds in BOTH modes: the Topological catalog (real levels)
-    // and the cycle-bearing one (Alphabetical fallback, singleton groups).
-    for kinds in [ mkAcyclicLeveledCatalog (); mkCycleBearingCatalog () ] do
+    // The law holds in EVERY mode: the Topological catalog (real levels),
+    // the unresolvable-cycle one (Alphabetical fallback, singleton groups),
+    // and the resolved-self-loop one (Topological since 2026-07-06 — the
+    // self-loop rule — with a Phase-2 surface).
+    for kinds in
+        [ mkAcyclicLeveledCatalog ()
+          mkCycleBearingCatalog ()
+          mkAcyclicLeveledCatalog () @ [ mkStaticSelfCycleKind "LvlCyc" "OSUSR_TEST_LVL_CYC" ] ] do
         let fused, leveled = composeBoth kinds
         let fusedSegments = segments fused |> List.sort
         let leveledSegments = leveledSegmentsOf leveled |> List.sort
@@ -843,17 +889,38 @@ let ``P2: the leveled plan deploys FK parents at earlier Phase-1 levels; FK-inde
 
 [<Fact>]
 let ``P2: an unresolved cycle anywhere degrades the plan to singleton groups — parallelism is never licensed on an alphabetical order`` () =
-    // One self-FK kind puts the WHOLE catalog into Mode = Alphabetical
-    // (the resolver does not break 1-node SCCs); under it "parents
-    // precede children" no longer holds, so the mint refuses multi-member
-    // groups — the leveled deploy degrades to exactly the fused
-    // sequential order, never to unproven concurrency. (The P2-wire
-    // finding: before the mode guard, this catalog collapsed the real
-    // Root←Mid←Leaf FK chain into ONE concurrent group.)
+    // One UNRESOLVABLE cycle (the mutual-weak-FK pair — the resolver
+    // refuses to choose between two Weak edges) puts the WHOLE catalog
+    // into Mode = Alphabetical; under it "parents precede children" no
+    // longer holds, so the mint refuses multi-member groups — the leveled
+    // deploy degrades to exactly the fused sequential order, never to
+    // unproven concurrency. (The P2-wire finding: before the mode guard,
+    // this catalog collapsed the real Root←Mid←Leaf FK chain into ONE
+    // concurrent group.)
     let _, leveled = composeBoth (mkCycleBearingCatalog ())
     for level in leveled.Phase1Levels @ leveled.Phase2Levels do
         Assert.Equal(1, ParallelSafe.members level |> List.length)
-    // The self-cycle kind's deferred FK still lands in Phase 2.
+    // The cycle pair's deferred FKs still land in Phase 2.
+    Assert.NotEmpty leveled.Phase2Levels
+
+[<Fact>]
+let ``P2: a nullable self-FK no longer degrades the order — the self-loop resolves, levels stay licensed, the deferral stays`` () =
+    // The 2026-07-06 self-loop rule (the peer-canary finding): the common
+    // OutSystems shape (Category.Parent / Employee.Manager) must not cost
+    // the estate its topological order — the self-edge breaks for
+    // ordering, the resolved SCC keeps the kind in `Cycles`, and the
+    // nullable self-FK still re-points by Phase-2 UPDATE.
+    let _, leveled =
+        composeBoth (mkAcyclicLeveledCatalog () @ [ mkStaticSelfCycleKind "LvlCyc" "OSUSR_TEST_LVL_CYC" ])
+    // The acyclic chain's root level still carries ≥2 concurrent members —
+    // parallelism is NOT surrendered to the self-loop.
+    let rootLevel =
+        leveled.Phase1Levels
+        |> List.find (fun lvl ->
+            ParallelSafe.members lvl |> List.exists (fun s -> s.Contains "OSUSR_TEST_LVL_ROOT"))
+    Assert.True(ParallelSafe.members rootLevel |> List.length >= 2,
+                "the self-loop must not degrade the acyclic chain's parallel levels")
+    // The self-FK still defers: Phase 2 re-points it.
     Assert.NotEmpty leveled.Phase2Levels
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
@@ -327,9 +327,14 @@ let ``A44 clause 3 — the reverse leg (B→A) routes to RunReverseLeg; a peer (
     | other -> Assert.Fail(sprintf "expected RunReverseLeg for B→A, got %A" other)
     let peerCfg, peerFlow = mk Rendition.Physical Rendition.Physical
     Assert.Equal(MovementDirection.UpPeer, (Command.resolveFlowSpec peerCfg peerFlow commit |> mustOk).Direction)
+    // 2026-07-06 (the partial-transfer readiness program): the A→A peer no
+    // longer rides the name-blind `Transfer` — it routes to `TransferPeer`,
+    // the SsKey-aligned leg (per-side OSSYS contracts, shape + subset-FK
+    // gates). An env→env flow with UNSET renditions keeps `Transfer` (the
+    // identical-rendition escape hatch) — pinned below.
     match (Command.planFlow peerCfg peerFlow commit).Action with
-    | PlanAction.Transfer _ -> ()
-    | other -> Assert.Fail(sprintf "expected Transfer for A→A peer, got %A" other)
+    | PlanAction.TransferPeer _ -> ()
+    | other -> Assert.Fail(sprintf "expected TransferPeer for A→A peer, got %A" other)
 
 // ---------------------------------------------------------------------------
 // CLAUSE 2 — TOTALITY / SPANNING: `reachable ⇔ expressible` (THE forcing

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -608,10 +608,19 @@ let ``planMovement: a data move with Direction=UpLegacy routes to RunReverseLeg,
     match planOf legacy with
     | PlanAction.RunReverseLeg (ModelSource.ModelFile "m.json", None, "env:QA_CONN", "env:DEV_CONN", _, true) -> ()
     | other -> Assert.Fail(sprintf "expected RunReverseLeg, got %A" other)
+    // 2026-07-06 (the partial-transfer readiness program): a peer (UpPeer)
+    // data move routes to `TransferPeer` (SsKey-aligned, per-side OSSYS
+    // contracts + shape/subset-FK gates); an env→env move whose renditions
+    // are UNSET derives `Down` and keeps the name-blind generic `Transfer`
+    // (the identical-rendition escape hatch).
     let peer = { legacy with Direction = MovementDirection.UpPeer }
     match planOf peer with
+    | PlanAction.TransferPeer ("env:QA_CONN", "env:DEV_CONN", _, true) -> ()
+    | other -> Assert.Fail(sprintf "expected TransferPeer, got %A" other)
+    let down = { legacy with Direction = MovementDirection.Down }
+    match planOf down with
     | PlanAction.Transfer ("env:QA_CONN", "env:DEV_CONN", _, true) -> ()
-    | other -> Assert.Fail(sprintf "expected Transfer, got %A" other)
+    | other -> Assert.Fail(sprintf "expected Transfer for an unset-rendition env→env move, got %A" other)
 
 // -- flow resolution (THE_CLI.md 2026-06-08; slice F2) ----------------------
 

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -435,7 +435,7 @@ let ``J3: the rendered pair is SsKey-aligned by construction; the repoint is the
     // identity repoint. The rendition difference rides each contract's
     // physical coordinates at its own SQL boundary (source reads by B's
     // names, sink writes by A's), the LE-2-proven mechanism.
-    let renameMap = RenameProjection.renames diff |> RenameProjection.renameMap
+    let renameMap = RenameProjection.renames diff |> RenameProjection.renameMapByKind
     Assert.True(Map.isEmpty renameMap)
 
 // -- planMovement routing (the pure surface→engine map) --------------------

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -290,6 +290,41 @@ let ``shapeGate: nullable-in-source but NOT-NULL-in-sink blocks; the reverse is 
     | Ok advisories -> Assert.True(advisories |> List.exists (fun l -> l.Contains "permissive"), sprintf "expected the loosening advisory, got %A" advisories)
     | other -> Assert.Fail(sprintf "expected an advisory pass, got %A" other)
 
+// --- THE GO BOARD (pure verdict algebra + render marks) -----------------------
+
+[<Fact>]
+let ``GoBoard: green iff zero red items; advisories never block; exit 0/5`` () =
+    let g = GoBoard.item "a" (GoBoard.Status.Green "ok")
+    let adv = GoBoard.item "b" (GoBoard.Status.Advisory "note")
+    let red = GoBoard.item "c" (GoBoard.Status.Red ("broken", "fix it"))
+    let board items : GoBoard.Board = { Flow = "golden"; From = "qa"; To = "uat"; Items = items }
+    Assert.True(GoBoard.isGreen (board [ g; adv ]))
+    Assert.Equal(0, GoBoard.exitCode (board [ g; adv ]))
+    Assert.False(GoBoard.isGreen (board [ g; adv; red ]))
+    Assert.Equal(5, GoBoard.exitCode (board [ g; adv; red ]))
+    Assert.Equal(1, GoBoard.redCount (board [ g; red ]))
+
+[<Fact>]
+let ``GoBoard: the render carries the marks, the remedy, the detail, and the verdict with the next move`` () =
+    let board : GoBoard.Board =
+        { Flow = "golden"; From = "qa"; To = "uat"
+          Items =
+            [ GoBoard.item "routing" (GoBoard.Status.Green "peer leg")
+              GoBoard.itemWith "relationships" (GoBoard.Status.Red ("2 escapes", "add the reconcile")) [ "Customer.CityId -> City" ]
+              GoBoard.item "execute gates" (GoBoard.Status.Advisory "two gates at run time") ] }
+    let text = GoBoard.render board |> String.concat "\n"
+    Assert.Contains("[ GO ] routing", text)
+    Assert.Contains("[STOP] relationships", text)
+    Assert.Contains("-> add the reconcile", text)
+    Assert.Contains("Customer.CityId -> City", text)
+    Assert.Contains("[note] execute gates", text)
+    Assert.Contains("VERDICT — RED. 1 open decision", text)
+    Assert.Contains("check go golden", text)
+    let green = { board with Items = board.Items |> List.filter (fun i -> i.Axis <> "relationships") }
+    let greenText = GoBoard.render green |> String.concat "\n"
+    Assert.Contains("VERDICT — GREEN", greenText)
+    Assert.Contains("PROJECTION_ALLOW_EXECUTE=1 projection golden --go", greenText)
+
 // --- the Preflight classification of the two new axes -------------------------
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -105,6 +105,29 @@ let ``resolveLoadSet: every unknown name is aggregated into one named refusal`` 
         Assert.DoesNotContain("Customer", e.Message)
     | other -> Assert.Fail(sprintf "expected the aggregated refusal, got %A" other)
 
+[<Fact>]
+let ``resolveLoadSet: a duplicate logical name refuses as ambiguous; the Module.Entity form disambiguates`` () =
+    // 2026-07-06 (adversarial MEDIUM #6): the prior Map.ofList silently
+    // last-won a duplicate name across modules.
+    let dupCity =
+        { Kind.create (SsKey.synthesizedComposite "PEER_KIND" [ "City2" ] |> Result.value) (nm "City")
+            (TableId.create "dbo" "OSUSR_ZZZ_CITY" |> Result.value)
+            [ idPk "City2" ] with Attributes = [ idPk "City2" ] }
+    let m2 =
+        Module.create (SsKey.synthesizedComposite "PEER_MOD" [ "Ops" ] |> Result.value)
+            (nm "Ops") [ dupCity ] true []
+        |> Result.value
+    let twoModules = Catalog.create [ srcCell.Modules.Head; m2 ] [] |> Result.value
+    match Transfer.resolveLoadSet twoModules [ "City" ] with
+    | Error [ e ] ->
+        Assert.Equal("transfer.tablesAmbiguous", e.Code)
+        Assert.Contains("AppCore.City", e.Message)
+        Assert.Contains("Ops.City", e.Message)
+    | other -> Assert.Fail(sprintf "expected the ambiguity refusal, got %A" other)
+    match Transfer.resolveLoadSet twoModules [ "AppCore.City" ] with
+    | Ok (Some set) -> Assert.Equal<Set<SsKey>>(keys [ "City" ], set)
+    | other -> Assert.Fail(sprintf "expected the qualified form to resolve, got %A" other)
+
 // --- the escaping-FK detector ------------------------------------------------
 
 [<Fact>]
@@ -140,17 +163,30 @@ let ``escapingFks: the chain stops at the subset boundary (Order alone escapes t
 // --- the subset-FK gate's refuse/downgrade contract ---------------------------
 
 [<Fact>]
-let ``subsetFkGate: a preview never refuses; a live run with escapes refuses by name; --allow-drops downgrades`` () =
+let ``subsetFkGate: a preview never refuses; a live run with escapes refuses by name — --allow-drops does NOT bypass`` () =
+    // 2026-07-06 (adversarial CRITICAL #2): the --allow-drops bypass is
+    // GONE — nothing on the write plane drops an escaping FK; the rows
+    // would land carrying SOURCE-environment surrogates (silent
+    // cross-wiring). The gate refuses until the target is reconciled or
+    // the subset widened.
     let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) Set.empty
-    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate false false escapes))
-    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate true true escapes))
-    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate true false []))
-    match PeerTransfer.subsetFkGate true false escapes with
+    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate false escapes))
+    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate true []))
+    match PeerTransfer.subsetFkGate true escapes with
     | Error [ e ] ->
         Assert.Equal("transfer.peer.subsetFkEscapes", e.Code)
         Assert.Contains("City", e.Message)
-        Assert.Contains("--allow-drops", e.Message)
+        Assert.Contains("SOURCE-environment references", e.Message)
     | other -> Assert.Fail(sprintf "expected the named refusal, got %A" other)
+
+[<Fact>]
+let ``narrateEscapes: proposals carry the RESOLVABLE Module.Entity:Column reconcile form`` () =
+    // Adversarial MEDIUM #8: the bare logical name resolves by PHYSICAL
+    // table only — the proposal must be copy-pasteable.
+    let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) Set.empty
+    let lines = PeerTransfer.narrateEscapes escapes
+    Assert.True(lines |> List.exists (fun l -> l.Contains "AppCore.City:Name"),
+                sprintf "expected the Module.Entity:Column form, got %A" lines)
 
 // --- the shape gate -----------------------------------------------------------
 
@@ -224,7 +260,9 @@ let ``shapeGate: a data-type divergence blocks; a widened length is advisory`` (
     | other -> Assert.Fail(sprintf "expected an advisory pass, got %A" other)
 
 [<Fact>]
-let ``shapeGate: nullable-in-source but mandatory-in-sink blocks; the reverse is advisory`` () =
+let ``shapeGate: nullable-in-source but NOT-NULL-in-sink blocks; the reverse is advisory`` () =
+    // The verdict judges the COLUMN plane (`ColumnRealization.IsNullable`) —
+    // the same plane the Nullability facet fires on (adversarial LOW #12).
     let tightened =
         sinkCell
         |> mapKind "Customer" (fun k ->
@@ -236,7 +274,7 @@ let ``shapeGate: nullable-in-source but mandatory-in-sink blocks; the reverse is
                             { a with IsMandatory = true; Column = ColumnRealization.create "SECONDCITYID" false |> Result.value }
                         else a) })
     match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell tightened with
-    | Error [ e ] -> Assert.Contains("mandatory in the sink", e.Message)
+    | Error [ e ] -> Assert.Contains("NOT NULL in the sink", e.Message)
     | other -> Assert.Fail(sprintf "expected the tightening refusal, got %A" other)
     let loosened =
         sinkCell

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -1,0 +1,261 @@
+module Projection.Tests.PeerTransferTests
+
+// The peer (A→A) leg's pure gates (2026-07-06, the partial-transfer
+// readiness program; `PeerTransfer.fs`): the SS_KEY-keyed shape gate, the
+// escaping-FK detector + strategy proposals, the subset-FK gate's
+// refuse/downgrade contract, `Transfer.resolveLoadSet`'s refusal semantics
+// (previously only exercised inside docker canaries), and the two new
+// `Preflight` classification axes.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+// --- the two espace-variant contracts (same SsKeys, different physical) -----
+
+let private nm (s: string) : Name = Name.create s |> Result.value
+let private kKey (s: string) : SsKey = SsKey.synthesizedComposite "PEER_KIND" [ s ] |> Result.value
+let private aKey (k: string) (a: string) : SsKey = SsKey.synthesizedComposite "PEER_ATTR" [ k; a ] |> Result.value
+let private rKey (k: string) (r: string) : SsKey = SsKey.synthesizedComposite "PEER_REF" [ k; r ] |> Result.value
+let private xKey (k: string) (x: string) : SsKey = SsKey.synthesizedComposite "PEER_IDX" [ k; x ] |> Result.value
+
+let private idPk (kind: string) : Attribute =
+    { Attribute.create (aKey kind "Id") (nm "Id") Integer with
+        Column       = ColumnRealization.create "ID" false |> Result.value
+        IsPrimaryKey = true
+        IsIdentity   = true
+        IsMandatory  = true }
+
+let private textCol (kind: string) (logical: string) (mandatory: bool) : Attribute =
+    { Attribute.create (aKey kind logical) (nm logical) Text with
+        Column      = ColumnRealization.create (logical.ToUpperInvariant()) (not mandatory) |> Result.value
+        Length      = Some 200
+        IsMandatory = mandatory }
+
+let private fkCol (kind: string) (logical: string) (mandatory: bool) : Attribute =
+    { Attribute.create (aKey kind logical) (nm logical) Integer with
+        Column      = ColumnRealization.create (logical.ToUpperInvariant()) (not mandatory) |> Result.value
+        IsMandatory = mandatory }
+
+/// One cell of the model at a physical prefix: City (unique NAME — the
+/// reconcile candidate), Customer (mandatory CityId FK→City, optional
+/// SecondCityId FK→City, unique EMAIL), Order (mandatory CustomerId
+/// FK→Customer).
+let private cellAt (prefix: string) : Catalog =
+    let city =
+        { Kind.create (kKey "City") (nm "City")
+            (TableId.create "dbo" (prefix + "CITY") |> Result.value)
+            [ idPk "City"; textCol "City" "Name" true ] with
+            Indexes =
+                [ { Index.create (xKey "City" "ByName") (nm "IDX_CITY_NAME")
+                      [ IndexColumn.create (aKey "City" "Name") Ascending ] with
+                      Uniqueness = Unique } ] }
+    let customer =
+        { Kind.create (kKey "Customer") (nm "Customer")
+            (TableId.create "dbo" (prefix + "CUSTOMER") |> Result.value)
+            [ idPk "Customer"
+              textCol "Customer" "Email" true
+              fkCol "Customer" "CityId" true
+              fkCol "Customer" "SecondCityId" false ] with
+            References =
+                [ Reference.create (rKey "Customer" "City") (nm "CityId") (aKey "Customer" "CityId") (kKey "City")
+                  Reference.create (rKey "Customer" "SecondCity") (nm "SecondCityId") (aKey "Customer" "SecondCityId") (kKey "City") ]
+            Indexes =
+                [ { Index.create (xKey "Customer" "ByEmail") (nm "IDX_CUSTOMER_EMAIL")
+                      [ IndexColumn.create (aKey "Customer" "Email") Ascending ] with
+                      Uniqueness = Unique } ] }
+    let order =
+        { Kind.create (kKey "Order") (nm "Order")
+            (TableId.create "dbo" (prefix + "ORDER") |> Result.value)
+            [ idPk "Order"; fkCol "Order" "CustomerId" true ] with
+            References =
+                [ Reference.create (rKey "Order" "Customer") (nm "CustomerId") (aKey "Order" "CustomerId") (kKey "Customer") ] }
+    let m =
+        Module.create (SsKey.synthesizedComposite "PEER_MOD" [ "AppCore" ] |> Result.value)
+            (nm "AppCore") [ city; customer; order ] true []
+        |> Result.value
+    Catalog.create [ m ] [] |> Result.value
+
+let private srcCell  = cellAt "OSUSR_AAA_"
+let private sinkCell = cellAt "OSUSR_BBB_"
+
+let private keys (names: string list) : Set<SsKey> = names |> List.map kKey |> Set.ofList
+
+// --- Transfer.resolveLoadSet (the previously-untested resolver) -------------
+
+[<Fact>]
+let ``resolveLoadSet: an empty declaration is None (all kinds)`` () =
+    match Transfer.resolveLoadSet srcCell [] with
+    | Ok None -> ()
+    | other -> Assert.Fail(sprintf "expected Ok None, got %A" other)
+
+[<Fact>]
+let ``resolveLoadSet: logical names resolve case-insensitively to SsKeys`` () =
+    match Transfer.resolveLoadSet srcCell [ "customer"; "CITY" ] with
+    | Ok (Some set) -> Assert.Equal<Set<SsKey>>(keys [ "Customer"; "City" ], set)
+    | other -> Assert.Fail(sprintf "expected the two keys, got %A" other)
+
+[<Fact>]
+let ``resolveLoadSet: every unknown name is aggregated into one named refusal`` () =
+    match Transfer.resolveLoadSet srcCell [ "Customer"; "Ghost"; "Phantom" ] with
+    | Error [ e ] ->
+        Assert.Equal("transfer.tablesUnknown", e.Code)
+        Assert.Contains("Ghost", e.Message)
+        Assert.Contains("Phantom", e.Message)
+        Assert.DoesNotContain("Customer", e.Message)
+    | other -> Assert.Fail(sprintf "expected the aggregated refusal, got %A" other)
+
+// --- the escaping-FK detector ------------------------------------------------
+
+[<Fact>]
+let ``escapingFks: a subset whose FK closure is inside it has no escapes`` () =
+    Assert.Empty(PeerTransfer.escapingFks srcCell (keys [ "City"; "Customer"; "Order" ]) Set.empty)
+
+[<Fact>]
+let ``escapingFks: an in-subset child names every out-of-subset parent, with reconcile candidates`` () =
+    let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) Set.empty
+    Assert.Equal(2, escapes.Length)   // CityId (mandatory) + SecondCityId (optional), both → City
+    for e in escapes do
+        Assert.Equal("Customer", Name.value e.KindName)
+        Assert.Equal("City", Name.value e.TargetName)
+        // The proposal: City's single-column unique non-PK index → Name.
+        Assert.Equal<string list>([ "Name" ], e.CandidateReconcileColumns |> List.map Name.value)
+    let byColumn = escapes |> List.map (fun e -> Name.value e.Column, e.Nullable) |> Map.ofList
+    Assert.False(byColumn.["CityId"])        // mandatory FK — a hard escape
+    Assert.True(byColumn.["SecondCityId"])   // optional FK — rows with NULL pass
+
+[<Fact>]
+let ``escapingFks: a reconciled target is strategized — no escape`` () =
+    let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) (keys [ "City" ])
+    Assert.Empty(escapes)
+
+[<Fact>]
+let ``escapingFks: the chain stops at the subset boundary (Order alone escapes to Customer, not City)`` () =
+    let escapes = PeerTransfer.escapingFks srcCell (keys [ "Order" ]) Set.empty
+    Assert.Equal(1, escapes.Length)
+    Assert.Equal("Customer", Name.value escapes.Head.TargetName)
+    // Customer's unique non-PK column proposes the re-key.
+    Assert.Equal<string list>([ "Email" ], escapes.Head.CandidateReconcileColumns |> List.map Name.value)
+
+// --- the subset-FK gate's refuse/downgrade contract ---------------------------
+
+[<Fact>]
+let ``subsetFkGate: a preview never refuses; a live run with escapes refuses by name; --allow-drops downgrades`` () =
+    let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) Set.empty
+    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate false false escapes))
+    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate true true escapes))
+    Assert.True(Result.isSuccess (PeerTransfer.subsetFkGate true false []))
+    match PeerTransfer.subsetFkGate true false escapes with
+    | Error [ e ] ->
+        Assert.Equal("transfer.peer.subsetFkEscapes", e.Code)
+        Assert.Contains("City", e.Message)
+        Assert.Contains("--allow-drops", e.Message)
+    | other -> Assert.Fail(sprintf "expected the named refusal, got %A" other)
+
+// --- the shape gate -----------------------------------------------------------
+
+[<Fact>]
+let ``shapeGate: two espace-variant cells of one model are one shape (no blocking, no advisory)`` () =
+    match PeerTransfer.shapeGate None srcCell sinkCell with
+    | Ok [] -> ()
+    | other -> Assert.Fail(sprintf "expected a clean pass, got %A" other)
+
+let private mapKind (name: string) (f: Kind -> Kind) (c: Catalog) : Catalog =
+    { c with
+        Modules =
+            c.Modules
+            |> List.map (fun m ->
+                { m with Kinds = m.Kinds |> List.map (fun k -> if Name.value k.Name = name then f k else k) }) }
+
+let private dropKind (name: string) (c: Catalog) : Catalog =
+    { c with
+        Modules =
+            c.Modules
+            |> List.map (fun m -> { m with Kinds = m.Kinds |> List.filter (fun k -> Name.value k.Name <> name) }) }
+
+[<Fact>]
+let ``shapeGate: a source kind missing from the sink blocks — inside scope only`` () =
+    let sinkNoOrder = dropKind "Order" sinkCell
+    match PeerTransfer.shapeGate (Some (keys [ "Order" ])) srcCell sinkNoOrder with
+    | Error [ e ] ->
+        Assert.Equal("transfer.peer.shapeDivergence", e.Code)
+        Assert.Contains("Order", e.Message)
+    | other -> Assert.Fail(sprintf "expected the shape refusal, got %A" other)
+    // The same divergence OUTSIDE the scoped subset does not block the run.
+    match PeerTransfer.shapeGate (Some (keys [ "City"; "Customer" ])) srcCell sinkNoOrder with
+    | Ok _ -> ()
+    | other -> Assert.Fail(sprintf "expected the scoped gate to pass, got %A" other)
+
+[<Fact>]
+let ``shapeGate: a source-only attribute blocks (its values have no landing column)`` () =
+    let sinkNoEmail =
+        sinkCell
+        |> mapKind "Customer" (fun k ->
+            { k with
+                Attributes = k.Attributes |> List.filter (fun a -> Name.value a.Name <> "Email")
+                Indexes = [] })
+    match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell sinkNoEmail with
+    | Error [ e ] ->
+        Assert.Equal("transfer.peer.shapeDivergence", e.Code)
+        Assert.Contains("Email", e.Message)
+    | other -> Assert.Fail(sprintf "expected the shape refusal, got %A" other)
+
+[<Fact>]
+let ``shapeGate: a data-type divergence blocks; a widened length is advisory`` () =
+    let typeChanged =
+        sinkCell
+        |> mapKind "Customer" (fun k ->
+            { k with
+                Attributes =
+                    k.Attributes
+                    |> List.map (fun a -> if Name.value a.Name = "Email" then { a with Type = Integer; Length = None } else a) })
+    match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell typeChanged with
+    | Error [ e ] -> Assert.Contains("data type", e.Message)
+    | other -> Assert.Fail(sprintf "expected the type refusal, got %A" other)
+    let widened =
+        sinkCell
+        |> mapKind "Customer" (fun k ->
+            { k with
+                Attributes =
+                    k.Attributes
+                    |> List.map (fun a -> if Name.value a.Name = "Email" then { a with Length = Some 400 } else a) })
+    match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell widened with
+    | Ok advisories -> Assert.True(advisories |> List.exists (fun l -> l.Contains "wider"), sprintf "expected the widening advisory, got %A" advisories)
+    | other -> Assert.Fail(sprintf "expected an advisory pass, got %A" other)
+
+[<Fact>]
+let ``shapeGate: nullable-in-source but mandatory-in-sink blocks; the reverse is advisory`` () =
+    let tightened =
+        sinkCell
+        |> mapKind "Customer" (fun k ->
+            { k with
+                Attributes =
+                    k.Attributes
+                    |> List.map (fun a ->
+                        if Name.value a.Name = "SecondCityId" then
+                            { a with IsMandatory = true; Column = ColumnRealization.create "SECONDCITYID" false |> Result.value }
+                        else a) })
+    match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell tightened with
+    | Error [ e ] -> Assert.Contains("mandatory in the sink", e.Message)
+    | other -> Assert.Fail(sprintf "expected the tightening refusal, got %A" other)
+    let loosened =
+        sinkCell
+        |> mapKind "Customer" (fun k ->
+            { k with
+                Attributes =
+                    k.Attributes
+                    |> List.map (fun a ->
+                        if Name.value a.Name = "CityId" then
+                            { a with IsMandatory = false; Column = ColumnRealization.create "CITYID" true |> Result.value }
+                        else a) })
+    match PeerTransfer.shapeGate (Some (keys [ "Customer" ])) srcCell loosened with
+    | Ok advisories -> Assert.True(advisories |> List.exists (fun l -> l.Contains "permissive"), sprintf "expected the loosening advisory, got %A" advisories)
+    | other -> Assert.Fail(sprintf "expected an advisory pass, got %A" other)
+
+// --- the Preflight classification of the two new axes -------------------------
+
+[<Fact>]
+let ``classify: the peer gates carry their own exits (shape 5; subset-FK 9; ossys read 6)`` () =
+    Assert.Equal((5, Preflight.ShapeDivergence), Preflight.classify "transfer.peer.shapeDivergence")
+    Assert.Equal((9, Preflight.SubsetFkEscape), Preflight.classify "transfer.peer.subsetFkEscapes")
+    Assert.Equal((6, Preflight.SchemaReadFailed), Preflight.classify "source.ossys.readFailed")

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -185,7 +185,7 @@ let ``narrateEscapes: proposals carry the RESOLVABLE Module.Entity:Column reconc
     // table only — the proposal must be copy-pasteable.
     let escapes = PeerTransfer.escapingFks srcCell (keys [ "Customer" ]) Set.empty
     let lines = PeerTransfer.narrateEscapes escapes
-    Assert.True(lines |> List.exists (fun l -> l.Contains "AppCore.City:Name"),
+    Assert.True(lines |> List.exists (fun l -> l.Contains "AppCore.City:Name" && l.Contains "escapes the subset"),
                 sprintf "expected the Module.Entity:Column form, got %A" lines)
 
 // --- the shape gate -----------------------------------------------------------
@@ -343,6 +343,25 @@ let ``GoBoard: the render carries the marks, the remedy, the detail, and the ver
     let greenText = GoBoard.render green |> String.concat "\n"
     Assert.Contains("VERDICT — GREEN", greenText)
     Assert.Contains("PROJECTION_ALLOW_EXECUTE=1 projection golden --go", greenText)
+
+[<Fact>]
+let ``GoBoard: the JSON projection carries verdict, redCount, and per-item status/remedy/detail`` () =
+    let board : GoBoard.Board =
+        { Flow = "golden"; From = "qa"; To = "uat"
+          Items =
+            [ GoBoard.item "routing" (GoBoard.Status.Green "peer leg")
+              GoBoard.itemWith "relationships" (GoBoard.Status.Red ("2 escapes", "add the reconcile")) [ "Customer.CityId -> City" ] ] }
+    let json = GoBoard.toJsonString board
+    use doc = System.Text.Json.JsonDocument.Parse json
+    let root = doc.RootElement
+    Assert.Equal("red", root.GetProperty("verdict").GetString())
+    Assert.Equal(1, root.GetProperty("redCount").GetInt32())
+    let items = root.GetProperty("items")
+    Assert.Equal(2, items.GetArrayLength())
+    let rel = items.[1]
+    Assert.Equal("red", rel.GetProperty("status").GetString())
+    Assert.Equal("add the reconcile", rel.GetProperty("remedy").GetString())
+    Assert.Equal("Customer.CityId -> City", rel.GetProperty("detail").[0].GetString())
 
 // --- the Preflight classification of the two new axes -------------------------
 

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -290,6 +290,25 @@ let ``shapeGate: nullable-in-source but NOT-NULL-in-sink blocks; the reverse is 
     | Ok advisories -> Assert.True(advisories |> List.exists (fun l -> l.Contains "permissive"), sprintf "expected the loosening advisory, got %A" advisories)
     | other -> Assert.Fail(sprintf "expected an advisory pass, got %A" other)
 
+// --- the ENGINE-level subset-escape gate (the parity sweep, 2026-07-06) -------
+// The peer FACE narrates rich proposals; this backstop refuses from ANY leg
+// (legacy reverse / forward transfer) so the cross-wiring hazard is
+// unreachable engine-wide.
+
+[<Fact>]
+let ``subsetEscapeGate: a full transfer or a closed/reconciled subset passes; an escaping edge refuses on the leg-neutral code`` () =
+    Assert.Equal(None, Transfer.subsetEscapeGate srcCell None Set.empty)
+    Assert.Equal(None, Transfer.subsetEscapeGate srcCell (Some (keys [ "City"; "Customer"; "Order" ])) Set.empty)
+    Assert.Equal(None, Transfer.subsetEscapeGate srcCell (Some (keys [ "Customer" ])) (keys [ "City" ]))
+    match Transfer.subsetEscapeGate srcCell (Some (keys [ "Customer" ])) Set.empty with
+    | Some e ->
+        Assert.Equal("transfer.subsetFkEscapes", e.Code)
+        Assert.Contains("Customer.CityId -> City", e.Message)
+        Assert.Contains("SOURCE-environment references", e.Message)
+    | None -> Assert.Fail "expected the engine-level escape refusal"
+    // The classification rides the SAME axis as the peer face's refusal.
+    Assert.Equal((9, Preflight.SubsetFkEscape), Preflight.classify "transfer.subsetFkEscapes")
+
 // --- THE GO BOARD (pure verdict algebra + render marks) -----------------------
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -159,6 +159,7 @@
     <Compile Include="ReconciliationCompositeKeyTests.fs" />
     <Compile Include="ConnectionResolverTests.fs" />
     <Compile Include="TransferSpecTests.fs" />
+    <Compile Include="PeerTransferTests.fs" />
     <Compile Include="CaptureJournalTests.fs" />
     <Compile Include="RowQuantumTests.fs" />
     <Compile Include="ModelResolutionTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RenameProjectionTests.fs
@@ -58,8 +58,9 @@ let ``6.B.2: a renamed column is re-pointed by the rename map, not matched by or
     // Email's value onto Contact by NAME; Phone is untouched. A positional
     // (ordinal) scheme could not distinguish this — the re-point is by identity.
     let map =
-        RenameProjection.renameMap
-            [ { Attribute = aKey "Email"; SourceName = nm "Email"; SinkName = nm "Contact" } ]
+        RenameProjection.renameMapByKind
+            [ { Kind = kKey "Customer"; Attribute = aKey "Email"; SourceName = nm "Email"; SinkName = nm "Contact" } ]
+        |> RenameProjection.forKind (kKey "Customer")
     let row = rowOf [ "Email", "alice@x"; "Phone", "555" ]
     let out = RenameProjection.repointRow map row
     Assert.Equal("alice@x", out.Values.[nm "Contact"])
@@ -69,8 +70,9 @@ let ``6.B.2: a renamed column is re-pointed by the rename map, not matched by or
 [<Fact>]
 let ``6.B.2: the value follows the name regardless of insertion order (not ordinal)`` () =
     let map =
-        RenameProjection.renameMap
-            [ { Attribute = aKey "Email"; SourceName = nm "Email"; SinkName = nm "Contact" } ]
+        RenameProjection.renameMapByKind
+            [ { Kind = kKey "Customer"; Attribute = aKey "Email"; SourceName = nm "Email"; SinkName = nm "Contact" } ]
+        |> RenameProjection.forKind (kKey "Customer")
     // Same cells, reversed insertion order — the re-point result is identical,
     // because it keys on the name, not the position.
     let a = RenameProjection.repointRow map (rowOf [ "Email", "x"; "Phone", "y" ])
@@ -90,7 +92,10 @@ let ``6.B.2: end-to-end — diff-derived renames re-point a source row onto the 
     // re-point a source-shaped row onto the sink's names.
     let a = catOf (custKind "Email" "EMAIL")
     let b = catOf (custKind "Contact" "CONTACT")
-    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMap
+    let map =
+        RenameProjection.renames (betweenOk a b)
+        |> RenameProjection.renameMapByKind
+        |> RenameProjection.forKind (kKey "Customer")
     let sourceRow = rowOf [ "Id", "1"; "Email", "bob@x" ]
     let sinkRow = RenameProjection.repointRow map sourceRow
     Assert.Equal("bob@x", sinkRow.Values.[nm "Contact"])
@@ -107,7 +112,10 @@ let ``6.B.2: end-to-end — diff-derived renames re-point a source row onto the 
 let ``A5: the migrate-with-data rename map derives from between(sinkSource=A, target=B) and re-points A->B`` () =
     let a = catOf (custKind "Email" "EMAIL")    // sinkSource — the data source's schema A
     let b = catOf (custKind "Contact" "CONTACT") // target — the migrated sink schema B
-    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMap
+    let map =
+        RenameProjection.renames (betweenOk a b)
+        |> RenameProjection.renameMapByKind
+        |> RenameProjection.forKind (kKey "Customer")
     // A row carrying the A-schema name re-points onto the B name (not lost to NULL).
     let aRow = rowOf [ "Id", "1"; "Email", "alice@x" ]
     let repointed = RenameProjection.repointRow map aRow
@@ -120,10 +128,50 @@ let ``A5: a no-renames A->B diff yields an empty rename map (the data leg stays 
     // not renames (here, identical), the rename map is empty ⇒ identity repoint.
     let a = catOf (custKind "Email" "EMAIL")
     let b = catOf (custKind "Email" "EMAIL")
-    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMap
+    let map = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMapByKind
     Assert.True(Map.isEmpty map)
 
 // =====================================================================
+// =====================================================================
+// 2026-07-06 (the phase-2 adversarial review, CRITICAL #1) — the rename
+// map is KIND-SCOPED. The prior flat map was kind-blind: a rename
+// recorded for ONE kind's attribute re-keyed the same NAME in EVERY
+// kind's rows, so `Invoice.Status → State` silently emptied
+// `Order.Status` (the re-keyed value became unreachable at the sink
+// getter; the column wrote NULL). These pins make the poisoning
+// structurally impossible to reintroduce.
+// =====================================================================
+
+[<Fact>]
+let ``kind-scoping: a rename in one kind does NOT re-key the same name in another kind`` () =
+    let invoice (statusName: string) =
+        Kind.create (kKey "Invoice") (nm "Invoice")
+            (TableId.create "dbo" "RP_INVOICE" |> Result.value)
+            [ attr (aKey "Invoice.Id") "Id" "ID" true
+              attr (aKey "Invoice.Status") statusName (statusName.ToUpperInvariant()) false ]
+    let order () =
+        Kind.create (kKey "Order") (nm "Order")
+            (TableId.create "dbo" "RP_ORDER" |> Result.value)
+            [ attr (aKey "Order.Id") "Id" "ID" true
+              attr (aKey "Order.Status") "Status" "STATUS" false ]
+    let catTwo (inv: Kind) (ord: Kind) : Catalog =
+        IRBuilders.mkCatalog [ IRBuilders.mkModule (kKey "Mod") (nm "M") [ inv; ord ] ]
+    // A: Invoice.Status + Order.Status. B: Invoice.State (RENAMED, same
+    // SsKey) + Order.Status (untouched).
+    let a = catTwo (invoice "Status") (order ())
+    let b = catTwo (invoice "State") (order ())
+    let byKind = RenameProjection.renames (betweenOk a b) |> RenameProjection.renameMapByKind
+    // Invoice's map carries the rename; Order's map is EMPTY.
+    Assert.Equal("State", Name.value (RenameProjection.forKind (kKey "Invoice") byKind).[nm "Status"])
+    Assert.True(Map.isEmpty (RenameProjection.forKind (kKey "Order") byKind))
+    // The poisoning scenario, dead: an Order row's Status survives untouched
+    // under ORDER's map, while an Invoice row's Status re-keys under INVOICE's.
+    let orderRow = RenameProjection.repointRow (RenameProjection.forKind (kKey "Order") byKind) (rowOf [ "Id", "7"; "Status", "OPEN" ])
+    Assert.Equal("OPEN", orderRow.Values.[nm "Status"])
+    let invoiceRow = RenameProjection.repointRow (RenameProjection.forKind (kKey "Invoice") byKind) (rowOf [ "Id", "9"; "Status", "PAID" ])
+    Assert.Equal("PAID", invoiceRow.Values.[nm "State"])
+    Assert.False(invoiceRow.Values.ContainsKey(nm "Status"))
+
 // AC-I7 — the composed Transfer: a column rename AND a Dev→UAT re-key in
 // ONE run. `Transfer.runReconcilingWithRenames` threads BOTH legs through
 // the single `runCore` path: re-point each ingested row's values onto the
@@ -236,7 +284,10 @@ let private orderLoad (plan: DataLoadPlan) : DataLoadKind =
 let ``AC-I7: composed rename+rekey — FK value follows its SsKey to BUYER AND re-keys through the remap`` () =
     // Source Order row: Owner FK points at Dev User 280 (alice).
     let sourceOrder = [ rowOf [ "Id", "1000"; "Owner", "280" ] ]
-    let renameMap = RenameProjection.renames (betweenOk rpSourceContract rpSinkContract) |> RenameProjection.renameMap
+    let renameMap =
+        RenameProjection.renames (betweenOk rpSourceContract rpSinkContract)
+        |> RenameProjection.renameMapByKind
+        |> RenameProjection.forKind rpOrderKey
     let plan = composePlan renameMap rpReconciliation sourceOrder
     let load = orderLoad plan
     let row = List.exactlyOne load.Rows
@@ -267,7 +318,10 @@ let ``AC-I7 discrimination: dropping the RECONCILE leg leaves the FK at the sour
     // re-keyed to the UAT identity 18 — proving the reconcile leg is
     // load-bearing.
     let sourceOrder = [ rowOf [ "Id", "1000"; "Owner", "280" ] ]
-    let renameMap = RenameProjection.renames (betweenOk rpSourceContract rpSinkContract) |> RenameProjection.renameMap
+    let renameMap =
+        RenameProjection.renames (betweenOk rpSourceContract rpSinkContract)
+        |> RenameProjection.renameMapByKind
+        |> RenameProjection.forKind rpOrderKey
     let plan = composePlan renameMap Map.empty sourceOrder
     let row = List.exactlyOne (orderLoad plan).Rows
     Assert.Equal(Some "280", Map.tryFind (nm "Buyer") row.Values)
@@ -280,7 +334,10 @@ let ``AC-I7 adversarial: an ordinal rename would mis-assign — the SsKey re-poi
     // the Email-shaped junk value into the FK column. The identity re-point
     // keys on the NAME (Owner → Buyer), so the FK value 280 lands in BUYER
     // regardless of cell order, and re-keys to 18.
-    let renameMap = RenameProjection.renames (betweenOk rpSourceContract rpSinkContract) |> RenameProjection.renameMap
+    let renameMap =
+        RenameProjection.renames (betweenOk rpSourceContract rpSinkContract)
+        |> RenameProjection.renameMapByKind
+        |> RenameProjection.forKind rpOrderKey
     // Adversarial cell order: a decoy column precedes Owner. An ordinal
     // scheme keyed on position would grab "decoy" for BUYER.
     let sourceOrder = [ rowOf [ "Decoy", "ZZZ"; "Owner", "280"; "Id", "1000" ] ]

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -113,13 +113,20 @@ let ``selector: a table subset falls back to the materialized path (streaming do
     | other -> Assert.Fail(sprintf "expected Materialized fallback, got %A" other)
 
 [<Fact>]
-let ``selector: WipeAndLoad and --resumable fall back to the materialized path`` () =
+let ``selector: WipeAndLoad falls back to the materialized path; --resumable needs sink-resident resume`` () =
     match choose EmissionMode.WipeAndLoad false [] false None with
     | Ok Projection.Pipeline.ReverseLegRealization.Materialized -> ()
     | other -> Assert.Fail(sprintf "expected Materialized for WipeAndLoad, got %A" other)
-    match choose EmissionMode.Incremental true [] false None with
+    // 2026-07-06 (the phase-2 permission audit): a MATERIALIZED --resumable
+    // against a sink that cannot host the G10 progress table (ManagedDml /
+    // undeclared — sinkResidentResume=false) now refuses BY NAME instead of
+    // sailing into a raw CREATE TABLE permission failure mid-run. The
+    // FullRights admission is pinned below.
+    let codeOf r = match r with Error (es: ValidationError list) -> (List.head es).Code | Ok _ -> "OK"
+    Assert.Equal("transfer.reverseLeg.resumableSinkUnsupported", codeOf (choose EmissionMode.Incremental true [] false None))
+    match chooseOn EmissionMode.Incremental true [] false None true with
     | Ok Projection.Pipeline.ReverseLegRealization.Materialized -> ()
-    | other -> Assert.Fail(sprintf "expected Materialized for --resumable, got %A" other)
+    | other -> Assert.Fail(sprintf "expected Materialized for --resumable on a FullRights sink, got %A" other)
 
 [<Fact>]
 let ``selector: an EXPLICIT --streaming on an inadmissible request refuses BY NAME — never a silent downgrade`` () =


### PR DESCRIPTION
## What this PR is

The production-readiness program for the partial-transfer use case: moving a **subset of tables** between two managed Cloud OutSystems environments (e.g. QA → UAT) whose physical `OSUSR_*` table names differ — SS_KEY-aligned contracts, explicit strategies for escaping FK relationships (including the single-owner pin), a red→green go-readiness board, a live-rehearsed runbook, a transfer→verify→revert proving loop, cross-leg parity, and a final refactor/DX pass.

First-class docs on the branch: `PARTIAL_TRANSFER_READINESS_LOG.md` (21 append-only entries) and `PARTIAL_TRANSFER_RUNBOOK.md`.

## The phases

1. **The peer leg** — SsKey-aligned QA→UAT transfer (per-side OSSYS contracts, shape gate exit 5, subset-FK gate exit 9); a whole-estate load-order bug found by the first e2e canary and fixed; Release-build fix.
2. **Adversarial hardening + mock environments** — 2 CRITICAL + 3 HIGH + 5 MEDIUM fixes; the mock-OutSystems stack (`OssysSeedBuilder`/`DmlPrincipal`/`MockOutSystemsEnv`); five managed-grant e2e scenarios; the VIEW-DEFINITION extraction bug caught in the mocks' first hour.
3. **The preview engine** — `projection check go <flow>` (THE GO BOARD): reason + remedy per red line, the engine dry run as the row/identity/drop forecast, exit 0/5, `--format json`; red→green→red proven e2e.
4. **The live rehearsal** — the runbook executed verbatim with the real CLI; narration hotspots fixed; live-environment hotspots documented.
5. **The proving loop** — `transfer-undo.sql` on every successful Execute + `projection revert` (preview default; env-gated one-transaction live run; wrong-sink provenance guard with `--force`).
6. **The parity sweep** — the escaping-FK guard made leg-neutral at the engine; the streaming arm gains the ordered-load gate; the forward transfer's `--resumable` refuses by name on managed sinks.
7. **The final pass (two Opus critiques)** — `ConnectionRef.Raw` (+DECISIONS amendment), `TransferSubset.escapingEdges` (one traversal for both escape consumers), `parseReconcileInputs` (four parse blocks collapsed), the `DmlPrincipal` promotion finished, copy sweep; sample-config `reverse` flow inconsistency fixed.
8. **The single-owner pin (this chapter)** — configuration-domain subsets whose every reference belongs to ONE designated sink row. Three rule forms, one grammar: `Module.Entity:Column` (dynamic match — the unchanged fallback), `Module.Entity:=<key>` (the pin: every reference re-keys to the one sink row), `Module.Entity:Column:=<key>` (match first, pinned owner for the rest). Zero new engine cases — the forms map onto the existing `FallbackToAssigned` algebra, so gates/board/escape coverage inherit. Safety: a pinned key naming no sink row refuses by name (`transfer.reconcile.pinnedOwnerMissing`, not downgradable by `--allow-drops`) on both preWrite chains, and the go board gains a `pinned owners` axis probing every pin against the live sink. Proven pure + docker e2e (the pin overrides even a cross-city source reference; zero rows written to the pinned table; a missing pin refuses pre-write with the sink untouched).

## Verification

- Fast pool: **PASSED** · Docker pool: **PASSED IN FULL (484s)** with the pin aboard · Release builds: **clean** · Two manual live rehearsals recorded in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWCGUN1VUnw73XDsH4qEke