### PR TITLE
OSSYS extraction: retire the SequentialAccess row-mapping bug class (capture-then-map)

### DIFF
--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -830,3 +830,42 @@ docker sweep GREEN.
 
 **Final verdict:** the full docker pool PASSED IN FULL (484s) with the pin aboard.
 Ready for the live test.
+
+## Entry 22 — 2026-07-07, THE SEQUENTIAL-ACCESS CATCH: the live run's first real estate killed both contract reads at row-mapping
+
+**What the live run hit (step one, contracts):** both OSSYS metamodel reads died with
+`adapter.ossysSql.rowMapping: Failed to map row 0 of result set 'attributes': Invalid
+attempt to read from column ordinal '2'. With CommandBehavior.SequentialAccess, you may
+only read from column ordinal '18' or greater.` — the go board's "a metamodel could not
+be read" red line. A one-off reorder of the offending read just moves the violation
+(fix the ordinal-2 re-read by hoisting it and the very next read of ordinal 0 throws
+the same class), which is the tell that the CONTRACT, not the call site, was wrong.
+
+**Root cause.** `MetadataSnapshotRunner` executes the rowsets script with
+`CommandBehavior.SequentialAccess` (cells stream; the drained JSON rowsets skip
+without buffering), whose live-reader contract is *each ordinal visited at most once,
+strictly ascending*. The typed mappers assumed random access. One mapper violated it:
+`mapAttributeRow`'s PhysicalCol fallback — NULL `PhysicalColumnName` (ordinal 17) →
+re-read AttrName (ordinal 2). The canary never fired it because the edge-case seed
+populates every `Physical_Column_Name` and the script's sys.columns backfill covers
+the rest; a real estate carries orphan attributes (metadata outliving a dropped
+column) whose physical name survives NULL to the mapper.
+
+**The refactor (class-retiring, not site-patching):** capture-then-map. `captureRow`
+is now the ONLY cell-access site against the live reader — one ascending,
+single-visit sweep materializing each row at rest (`RowAtRest`) — and all 13 mappers
+consume the captured row, where ordinal access carries no order or visit-count
+obligation. The typed accessors (`readString`/`readInt`/`readBool`/`readGuidOpt` +
+opts) keep their NULL-guard semantics (DBNull carried verbatim from `GetValue`);
+capture failures classify through the same `RowMappingFailure` axis. SequentialAccess
+stays (its win — no double row-buffering, free JSON-rowset drain — is untouched);
+`ReadSide`'s streaming reader already honored the contract by construction and is
+unchanged.
+
+**Proven:** new `MetadataSnapshotSequentialAccessTests` (docker) seeds the edge-case
+fixture PLUS the orphan shape (active attribute, NULL `Physical_Column_Name`, name
+matching no physical column) — on the pre-refactor code it reproduces the live
+failure verbatim; on the refactored runner the extraction succeeds and the orphan
+falls back to the upper-cased attr name while its neighbors keep their real physical
+names. Fast pool green (39s); the full docker-pool sweep verdict is appended below
+when it completes.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -867,5 +867,8 @@ fixture PLUS the orphan shape (active attribute, NULL `Physical_Column_Name`, na
 matching no physical column) — on the pre-refactor code it reproduces the live
 failure verbatim; on the refactored runner the extraction succeeds and the orphan
 falls back to the upper-cased attr name while its neighbors keep their real physical
-names. Fast pool green (39s); the full docker-pool sweep verdict is appended below
-when it completes.
+names.
+
+**Final verdict:** the full sweep PASSED IN FULL — fast pool 3937/3937 (39s), docker
+pool 289/289 (518s, regression test aboard), scale pool 16/16 (79s). The contracts
+gate no longer dies on estates carrying orphan attributes.

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
@@ -365,24 +365,62 @@ module MetadataSnapshotRunner =
         }
 
     // -------------------------------------------------------------------
