### PR TITLE
OSSYS extraction: skip entity-less espaces as a named erasure (V1 parity)

### DIFF
--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -872,3 +872,43 @@ names.
 **Final verdict:** the full sweep PASSED IN FULL — fast pool 3937/3937 (39s), docker
 pool 289/289 (518s, regression test aboard), scale pool 16/16 (79s). The contracts
 gate no longer dies on estates carrying orphan attributes.
+
+## Entry 23 — 2026-07-07, THE ENTITY-LESS ESPACE: the read that survived row-mapping died at module assembly
+
+**What the live run hit (contracts, take two):** with the SequentialAccess fix aboard,
+the extraction completed and the metamodel read died one stage later —
+`module.kinds.empty: Module OssysOriginal <guid> must contain at least one Kind.`
+(The `OssysOriginal <guid>` is the module's SsKey rendered via `%A`; the guid is the
+espace's SS_Key.)
+
+**Root cause.** A real estate routinely carries espaces with NO entities — UI, theme,
+and service modules. The rowsets script's `#E` exports every espace (module filter +
+IncludeSystem only; no entity-existence condition), and `parseRowsetBundle` fed every
+module row to `Module.create`, whose LR1/A39 non-empty-kinds invariant (shipped
+2026-05-18, deliberately) refuses the empty module — one entity-less espace failed the
+WHOLE read. V1's posture is explicit and triplicated: "Module 'X' contains no entities
+and will be skipped" (`ModuleDocumentMapper` / `ModelDeserializerFacade` /
+`FullExportApplicationService`) — a parity gap the canary never exposed because every
+seeded espace has entities.
+
+**The fix (skip as a NAMED erasure, per the compensating constraint the LR1 decision
+codified — "adapters always produce non-empty modules"):** `parseRowsetBundle` now
+skips espaces with no entity rows, and the new pure producer
+`OssysRowsetReader.entityLessModules` names each skip (`adapter.ossys.module.entityLess`,
+Info — the normal shape of a real estate); `LiveModelRead` wires it into the existing
+notice rollup alongside the columnReality/primaryKey divergences, so the erasure rides
+the notice artifact + the one calm Warn line, never silence. `Module.create`'s
+invariant is UNTOUCHED — it remains the guard against corrupt shapes; the adapter now
+honors its side of the contract.
+
+**Named residual:** the JSON path (`OssysJsonReader.parseModule`) carries the same
+latent shape — a V1 `osm_model.json` bearing an entities-less module (V1's own mapper
+guards against reading one, so V1 tools skip it at read time) would still fail V2's
+JSON read with `module.kinds.empty`. Not the live-transfer path (contracts ride the
+rowset path on both sides); fix deferred until a JSON-path consumer meets one.
+
+**Proven:** pure (`OsmRowsetReaderTests` — skip yields the populated-modules-only
+catalog; the notice producer emits exactly one Info entry per skipped module, zero
+when all are populated) and docker e2e (`EntityLessModuleReadDockerTests` — edge-case
+seed + an entity-less espace: extraction → bundle → catalog parse succeeds, module
+absent, erasure named). Full-sweep verdict below.

--- a/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
@@ -710,6 +710,38 @@ module OssysRowsetReader =
                             "Failed to build module '%s' from rowset bundle."
                             moduleRow.EspaceName))
 
+    /// NAME the entity-less-module erasure (2026-07-07, the live
+    /// partial-transfer catch). An espace with no entities — a UI /
+    /// theme / service module, routine on a real estate — carries
+    /// nothing this engine publishes or transfers, and `Module.create`
+    /// (LR1 / A39) rightly refuses an empty-kinds module; feeding it
+    /// one killed the whole metamodel read (`module.kinds.empty`).
+    /// `parseRowsetBundle` skips those espaces (V1 parity: "Module 'X'
+    /// contains no entities and will be skipped" — V1's
+    /// `ModuleDocumentMapper` / `ModelDeserializerFacade` /
+    /// `FullExportApplicationService`); this pure producer names each
+    /// skip so the live read surfaces the erasure instead of silence.
+    /// Info severity — the normal shape of a real estate, individually
+    /// listed in the notice artifact. Deterministic — ordered by module
+    /// name then espace id.
+    let entityLessModules (bundle: RowsetBundle) : DiagnosticEntry list =
+        let populatedEspaces =
+            bundle.Kinds |> List.map (fun k -> k.EspaceId) |> Set.ofList
+        bundle.Modules
+        |> List.filter (fun m -> not (Set.contains m.EspaceId populatedEspaces))
+        |> List.sortBy (fun m -> m.EspaceName, m.EspaceId)
+        |> List.map (fun m ->
+            { DiagnosticEntry.create
+                "adapter:OSSYS" DiagnosticSeverity.Info
+                "adapter.ossys.module.entityLess"
+                (sprintf
+                    "Module %s (espace %d) contains no entities and is skipped from the model read — nothing to publish or transfer."
+                    m.EspaceName m.EspaceId)
+              with Metadata =
+                    Map.ofList
+                        [ "espaceId", string m.EspaceId
+                          "moduleName", m.EspaceName ] })
+
     /// V1 rowset bundle → V2 Catalog. Sibling to `parseDocument` (JSON
     /// path). The flat-list bundle joins by FK ID columns at load time
     /// (`AttributeRow.EntityId` ↔ `KindRow.EntityId`; `KindRow.EspaceId`
