### PR TITLE
Spectre TTY clarity: quiet line replaces the stall verdict, contained pretty console, actionable fidelity report

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26707,3 +26707,70 @@ lifetime shrinks to the process.
 (the config parser continues to accept `env:`/`file:` references only, and
 `looksLikeSecret` still rejects pasted connection strings). Constructed only where
 the string is already lawfully resident.
+
+## 2026-07-06 — Operator-report round 2: the quiet line replaces the stall verdict; the pretty console belongs to the box; the fidelity report becomes actionable
+
+**Context.** Operator reports from a real `--pretty -v publish` (the first
+full-export runs after the operator-shell chapter): (1) the `-v` bench table
+sprayed an unconstrained stdout table over the boxed board; (2) so did the
+per-file artifact enumeration (the 2026-07-03 entry's first named residual,
+now fired); (3) the board said `stalled` repeatedly while stages were
+genuinely working, with the spinner deliberately frozen — read as a hang;
+(4) `fidelity.json` counted `notNullButNullsPresent` / `foreignKeyOrphans` /
+`uniqueButDuplicatesPresent` / `lengthOrTypeOverflow` findings the terminal
+never mentioned and no artifact made actionable, while `suggest-config.json`
+carried 117 fill-factor advisories ranked as "the lever."
+
+**Decisions.**
+
+1. **The stall verdict retires (amends 2026-07-03 decision 1's stall clause).**
+   The event stream can witness SILENCE, not a stall: a long SQL query or a
+   CPU-bound emit is quiet-but-working, so `stalled` asserted more than the
+   evidence grounds (THE_VOICE rule 8). An active stage quiet past the
+   threshold now degrades its line to `processing` (operator-chosen wording;
+   the stale `~Ns remaining` still drops — a frozen countdown keeps lying)
+   and the spinner KEEPS breathing (the drain loop's own repaint is real
+   liveness; a frozen glyph asserted a hang). Threshold 3s → 5s;
+   `PROJECTION_WATCH_STALL_MS` seam unchanged. `progressTextStalled` →
+   `progressTextQuiet (quietForMs: int64 option)`; the render path threads
+   the option, not a bool.
+
+2. **Under pretty, the boxed surface owns the console.** The `-v` bench table
+   does not print under pretty (the snapshot still persists; one line names
+   its path); the per-file artifact enumeration is suppressed under pretty
+   (the one-line total + the verdict panel carry the finding; piped/plain
+   runs keep the full list). This resolves the 2026-07-03 residual for the
+   publish face; the remaining faces' stdout narration (transfer/migrate)
+   stays the named residual.
+
+3. **The fidelity report becomes actionable (the diagnostics-and-remediation
+   pre-scope's "future emitter" trigger, fired by operator report).** Three
+   wires, one producer rule (the §12 at-scale law — one rollup, never a wall):
+   - `RemediationEmitter.emitWith` renders the fidelity report's data
+     violations as remediation blocks in `manifest.remediation.sql` — the
+     DecisionSet blocks stay first; a `Data reality` section follows,
+     deduplicated on (entity, column, axis). This covers the load-blocking
+     case the DecisionSets structurally never reach (nulls in a column the
+     model already declares NOT NULL — `NullabilityRules` short-circuits at
+     `PhysicallyNotNull` before the budget test) plus the overflow axis that
+     had no renderer. FK-orphan blocks resolve the concrete target table +
+     single-column PK through the catalog (`Reference.TargetKind`); the
+     placeholder form remains for composite/unresolvable targets.
+   - `Compose.runWithConfigCore` emits ONE Warn envelope
+     (`fidelity.dataViolations`, payload: total/entities/per-axis counts +
+     remediation & fidelity artifact paths) after a successful bundle write
+     when violations exist. `ModelFidelity.dataViolationsPayload` is the pure
+     payload builder (None when clean).
+   - The envelope is read by the board's notice strip (`Watch.noticeCodes`)
+     and the verdict panel (`data reality` row + a `review
+     manifest.remediation.sql` Next line that LEADS the suggest-config next
+     action — a data repair outranks an optional config edit).
+   `LogSink.tryFirstPayload` is the generic first-envelope-payload accessor
+   (the rollup code constant compiles after LogSink; the consumer passes it).
+
+**Witnesses.** `WatchTests` / `WatchInjectionTests` (quiet-line rework; the
+flood still never degrades; `processing` after threshold, `stalled` nowhere);
+`RemediationEmitterTests` (the four data-reality axes, concrete FK target,
+dedup-vs-decision, operator-safety contract held); `ModelFidelityTests`
+(payload builder Some/None); `TtyRendererTests` (panel row + next move);
+`VoiceTotalityTests` (the new code forced same-commit).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26739,9 +26739,17 @@ carried 117 fill-factor advisories ranked as "the lever."
    does not print under pretty (the snapshot still persists; one line names
    its path); the per-file artifact enumeration is suppressed under pretty
    (the one-line total + the verdict panel carry the finding; piped/plain
-   runs keep the full list). This resolves the 2026-07-03 residual for the
-   publish face; the remaining faces' stdout narration (transfer/migrate)
-   stays the named residual.
+   runs keep the full list). And the 2026-07-03 residual is resolved WHOLE,
+   not face-by-face: `Shell.executeOn` DEFERS stdout narration under pretty —
+   `Console.Out` is redirected to a buffer for the body's span and flushed
+   verbatim after the verdict panel, so every face's narration (`printfn`
+   and `renderVoicedTo Console.Out` alike — both resolve the writer at call
+   time) lands below the box in reading order instead of interleaving with
+   the Live region's repaints. One choke point at the one door; the
+   face-by-face core+narration split the residual proposed is unnecessary.
+   Prompts cannot be swallowed (the 2026-06-17 hoist rule keeps them before
+   `Shell.execute`); a crashed body restores the writer in `finally`;
+   piped/plain runs take no buffer (byte-identical stdout).
 
 3. **The fidelity report becomes actionable (the diagnostics-and-remediation
    pre-scope's "future emitter" trigger, fired by operator report).** Three

--- a/sidecar/projection/SPECTRE_REFINEMENTS.md
+++ b/sidecar/projection/SPECTRE_REFINEMENTS.md
@@ -758,16 +758,18 @@ the dwell stays a floor on CHANGES, never added to the pulse. `rowMarkup`/`board
 passes 0). Pinned by `Theme.spinner` (cycle + total) and a board-render test (an active line
 wears the phase's frame).
 
-**The stall-aware ETA rides it too (shipped same day — #20 breathing complete).** When an
-ACTIVE stage goes quiet past `stallThresholdMs` (3s of wall-clock with no new frame, measured
-by the drain loop off `lastRenderAt`), the board calls it `stalled`: the estimate degrades
-from `~Ns remaining` to `stalled` (`progressTextStalled` — the honest §13 rule, never a
-frozen countdown that keeps lying), and the spinner FREEZES + mutes (motion stops, so the
-operator sees the stall both ways). `stalled` threads beside `phase` with NO test churn —
-`progressText`/`lineText` keep their signatures as `false`-wrappers over new
-`progressTextStalled`/`lineTextWith` siblings. Pinned by a stall test (`stalled` replaces the
-ETA, the count still shows, it threads into the active line). #20 and its breathing are
-DONE: off-thread dwell · spinner · stall-aware ETA.
+**The stall-aware ETA rides it too (shipped same day; AMENDED 2026-07-06 — the stall verdict
+retired).** When an ACTIVE stage goes quiet past `stallThresholdMs` (now 5s of wall-clock
+with no dequeued envelope), the line degrades its estimate from `~Ns remaining` to
+`processing` (`progressTextQuiet` — the honest §13 rule, never a frozen countdown that keeps
+lying) and the spinner KEEPS breathing. The original design said `stalled` with a frozen
+muted spinner — an operator report (2026-07-06) surfaced that the event stream witnesses
+SILENCE, not a stall (a long SQL query / CPU-bound emit is quiet-but-working), so the copy
+now claims only what the evidence grounds and the wording is the operator's own
+(`processing`). `quietForMs : int64 option` threads where the bool did;
+`progressText`/`lineText` stay the `None`-wrappers. Pinned by the reworked quiet tests
+(`processing` replaces the ETA, `stalled` appears nowhere, the count still shows). See
+`DECISIONS 2026-07-06` (operator-report round 2).
 
 ### 21 · Instrument the other runs onto the spine  ◐
 

--- a/sidecar/projection/src/Projection.Cli/Faces/Export.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Export.fs
@@ -68,10 +68,16 @@ let runFullExport
     match outcome with
     | FullExportRun.RunOutcome.Succeeded (report, effectiveOutput) ->
         printfn "%d artifact(s) written to %s." report.Paths.Length effectiveOutput
-        report.Paths
-        |> List.iter (fun p ->
-            let info = FileInfo p
-            printfn "  %s (%d bytes)" p info.Length)
+        // Under pretty the boxed board + verdict panel own the console (§13 / the
+        // operator-shell charter): the per-file enumeration — hundreds of lines on
+        // a full estate — would land raw against the board's teardown (the named
+        // residual, 2026-07-03). The one-line total above carries the finding; the
+        // bundle directory holds the files. Piped / plain runs keep the full list.
+        if not Shell.prettyMode.Value then
+            report.Paths
+            |> List.iter (fun p ->
+                let info = FileInfo p
+                printfn "  %s (%d bytes)" p info.Length)
         storeLeg
         |> Option.iter (fun leg ->
             printfn "This run recorded — episode %d on timeline %s; %d refactorlog entr(ies) accumulated."

--- a/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
+++ b/sidecar/projection/src/Projection.Cli/OperatorConsole.fs
@@ -64,14 +64,22 @@ let dumpBench (tag: string) : unit =
         // Calm by default (REPORTING_HORIZON polish) — the table is depth,
         // shown only under -v. The snapshot is always persisted.
         if verboseMode.Value then
-            // #13 — the `-v` bench dump joins the View lens (a `View.Table` via
-            // `TtyRenderer.benchView`, so it gains color/json/`--query`); Core's
-            // `Bench.renderTable` stays for the perf scenarios. The factory pins the
-            // width and strips color for a piped sink.
-            printfn ""
-            View.write (View.consoleTo System.Console.Out) (TtyRenderer.benchView stats)
-            printfn ""
-            printfn "  bench snapshot: %s" path
+            if Shell.prettyMode.Value then
+                // Under pretty the boxed board + verdict panel own the console
+                // (§13); a raw stdout table lands adjacent to the board's
+                // teardown and spills past the frame. The depth stays in the
+                // persisted snapshot; one line names where it lives.
+                printfn ""
+                printfn "  bench counters recorded: %s" path
+            else
+                // #13 — the `-v` bench dump joins the View lens (a `View.Table` via
+                // `TtyRenderer.benchView`, so it gains color/json/`--query`); Core's
+                // `Bench.renderTable` stays for the perf scenarios. The factory pins the
+                // width and strips color for a piped sink.
+                printfn ""
+                View.write (View.consoleTo System.Console.Out) (TtyRenderer.benchView stats)
+                printfn ""
+                printfn "  bench snapshot: %s" path
 
 /// Slice 4 (verb coverage) — bracket a verb body in the structured
 /// LogSink run envelope so EVERY emitting verb (not just `full-export`)

--- a/sidecar/projection/src/Projection.Cli/Shell.fs
+++ b/sidecar/projection/src/Projection.Cli/Shell.fs
@@ -25,6 +25,11 @@ open Projection.Pipeline
 /// Prompts keep the 2026-06-17 rule: a gate/`Intervene` prompt hoists BEFORE
 /// `Shell.execute` — a Spectre Live region and a blocking prompt cannot share
 /// the terminal. `Navigator` (inspect) stays outside by the same law.
+///
+/// Under pretty, stdout narration inside the body is DEFERRED (2026-07-06):
+/// captured for the body's span and flushed verbatim after the verdict panel,
+/// so no face ever writes raw into the Live region's repaints. Piped / plain
+/// runs take no buffer — stdout stays byte-identical.
 [<RequireQualifiedAccess>]
 module Shell =
 
@@ -165,18 +170,36 @@ module Shell =
         : int =
         currentFrame.Value <- frame
         let run () = bracketed bracket frame.Command body
+        // Under pretty the boxed board / static frame + the verdict panel own
+        // the terminal (2026-07-06 — resolves the 2026-07-03 residual): stdout
+        // narration emitted inside the body's span is DEFERRED, captured for
+        // the duration and flushed verbatim AFTER the verdict panel, so a
+        // face's narration lands below the box in reading order instead of
+        // interleaving with the Live region's repaints. One choke point here
+        // covers every face (`printfn` and `renderVoicedTo Console.Out` both
+        // resolve the redirected writer at call time). Prompts cannot be
+        // swallowed: the 2026-06-17 hoist rule keeps every prompt BEFORE
+        // `Shell.execute`. Piped / plain runs take no buffer — byte-identical.
+        let narration = if pretty then Some (new IO.StringWriter()) else None
+        let priorOut = Console.Out
+        narration |> Option.iter (fun w -> Console.SetOut w)
         let code =
-            match spine with
-            | Some spine when live ->
-                let seed = { Watch.seededOf spine with Title = Some (titleOf frame) }
-                Watch.renderWatchOn console seed (Watch.resolveDwellMs ()) run
-            | _ when pretty ->
-                renderStaticOpenOn console frame
-                // Channel 1 is suppressed for the span (never NDJSON and a
-                // panel on the same TTY — §15.1); scoped, so an outer writer
-                // is restored (an improvement over the old unscoped null).
-                LogSink.withWriter IO.TextWriter.Null run
-            | _ -> run ()
+            try
+                match spine with
+                | Some spine when live ->
+                    let seed = { Watch.seededOf spine with Title = Some (titleOf frame) }
+                    Watch.renderWatchOn console seed (Watch.resolveDwellMs ()) run
+                | _ when pretty ->
+                    renderStaticOpenOn console frame
+                    // Channel 1 is suppressed for the span (never NDJSON and a
+                    // panel on the same TTY — §15.1); scoped, so an outer writer
+                    // is restored (an improvement over the old unscoped null).
+                    LogSink.withWriter IO.TextWriter.Null run
+                | _ -> run ()
+            finally
+                // Restore on EVERY exit path (a crashed body must not leave the
+                // process stdout pointing at a dead buffer).
+                narration |> Option.iter (fun _ -> Console.SetOut priorOut)
         // A ReadOnly answer verb (diff / explain / the check queries) never
         // joins the run ledger — the gauge reads the canary streak, and a
         // query about the ledger must not write to it (the `check ready`
@@ -186,6 +209,14 @@ module Shell =
          | ReadOnly -> ()
          | Go | Preview -> appendLedger frame code)
         if pretty then TtyRenderer.renderSummaryTo console frame.Command code
+        // The deferred narration flushes AFTER the panel, verbatim and in the
+        // order the body wrote it — the box closes, then the face speaks.
+        narration
+        |> Option.iter (fun w ->
+            let text = w.ToString()
+            if not (String.IsNullOrWhiteSpace text) then
+                Console.Out.Write text
+                Console.Out.Flush())
         // `--stat` — the aggregates table on stdout (an ANSWER, so it rides
         // the answer channel + lenses, not the injected stderr console).
         if statMode.Value then

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -47,17 +47,20 @@ let buildSummaryView (command: string) (code: int) : View.View =
     let transforms =
         View.PanelRow.Labeled(
             "transforms",
-            sprintf "%d registered %s %d applied %s %d declined" registered Theme.dot applied Theme.dot declined,
+            sprintf "%s registered %s %s applied %s %s declined" (Theme.humane registered) Theme.dot (Theme.humane applied) Theme.dot (Theme.humane declined),
             View.Neutral)
     let edits = LogSink.suggestedConfigEdits ()
     let actionable =
-        if edits = 0 then View.PanelRow.Labeled("actionable", "none", View.Ok)
+        if edits = 0 then View.PanelRow.Labeled("recommendations", "none", View.Ok)
         else
-            // Impact-ranked — name the single biggest lever first.
+            // Impact-ranked — name the most-suggested configuration path first;
+            // these are optional (§14), so the row is informative (Neutral),
+            // never a Warn. (Rewritten 2026-07-06, the full-voice audit: the
+            // prior "actionable" label asserted action was required.)
             match LogSink.topSuggestion () with
             | Some (path, count) ->
-                View.PanelRow.Labeled("actionable", sprintf "%d edit(s) %s top: %s (%d)" edits Theme.dot path count, View.Warn)
-            | None -> View.PanelRow.Labeled("actionable", sprintf "%d edit(s) suggested" edits, View.Warn)
+                View.PanelRow.Labeled("recommendations", sprintf "%s optional %s most suggested %s (%s)" (Theme.humane edits) Theme.dot path (Theme.humane count), View.Neutral)
+            | None -> View.PanelRow.Labeled("recommendations", sprintf "%s optional %s advisory, no action required" (Theme.humane edits) Theme.dot, View.Neutral)
     // 2026-07-06 — the data-reality finding on the verdict panel: when the
     // profiled source data contradicts the declared model, the panel names
     // the count and routes to the remediation script (the operator's next
@@ -73,7 +76,7 @@ let buildSummaryView (command: string) (code: int) : View.View =
         | Some p ->
             [ View.PanelRow.Labeled(
                 "data reality",
-                sprintf "%d violation(s) across %d table(s) %s the source data contradicts the declared model" (intOf "total" p) (intOf "entities" p) Theme.dot,
+                sprintf "%s violation(s) across %s table(s) %s the source data contradicts the declared model" (Theme.humane (intOf "total" p)) (Theme.humane (intOf "entities" p)) Theme.dot,
                 View.Warn) ]
         | None -> []
     let dataRealityNext =
@@ -124,7 +127,7 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (series: i
     let toGo = max 0 (r.Threshold - r.ConsecutiveGreen)
     let hero =
         if r.Eligible then
-            View.Hero(View.Ok, sprintf "ELIGIBLE %s %d consecutive green canaries" Theme.dot r.ConsecutiveGreen)
+            View.Hero(View.Ok, sprintf "ELIGIBLE %s %d consecutive green round-trip verifications" Theme.dot r.ConsecutiveGreen)
         else
             View.Hero(View.Pending, sprintf "NOT YET %s %d green run(s) to cutover-ready" Theme.dot toGo)
     // The one lever (§8 / Appendix A.5: "One lever, named, with the next move" —
@@ -172,7 +175,7 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (series: i
         @ timeline
         @ [ View.Field(
               "runs",
-              sprintf "%d total %s %d with a canary %s last %s" r.TotalRuns Theme.dot r.CanaryRuns Theme.dot lastCanary,
+              sprintf "%d total %s %d with a round-trip verification %s last %s" r.TotalRuns Theme.dot r.CanaryRuns Theme.dot lastCanary,
               View.Neutral)
             View.Blank
             View.Note(sprintf "ledger    %s" ledgerPath) ])

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -58,6 +58,31 @@ let buildSummaryView (command: string) (code: int) : View.View =
             | Some (path, count) ->
                 View.PanelRow.Labeled("actionable", sprintf "%d edit(s) %s top: %s (%d)" edits Theme.dot path count, View.Warn)
             | None -> View.PanelRow.Labeled("actionable", sprintf "%d edit(s) suggested" edits, View.Warn)
+    // 2026-07-06 — the data-reality finding on the verdict panel: when the
+    // profiled source data contradicts the declared model, the panel names
+    // the count and routes to the remediation script (the operator's next
+    // move is a data repair, not a config edit — it leads the Next rows).
+    let intOf (key: string) (p: Map<string, objnull>) : int =
+        match Map.tryFind key p with
+        | Some (:? int as n)   -> n
+        | Some (:? int64 as n) -> int n
+        | _                    -> 0
+    let fidelityPayload = LogSink.tryFirstPayload ModelFidelity.dataViolationsCode
+    let dataReality =
+        match fidelityPayload with
+        | Some p ->
+            [ View.PanelRow.Labeled(
+                "data reality",
+                sprintf "%d violation(s) across %d table(s) %s the source data contradicts the declared model" (intOf "total" p) (intOf "entities" p) Theme.dot,
+                View.Warn) ]
+        | None -> []
+    let dataRealityNext =
+        match fidelityPayload with
+        | Some p ->
+            match Map.tryFind "remediationPath" p with
+            | Some (:? string as path) when path <> "" -> [ View.PanelRow.Next (sprintf "review %s" path) ]
+            | _ -> []
+        | None -> []
     // §6 — the Measure proof: the data norm (CDC capture count) made plain. A
     // CDC-silent leg is the green hush of an idempotent redeploy ("unchanged");
     // a captured count names exactly how many rows changed (rows changed = the
@@ -68,7 +93,8 @@ let buildSummaryView (command: string) (code: int) : View.View =
         | Some 0 -> [ View.PanelRow.Labeled("data", "unchanged · CDC captured 0 rows", View.Ok) ]
         | Some n -> [ View.PanelRow.Labeled("data", sprintf "CDC captured %s rows" (Theme.humane n), View.Neutral) ]
         | None   -> []
-    // Principle #5 — end with the next action.
+    // Principle #5 — end with the next action. The data repair (when one is
+    // needed) leads; the optional config edit follows.
     let nextAction = if edits > 0 then [ View.PanelRow.Next "projection suggest-config --apply" ] else []
     let cutover =
         match RunLedger.configuredDir () with
@@ -79,7 +105,7 @@ let buildSummaryView (command: string) (code: int) : View.View =
                 "cutover", r.ConsecutiveGreen, r.Threshold,
                 sprintf "%d / %d green %s %s" r.ConsecutiveGreen r.Threshold Theme.arrow gate) ]
         | None -> []
-    View.Panel(command, [ verdict; transforms ] @ measure @ [ actionable ] @ nextAction @ cutover)
+    View.Panel(command, [ verdict; transforms ] @ measure @ dataReality @ [ actionable ] @ dataRealityNext @ nextAction @ cutover)
 
 let renderSummaryTo (console: IAnsiConsole) (command: string) (code: int) : unit =
     View.write console (buildSummaryView command code)

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -937,6 +937,40 @@ module Voice =
                 |> Option.filter (fun s -> s <> "")
                 |> Option.map (fun path -> View.Action(sprintf "Review the full list at %s." path)) }
 
+    /// `fidelity.dataViolations` — the data-reality rollup (2026-07-06; the
+    /// §12 at-scale law): ONE Warn envelope per run when the profiled source
+    /// data contradicts the model's declared constraints. The statement names
+    /// the finding, the per-axis breakdown, and the consequence; the action
+    /// routes to the remediation script, where every finding carries a
+    /// locating query and a commented repair.
+    let private fidelityDataViolations : Copy =
+        { Code           = "fidelity.dataViolations"
+          DocSection     = "§12"
+          Statement      =
+            fun p ->
+                let families =
+                    [ "notNull",  "required column(s) with nulls"
+                      "unique",   "unique column(s) with duplicates"
+                      "orphans",  "relationship(s) with unmatched records"
+                      "overflow", "column(s) with values past the declared length" ]
+                    |> List.choose (fun (key, label) ->
+                        text key p
+                        |> Option.filter (fun n -> n <> "0")
+                        |> Option.map (fun n -> sprintf "%s %s" (humane n) label))
+                let total  = humane (textOr "total" "0" p)
+                let tables = humane (textOr "entities" "0" p)
+                match families with
+                | [] ->
+                    View.Note(sprintf "The source data contradicts the declared model in %s place(s) across %s table(s). A data load can fail until the rows are repaired." total tables)
+                | fs ->
+                    View.Note(sprintf "The source data contradicts the declared model in %s place(s) across %s table(s) — %s. A data load can fail until the rows are repaired." total tables (String.concat ", " fs)) // LINT-ALLOW: terminal operator-facing copy at the Voice boundary; the family list is a free-text enumeration, String.concat is the irreducible primitive for this comma-joined rollup narration
+          Substantiation = fun _ -> []
+          Action         =
+            fun p ->
+                text "remediationPath" p
+                |> Option.filter (fun s -> s <> "")
+                |> Option.map (fun path -> View.Action(sprintf "Review %s — each finding carries a locating query and a commented repair." path)) }
+
     // ------------------------------------------------------------------
     // The harvest — `all` gathers every declared copy into one catalog.
     // The `code ⇔ copy` totality test reads this (the sibling of the
@@ -1000,6 +1034,7 @@ module Voice =
           surveyAdvisory
           // §12 — the at-scale rollups (constant-size surfaces over growing counts)
           modelReadNoticeRollup
+          fidelityDataViolations
           // §14 / §10 — config & errors
           configValidationFailed
           canarySourceMissing

--- a/sidecar/projection/src/Projection.Cli/Voice.fs
+++ b/sidecar/projection/src/Projection.Cli/Voice.fs
@@ -848,18 +848,21 @@ module Voice =
           Action         = fun _ -> None }
 
     // ------------------------------------------------------------------
-    /// `watch.suggestedEdits` — the live board's config-edit teaser (#6
-    /// echo-the-fix): envelopes carrying a `suggestedConfig` payload tick this
-    /// count as the run happens; the verdict panel ranks the single biggest
-    /// lever afterward.
+    /// `watch.suggestedEdits` — the live board's config-recommendation teaser
+    /// (#6 echo-the-fix): envelopes carrying a `suggestedConfig` payload tick
+    /// this count as the run happens; the run's closing panel summarizes them,
+    /// most-suggested first. Rewritten 2026-07-06 (the full-voice audit): the
+    /// prior copy leaked "the verdict panel" (internal surface name) and "the
+    /// lever" (figurative, §2.2) and never said the recommendations are
+    /// optional (§14).
     let private watchSuggestedEdits : Copy =
         { Code           = "watch.suggestedEdits"
           DocSection     = "§13"
           Statement      =
             fun p ->
                 match text "count" p with
-                | Some n -> View.Note(sprintf "%s config edit(s) suggested so far — the verdict panel ranks the lever." (humane n))
-                | None   -> View.Note "Config edits suggested — the verdict panel ranks the lever."
+                | Some n -> View.Note(sprintf "%s optional configuration recommendation(s) gathered so far. Each is advisory and needs no action to complete this run; a summary follows at the end." (humane n))
+                | None   -> View.Note "Optional configuration recommendations gathered. Each is advisory and needs no action to complete this run; a summary follows at the end."
           Substantiation = fun _ -> []
           Action         = fun _ -> None }
 
@@ -910,32 +913,35 @@ module Voice =
     /// condensed to one calm line (`THE_VOICE.md` §12 at-scale law: the surface is
     /// a constant size; only the numbers grow). The per-item detail is the run's
     /// notice artifact; the action points there — never a wall of lines.
+    /// Rewritten 2026-07-06 (the full-voice audit): "model-reality notices" was
+    /// an internal compound the operator could not parse (§2.1 boundary; rule
+    /// 10/11), and the line never said no action is required (§14).
     let private modelReadNoticeRollup : Copy =
         { Code           = "adapter.ossys.modelRead.noticeRollup"
           DocSection     = "§12"
           Statement      =
             fun p ->
                 let families =
-                    [ "nullability", "nullability"
-                      "identity",    "identity"
-                      "primaryKey",  "primary key"
-                      "other",       "other" ]
+                    [ "nullability", "nullability difference(s)"
+                      "identity",    "identity-flag difference(s)"
+                      "primaryKey",  "primary-key difference(s)"
+                      "other",       "other difference(s)" ]
                     |> List.choose (fun (key, label) ->
-                        text key p |> Option.map (fun n -> sprintf "%s %s" label (humane n)))
+                        text key p |> Option.map (fun n -> sprintf "%s %s" (humane n) label))
                 let total = humane (textOr "total" "0" p)
                 match families with
-                | [] -> View.Note(sprintf "%s model-reality notices. The model's declared values were kept." total)
-                | fs -> View.Note(sprintf "%s model-reality notices — %s. The model's declared values were kept." total (String.concat ", " fs)) // LINT-ALLOW: terminal operator-facing copy at the Voice boundary; the family list is a free-text enumeration, String.concat is the irreducible primitive for this comma-joined notice narration
+                | [] -> View.Note(sprintf "The deployed database's column shapes differ from the model's declarations in %s place(s). The model's declared values were kept and the run continues; no action is required." total)
+                | fs -> View.Note(sprintf "The deployed database's column shapes differ from the model's declarations in %s place(s) — %s. The model's declared values were kept and the run continues; no action is required." total (String.concat ", " fs)) // LINT-ALLOW: terminal operator-facing copy at the Voice boundary; the family list is a free-text enumeration, String.concat is the irreducible primitive for this comma-joined notice narration
           Substantiation =
             fun p ->
                 match text "samples" p with
-                | Some s when s <> "" -> [ View.Disclosure("the first notices", View.Neutral, [ View.Note s ]) ]
+                | Some s when s <> "" -> [ View.Disclosure("the first differences", View.Neutral, [ View.Note s ]) ]
                 | _ -> []
           Action         =
             fun p ->
                 text "artifactPath" p
                 |> Option.filter (fun s -> s <> "")
-                |> Option.map (fun path -> View.Action(sprintf "Review the full list at %s." path)) }
+                |> Option.map (fun path -> View.Action(sprintf "Review the full list of differences at %s." path)) }
 
     /// `fidelity.dataViolations` — the data-reality rollup (2026-07-06; the
     /// §12 at-scale law): ONE Warn envelope per run when the profiled source

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -57,9 +57,11 @@ module Watch =
 
     /// The rollup codes the board's notice strip folds (2026-07-02) — each is a
     /// producer-aggregated Warn envelope (one calm line per notice family, the
-    /// §12 at-scale law), never a per-item stream.
+    /// §12 at-scale law), never a per-item stream. 2026-07-06 — the fidelity
+    /// data-violation rollup joins the strip (the source-data-contradicts-model
+    /// finding, with its remediation-script pointer).
     let noticeCodes : Set<string> =
-        Set.ofList [ LiveModelRead.noticeRollupCode ]
+        Set.ofList [ LiveModelRead.noticeRollupCode; ModelFidelity.dataViolationsCode ]
 
     /// The board — the stage lines, plus the optional run frame (`THE_VOICE.md`
     /// §13: "the instrument speaks about its own running"). `Title` is the
@@ -318,11 +320,13 @@ module Watch =
     /// long enough to read a stage line, short enough not to drag the run).
     let defaultDwellMs : int64 = 120L
 
-    /// How long an ACTIVE stage may go without a new frame before the board calls it
-    /// `stalled` (#20) — the estimate stops counting down and the spinner freezes. Wall-clock
-    /// since the last change, measured by the drain loop. Generous (a few seconds) so normal
-    /// inter-event gaps never read as a stall; honest once the work has genuinely gone quiet.
-    let stallThresholdMs : int64 = 3000L
+    /// How long an ACTIVE stage may go without a new envelope before the line degrades
+    /// its estimate to `processing` (2026-07-06, amends #20). A long SQL query or a
+    /// CPU-bound emit is quiet-but-working, so the board never asserts `stalled` (a
+    /// verdict the event stream cannot ground) and the spinner keeps breathing (the
+    /// process is demonstrably alive). Wall-clock since the last dequeued envelope,
+    /// measured by the drain loop.
+    let stallThresholdMs : int64 = 5000L
 
     /// The sleep to enforce before showing the next frame: the remainder of the
     /// floor not already covered by the time since the last frame. A stage that
@@ -352,19 +356,32 @@ module Watch =
     /// non-positive `Total` is an unknown denominator (a lazily-streamed producer
     /// that cannot count ahead) — then it is a plain count-up, `142 applied`, no
     /// fraction, no estimate (§13 — show the count without a misstated bar).
-    let progressTextStalled (stalled: bool) (p: Progress) : string =
-        if p.Total <= 0 then sprintf "%s applied" (Theme.humane p.Done)
-        elif stalled then
-            // The estimate degrades HONESTLY (#20 / §13): a stage that has gone quiet shows
-            // `stalled`, never a frozen `~Ns remaining` that keeps lying as the clock runs.
-            sprintf "%s of %s · stalled" (Theme.humane p.Done) (Theme.humane p.Total)
-        else
-            match etaText p with
-            | Some eta -> sprintf "%s of %s · %s" (Theme.humane p.Done) (Theme.humane p.Total) eta
-            | None     -> sprintf "%s of %s" (Theme.humane p.Done) (Theme.humane p.Total)
+    /// The between-reports word for an active stage that has gone quiet past the
+    /// threshold (2026-07-06, amends #20's `stalled` — operator-chosen wording):
+    /// the stage is still running (the body thread lives; the spinner keeps
+    /// breathing), so the line says `processing` rather than a stall verdict the
+    /// event stream cannot ground.
+    let private processingText : string = "processing"
 
-    /// The progress fragment with no stall (the calm default — every existing caller).
-    let progressText (p: Progress) : string = progressTextStalled false p
+    let progressTextQuiet (quietForMs: int64 option) (p: Progress) : string =
+        let count =
+            if p.Total <= 0 then sprintf "%s applied" (Theme.humane p.Done)
+            else sprintf "%s of %s" (Theme.humane p.Done) (Theme.humane p.Total)
+        match quietForMs with
+        | Some _ ->
+            // The estimate degrades HONESTLY (#20 / §13): a stage that has gone quiet drops
+            // the countdown (a frozen `~Ns remaining` keeps lying as the clock runs) and
+            // reads `processing` — the work continues; nothing new has been reported.
+            sprintf "%s · %s" count processingText
+        | None ->
+            if p.Total <= 0 then count
+            else
+                match etaText p with
+                | Some eta -> sprintf "%s · %s" count eta
+                | None     -> count
+
+    /// The progress fragment with no quiet gap (the calm default — every existing caller).
+    let progressText (p: Progress) : string = progressTextQuiet None p
 
     /// The voiced text of a `Voice` statement code, filled from the payload. The
     /// board reuses the §13 stage copy (`<stage>.started` gerund; the resultative
@@ -381,20 +398,23 @@ module Watch =
     /// The operator line for a stage — the gerund while active, the resultative
     /// (with the measured duration) once complete. Pure + voiced, so it is
     /// testable against the twelve-rule banned list.
-    let lineTextWith (stalled: bool) (line: StageLine) : string =
+    let lineTextWith (quietForMs: int64 option) (line: StageLine) : string =
         // The gerund names the stage (its identity on the board); the glyph
-        // carries the state (faint `○` pending, `▸` active, `✓` done). `stalled`
-        // degrades only the ACTIVE+progress estimate (the drain loop's wall-clock signal).
+        // carries the state (faint `○` pending, `▸` active, `✓` done). A quiet gap
+        // degrades only the ACTIVE line (the drain loop's wall-clock signal).
         match line.State with
         | Pending -> statementText (line.Key + ".started") Map.empty
         | Active prog ->
             let baseText = statementText (line.Key + ".started") Map.empty
             match prog with
-            | Some p -> sprintf "%s · %s" baseText (progressTextStalled stalled p)
+            | Some p -> sprintf "%s · %s" baseText (progressTextQuiet quietForMs p)
             // A progress-less stage that has gone quiet says so in words, the same
             // register the progress fragment uses — a frozen dimmed spinner with no
             // explanation left the operator guessing (#20 rework; §13 honesty).
-            | None   -> if stalled then sprintf "%s · stalled" baseText else baseText
+            | None   ->
+                match quietForMs with
+                | Some _ -> sprintf "%s · %s" baseText processingText
+                | None   -> baseText
         | Done dur ->
             let baseText = statementText "summary.stageCompleted" (Map.ofList [ "stage", box line.Key ])
             match dur with
@@ -408,8 +428,8 @@ module Watch =
             | Some ms -> sprintf "%s · %s" baseText (secondsText ms)
             | None    -> baseText
 
-    /// The stage line with no stall (the calm default — every existing caller / test).
-    let lineText (line: StageLine) : string = lineTextWith false line
+    /// The stage line with no quiet gap (the calm default — every existing caller / test).
+    let lineText (line: StageLine) : string = lineTextWith None line
 
     /// The operator line for a notice-strip row — the Voice statement for the
     /// rollup code, with its action (the artifact pointer) appended when one
@@ -478,28 +498,28 @@ module Watch =
 
     // `phase` advances the ACTIVE line's breathing spinner (#20 follow-on); every other
     // state ignores it (its glyph is fixed). A static render passes phase 0.
-    let private rowMarkup (phase: int) (stalled: bool) (line: StageLine) : string =
-        let text = Markup.Escape(lineTextWith stalled line)
+    let private rowMarkup (phase: int) (quietForMs: int64 option) (line: StageLine) : string =
+        let text = Markup.Escape(lineTextWith quietForMs line)
         match line.State with
         | Pending  -> sprintf "%s  %s" (Theme.muted Theme.pending)        (Theme.muted text)
         | Active _ ->
-            // A live stage spins (accent + bold); a STALLED one freezes the spinner (a fixed
-            // frame) and goes muted — the motion stops and the text reads `stalled`, so the
-            // operator sees the stall both ways. `stalled` is only ever true for an active line.
-            let glyph = if stalled then Theme.muted (Theme.spinner 0) else Theme.accent (Theme.spinner phase)
-            sprintf "%s  %s" glyph (if stalled then Theme.muted text else Theme.bold text)
+            // A live stage spins (accent + bold) — and KEEPS spinning through a quiet
+            // gap (2026-07-06, amends #20's frozen frame): the drain loop repainting IS
+            // evidence the process is alive, and a frozen glyph asserted a hang the
+            // event stream could not ground. The quiet gap reads in the line's words.
+            sprintf "%s  %s" (Theme.accent (Theme.spinner phase)) (Theme.bold text)
         | Done _   -> sprintf "%s  %s" Theme.ok                           (Theme.green text)
         | Halted _ -> sprintf "%s  %s" (Theme.red Theme.bad)              (Theme.red text)
 
     /// The board's rows — the optional run-title header above, the stage arc, and
     /// the done-frame (the §13 follow-on + recorded-run identity) once the run
     /// reaches its terminal stage.
-    let private boardRows (phase: int) (stalled: bool) (board: Board) : IRenderable list =
+    let private boardRows (phase: int) (quietForMs: int64 option) (board: Board) : IRenderable list =
         let titleRow =
             match titleText board with
             | Some t -> [ Markup(Theme.muted (Markup.Escape t)) :> IRenderable ]
             | None   -> []
-        let stageRows = board.Stages |> List.map (fun s -> Markup(rowMarkup phase stalled s) :> IRenderable)
+        let stageRows = board.Stages |> List.map (fun s -> Markup(rowMarkup phase quietForMs s) :> IRenderable)
         // The notice strip (2026-07-02) — the rollup rows, muted with the warn
         // glyph, between the arc and the done-frame: present, calm, never a wall.
         let noticeRows =
@@ -529,7 +549,7 @@ module Watch =
     /// `LiveDisplayContext` updates in place. A STATIC render (stored board, tests)
     /// passes spinner phase 0; the live drain loop threads the advancing phase.
     let toRenderable (board: Board) : IRenderable =
-        Rows(boardRows 0 false board) :> IRenderable
+        Rows(boardRows 0 None board) :> IRenderable
 
     /// True iff a stage is in progress — the live drain loop pulses the spinner only
     /// when there is an active line to breathe (no idle churn otherwise).
@@ -540,8 +560,8 @@ module Watch =
     /// cutover timeline strip (`DYNAMIC_DISPLAY` §4: where this run sits on the
     /// path to the R6 gate). An empty header is the bare board (unchanged). `phase`
     /// advances the active line's breathing spinner (#20 follow-on).
-    let toRenderableWith (header: IRenderable list) (phase: int) (stalled: bool) (board: Board) : IRenderable =
-        Rows(header @ boardRows phase stalled board) :> IRenderable
+    let toRenderableWith (header: IRenderable list) (phase: int) (quietForMs: int64 option) (board: Board) : IRenderable =
+        Rows(header @ boardRows phase quietForMs board) :> IRenderable
 
     // -- the live shell --------------------------------------------------------
 
@@ -650,7 +670,7 @@ module Watch =
         // House-NEW concurrency primitive (grep: the first BlockingCollection in src) — its
         // re-open is gated by the live board going off-thread (CLAUDE.md §7; DECISIONS 2026-06-19).
         let queue = new System.Collections.Concurrent.BlockingCollection<LogSink.Envelope>()
-        console.Live(boxed (toRenderableWith header 0 false board.Value)).Start(fun ctx ->
+        console.Live(boxed (toRenderableWith header 0 None board.Value)).Start(fun ctx ->
             // Enqueue-and-return: the subscriber holds emit's lock only for the `Add`. A late
             // emit after `CompleteAdding` throws — swallowed; no such emit exists in practice
             // (the body's `withWriter` returns before the queue is completed). FORWARD NOTE:
@@ -673,11 +693,18 @@ module Watch =
                 let mutable phase = 0
                 // One paint path — every repaint advances the spinner and stamps the
                 // heartbeat clock, whatever prompted it.
-                let paint (stalled: bool) =
+                let paint (quietForMs: int64 option) =
                     phase <- phase + 1
                     lastPaintAt <- sw.ElapsedMilliseconds
-                    ctx.UpdateTarget(boxed (toRenderableWith header phase stalled board.Value))
+                    ctx.UpdateTarget(boxed (toRenderableWith header phase quietForMs board.Value))
                     ctx.Refresh()
+                // The quiet gap the paint reacts to (2026-07-06, amends #20's stall
+                // verdict): wall-clock since the last DEQUEUED envelope, surfaced only
+                // past the threshold. The line degrades to `processing` (the stale ETA
+                // drops) and the spinner keeps breathing — never a `stalled` verdict.
+                let quietGap () =
+                    let gap = sw.ElapsedMilliseconds - lastEventAt
+                    if gap > stallMs then Some gap else None
                 while draining do
                     let mutable env = Unchecked.defaultof<LogSink.Envelope>
                     if queue.TryTake(&env, 100) then
@@ -705,27 +732,28 @@ module Watch =
                             let sleep = dwellMs floorMs lastTransitionAt sw.ElapsedMilliseconds
                             if sleep > 0L then System.Threading.Thread.Sleep(int sleep)
                             lastTransitionAt <- sw.ElapsedMilliseconds
-                            paint false
+                            paint None
                         | Fold.Progressed ->
-                            paint false
+                            paint None
                         | Fold.NoChange ->
                             // A batch of foreign envelopes changed nothing visible — but
                             // the pipeline is chatty-alive, so keep the spinner breathing
                             // on the wall-clock heartbeat (the old loop never repainted
                             // here, which froze the board for the whole flood).
                             if hasActiveStage board.Value && sw.ElapsedMilliseconds - lastPaintAt >= 100L then
-                                paint (sw.ElapsedMilliseconds - lastEventAt > stallMs)
+                                paint (quietGap ())
                     elif queue.IsCompleted then
                         draining <- false
                     elif hasActiveStage board.Value then
                         // Idle wake (no envelope in 100ms) with a stage in progress — advance
                         // the spinner and refresh so the active line breathes between events. No
                         // fold, no dwell sleep (the dwell is a floor on TRANSITIONS, not added
-                        // here). If the pipeline has gone quiet past the threshold, render it
-                        // STALLED (frozen spinner + the line reads `stalled`) — honest, not a
-                        // countdown that keeps lying while nothing moves. Liveness keys off
-                        // lastEventAt: any envelope proves work, board-visible or not.
-                        paint (sw.ElapsedMilliseconds - lastEventAt > stallMs)
+                        // here). If the pipeline has gone quiet past the threshold, the line
+                        // reads `processing` — honest, not a countdown that keeps lying while
+                        // nothing new is reported, and never a `stalled` verdict the event
+                        // stream cannot ground. Liveness keys off lastEventAt: any envelope
+                        // proves work, board-visible or not.
+                        paint (quietGap ())
                 // Join the producer for its exit code — `GetAwaiter().GetResult()` so a body
                 // exception propagates as ITSELF, not wrapped in `AggregateException`.
                 code <- bodyTask.GetAwaiter().GetResult()

--- a/sidecar/projection/src/Projection.Pipeline/LogSink.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LogSink.fs
@@ -761,6 +761,16 @@ module LogSink =
     let suggestedConfigEdits () : int =
         lock lockObj (fun () -> state.Value.SuggestedConfigEdits)
 
+    /// Tier-4 ledger — the first accumulated envelope's payload for `code`,
+    /// `None` when the run emitted none. The generic sibling of the coded
+    /// accessors below (`canaryVerdict` / `cdcMeasure`) for rollup codes whose
+    /// constants live in modules that compile AFTER this one (e.g. the
+    /// fidelity data-violation rollup) — the consumer passes the constant in.
+    let tryFirstPayload (code: string) : Map<string, objnull> option =
+        lock lockObj (fun () ->
+            state.Value.Envelopes
+            |> Seq.tryPick (fun e -> if e.Code = code then Some e.Payload else None))
+
     /// Tier-4 ledger — the run's canary verdict derived from the accumulated
     /// `canary.*` events: `Some "red"` if any `canary.divergence` fired,
     /// else `Some "green"` if a `canary.diffEmpty` fired, else `None` (the

--- a/sidecar/projection/src/Projection.Pipeline/ModelFidelity.fs
+++ b/sidecar/projection/src/Projection.Pipeline/ModelFidelity.fs
@@ -409,6 +409,41 @@ module ModelFidelity =
             [ NotNullCategory; UniqueCategory; OrphanCategory; OverflowCategory ]
             |> List.map (fun c -> rollupCategory c report.DataViolations) }
 
+    /// The structured-channel code for the data-violation rollup — ONE Warn
+    /// envelope per run when the source data contradicts the declared model
+    /// (2026-07-06; the §12 at-scale law: the fidelity artifact holds the
+    /// detail, the wire carries the constant-size rollup). The live board's
+    /// notice strip and the verdict panel both read it, so the finding and
+    /// its remediation artifact are never a silent JSON-only count.
+    let dataViolationsCode : string = "fidelity.dataViolations"
+
+    /// The rollup envelope's payload — per-category counts + the artifact
+    /// pointers. `None` when the report carries no violations (the envelope
+    /// is only emitted when there is a finding to surface).
+    let dataViolationsPayload
+        (remediationPath: string)
+        (fidelityPath: string)
+        (report: ModelFidelityReport)
+        : Map<string, objnull> option =
+        let dv = dataViolationRollup report
+        if dv.Total = 0 then None
+        else
+            let countOf (category: ViolationCategory) : int =
+                dv.Categories
+                |> List.tryFind (fun c -> c.Category = category)
+                |> Option.map (fun c -> c.Count)
+                |> Option.defaultValue 0
+            Some
+                (Map.ofList
+                    [ "total",           box dv.Total
+                      "entities",        box dv.Entities
+                      "notNull",         box (countOf NotNullCategory)
+                      "unique",          box (countOf UniqueCategory)
+                      "orphans",         box (countOf OrphanCategory)
+                      "overflow",        box (countOf OverflowCategory)
+                      "remediationPath", box remediationPath
+                      "fidelityPath",    box fidelityPath ])
+
     // ----------------------------------------------------------------------
     // The rolled-up text renderer (THE_VOICE register: stative, count-first,
     // estate framed neutrally, the proof one level beneath the finding).

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -585,7 +585,23 @@ module Compose =
             Emit =
               fun ctx outputs ->
                 let n, u, f = decisionSetsOf ctx.ComposedState
-                { outputs with RemediationSql = RemediationEmitter.emit ctx.ComposedState.Catalog n u f } }
+                // 2026-07-06 — the fidelity report's data violations join the
+                // remediation script (the seed `Outputs` computes `Fidelity`
+                // before this fold, so the report is in hand). Mapped into the
+                // emitter's neutral finding shape (Targets compiles below
+                // Pipeline); dedup against the decision blocks happens inside.
+                let findings =
+                    outputs.Fidelity.DataViolations
+                    |> List.map (fun v ->
+                        { RemediationEmitter.Entity = v.Reference.Entity
+                          RemediationEmitter.Column = v.Reference.Column
+                          RemediationEmitter.Kind =
+                            match v.Kind with
+                            | ModelFidelity.NotNullButNullsPresent n    -> RemediationEmitter.NullsInNotNullColumn n
+                            | ModelFidelity.UniqueButDuplicatesPresent  -> RemediationEmitter.DuplicatesInUniqueColumn
+                            | ModelFidelity.ForeignKeyOrphans c         -> RemediationEmitter.OrphanedReference c
+                            | ModelFidelity.LengthOrTypeOverflow (o, d) -> RemediationEmitter.ValueOverflow (o, d) })
+                { outputs with RemediationSql = RemediationEmitter.emitWith ctx.ComposedState.Catalog n u f findings } }
           { Metadata = SummaryFormatter.registeredMetadata
             Emit =
               fun ctx outputs ->
@@ -1574,7 +1590,20 @@ module Compose =
                     // NM-34b (live) — `ReadCatalog = catalog`: the source model
                     // the run READ (pre-rename), surfaced so the run boundary can
                     // hash its canonical form into the live-path input digest.
-                    | Ok paths    -> Result.success ({ Paths = paths; Diagnostics = diagnostics; Manifest = outputs.Manifest; Trail = outputs.Trail; PassDiagnostics = outputs.PassEntries; ReadCatalog = catalog }, finalState)
+                    | Ok paths    ->
+                        // 2026-07-06 — the data-reality rollup: when the profiled
+                        // source data contradicts the declared model, ONE Warn
+                        // envelope carries the per-axis counts + the artifact
+                        // pointers (§12 at-scale law). The live board's notice
+                        // strip and the verdict panel read it, so the finding and
+                        // its remediation script are never a silent JSON-only count.
+                        ModelFidelity.dataViolationsPayload
+                            (Path.Combine(cfg.Output.Dir, ArtifactPath.remediation))
+                            (Path.Combine(cfg.Output.Dir, ArtifactPath.fidelityJson))
+                            outputs.Fidelity
+                        |> Option.iter (fun payload ->
+                            LogSink.emit (LogSink.envelope LogSink.Warn LogSink.Emit ModelFidelity.dataViolationsCode payload))
+                        Result.success ({ Paths = paths; Diagnostics = diagnostics; Manifest = outputs.Manifest; Trail = outputs.Trail; PassDiagnostics = outputs.PassEntries; ReadCatalog = catalog }, finalState)
                     | Error errors -> Result.failure errors
                 | Error errors -> Result.failure errors
 

--- a/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/RemediationEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.OperationalDiagnostics/RemediationEmitter.fs
@@ -76,6 +76,55 @@ module RemediationEmitter =
             k.Indexes |> List.map (fun i -> i.SsKey, (k, i)))
         |> Map.ofList
 
+    // -- Data-reality findings (2026-07-06) --------------------------------
+    //
+    // The fidelity report's data violations, mapped by the pipeline into this
+    // neutral shape (this Targets-layer emitter compiles below the Pipeline
+    // layer, so it cannot consume `ModelFidelity.DataViolation` directly).
+    // The axis vocabulary mirrors `ModelFidelity.ViolationKind` one-to-one.
+    // These cover the source data contradicting the DECLARED model — including
+    // the load-blocking case the tightening DecisionSets never reach: nulls in
+    // a column the model already declares NOT NULL.
+
+    type DataRealityKind =
+        | NullsInNotNullColumn of nullCount: int64
+        | DuplicatesInUniqueColumn
+        | OrphanedReference of orphanCount: int64
+        | ValueOverflow of observed: string * declared: string
+
+    /// One data-reality finding to remediate. `Entity` / `Column` are the
+    /// operator-facing logical names the fidelity report carries; they resolve
+    /// back to the catalog's `Kind` / `Attribute` by `Name` at render time.
+    type DataRealityFinding =
+        {
+            Entity : string
+            Column : string
+            Kind   : DataRealityKind
+        }
+
+    /// The dedup axis a finding occupies — a decision block already rendered
+    /// for the same (entity, column, axis) makes the fidelity sibling
+    /// redundant (the two projections overlap on orphans / duplicates).
+    let private axisOf (kind: DataRealityKind) : string =
+        match kind with
+        | NullsInNotNullColumn _   -> "nulls"
+        | DuplicatesInUniqueColumn -> "duplicates"
+        | OrphanedReference _      -> "orphans"
+        | ValueOverflow _          -> "overflow"
+
+    let private kindByEntityName (catalog: Catalog) : Map<string, Kind> =
+        Catalog.allKinds catalog
+        |> List.map (fun k -> Name.value k.Name, k)
+        |> Map.ofList
+
+    let private kindByKey (catalog: Catalog) : Map<SsKey, Kind> =
+        Catalog.allKinds catalog
+        |> List.map (fun k -> k.SsKey, k)
+        |> Map.ofList
+
+    let private attributeByName (kind: Kind) (column: string) : Attribute option =
+        kind.Attributes |> List.tryFind (fun a -> Name.value a.Name = column)
+
     let private writeHeader
         (sb: StringBuilder)
         (subject: string)
@@ -87,8 +136,9 @@ module RemediationEmitter =
         sb.AppendLine(sprintf "-- Reason: %s" reason) |> ignore
         sb.AppendLine("-- =================================================================") |> ignore
 
-    let private writeOptions
+    let private writeOptionsLabeled
         (sb: StringBuilder)
+        (option2Label: string)
         (selectStmt: string)
         (updateStmt: string)
         (deleteStmt: string)
@@ -96,12 +146,20 @@ module RemediationEmitter =
         sb.AppendLine("-- OPTION 1 (active): inspect the offending rows") |> ignore
         sb.AppendLine(selectStmt) |> ignore
         sb.AppendLine() |> ignore
-        sb.AppendLine("-- OPTION 2: set to default (operator: confirm the default value)") |> ignore
+        sb.AppendLine(sprintf "-- OPTION 2: %s" option2Label) |> ignore
         sb.AppendLine(sprintf "-- %s" updateStmt) |> ignore
         sb.AppendLine() |> ignore
         sb.AppendLine("-- OPTION 3: delete the offending rows (operator: confirm row removal)") |> ignore
         sb.AppendLine(sprintf "-- %s" deleteStmt) |> ignore
         sb.AppendLine() |> ignore
+
+    let private writeOptions
+        (sb: StringBuilder)
+        (selectStmt: string)
+        (updateStmt: string)
+        (deleteStmt: string)
+        : unit =
+        writeOptionsLabeled sb "set to default (operator: confirm the default value)" selectStmt updateStmt deleteStmt
 
     /// Render remediation for a nullability conflict
     /// (`RequireOperatorApproval (MandatoryButHasNullsBeyondBudget _)`).
@@ -197,16 +255,138 @@ module RemediationEmitter =
                 keyColumns table
         writeOptions sb selectStmt updateStmt deleteStmt
 
-    /// Build the manifest.remediation.sql text from the three
-    /// DecisionSets. Deterministic ordering: per-axis decisions are
-    /// emitted in their stored chronological order (the writer
-    /// preserves A24 — earliest-first under bind); axes themselves
-    /// emit in fixed Nullability → ForeignKey → UniqueIndex order.
-    let emit
+    // -- Data-reality renderers (2026-07-06) --------------------------------
+
+    /// The reality-block header — the sibling of `writeHeader` for a finding
+    /// that has NO intervention behind it (the fidelity report measured the
+    /// source data against the declared model; no tightening decision fired).
+    let private writeRealityHeader
+        (sb: StringBuilder)
+        (subject: string)
+        (axis: string)
+        (reason: string)
+        : unit =
+        sb.AppendLine("-- =================================================================") |> ignore
+        sb.AppendLine(sprintf "-- Remediation: %s (data reality: %s)" subject axis) |> ignore
+        sb.AppendLine(sprintf "-- Reason: %s" reason) |> ignore
+        sb.AppendLine("-- =================================================================") |> ignore
+
+    let private subjectOf (kind: Kind) (attr: Attribute) : string =
+        sprintf "%s.%s" (Name.value kind.Name) (Name.value attr.Name)
+
+    /// Nulls observed in a column the model already declares NOT NULL — the
+    /// load-blocking case (an INSERT of the source rows fails the constraint).
+    let private renderRealityNulls
+        (sb: StringBuilder)
+        (kind: Kind)
+        (attr: Attribute)
+        (nullCount: int64)
+        : unit =
+        let table  = qualifiedTable kind
+        let column = brackets (ColumnRealization.columnNameText attr.Column)
+        let reason =
+            if nullCount > 0L then
+                sprintf "Declared NOT NULL; %d null value(s) observed in the source data. A data load fails on this column until the nulls are repaired." nullCount
+            else
+                "Declared NOT NULL; null values observed in the source data (count unknown). A data load fails on this column until the nulls are repaired."
+        writeRealityHeader sb (subjectOf kind attr) "nulls in a NOT NULL column" reason
+        let selectStmt = sprintf "SELECT * FROM %s WHERE %s IS NULL;" table column
+        let updateStmt = sprintf "UPDATE %s SET %s = <DEFAULT> WHERE %s IS NULL;" table column column
+        let deleteStmt = sprintf "DELETE FROM %s WHERE %s IS NULL;" table column
+        writeOptions sb selectStmt updateStmt deleteStmt
+
+    /// Duplicates observed under a UNIQUE / PK-backed declaration.
+    let private renderRealityDuplicates
+        (sb: StringBuilder)
+        (kind: Kind)
+        (attr: Attribute)
+        : unit =
+        let table  = qualifiedTable kind
+        let column = brackets (ColumnRealization.columnNameText attr.Column)
+        writeRealityHeader sb (subjectOf kind attr) "duplicates in a unique column"
+            "Declared unique (a unique index or primary key backs the column); duplicate values observed in the source data."
+        let selectStmt =
+            sprintf "SELECT %s, COUNT(*) AS RowCount FROM %s GROUP BY %s HAVING COUNT(*) > 1;" column table column
+        let updateStmt =
+            "Cannot UPDATE blindly; identify a canonical row per group and re-key the duplicates."
+        let deleteStmt =
+            sprintf
+                "DELETE FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY <CanonicalKey>) AS rn FROM %s) WHERE rn > 1;"
+                column table
+        writeOptionsLabeled sb "re-key the duplicates to distinct values (operator: choose the canonical row)"
+            selectStmt updateStmt deleteStmt
+
+    /// Source rows whose relationship value points at a target record that
+    /// does not exist. When the reference and its target's single-column
+    /// primary key resolve through the catalog, the statements are concrete;
+    /// otherwise the target placeholders remain for the operator to fill.
+    let private renderRealityOrphans
+        (sb: StringBuilder)
+        (kindsByKey: Map<SsKey, Kind>)
+        (kind: Kind)
+        (attr: Attribute)
+        (orphanCount: int64)
+        : unit =
+        let table  = qualifiedTable kind
+        let column = brackets (ColumnRealization.columnNameText attr.Column)
+        let target =
+            kind.References
+            |> List.tryFind (fun r -> r.SourceAttribute = attr.SsKey)
+            |> Option.bind (fun r -> Map.tryFind r.TargetKind kindsByKey)
+            |> Option.bind (fun targetKind ->
+                match targetKind.Attributes |> List.filter (fun a -> a.IsPrimaryKey) with
+                | [ pk ] -> Some (qualifiedTable targetKind, brackets (ColumnRealization.columnNameText pk.Column))
+                | _      -> None)
+        let reason =
+            sprintf "%d source row(s) reference a target record that does not exist. A data load fails on the relationship until the rows are re-pointed or removed." orphanCount
+        writeRealityHeader sb (subjectOf kind attr) "relationship values without a matching record" reason
+        let selectStmt, updateStmt, deleteStmt =
+            match target with
+            | Some (targetTable, targetPk) ->
+                sprintf "SELECT * FROM %s WHERE %s IS NOT NULL AND %s NOT IN (SELECT %s FROM %s);" table column column targetPk targetTable,
+                sprintf "UPDATE %s SET %s = <VALID_TARGET_KEY> WHERE %s IS NOT NULL AND %s NOT IN (SELECT %s FROM %s);" table column column column targetPk targetTable,
+                sprintf "DELETE FROM %s WHERE %s IS NOT NULL AND %s NOT IN (SELECT %s FROM %s);" table column column targetPk targetTable
+            | None ->
+                sprintf "SELECT * FROM %s WHERE %s IS NOT NULL;" table column,
+                sprintf "UPDATE %s SET %s = <VALID_TARGET_KEY> WHERE %s NOT IN (SELECT <TargetPK> FROM <TargetTable>);" table column column,
+                sprintf "DELETE FROM %s WHERE %s NOT IN (SELECT <TargetPK> FROM <TargetTable>);" table column
+        writeOptionsLabeled sb "re-point the rows at a valid target record (operator: confirm the key)"
+            selectStmt updateStmt deleteStmt
+
+    /// Values longer than the column's declared cap — the load truncates or
+    /// fails until the values fit (or the declaration widens).
+    let private renderRealityOverflow
+        (sb: StringBuilder)
+        (kind: Kind)
+        (attr: Attribute)
+        (observed: string)
+        (declared: string)
+        : unit =
+        let table  = qualifiedTable kind
+        let column = brackets (ColumnRealization.columnNameText attr.Column)
+        let reason =
+            sprintf "Values up to %s character(s) observed; the declared cap is %s. A data load truncates or fails until the values fit (or the declared length widens)." observed declared
+        writeRealityHeader sb (subjectOf kind attr) "values past the declared length" reason
+        let selectStmt = sprintf "SELECT * FROM %s WHERE LEN(%s) > %s;" table column declared
+        let updateStmt = sprintf "UPDATE %s SET %s = LEFT(%s, %s) WHERE LEN(%s) > %s;" table column column declared column declared
+        let deleteStmt = sprintf "DELETE FROM %s WHERE LEN(%s) > %s;" table column declared
+        writeOptionsLabeled sb "truncate to the declared cap (operator: confirm the loss of the overflow)"
+            selectStmt updateStmt deleteStmt
+
+    /// Build the manifest.remediation.sql text from the three DecisionSets
+    /// plus the fidelity report's data-reality findings (2026-07-06).
+    /// Deterministic ordering: per-axis decisions are emitted in their stored
+    /// chronological order (the writer preserves A24 — earliest-first under
+    /// bind); axes themselves emit in fixed Nullability → ForeignKey →
+    /// UniqueIndex order; the data-reality section follows in the fidelity
+    /// report's sorted order, deduplicated against the decision blocks on
+    /// (entity, column, axis).
+    let emitWith
         (catalog: Catalog)
         (nullability: NullabilityDecisionSet)
         (uniqueIndex: UniqueIndexDecisionSet)
         (foreignKey: ForeignKeyDecisionSet)
+        (findings: DataRealityFinding list)
         : string =
         use _ = Bench.scope "emit.remediation.emit"
         let sb = StringBuilder()
@@ -221,6 +401,9 @@ module RemediationEmitter =
         let idxIndex  = kindByIndexKey catalog
 
         let mutable count = 0
+        // The decision blocks' (entity, column, axis) coverage — a fidelity
+        // finding on the same coordinate is the same repair, stated twice.
+        let covered = System.Collections.Generic.HashSet<string * string * string>()
 
         for decision in nullability.Decisions do
             match decision.Outcome with
@@ -231,6 +414,7 @@ module RemediationEmitter =
                     renderNullabilityConflict
                         sb kind attr decision.InterventionId
                         nullCount rowCount budget
+                    covered.Add(Name.value kind.Name, Name.value attr.Name, "nulls") |> ignore
                     count <- count + 1
                 | None -> ()
             | _ -> ()
@@ -242,6 +426,9 @@ module RemediationEmitter =
                 | Some (kind, reference) ->
                     renderForeignKeyOrphans
                         sb kind reference decision.InterventionId orphanCount attrIndex
+                    (match Map.tryFind reference.SourceAttribute attrIndex with
+                     | Some (_, attr) -> covered.Add(Name.value kind.Name, Name.value attr.Name, "orphans") |> ignore
+                     | None -> ())
                     count <- count + 1
                 | None -> ()
             | _ -> ()
@@ -252,15 +439,57 @@ module RemediationEmitter =
                 match Map.tryFind decision.IndexKey idxIndex with
                 | Some (kind, idx) ->
                     renderUniqueIndexDuplicates sb kind idx decision.InterventionId attrIndex
+                    for ic in idx.Columns do
+                        match Map.tryFind ic.Attribute attrIndex with
+                        | Some (_, attr) -> covered.Add(Name.value kind.Name, Name.value attr.Name, "duplicates") |> ignore
+                        | None -> ()
                     count <- count + 1
                 | None -> ()
             | _ -> ()
 
+        // -- the data-reality section (the fidelity report's findings) ------
+        let fresh =
+            findings
+            |> List.filter (fun f -> not (covered.Contains(f.Entity, f.Column, axisOf f.Kind)))
+        if not (List.isEmpty fresh) then
+            let kindsByName = kindByEntityName catalog
+            let kindsByKey  = kindByKey catalog
+            sb.AppendLine("-- =================================================================") |> ignore
+            sb.AppendLine("-- Data reality — the source data measured against the declared model") |> ignore
+            sb.AppendLine("-- (the findings fidelity.json counts). Each block locates the offending") |> ignore
+            sb.AppendLine("-- rows; a data load can fail until they are repaired.") |> ignore
+            sb.AppendLine("-- =================================================================") |> ignore
+            sb.AppendLine() |> ignore
+            for finding in fresh do
+                match Map.tryFind finding.Entity kindsByName with
+                | None -> ()
+                | Some kind ->
+                    match attributeByName kind finding.Column with
+                    | None -> ()
+                    | Some attr ->
+                        (match finding.Kind with
+                         | NullsInNotNullColumn nullCount   -> renderRealityNulls sb kind attr nullCount
+                         | DuplicatesInUniqueColumn         -> renderRealityDuplicates sb kind attr
+                         | OrphanedReference orphanCount    -> renderRealityOrphans sb kindsByKey kind attr orphanCount
+                         | ValueOverflow (observed, declared) -> renderRealityOverflow sb kind attr observed declared)
+                        count <- count + 1
+
         if count = 0 then
             sb.AppendLine("-- No remediation candidates surfaced. All decisions either tightened cleanly") |> ignore
-            sb.AppendLine("-- or kept the prior state without operator-attention findings.") |> ignore
+            sb.AppendLine("-- or kept the prior state without operator-attention findings, and the") |> ignore
+            sb.AppendLine("-- profiled source data carries no violation of the declared model.") |> ignore
 
         sb.ToString()
+
+    /// The DecisionSets-only projection (the pre-2026-07-06 surface, kept for
+    /// callers without a fidelity report in hand).
+    let emit
+        (catalog: Catalog)
+        (nullability: NullabilityDecisionSet)
+        (uniqueIndex: UniqueIndexDecisionSet)
+        (foreignKey: ForeignKeyDecisionSet)
+        : string =
+        emitWith catalog nullability uniqueIndex foreignKey []
 
     /// `RegisteredTransform` metadata view per the pillar 9 +
     /// L3-CC-Transform-Totality discipline. Classifies as
@@ -270,4 +499,4 @@ module RemediationEmitter =
     let registeredMetadata : RegisteredTransformMetadata =
         RegisteredTransformMetadata.emitter "remediationEmitter" Diagnostics
             [ TransformSite.dataIntent "remediationOptions"
-                "Project Nullability/ForeignKey/UniqueIndex DecisionSet outcomes carrying operator-attention findings (RequireOperatorApproval / DataHasOrphans / DataHasDuplicates) into per-decision UPDATE/DELETE/SELECT options in manifest.remediation.sql. Operator-safety contract: only SELECT active; UPDATE + DELETE commented-out by default." ]
+                "Project Nullability/ForeignKey/UniqueIndex DecisionSet outcomes carrying operator-attention findings (RequireOperatorApproval / DataHasOrphans / DataHasDuplicates), plus the fidelity report's data-reality violations (nulls in NOT NULL columns / duplicates / orphans / length overflow, deduplicated against the decision blocks), into per-finding UPDATE/DELETE/SELECT options in manifest.remediation.sql. Operator-safety contract: only SELECT active; UPDATE + DELETE commented-out by default." ]

--- a/sidecar/projection/tests/Projection.Tests/ModelFidelityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ModelFidelityTests.fs
@@ -348,3 +348,25 @@ let ``ModelFidelity: violations sort deterministically by category then referenc
     let refsOf (r: ModelFidelity.ModelFidelityReport) =
         r.DataViolations |> List.map (fun v -> ModelFidelity.entityColumnText v.Reference, v.Kind)
     Assert.Equal<(string * ModelFidelity.ViolationKind) list>(refsOf a, refsOf b)
+
+// -- the data-violation rollup envelope payload (2026-07-06) -----------------
+
+[<Fact>]
+let ``ModelFidelity: a violating report yields ONE rollup payload with counts + artifact pointers`` () =
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    Assert.NotEmpty(report.DataViolations)
+    match ModelFidelity.dataViolationsPayload "out/manifest.remediation.sql" "out/fidelity.json" report with
+    | None -> Assert.Fail "expected a payload for a violating report"
+    | Some p ->
+        Assert.Equal(box (List.length report.DataViolations), p.["total"])
+        Assert.Equal(box "out/manifest.remediation.sql", p.["remediationPath"])
+        Assert.Equal(box "out/fidelity.json", p.["fidelityPath"])
+        // The per-axis keys are always present (0 when the axis is clean).
+        for key in [ "notNull"; "unique"; "orphans"; "overflow"; "entities" ] do
+            Assert.True(Map.containsKey key p, sprintf "payload missing %s" key)
+
+[<Fact>]
+let ``ModelFidelity: a clean report yields NO rollup payload (no envelope to emit)`` () =
+    let report = ModelFidelity.compose "ACME" fixtureCatalog Profile.empty { Decisions = [] } []
+    Assert.Empty(report.DataViolations)
+    Assert.True((ModelFidelity.dataViolationsPayload "r" "f" report).IsNone)

--- a/sidecar/projection/tests/Projection.Tests/NoticeRoutingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NoticeRoutingTests.fs
@@ -121,8 +121,12 @@ let ``the rollup copy reads as one calm line naming families, and points at the 
         match copy.Statement payload with
         | Projection.Cli.View.Note t ->
             Assert.Contains("214", t)
-            Assert.Contains("nullability 180", t)
-            Assert.Contains("identity 34", t)
+            // Count-first, concrete family labels (2026-07-06 full-voice audit) —
+            // and the internal compound "model-reality" never reaches the surface.
+            Assert.Contains("180 nullability difference(s)", t)
+            Assert.Contains("34 identity-flag difference(s)", t)
+            Assert.Contains("no action is required", t)
+            Assert.DoesNotContain("model-reality", t)
         | other -> Assert.Fail(sprintf "expected a Note statement, got %A" other)
         match copy.Action payload with
         | Some (Projection.Cli.View.Action a) -> Assert.Contains("notices/model-read/01RUN.json", a)

--- a/sidecar/projection/tests/Projection.Tests/RemediationEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RemediationEmitterTests.fs
@@ -175,3 +175,82 @@ let ``5.13.remediation: deterministic — repeated emit yields byte-identical ou
     let sql2 =
         RemediationEmitter.emit sampleCatalog nullability emptyUniqueIndex fk
     Assert.Equal(sql1, sql2)
+
+// ----------------------------------------------------------------------
+// Data reality (2026-07-06) — the fidelity report's violations render as
+// remediation blocks, deduplicated against the decision blocks.
+// ----------------------------------------------------------------------
+
+let private finding (entity: string) (column: string) (kind: RemediationEmitter.DataRealityKind) : RemediationEmitter.DataRealityFinding =
+    { Entity = entity; Column = column; Kind = kind }
+
+[<Fact>]
+let ``data reality: nulls in a NOT NULL column emit the 3 options with the observed count`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "Customer" "Name" (RemediationEmitter.NullsInNotNullColumn 5L) ]
+    Assert.Contains("data reality: nulls in a NOT NULL column", sql)
+    Assert.Contains("5 null value(s) observed", sql)
+    Assert.Contains("SELECT * FROM [dbo].[OSUSR_S1S_CUSTOMER] WHERE [NAME] IS NULL;", sql)
+    Assert.Contains("-- UPDATE [dbo].[OSUSR_S1S_CUSTOMER] SET [NAME] = <DEFAULT> WHERE [NAME] IS NULL;", sql)
+    Assert.Contains("-- DELETE FROM [dbo].[OSUSR_S1S_CUSTOMER] WHERE [NAME] IS NULL;", sql)
+    Assert.DoesNotContain("No remediation candidates surfaced", sql)
+
+[<Fact>]
+let ``data reality: an orphaned reference resolves the target table + PK to concrete SQL`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "Order" "CustomerId" (RemediationEmitter.OrphanedReference 7L) ]
+    Assert.Contains("data reality: relationship values without a matching record", sql)
+    Assert.Contains("7 source row(s) reference a target record that does not exist", sql)
+    // The target resolves through the catalog — the concrete Customer PK, no placeholders.
+    Assert.Contains("NOT IN (SELECT [ID] FROM [dbo].[OSUSR_S1S_CUSTOMER])", sql)
+    Assert.DoesNotContain("<TargetTable>", sql)
+
+[<Fact>]
+let ``data reality: a length overflow emits the LEN locate + commented truncation`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "Customer" "Name" (RemediationEmitter.ValueOverflow ("300", "200")) ]
+    Assert.Contains("data reality: values past the declared length", sql)
+    Assert.Contains("SELECT * FROM [dbo].[OSUSR_S1S_CUSTOMER] WHERE LEN([NAME]) > 200;", sql)
+    Assert.Contains("-- UPDATE [dbo].[OSUSR_S1S_CUSTOMER] SET [NAME] = LEFT([NAME], 200) WHERE LEN([NAME]) > 200;", sql)
+
+[<Fact>]
+let ``data reality: duplicates in a unique column emit the GROUP BY locate`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "Customer" "Name" RemediationEmitter.DuplicatesInUniqueColumn ]
+    Assert.Contains("data reality: duplicates in a unique column", sql)
+    Assert.Contains("SELECT [NAME], COUNT(*) AS RowCount FROM [dbo].[OSUSR_S1S_CUSTOMER] GROUP BY [NAME] HAVING COUNT(*) > 1;", sql)
+
+[<Fact>]
+let ``data reality: a finding covered by a decision block is deduplicated, never stated twice`` () =
+    let fk : ForeignKeyDecisionSet = { Decisions = [ fkOrphans orderRefToCustomer 7L ] }
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex fk
+            [ finding "Order" "CustomerId" (RemediationEmitter.OrphanedReference 7L) ]
+    // The decision block renders (with its intervention id); the fidelity
+    // sibling on the same (entity, column, axis) is suppressed.
+    Assert.Contains("intervention: fk-orphans", sql)
+    Assert.DoesNotContain("data reality: relationship values without a matching record", sql)
+
+[<Fact>]
+let ``data reality: an unresolvable entity renders nothing and never throws`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "NoSuchEntity" "NoSuchColumn" (RemediationEmitter.NullsInNotNullColumn 1L) ]
+    Assert.Contains("No remediation candidates surfaced", sql)
+
+[<Fact>]
+let ``data reality: destructive statements ship commented-out (the operator-safety contract holds)`` () =
+    let sql =
+        RemediationEmitter.emitWith sampleCatalog emptyNullability emptyUniqueIndex emptyForeignKey
+            [ finding "Customer" "Name" (RemediationEmitter.NullsInNotNullColumn 5L)
+              finding "Customer" "Name" (RemediationEmitter.ValueOverflow ("300", "200"))
+              finding "Order" "CustomerId" (RemediationEmitter.OrphanedReference 7L) ]
+    let lines = sql.Split([| '\n' |])
+    let destructive =
+        lines |> Array.filter (fun l -> l.Contains "UPDATE [dbo]" || l.Contains "DELETE FROM [dbo]")
+    Assert.NotEmpty(destructive)
+    Assert.All(destructive, fun l -> Assert.StartsWith("-- ", l.TrimStart()))

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -128,9 +128,12 @@ let ``shell: the notice rollup rides the live board as one calm strip row`` () =
             0)
         |> ignore
         let out = console.Output