-    // Internal helpers — typed SqlDataReader column readers. Pattern
-    // mirrors V1's `Column.StringOrNull` etc. but uses ordinal-indexed
-    // access for performance + F# idioms.
+    // Internal helpers — capture-then-map row access.
+    //
+    // The runner executes with `CommandBehavior.SequentialAccess` (cells
+    // stream instead of row-buffering; the drained JSON-aggregate rowsets
+    // skip without a single cell access). Under SequentialAccess the LIVE
+    // reader permits each ordinal to be visited at most once, strictly
+    // ascending — an access contract a typed mapper's field order either
+    // honors or violates only at run time (`Invalid attempt to read from
+    // column ordinal …`). 2026-07-07: `mapAttributeRow`'s PhysicalCol
+    // fallback re-read ordinal 2 after ordinal 17 and killed BOTH
+    // contract reads of a partial transfer on an estate whose
+    // `PhysicalColumnName` resolves NULL. `captureRow` is therefore the
+    // ONLY cell-access site against the live reader — one ascending
+    // single-visit sweep materializing the row at rest — and every
+    // mapper consumes the captured `RowAtRest`, where ordinal access
+    // carries no order or visit-count obligation. Accessor surface
+    // mirrors V1's `Column.StringOrNull` etc.
     // -------------------------------------------------------------------
 
-    let private readString (reader: SqlDataReader) (ordinal: int) : string =
-        if reader.IsDBNull(ordinal) then
+    /// One result-set row at rest: every cell materialized exactly once,
+    /// in ascending ordinal order. NULL cells carry `DBNull.Value`
+    /// (exactly what `SqlDataReader.GetValue` returns), so the accessor
+    /// NULL-guards below stay faithful to the prior live `IsDBNull` reads.
+    [<Struct>]
+    type private RowAtRest = RowAtRest of cells: obj array
+
+    /// The single live-reader cell-access site (see the block comment
+    /// above): one strictly-ascending, single-visit sweep — exactly the
+    /// access contract `CommandBehavior.SequentialAccess` requires.
+    let private captureRow (reader: SqlDataReader) : RowAtRest =
+        let cells = Array.zeroCreate<obj> reader.FieldCount
+        for ordinal in 0 .. cells.Length - 1 do
+            cells.[ordinal] <- reader.GetValue(ordinal)
+        RowAtRest cells
+
+    let private cellAt (RowAtRest cells) (ordinal: int) : obj =
+        cells.[ordinal]
+
+    let private isDbNull (row: RowAtRest) (ordinal: int) : bool =
+        match cellAt row ordinal with
+        | :? DBNull -> true
+        | _ -> false
+
+    let private readString (row: RowAtRest) (ordinal: int) : string =
+        if isDbNull row ordinal then
             invalidOp (sprintf "MetadataSnapshotRunner: required column at ordinal %d was NULL" ordinal)
         else
-            reader.GetString(ordinal)
+            unbox<string> (cellAt row ordinal)
 
-    let private readStringOpt (reader: SqlDataReader) (ordinal: int) : string option =
-        if reader.IsDBNull(ordinal) then None
-        else Some (reader.GetString(ordinal))
+    let private readStringOpt (row: RowAtRest) (ordinal: int) : string option =
+        if isDbNull row ordinal then None
+        else Some (unbox<string> (cellAt row ordinal))
 
-    let private readInt (reader: SqlDataReader) (ordinal: int) : int =
+    let private readInt (row: RowAtRest) (ordinal: int) : int =
         // V1 sometimes returns int via flexible widening (Int16 / Int64);
-        // SqlDataReader.GetInt32 throws on type mismatch. Use Convert to
+        // a direct Int32 unbox throws on type mismatch. Use Convert to
         // tolerate width variation.
         //
         // Defensive-fallback (slice A.4.7'-prelude.defensive-hardening,
@@ -392,45 +430,45 @@ module MetadataSnapshotRunner =
         // produced Catalog). Raise on NULL so the caller's snapshot
         // contract is honored (any required-int column with NULL is a
         // V1-source data integrity issue, not a V2 adapter problem).
-        if reader.IsDBNull(ordinal) then
+        if isDbNull row ordinal then
             invalidOp (sprintf "MetadataSnapshotRunner: required int column at ordinal %d was NULL" ordinal)
         else
-            System.Convert.ToInt32(reader.GetValue(ordinal))
+            System.Convert.ToInt32(cellAt row ordinal)
 