@@ -718,6 +750,9 @@ module OssysRowsetReader =
     /// existing `Module.create` / `Catalog.create` aggregate-root
     /// smart constructors, so referential-integrity invariants are
     /// checked at the boundary identically to the JSON path.
+    /// Entity-less modules are SKIPPED as a named erasure (see
+    /// `entityLessModules` above — the notice producer the live read
+    /// wires so the skip is never silent).
     ///
     /// Big-O / pillar 7 perf clause: O(N + E + A + R) for the input
     /// bundle plus O(E + A) for the three Map.ofList constructions
@@ -796,8 +831,16 @@ module OssysRowsetReader =
               IndexColumnsByIndex  = indexColumnsByIndex
               TriggersByEntity     = triggersByEntity
               ColumnChecksByEntity = columnChecksByEntity }
+        // The entity-less skip (the erasure `entityLessModules` names):
+        // only espaces with at least one entity reach `Module.create`,
+        // whose non-empty-kinds invariant (LR1 / A39) is for CORRUPT
+        // shapes, not for the routine entity-less espaces of a real
+        // estate.
+        let populatedModules =
+            bundle.Modules
+            |> List.filter (fun m -> Map.containsKey m.EspaceId kindsByEspace)
         let moduleResults =
-            bundle.Modules |> Bench.iterMap "adapter.osm.parse.rowsetModule" (parseModuleRow ctx)
+            populatedModules |> Bench.iterMap "adapter.osm.parse.rowsetModule" (parseModuleRow ctx)
         match Result.aggregate moduleResults with
         | Ok modules ->
             Catalog.create modules []

--- a/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
@@ -126,6 +126,7 @@ module LiveModelRead =
             match! MetadataSnapshotRunner.runAsyncWithOptions cnn parameters options with
             | Error es -> return Result.failure es
             | Ok snapshot ->
+                let bundle = MetadataSnapshotRunner.toBundle snapshot
                 // F9 (audit 2026-06-17) — surface, never silently discard, every
                 // logical-vs-deployed `#ColumnReality` divergence the snapshot
                 // carries (the adapter keeps the LOGICAL value; the operator is
@@ -134,11 +135,14 @@ module LiveModelRead =
                 // The carried value is unchanged — diagnostic only, no
                 // auto-resolve. Since 2026-07-02 the surface is the notice
                 // rollup (one Warn envelope + the detail artifact), never a
-                // per-item stderr wall fighting the live board.
+                // per-item stderr wall fighting the live board. Since
+                // 2026-07-07 the rollup also names each entity-less module
+                // the rowset reader SKIPS (the erasure that used to fail the
+                // whole read as `module.kinds.empty`).
                 surfaceDivergences
                     (MetadataSnapshotRunner.columnRealityDivergences snapshot
-                     @ MetadataSnapshotRunner.primaryKeyDivergences snapshot)
-                let bundle = MetadataSnapshotRunner.toBundle snapshot
+                     @ MetadataSnapshotRunner.primaryKeyDivergences snapshot
+                     @ OssysRowsetReader.entityLessModules bundle)
                 // Slice 4 — under a pushed scope, prune reference rows
                 // whose target entity the server-side narrowing excluded
                 // (the cross-scope edges). `ModuleFilter.apply` applies