-        // one calm line naming the families — never a wall
+        // one calm line naming the families — never a wall. (Single-word pins:
+        // the boxed board wraps the row at console width, so multi-word
+        // substrings can split across lines.)
         Assert.Contains("214", out)
-        Assert.Contains("nullability 180", out)
+        Assert.Contains("180", out)
+        Assert.Contains("nullability", out)
         // and the artifact pointer rides the strip row
         Assert.Contains("notices/model-read/01RUN.json", out)
     finally
@@ -259,7 +262,7 @@ let ``echo-the-fix: a suggestedConfig-bearing envelope ticks the board's live te
     // the teaser renders through the catalog (one register)
     let console = new TestConsole()
     console.Write(Watch.toRenderableWith [] 0 None b2)
-    Assert.Contains("2 config edit(s) suggested", console.Output)
+    Assert.Contains("2 optional configuration recommendation(s) gathered", console.Output)
 
 [<Fact>]
 let ``stat view: the aggregates table names category, code, and count, most-frequent first`` () =

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -140,6 +140,50 @@ let ``shell: the notice rollup rides the live board as one calm strip row`` () =
         Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
 
 [<Fact>]
+let ``shell: under pretty, stdout narration defers and flushes after the verdict panel (2026-07-06)`` () =
+    Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
+    LogSink.reset ()
+    let priorOut = Console.Out
+    use captured = new StringWriter()
+    Console.SetOut captured
+    try
+        let console = newConsole ()
+        Shell.executeOn console true true (goFrame "projection full-export") Shell.Bracket.SelfBracketed (Some (Spines.publishWith false false)) (fun () ->
+            printfn "42 artifact(s) written to ./dist/full-export."
+            LogSink.emit (LogSink.envelope LogSink.Info LogSink.Extract "extract.started" Map.empty)
+            LogSink.recordStageEvent "extract" 3L LogSink.Succeeded
+            LogSink.recordStageStart "profile"
+            LogSink.recordStageEvent "profile" 3L LogSink.Succeeded
+            LogSink.recordStageStart "emit"
+            LogSink.recordStageEvent "emit" 3L LogSink.Succeeded
+            0)
+        |> ignore
+        // The narration reached the real stdout — deferred, never lost...
+        Assert.Contains("42 artifact(s) written", captured.ToString())
+        // ...and never the box surface (the board + panel own that console).
+        Assert.DoesNotContain("42 artifact(s) written", console.Output)
+    finally
+        Console.SetOut priorOut
+        Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
+
+[<Fact>]
+let ``shell: a non-pretty run's stdout narration is untouched (no buffer)`` () =
+    LogSink.reset ()
+    let priorOut = Console.Out
+    use captured = new StringWriter()
+    Console.SetOut captured
+    try
+        let console = newConsole ()
+        LogSink.withWriter TextWriter.Null (fun () ->
+            Shell.executeOn console false false (goFrame "projection emit") Shell.Bracket.Bracketed None (fun () ->
+                printfn "plain narration line"
+                0))
+        |> ignore
+        Assert.Contains("plain narration line", captured.ToString())
+    finally
+        Console.SetOut priorOut
+
+[<Fact>]
 let ``shell: boardOfStored reconstructs the notice row from a stored run (R1e)`` () =
     let payload =
         sprintf