-    let private readIntOpt (reader: SqlDataReader) (ordinal: int) : int option =
-        if reader.IsDBNull(ordinal) then None
-        else Some (readInt reader ordinal)
+    let private readIntOpt (row: RowAtRest) (ordinal: int) : int option =
+        if isDbNull row ordinal then None
+        else Some (readInt row ordinal)
 
-    let private readBool (reader: SqlDataReader) (ordinal: int) : bool =
-        let value = reader.GetValue(ordinal)
+    let private readBool (row: RowAtRest) (ordinal: int) : bool =
+        let value = cellAt row ordinal
         match value with
         | :? bool as b -> b
         | :? byte as b -> b <> 0uy
         | :? int as i  -> i <> 0
         | _ -> System.Convert.ToBoolean(value)
 
-    let private readBoolOpt (reader: SqlDataReader) (ordinal: int) : bool option =
-        if reader.IsDBNull(ordinal) then None
-        else Some (readBool reader ordinal)
+    let private readBoolOpt (row: RowAtRest) (ordinal: int) : bool option =
+        if isDbNull row ordinal then None
+        else Some (readBool row ordinal)
 
-    let private readGuidOpt (reader: SqlDataReader) (ordinal: int) : Guid option =
-        if reader.IsDBNull(ordinal) then None
-        else Some (reader.GetGuid(ordinal))
+    let private readGuidOpt (row: RowAtRest) (ordinal: int) : Guid option =
+        if isDbNull row ordinal then None
+        else Some (unbox<Guid> (cellAt row ordinal))
 
-    /// Read all rows of the current result set via `mapper`; advance to
-    /// the next result set when complete. Returns the rows in source
-    /// order.
+    /// Read all rows of the current result set — each row captured at
+    /// rest via `captureRow`, then handed to `mapper`; advance to the
+    /// next result set when complete. Returns the rows in source order.
     ///
-    /// Mapper failures (e.g., `InvalidCastException` from a widened SQL
-    /// type or `InvalidOperationException` from a required-but-NULL
-    /// column) re-raise as `RowMappingException` carrying the
-    /// `resultSetName` + zero-based `rowIndex` for downstream
-    /// classification (matrix row 32 cash-out — the typed
+    /// Capture + mapper failures (e.g., `InvalidCastException` from a
+    /// widened SQL type or `InvalidOperationException` from a
+    /// required-but-NULL column) re-raise as `RowMappingException`
+    /// carrying the `resultSetName` + zero-based `rowIndex` for
+    /// downstream classification (matrix row 32 cash-out — the typed
     /// `MetadataExtractionError.RowMappingFailure` variant).
     let private readResultSet<'T>
             (resultSetName: string)
             (reader: SqlDataReader)