--- a/sidecar/projection/tests/Projection.Tests.Integration/EntityLessModuleReadDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/EntityLessModuleReadDockerTests.fs
@@ -1,0 +1,66 @@
+namespace Projection.Tests
+
+// The entity-less-espace regression (2026-07-07, the live partial-transfer
+// catch, part two). A real estate routinely carries espaces with no
+// entities — UI / theme / service modules. V1 skips them ("Module 'X'
+// contains no entities and will be skipped"); V2's rowset path fed them
+// to `Module.create`, whose LR1/A39 non-empty-kinds invariant failed the
+// WHOLE metamodel read with `module.kinds.empty` — the go board's
+// "a metamodel could not be read" red line, hit right after the
+// SequentialAccess row-mapping fix let the extraction complete. The
+// edge-case seed never fires this shape (every seeded espace has
+// entities), which is how it shipped past the canary; this suite pins
+// it end-to-end: seed + one entity-less espace → extraction → bundle →
+// catalog parse succeeds WITHOUT the module, and the erasure is NAMED
+// (one notice from `OssysRowsetReader.entityLessModules`).
+//
+// Serial via Docker-SqlServer; blocking wait via TaskSync.
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Adapters.Osm
+open Projection.Adapters.OssysSql
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type EntityLessModuleReadDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``an espace with no entities is skipped as a named erasure — the metamodel read succeeds (V1 parity)`` () =
+        if not (Deploy.Docker.ensureRunning ()) then
+            printfn "SKIP EntityLessModuleRead: Docker daemon not reachable."
+        else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "EmptyEspace" (fun cnn _ -> task {
+                do! Deploy.executeBatch cnn (MetadataExtractionSql.readEdgeCaseSeed ())
+                // The estate shape the canary seed lacks: an active,
+                // non-system espace that owns no entities at all.
+                do! Deploy.executeBatch cnn
+                        "INSERT INTO [dbo].[ossys_Espace] ([Id], [Name], [Is_System], [Is_Active], [EspaceKind], [SS_Key]) \
+                         VALUES (800, N'PortalTheme', 0, 1, N'eSpace', '88888888-8888-8888-8888-888888888888');"
+                let! snapshotResult =
+                    MetadataSnapshotRunner.runAsync cnn MetadataSnapshotRunner.defaultParameters
+                let snapshot =
+                    match snapshotResult with
+                    | Ok s -> s
+                    | Error errors -> failwithf "extraction failed: %A" errors
+                let bundle = MetadataSnapshotRunner.toBundle snapshot
+                // The erasure is NAMED — exactly one notice, naming the
+                // skipped module.
+                let notices = OssysRowsetReader.entityLessModules bundle
+                let notice = Assert.Single(notices)
+                Assert.Equal("adapter.ossys.module.entityLess", notice.Code)
+                Assert.Contains("PortalTheme", notice.Message)
+                // ...and the catalog parse succeeds without the module —
+                // the read that used to die whole with `module.kinds.empty`.
+                let! catalogResult =
+                    CatalogReader.parse (CatalogReader.SnapshotRowsets bundle)
+                match catalogResult with
+                | Error errors -> Assert.Fail (sprintf "catalog parse failed: %A" errors)
+                | Ok catalog ->
+                    let names = catalog.Modules |> List.map (fun m -> Name.value m.Name)
+                    Assert.DoesNotContain("PortalTheme", names)
+                    Assert.Contains("AppCore", names)
+                return ()
+            }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="MockOutSystemsEnv.fs" />
     <Compile Include="LiveSourceDockerTests.fs" />
     <Compile Include="MetadataSnapshotSequentialAccessTests.fs" />
+    <Compile Include="EntityLessModuleReadDockerTests.fs" />
     <Compile Include="PayOnceCombinedVerbDockerTests.fs" />
     <Compile Include="PayOnceSchemaReadDockerTests.fs" />
     <Compile Include="ClosureOracleDockerTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
@@ -1504,3 +1504,64 @@ let ``PK recovery: the fallback requires a native attribute SS_Key to compare (s
               emailAttrRow None ]
     let attrs = parsedUserAttrs bundle
     Assert.Empty(attrs |> List.filter (fun a -> a.IsPrimaryKey))
+
+// ---------------------------------------------------------------------------
+// The entity-less-module skip (2026-07-07, the live partial-transfer catch).
+// A real estate routinely carries espaces with no entities (UI / theme /
+// service modules); V1 skips them ("Module 'X' contains no entities and
+// will be skipped"). V2's rowset path used to feed them to `Module.create`,
+// whose LR1/A39 non-empty-kinds invariant failed the WHOLE metamodel read
+// (`module.kinds.empty`). The skip is a NAMED erasure: `entityLessModules`
+// produces one Info notice per skipped module.
+// ---------------------------------------------------------------------------
+
+let private entityLessPortalRow : OssysRowsetTypes.ModuleRow =
+    {
+        EspaceId       = 2
+        EspaceName     = "PortalTheme"
+        IsSystemModule = false
+        IsActive       = true
+        EspaceKind     = Some "eSpace"
+        EspaceSsKey    = None
+    }
+
+[<Fact>]
+let ``V1 parity: an entity-less espace is skipped, not a module.kinds.empty failure of the whole read`` () =
+    let bundle : OssysRowsetTypes.RowsetBundle =
+        {
+            Modules      = [ moduleRow None; entityLessPortalRow ]
+            Kinds        = [ userKindRow None ]
+            Attributes   = [ idAttrRow None; emailAttrRow None ]
+            References   = []
+            Indexes      = []
+            IndexColumns = []
+            Triggers     = []
+            ColumnChecks = []
+        }
+    match parseSync (CatalogReader.SnapshotRowsets bundle) with
+    | Error errors -> failwithf "expected Ok; got Error: %A" errors
+    | Ok catalog ->
+        let names = catalog.Modules |> List.map (fun m -> Name.value m.Name)
+        Assert.Equal<string list>([ "AppCore" ], names)
+
+[<Fact>]
+let ``the entity-less skip is a NAMED erasure: one Info notice per skipped module, none when every module is populated`` () =
+    let bundle : OssysRowsetTypes.RowsetBundle =
+        {
+            Modules      = [ moduleRow None; entityLessPortalRow ]
+            Kinds        = [ userKindRow None ]
+            Attributes   = [ idAttrRow None; emailAttrRow None ]
+            References   = []
+            Indexes      = []
+            IndexColumns = []
+            Triggers     = []
+            ColumnChecks = []
+        }
+    let notices = OssysRowsetReader.entityLessModules bundle
+    let notice = Assert.Single(notices)
+    Assert.Equal("adapter.ossys.module.entityLess", notice.Code)
+    Assert.Equal(DiagnosticSeverity.Info, notice.Severity)
+    Assert.Contains("PortalTheme", notice.Message)
+    Assert.Equal(Some "2", Map.tryFind "espaceId" notice.Metadata)
+    let populatedOnly = { bundle with Modules = [ moduleRow None ] }
+    Assert.Empty(OssysRowsetReader.entityLessModules populatedOnly)


### PR DESCRIPTION
## What

Follow-up to #655 (same live partial-transfer run): with the SequentialAccess row-mapping fix aboard, the OSSYS metamodel read completed extraction and then died at module assembly with `module.kinds.empty: Module OssysOriginal <guid> must contain at least one Kind.` — the go board's "a metamodel could not be read" red line.

## Root cause

A real estate routinely carries espaces with **no entities** (UI / theme / service modules). The rowsets SQL's `#E` exports every espace (module-name + IncludeSystem filters only; no entity-existence condition), and `parseRowsetBundle` fed every module row to `Module.create`, whose LR1/A39 non-empty-kinds invariant — shipped deliberately 2026-05-18 — refuses the empty module and fails the **whole** read. V1's posture is explicit and triplicated: *"Module 'X' contains no entities and will be skipped"* (`ModuleDocumentMapper` / `ModelDeserializerFacade` / `FullExportApplicationService`) — a parity gap the canary never exposed because every seeded espace has entities.

## Fix

- `OssysRowsetReader.parseRowsetBundle` skips espaces with no entity rows before `Module.create` (the adapter now honors the compensating constraint the LR1 decision codified: "adapters always produce non-empty modules"). The invariant itself is untouched — it remains the guard against corrupt shapes.
- The skip is a **named erasure**: new pure producer `OssysRowsetReader.entityLessModules` emits one Info notice per skipped module (`adapter.ossys.module.entityLess`, deterministic order), and `LiveModelRead` wires it into the existing notice rollup alongside the columnReality/primaryKey divergences — the erasure rides the notice artifact + the one calm Warn line, never silence.
- Named residual (readiness log Entry 23): the JSON path (`OssysJsonReader`) carries the same latent shape; it is not the live-transfer path (contracts ride the rowset path on both sides), so the fix is deferred until a JSON-path consumer meets one.

## Tests

- **Pure** (`OsmRowsetReaderTests`): an entity-less espace in the bundle yields the populated-modules-only catalog instead of a whole-read failure; the notice producer emits exactly one Info entry per skipped module (code, severity, metadata pinned) and zero when every module is populated.
- **Docker e2e** (`EntityLessModuleReadDockerTests`): edge-case seed + an entity-less espace → extraction → bundle → catalog parse succeeds, module absent, erasure named.
- Focused runs green; the branch was rebased onto the #655 squash with an **empty content diff**, so the pre-rebase full-sweep results apply to this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m