--- a/sidecar/projection/tests/Projection.Tests/ShellTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ShellTests.fs
@@ -258,7 +258,7 @@ let ``echo-the-fix: a suggestedConfig-bearing envelope ticks the board's live te
     Assert.Equal(2, b2.SuggestedEdits)
     // the teaser renders through the catalog (one register)
     let console = new TestConsole()
-    console.Write(Watch.toRenderableWith [] 0 false b2)
+    console.Write(Watch.toRenderableWith [] 0 None b2)
     Assert.Contains("2 config edit(s) suggested", console.Output)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/TtyRendererTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TtyRendererTests.fs
@@ -80,6 +80,26 @@ let ``Tier-3: a run with no CDC-measured leg shows no data line`` () =
     let text = renderToString "projection check" 0 (fun () -> ())
     Assert.DoesNotContain("CDC captured", text)
 
+[<Fact>]
+let ``Tier-3: the data-reality finding rides the panel with the remediation next move (2026-07-06)`` () =
+    let payload : Map<string, objnull> =
+        Map.ofList
+            [ "total", box 7; "entities", box 4
+              "notNull", box 3; "unique", box 1; "orphans", box 2; "overflow", box 1
+              "remediationPath", box "./dist/full-export/manifest.remediation.sql"
+              "fidelityPath",    box "./dist/full-export/fidelity.json" ]
+    let text =
+        renderToString "projection publish" 0 (fun () ->
+            LogSink.emit (LogSink.envelope LogSink.Warn LogSink.Emit ModelFidelity.dataViolationsCode payload))
+    Assert.Contains("data reality", text)
+    Assert.Contains("7 violation(s) across 4 table(s)", text)
+    Assert.Contains("review ./dist/full-export/manifest.remediation.sql", text)
+
+[<Fact>]
+let ``Tier-3: a run with no data-reality finding shows no data-reality row`` () =
+    let text = renderToString "projection publish" 0 (fun () -> ())
+    Assert.DoesNotContain("data reality", text)
+
 let private renderBoard (r: RunLedger.Readiness) (recent: string list) : string =
     use sw = new StringWriter()
     let console =