-            (mapper: SqlDataReader -> 'T)
+            (mapper: RowAtRest -> 'T)
             : Task<'T list> =
         task {
             let acc = ResizeArray<'T>()
@@ -441,7 +479,7 @@ module MetadataSnapshotRunner =
                 if advanced then
                     let row =
                         try
-                            mapper reader
+                            mapper (captureRow reader)
                         with
                         | :? RowMappingException -> reraise ()
                         | ex -> raise (RowMappingException (resultSetName, rowIndex, ex))
@@ -463,7 +501,7 @@ module MetadataSnapshotRunner =
             return ()
         }
 
-    let private mapModuleRow (r: SqlDataReader) : OssysModuleRow =
+    let private mapModuleRow (r: RowAtRest) : OssysModuleRow =
         { EspaceId       = readInt r 0
           EspaceName     = readString r 1
           IsSystemModule = readBool r 2
@@ -471,7 +509,7 @@ module MetadataSnapshotRunner =
           EspaceKind     = readStringOpt r 4
           EspaceSsKey    = readGuidOpt r 5 }
 
-    let private mapEntityRow (r: SqlDataReader) : OssysEntityRow =
+    let private mapEntityRow (r: RowAtRest) : OssysEntityRow =
         { EntityId          = readInt r 0
           EntityName        = readString r 1
           PhysicalTableName = readString r 2
@@ -484,7 +522,7 @@ module MetadataSnapshotRunner =
           EntitySsKey       = readGuidOpt r 9
           Description       = readStringOpt r 10 }
 
-    let private mapAttributeRow (r: SqlDataReader) : OssysAttributeRow =
+    let private mapAttributeRow (r: RowAtRest) : OssysAttributeRow =
         { AttrId         = readInt r 0
           EntityId       = readInt r 1
           AttrName       = readString r 2
@@ -507,7 +545,10 @@ module MetadataSnapshotRunner =
           PhysicalCol    =
               // ordinal 17 = PhysicalColumnName; V1 reads it as
               // nullable but V2 requires non-null for `KindRow.PhysicalCol`.
-              // Fall back to AttrName when V1 source omits.
+              // Fall back to AttrName when V1 source omits. The fallback's
+              // ordinal-2 re-read is free on the captured row — against
+              // the LIVE SequentialAccess reader it was the 2026-07-07
+              // partial-transfer killer (see the capture-then-map block).
               match readStringOpt r 17 with
               | Some n when not (System.String.IsNullOrWhiteSpace n) -> n
               | _ -> (readString r 2).ToUpperInvariant()
@@ -519,13 +560,13 @@ module MetadataSnapshotRunner =
           // this is non-null on a live extraction.
           Order          = readIntOpt r 23 }
 
-    let private mapReferenceRow (r: SqlDataReader) : OssysReferenceRow =
+    let private mapReferenceRow (r: RowAtRest) : OssysReferenceRow =
         { AttrId          = readInt r 0
           RefEntityId     = readIntOpt r 1
           RefEntityName   = readStringOpt r 2
           RefPhysicalName = readStringOpt r 3 }
 
-    let private mapPhysicalTableRow (r: SqlDataReader) : OssysPhysicalTableRow =
+    let private mapPhysicalTableRow (r: RowAtRest) : OssysPhysicalTableRow =
         { EntityId   = readInt r 0
           SchemaName = readString r 1
           TableName  = readString r 2
@@ -536,7 +577,7 @@ module MetadataSnapshotRunner =
     // V1's SELECT-projection ordering in `outsystems_metadata_rowsets.sql`
     // (see line numbers cited in each mapper's docstring).
 
-    let private mapColumnRealityRow (r: SqlDataReader) : OssysColumnRealityRow =
+    let private mapColumnRealityRow (r: RowAtRest) : OssysColumnRealityRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1025-1040
         { AttrId                = readInt        r 0
           IsNullable            = readBool       r 1
@@ -552,18 +593,18 @@ module MetadataSnapshotRunner =
           DefaultDefinition     = readStringOpt  r 11
           PhysicalColumn        = readStringOpt  r 12 }
 
-    let private mapColumnCheckRow (r: SqlDataReader) : OssysColumnCheckRow =
+    let private mapColumnCheckRow (r: RowAtRest) : OssysColumnCheckRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1042-1048
         { AttrId         = readInt       r 0
           ConstraintName = readString    r 1
           Definition     = readStringOpt r 2
           IsNotTrusted   = readBool      r 3 }
 
-    let private mapPhysColsPresentRow (r: SqlDataReader) : OssysPhysColsPresentRow =
+    let private mapPhysColsPresentRow (r: RowAtRest) : OssysPhysColsPresentRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1056-1059
         { AttrId = readInt r 0 }
 
-    let private mapAllIdxRow (r: SqlDataReader) : OssysAllIdxRow =
+    let private mapAllIdxRow (r: RowAtRest) : OssysAllIdxRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1061-1082
         { EntityId             = readInt        r 0
           ObjectId             = readInt        r 1
@@ -585,7 +626,7 @@ module MetadataSnapshotRunner =
           PartitionColumnsJson = readStringOpt  r 17
           DataCompressionJson  = readStringOpt  r 18 }
 
-    let private mapIdxColMappedRow (r: SqlDataReader) : OssysIdxColMappedRow =
+    let private mapIdxColMappedRow (r: RowAtRest) : OssysIdxColMappedRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1084-1092
         { EntityId       = readInt       r 0
           IndexName      = readString    r 1
@@ -595,7 +636,7 @@ module MetadataSnapshotRunner =
           Direction      = readStringOpt r 5
           HumanAttr      = readStringOpt r 6 }
 
-    let private mapFkRealityRow (r: SqlDataReader) : OssysFkRealityRow =
+    let private mapFkRealityRow (r: RowAtRest) : OssysFkRealityRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1095-1106
         { EntityId           = readInt        r 0
           FkObjectId         = readInt        r 1
@@ -608,7 +649,7 @@ module MetadataSnapshotRunner =
           ReferencedTable    = readStringOpt  r 8
           IsNoCheck          = readBool       r 9 }
 
-    let private mapFkColumnRow (r: SqlDataReader) : OssysFkColumnRow =
+    let private mapFkColumnRow (r: RowAtRest) : OssysFkColumnRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1109-1119
         { EntityId           = readInt        r 0
           FkObjectId         = readInt        r 1
@@ -620,7 +661,7 @@ module MetadataSnapshotRunner =
           ReferencedAttrId   = readIntOpt     r 7
           ReferencedAttrName = readStringOpt  r 8 }
 
-    let private mapTriggerRow (r: SqlDataReader) : OssysTriggerRow =
+    let private mapTriggerRow (r: RowAtRest) : OssysTriggerRow =
         // V1 SELECT at outsystems_metadata_rowsets.sql:1146-1151
         { EntityId          = readInt       r 0
           TriggerName       = readString    r 1
@@ -763,7 +804,7 @@ module MetadataSnapshotRunner =
                 // JSON-aggregation tail (#AttrCheckJson, #FkAttrMap,
                 // #AttrHasFK, #FkColumnsJson, #FkAttrJson, #AttrJson,
                 // #RelJson, #IdxJson, #TriggerJson, #ModuleJson).
-                let read (name: string) (mapper: SqlDataReader -> 'T) : Task<'T list> =
+                let read (name: string) (mapper: RowAtRest -> 'T) : Task<'T list> =
                     task {
                         use _ = Bench.scope "adapter.osm.extract.rowset"
                         use _ = Bench.scope (sprintf "adapter.osm.extract.rowset.%s" name)

--- a/sidecar/projection/tests/Projection.Tests.Integration/MetadataSnapshotSequentialAccessTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/MetadataSnapshotSequentialAccessTests.fs
@@ -1,0 +1,68 @@
+namespace Projection.Tests
+
+// The SequentialAccess row-mapping regression (2026-07-07). The OSSYS
+// metadata runner executes with `CommandBehavior.SequentialAccess`; the
+// live reader therefore permits each column ordinal to be visited at
+// most once, strictly ascending. `mapAttributeRow`'s PhysicalCol
+// fallback (NULL `PhysicalColumnName` → upper-cased AttrName — a
+// re-read of ordinal 2 after ordinal 17) violated that contract and
+// killed BOTH contract reads of a partial transfer, on an estate where
+// an attribute's physical name resolves NULL (the physical column is
+// absent, so the script's sys.columns backfill cannot supply a name).
+// The runner now captures each row at rest — one ascending,
+// single-visit sweep — before mapping; this suite pins the estate
+// shape that detonated:
+//
+//   * an ACTIVE attribute whose Physical_Column_Name is NULL and whose
+//     Name matches no physical column (an orphan — metadata outliving
+//     a dropped column), so NULL survives to the mapper and the
+//     fallback path actually executes under SequentialAccess. The
+//     edge-case seed alone never fires it (every seeded attribute
+//     carries a physical name), which is exactly how the defect
+//     shipped past the canary.
+//
+// Serial via Docker-SqlServer; blocking wait via TaskSync.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Adapters.OssysSql
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type MetadataSnapshotSequentialAccessTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``a NULL PhysicalColumnName maps under SequentialAccess — the PhysicalCol fallback reads the captured row, not the live reader`` () =
+        if not (Deploy.Docker.ensureRunning ()) then
+            printfn "SKIP SeqAccessRegression: Docker daemon not reachable."
+        else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "SeqAccess" (fun cnn _ -> task {
+                do! Deploy.executeBatch cnn (MetadataExtractionSql.readEdgeCaseSeed ())
+                // The orphan: active metadata on City (2001), NULL
+                // Physical_Column_Name, and a Name ('ArchivedNote')
+                // matching no column of OSUSR_DEF_CITY — neither the
+                // seed nor the script's catalog backfill can supply a
+                // physical name, so the mapper's fallback must fire.
+                do! Deploy.executeBatch cnn
+                        "INSERT INTO [dbo].[ossys_Entity_Attr] \
+                            ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Length], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Order_Num]) \
+                         VALUES (20014, 2001, N'ArchivedNote', 'dddddddd-0000-0000-0000-000000000004', N'Text', 200, 0, 1, 0, 0, 30);"
+                let! snapshotResult =
+                    MetadataSnapshotRunner.runAsync cnn MetadataSnapshotRunner.defaultParameters
+                match snapshotResult with
+                | Error errors ->
+                    Assert.Fail (sprintf "extraction failed: %A" errors)
+                | Ok snapshot ->
+                    let orphan =
+                        snapshot.Attributes |> List.find (fun a -> a.AttrId = 20014)
+                    Assert.Equal("ARCHIVEDNOTE", orphan.PhysicalCol)
+                    // Neighbors on the same entity keep their real
+                    // physical names — the fallback fired for the
+                    // orphan only, not as a blanket rewrite.
+                    let named =
+                        snapshot.Attributes |> List.find (fun a -> a.AttrId = 20012)
+                    Assert.Equal("NAME", named.PhysicalCol)
+                return ()
+            }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="DmlPrincipal.fs" />
     <Compile Include="MockOutSystemsEnv.fs" />
     <Compile Include="LiveSourceDockerTests.fs" />
+    <Compile Include="MetadataSnapshotSequentialAccessTests.fs" />
     <Compile Include="PayOnceCombinedVerbDockerTests.fs" />
     <Compile Include="PayOnceSchemaReadDockerTests.fs" />
     <Compile Include="ClosureOracleDockerTests.fs" />


### PR DESCRIPTION
## What the live run hit

A partial transfer stopped at the contracts gate — both OSSYS metamodel reads (source + sink) died with:

```
adapter.ossysSql.rowMapping: Failed to map row 0 of result set 'attributes':
Invalid attempt to read from column ordinal '2'. With CommandBehavior.SequentialAccess,
you may only read from column ordinal '18' or greater.
```

Fixing the one read just moves the violation to the next ordinal (hoist the ordinal-2 read and ordinal 0 throws the same class) — the tell that the access **contract**, not the call site, was wrong.

## Root cause

`MetadataSnapshotRunner` executes the rowsets script with `CommandBehavior.SequentialAccess`, whose live-reader contract is *each ordinal visited at most once, strictly ascending*. The typed mappers assumed random access; `mapAttributeRow`'s PhysicalCol fallback (NULL `PhysicalColumnName` → upper-cased AttrName) re-read ordinal 2 after ordinal 17. The canary never fired the fallback because the edge-case seed populates every `Physical_Column_Name` and the script's `sys.columns` backfill covers the rest; a real estate carries orphan attributes (metadata outliving a dropped column) whose physical name survives NULL to the mapper.

## The refactor — class-retiring, not site-patching

- `captureRow` is now the **only** cell-access site against the live reader: one ascending, single-visit sweep per row materializing a `RowAtRest` — exactly the SequentialAccess contract, satisfied in one place.
- All 13 typed mappers consume the captured row, where ordinal access carries no order or visit-count obligation.
- Accessor semantics preserved: DBNull guards (NULL cells carry `DBNull.Value` verbatim from `GetValue`), `Convert.ToInt32` width tolerance, bool coercion; capture failures classify through the same `RowMappingFailure` axis.
- `SequentialAccess` stays: the drained JSON-aggregate rowsets still skip without a single cell access, and mapped rowsets read each cell exactly once. `ReadSide`'s streaming reader already honored the contract by construction and is unchanged.

## Proof

- New `MetadataSnapshotSequentialAccessTests` (Docker pool) seeds the edge-case fixture **plus the orphan shape** (active attribute, NULL `Physical_Column_Name`, name matching no physical column). On the pre-refactor code it reproduces the live failure verbatim; on the refactored runner extraction succeeds, the fallback fires for the orphan only, and neighbors keep their real physical names.
- Fast (pure) pool: **passed** (39s). Full Docker pool sweep running at PR-open time; verdict appended to `PARTIAL_TRANSFER_READINESS_LOG.md` Entry 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m)_