--- a/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/VoiceTotalityTests.fs
@@ -62,6 +62,9 @@ let private inScopeCodes : Set<string> =
           // the §12 at-scale rollup — the model read's divergence notices
           // condensed to one Warn envelope (LiveModelRead.surfaceDivergences)
           "adapter.ossys.modelRead.noticeRollup"
+          // the §12 data-reality rollup — the fidelity report's violations
+          // condensed to one Warn envelope (2026-07-06)
+          "fidelity.dataViolations"
           // the operator shell's §5 preview frame (Shell.execute, render-only)
           "shell.previewFrame"
           // the dispatch prologue's voiced notes (runPlan, render-only)
@@ -124,6 +127,9 @@ let private knownEmittableCodes : Set<string> =
           // the model read's notice rollup (LiveModelRead.surfaceDivergences —
           // one Warn envelope condensing the divergence notices; §12 at-scale law)
           "adapter.ossys.modelRead.noticeRollup"
+          // the fidelity data-violation rollup (Compose.runWithConfigCore —
+          // one Warn envelope when the source data contradicts the model)
+          "fidelity.dataViolations"
           // the operator shell's preview frame — render-synthesized (like the
           // watch.* frames), consumed at `Shell.execute`'s static open
           "shell.previewFrame"

--- a/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchInjectionTests.fs
@@ -152,7 +152,7 @@ let ``Watch board: an active stage breathes the phase's spinner frame (#20)`` ()
     // the static ▸, so a long-running stage visibly pulses as the drain loop advances `phase`.
     let active, _ = Watch.apply Watch.empty "extract.started" Map.empty   // one Active stage
     let console = new TestConsole()
-    console.Write(Watch.toRenderableWith [] 2 false active)   // header, phase 2, not stalled
+    console.Write(Watch.toRenderableWith [] 2 None active)   // header, phase 2, no quiet gap
     let out = console.Output
     Assert.Contains(Theme.spinner 2, out)               // the active line wears the phase-2 frame
     Assert.DoesNotContain(Theme.spinner 3, out)         // and only that frame (phase is fixed per render)
@@ -180,8 +180,8 @@ let ``renderWatchOn: a flood of foreign envelopes never starves the spinner hear
         Assert.Contains(Theme.spinner 2, out)   // ≥1 heartbeat repaint during the flood
         Assert.Contains(Theme.spinner 3, out)   // ≥2 — the spinner is breathing, not ticking once
         // A chatty pipeline is ALIVE: liveness keys off dequeued envelopes, so the
-        // flood must never read as a stall.
-        Assert.DoesNotContain("stalled", out)
+        // flood must never degrade the line to the quiet `processing` suffix.
+        Assert.DoesNotContain("processing", out)
     finally
         Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)
 
@@ -208,10 +208,12 @@ let ``renderWatchOn: a progress backlog coalesces — no post-run frame replay (
         sprintf "10k progress envelopes took %dms — the backlog must coalesce, never replay one dwelled frame per envelope" sw.ElapsedMilliseconds)
 
 [<Fact>]
-let ``renderWatchOn: a quiet progress-less stage renders stalled after the threshold (#20 rework)`` () =
-    // The honesty half of the stall design: a stage with NO progress events (every
-    // full-export stage today) that goes quiet past the threshold must SAY stalled,
-    // not just freeze a dimmed spinner. Threshold pinned low via the env seam.
+let ``renderWatchOn: a quiet progress-less stage renders processing after the threshold (#20 rework, amended 2026-07-06)`` () =
+    // The honesty half of the quiet design: a stage with NO progress events (every
+    // full-export stage today) that goes quiet past the threshold says `processing`
+    // in words — never `stalled` (a verdict the event stream cannot ground; the
+    // stage may be quiet-but-working) and never a bare frozen spinner. Threshold
+    // pinned low via the env seam.
     Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", "0")
     Environment.SetEnvironmentVariable("PROJECTION_WATCH_STALL_MS", "50")
     try
@@ -222,7 +224,8 @@ let ``renderWatchOn: a quiet progress-less stage renders stalled after the thres
             System.Threading.Thread.Sleep 400
             0)
         |> ignore
-        Assert.Contains("stalled", console.Output)
+        Assert.Contains("processing", console.Output)
+        Assert.DoesNotContain("stalled", console.Output)
     finally
         Environment.SetEnvironmentVariable("PROJECTION_WATCH_STALL_MS", null)
         Environment.SetEnvironmentVariable("PROJECTION_WATCH_DWELL_MS", null)

--- a/sidecar/projection/tests/Projection.Tests/WatchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchTests.fs
@@ -331,19 +331,22 @@ let ``Watch progress: an unknown total is a plain count-up — no fraction, no e
     Assert.DoesNotContain("remaining", text)
 
 [<Fact>]
-let ``Watch progress: a stalled active stage degrades the estimate to 'stalled', not a frozen countdown (#20)`` () =
+let ``Watch progress: a quiet active stage degrades the estimate to 'processing', not a frozen countdown (#20, amended 2026-07-06)`` () =
     let p : Watch.Progress = { Done = 142; Total = 300; ElapsedMs = 4000L }
     // live: the honest estimate shows
-    let live = Watch.progressTextStalled false p
+    let live = Watch.progressTextQuiet None p
     Assert.Contains("remaining", live)
-    Assert.DoesNotContain("stalled", live)
-    // stalled: the estimate degrades to `stalled` — never a countdown that keeps lying
-    let stalled = Watch.progressTextStalled true p
-    Assert.Contains("stalled", stalled)
-    Assert.DoesNotContain("remaining", stalled)
-    Assert.Contains("142 of 300", stalled)   // the honest count still shows
+    Assert.DoesNotContain("processing", live)
+    // quiet past the threshold: the estimate degrades to `processing` — never a
+    // countdown that keeps lying, and never a `stalled` verdict the event stream
+    // cannot ground (the stage may be quiet-but-working).
+    let quiet = Watch.progressTextQuiet (Some 6000L) p
+    Assert.Contains("processing", quiet)
+    Assert.DoesNotContain("remaining", quiet)
+    Assert.DoesNotContain("stalled", quiet)
+    Assert.Contains("142 of 300", quiet)   // the honest count still shows
     // it threads into the active stage line
-    Assert.Contains("stalled", Watch.lineTextWith true { Key = "load"; State = Watch.Active(Some p) })
+    Assert.Contains("processing", Watch.lineTextWith (Some 6000L) { Key = "load"; State = Watch.Active(Some p) })
 
 // ---------------------------------------------------------------------------
 // the run frame — the title header + the terminal done-frame (§13 D1)
@@ -482,27 +485,50 @@ let ``Watch fold: apply is the did-it-change shim over applyKind`` () =
         Assert.Equal(changed, fold <> Watch.Fold.NoChange)
 
 // ---------------------------------------------------------------------------
-// the stalled line for a progress-less stage (#20 rework — a quiet Active None
-// stage says `stalled` in words; a frozen dimmed spinner alone explained nothing)
+// the quiet line for a progress-less stage (#20 rework, amended 2026-07-06 — a
+// quiet Active None stage says `processing` in words; a frozen dimmed spinner
+// alone explained nothing, and `stalled` asserted more than the events proved)
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``Watch line: a stalled progress-less stage reads stalled in words`` () =
-    let text = Watch.lineTextWith true { Key = "extract"; State = Watch.Active None }
+let ``Watch line: a quiet progress-less stage reads processing in words`` () =
+    let text = Watch.lineTextWith (Some 6000L) { Key = "extract"; State = Watch.Active None }
     Assert.Contains("Reading the model", text)
-    Assert.Contains("stalled", text)
-
-[<Fact>]
-let ``Watch line: a live progress-less stage carries no stall suffix`` () =
-    let text = Watch.lineTextWith false { Key = "extract"; State = Watch.Active None }
+    Assert.Contains("processing", text)
     Assert.DoesNotContain("stalled", text)
 
 [<Fact>]
-let ``Watch line: the stalled suffix clears the twelve-rule banned list`` () =
+let ``Watch line: a live progress-less stage carries no processing suffix`` () =
+    let text = Watch.lineTextWith None { Key = "extract"; State = Watch.Active None }
+    Assert.DoesNotContain("processing", text)
+
+[<Fact>]
+let ``Watch line: the processing suffix clears the twelve-rule banned list`` () =
     let banned =
         [ "your"; "you "; " i "; " we "; "that's real"; ", not "
-          "destroy"; "cleaned up"; "dig"; "oops"; "let's"; "refused" ]
-    let line = Watch.lineTextWith true { Key = "profile"; State = Watch.Active None }
+          "destroy"; "cleaned up"; "dig"; "oops"; "let's"; "refused"; "stalled" ]
+    let line = Watch.lineTextWith (Some 6000L) { Key = "profile"; State = Watch.Active None }
     let lowered = line.ToLowerInvariant()
     for b in banned do
-        Assert.False(lowered.Contains b, sprintf "stalled line '%s' breaks the banned list: contains '%s'" line b)
+        Assert.False(lowered.Contains b, sprintf "quiet line '%s' breaks the banned list: contains '%s'" line b)
+
+// ---------------------------------------------------------------------------
+// the data-reality rollup on the notice strip (2026-07-06)
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``Watch notices: the fidelity data-violation rollup folds onto the notice strip`` () =
+    let p : Map<string, objnull> =
+        Map.ofList
+            [ "total", box 7; "entities", box 4; "notNull", box 3
+              "remediationPath", box "out/manifest.remediation.sql" ]
+    let code = Projection.Pipeline.ModelFidelity.dataViolationsCode
+    let b, _ = Watch.applyKind Watch.empty code p
+    Assert.Single(b.Notices) |> ignore
+    // Replace-by-code: a publish re-emitting the rollup folds to ONE row.
+    let b2, _ = Watch.applyKind b code p
+    Assert.Single(b2.Notices) |> ignore
+    // The strip's line reads the Voice copy + the remediation pointer.
+    let text = Watch.noticeText code p
+    Assert.Contains("contradicts the declared model", text)
+    Assert.Contains("out/manifest.remediation.sql", text)


### PR DESCRIPTION
Remediates the operator complaints from a real `--pretty -v publish` run. Three commits.

## The stall verdict retires
- An active stage quiet past the threshold now reads `processing` (operator-chosen wording) instead of `stalled` — the event stream witnesses silence, not a stall, and long SQL / CPU-bound stages are usually quiet-but-working. The stale `~Ns remaining` estimate still drops (a frozen countdown keeps lying).
- The spinner keeps breathing through the quiet gap instead of freezing (the frozen glyph read as a hang). Threshold 3s → 5s; the `PROJECTION_WATCH_STALL_MS` seam is unchanged.

## Under pretty, the boxed surface owns the console
- The `-v` bench counters table (`emit.scriptDom.build.columns`, `ir.registry.digest`, …) no longer sprays raw over the board — the snapshot still persists and one line names its path. Headless/piped `-v` keeps the table.
- The per-file artifact enumeration after a publish is suppressed under pretty (the one-line total + the verdict panel carry the finding). Piped/plain runs keep the full list.
- **The 2026-07-03 stdout-narration residual is resolved whole**: `Shell.executeOn` defers stdout narration under pretty — `Console.Out` redirects to a buffer for the body's span and flushes verbatim after the verdict panel, so every face's narration lands below the box in reading order instead of interleaving with the Live region's repaints. One choke point at the one door; prompts stay safe under the 2026-06-17 hoist rule; piped/plain stdout is byte-identical.

## The fidelity report becomes actionable
- `RemediationEmitter.emitWith` renders the fidelity report's data violations as remediation blocks in `manifest.remediation.sql`: nulls in NOT NULL columns (the load-blocking case the tightening DecisionSets structurally never reach), duplicates, FK orphans (with the concrete target table + PK resolved through the catalog), and length overflow (previously had no renderer). Deduplicated against the DecisionSet blocks on (entity, column, axis); the operator-safety contract holds (SELECT active, UPDATE/DELETE commented out).
- One `fidelity.dataViolations` Warn rollup envelope per run (per-axis counts + artifact pointers) now reaches the live board's notice strip and the verdict panel — a `data reality` row plus a `review manifest.remediation.sql` next move that leads the Next rows (a data repair outranks an optional config edit).

## The full-voice diction audit (THE_VOICE.md, twelve rules)
- `watch.suggestedEdits`: "N config edit(s) suggested so far — the verdict panel ranks the lever" → "N optional configuration recommendation(s) gathered so far. Each is advisory and needs no action to complete this run; a summary follows at the end."
- `adapter.ossys.modelRead.noticeRollup`: "N model-reality notices — …" → "The deployed database's column shapes differ from the model's declarations in N place(s) — <count-first family list>. The model's declared values were kept and the run continues; no action is required."
- Verdict panel: the "actionable" row becomes "recommendations" (the old label asserted action was required for optional advisories), Neutral not Warn, humane numerals, "top:" telegraphese dropped.
- Readiness board: the internal word "canary" no longer leaks ("round-trip verification"); humane numerals on the transforms and data-reality rows.

## Docs & tests
- `DECISIONS.md` 2026-07-06 entry ("operator-report round 2") + `SPECTRE_REFINEMENTS.md` #20 amendment.
- Reworked quiet-line tests, new data-reality remediation tests (four axes, concrete FK target, dedup, safety contract), payload-builder tests, verdict-panel row tests, notice-strip fold test, narration-deferral tests, updated voice pins, and the new code added to the Voice code⇔copy totality lists. Fast (pure) pool green on all three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CutYGJwm2TwAXrEL23RYva