### PR TITLE
Transfer contract reads: bind the model scope + resolve inactive-shadow duplicate kinds

### DIFF
--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -969,4 +969,10 @@ survivor/shadow ids in metadata; reference re-aim; two-active still refuses on
 A4; normalization idempotent; entity-less tests re-homed onto `normalizeBundle`)
 and docker e2e (`EntityLessModuleReadDockerTests` — seed + an inactive City
 shadow in a second espace: extraction → normalize → parse succeeds, City carried
-exactly once in its active home, both erasures named). Full-sweep verdict below.
+exactly once in its active home, both erasures named).
+
+**Final verdict:** the full sweep PASSED IN FULL — fast pool 3943/3943 (52s), docker
+pool 291/291 (649s), scale pool 16/16 (111s), the normalization + scope-parity tests
+aboard. Three live-run catches (Entries 22-24) closed in one day; the contracts gate
+now reads a whole real estate — orphan attributes, entity-less espaces, and
+moved-entity shadows — under the same model scope every other verb honors.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -911,4 +911,62 @@ rowset path on both sides); fix deferred until a JSON-path consumer meets one.
 catalog; the notice producer emits exactly one Info entry per skipped module, zero
 when all are populated) and docker e2e (`EntityLessModuleReadDockerTests` — edge-case
 seed + an entity-less espace: extraction → bundle → catalog parse succeeds, module
-absent, erasure named). Full-sweep verdict below.
+absent, erasure named).
+
+**Final verdict:** the full sweep PASSED IN FULL — fast pool 3939/3939 (51s), docker
+pool 290/290 (629s), scale pool 16/16 (113s), the new tests aboard both pools. Both
+live-run catches of this program (Entries 22 + 23) are closed; the contracts gate
+reads real estates carrying orphan attributes AND entity-less espaces.
+
+## Entry 24 — 2026-07-07, THE DUPLICATE SS_KEY: scope parity for contract reads + the inactive-shadow erasure
+
+**What the live run hit (contracts, take three):** `catalog.kinds.duplicateKey:
+Catalog has Kind SsKey OssysOriginal <guid> duplicated across modules; A4 requires
+Kind identity to be globally unique.` The estate didn't change — each prior fix
+(Entries 22, 23) peeled the read one stage deeper into what a whole real estate
+actually looks like.
+
+**Root cause, two-ply:**
+
+1. **The transfer's contract reads ignored the projection.json model scope.**
+   Full-export/publish read through `readConfigModel` →
+   `SnapshotScopeBinding.fromModel cfg.Model` (declared `model.modules` narrow at
+   query time; `includeInactiveModules` defaults false; `onlyActiveAttributes`
+   defaults true). The peer transfer's `acquireContracts` → `Source.ofOssys` →
+   `LiveModelRead.fromConnSpec` read with `defaultParameters` — the
+   show-me-everything stance (all modules, system included, INACTIVE ENTITIES
+   included). The transfer saw strictly more estate than any other verb.
+2. **What the wider view exposed:** an entity MOVED between modules leaves an
+   inactive `ossys_Entity` row in the old espace with the SAME SS_Key as the
+   active row in its new home. Load both → two Kinds, one SsKey → A4 refusal
+   kills the whole read.
+
+**Fix 1 — scope parity (one modeled estate, every verb reads it the same way).**
+`Source.ofOssysWith` + `PeerTransfer.acquireContractsWith` are the new
+scope-bearing siblings (zero-default `ofOssys` / `acquireContracts` delegate, per
+the sibling-wrapper discipline); `runPeerTransfer` + `runCheckGo` take the
+contract scope and the dispatcher binds it from `SnapshotScopeBinding.fromModel
+shaping.Model` — the transfer and its go board now read the SAME modeled estate
+as full-export/publish, on both sides. An unscoped config still binds
+`onlyActiveAttributes=true` (the config default), which also pre-empts the
+inactive-duplicate-attribute layer beneath this one.
+
+**Fix 2 — the inactive-shadow erasure (robustness inside any scope).** The
+entity-less skip generalizes into `OssysRowsetReader.normalizeBundle` — the ONE
+normalization pass every rowset parse applies (idempotent; the live read calls it
+directly to surface the notices):
+- step 1, inactive-shadow resolution (`adapter.ossys.kind.inactiveShadow`, Info):
+  duplicate SS_Key with EXACTLY ONE active row → the active row is carried, each
+  inactive shadow dropped + named, and references aimed at a shadow's EntityId
+  re-aim at the survivor (same GUID — identity is the conserved charge). Two
+  active, or all inactive → carried UNCHANGED; the A4 refusal stays the terminal
+  for a contradiction only the operator can adjudicate.
+- step 2, the Entry-23 entity-less skip, computed AFTER step 1 — a module whose
+  only entity was a dropped shadow skips too.
+
+**Proven:** pure (`OsmRowsetReaderTests` — shadow dropped + named with the
+survivor/shadow ids in metadata; reference re-aim; two-active still refuses on
+A4; normalization idempotent; entity-less tests re-homed onto `normalizeBundle`)
+and docker e2e (`EntityLessModuleReadDockerTests` — seed + an inactive City
+shadow in a second espace: extraction → normalize → parse succeeds, City carried
+exactly once in its active home, both erasures named). Full-sweep verdict below.

--- a/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
+++ b/sidecar/projection/src/Projection.Adapters.Osm/OssysRowsetReader.fs
@@ -710,37 +710,137 @@ module OssysRowsetReader =
                             "Failed to build module '%s' from rowset bundle."
                             moduleRow.EspaceName))
 
-    /// NAME the entity-less-module erasure (2026-07-07, the live
-    /// partial-transfer catch). An espace with no entities — a UI /
-    /// theme / service module, routine on a real estate — carries
-    /// nothing this engine publishes or transfers, and `Module.create`
-    /// (LR1 / A39) rightly refuses an empty-kinds module; feeding it
-    /// one killed the whole metamodel read (`module.kinds.empty`).
-    /// `parseRowsetBundle` skips those espaces (V1 parity: "Module 'X'
-    /// contains no entities and will be skipped" — V1's
-    /// `ModuleDocumentMapper` / `ModelDeserializerFacade` /
-    /// `FullExportApplicationService`); this pure producer names each
-    /// skip so the live read surfaces the erasure instead of silence.
-    /// Info severity — the normal shape of a real estate, individually
-    /// listed in the notice artifact. Deterministic — ordered by module
-    /// name then espace id.
-    let entityLessModules (bundle: RowsetBundle) : DiagnosticEntry list =
+    /// Stable notice codes for the bundle-normalization erasures (the
+    /// `<domain>.<subject>.<problem>` convention; sites emit codes, the
+    /// Voice owns copy).
+    [<Literal>]
+    let CodeModuleEntityLess = "adapter.ossys.module.entityLess"
+
+    [<Literal>]
+    let CodeKindInactiveShadow = "adapter.ossys.kind.inactiveShadow"
+
+    /// The bundle NORMALIZATION pass — the named erasures a raw OSSYS
+    /// rowset bundle needs before the aggregate-root smart constructors
+    /// see it (2026-07-07, the live partial-transfer program; readiness
+    /// log Entries 23 + 24). Two steps, applied in order:
+    ///
+    ///   1. **Inactive-shadow resolution** (`CodeKindInactiveShadow`).
+    ///      The same entity SS_Key on multiple kind rows is the routine
+    ///      trace of an entity MOVED between modules — the old espace
+    ///      keeps an INACTIVE `ossys_Entity` row with the same SS_Key
+    ///      (visible whenever the read includes inactive entities).
+    ///      When exactly one duplicate is active, the active row is
+    ///      carried, each inactive shadow is dropped, and references
+    ///      aimed at a shadow's EntityId re-aim at the survivor (same
+    ///      identity — the GUID is the conserved charge). Any other
+    ///      duplicate shape (two active; all inactive) is carried
+    ///      UNCHANGED — the A4 refusal at `Catalog.create` is the
+    ///      correct terminal for a contradiction only the operator can
+    ///      adjudicate.
+    ///
+    ///   2. **Entity-less module skip** (`CodeModuleEntityLess`; V1
+    ///      parity — "Module 'X' contains no entities and will be
+    ///      skipped", V1's `ModuleDocumentMapper` /
+    ///      `ModelDeserializerFacade` / `FullExportApplicationService`).
+    ///      An espace with no entities carries nothing this engine
+    ///      publishes or transfers, and `Module.create` (LR1 / A39)
+    ///      rightly refuses an empty-kinds module. Computed AFTER step 1,
+    ///      so a module whose only entity was a dropped shadow skips too.
+    ///
+    /// Pure, deterministic (notices ordered by name then id within each
+    /// step), and idempotent — a normalized bundle re-normalizes to
+    /// itself with zero notices. `parseRowsetBundle` applies it
+    /// internally (every consumer gets the semantics); the live read
+    /// (`LiveModelRead`) calls it directly to surface the notices, so
+    /// no erasure is ever silent.
+    let normalizeBundle (bundle: RowsetBundle) : RowsetBundle * DiagnosticEntry list =
+        // -- step 1: inactive-shadow resolution ---------------------------
+        let moduleNameByEspaceId =
+            bundle.Modules |> List.map (fun m -> m.EspaceId, m.EspaceName) |> Map.ofList
+        let moduleNameOf (espaceId: int) : string =
+            Map.tryFind espaceId moduleNameByEspaceId
+            |> Option.defaultValue (sprintf "espace-%d" espaceId)
+        let resolvedDuplicates =
+            bundle.Kinds
+            |> List.choose (fun k -> k.EntitySsKey |> Option.map (fun g -> g, k))
+            |> List.groupBy fst
+            |> List.choose (fun (ssKey, pairs) ->
+                let kinds = pairs |> List.map snd
+                if List.length kinds < 2 then None
+                else
+                    match kinds |> List.partition (fun k -> k.IsActive) with
+                    | [ survivor ], shadows -> Some (ssKey, survivor, shadows)
+                    | _ -> None)
+        let shadowEntityIds =
+            resolvedDuplicates
+            |> List.collect (fun (_, _, shadows) -> shadows |> List.map (fun s -> s.EntityId))
+            |> Set.ofList
+        let survivorEntityIdByShadow =
+            resolvedDuplicates
+            |> List.collect (fun (_, survivor, shadows) ->
+                shadows |> List.map (fun s -> s.EntityId, survivor.EntityId))
+            |> Map.ofList
+        let shadowNotices =
+            resolvedDuplicates
+            |> List.sortBy (fun (_, survivor, _) -> survivor.EntityName, survivor.EntityId)
+            |> List.collect (fun (ssKey, survivor, shadows) ->
+                shadows
+                |> List.sortBy (fun s -> s.EntityId)
+                |> List.map (fun s ->
+                    { DiagnosticEntry.create
+                        "adapter:OSSYS" DiagnosticSeverity.Info
+                        CodeKindInactiveShadow
+                        (sprintf
+                            "Entity %s (id %d, inactive) in module %s carries the same SS_Key %O as the active entity %s (id %d) in module %s — the trace of an entity moved between modules. The inactive shadow is dropped; the active entity is carried."
+                            s.EntityName s.EntityId (moduleNameOf s.EspaceId)
+                            ssKey survivor.EntityName survivor.EntityId (moduleNameOf survivor.EspaceId))
+                      with Metadata =
+                            Map.ofList
+                                [ "ssKey",            string ssKey
+                                  "shadowEntityId",   string s.EntityId
+                                  "shadowModule",     moduleNameOf s.EspaceId
+                                  "survivorEntityId", string survivor.EntityId
+                                  "survivorModule",   moduleNameOf survivor.EspaceId ] }))
+        let survivingKinds =
+            bundle.Kinds
+            |> List.filter (fun k -> not (Set.contains k.EntityId shadowEntityIds))
+        // Re-aim references that target a dropped shadow's EntityId at the
+        // survivor — same SS_Key, so the resolved reference identity is
+        // unchanged; only the join id moves.
+        let reaimedReferences =
+            if Map.isEmpty survivorEntityIdByShadow then bundle.References
+            else
+                bundle.References
+                |> List.map (fun r ->
+                    match r.RefEntityId with
+                    | Some id when Map.containsKey id survivorEntityIdByShadow ->
+                        { r with RefEntityId = Some (Map.find id survivorEntityIdByShadow) }
+                    | _ -> r)
+        // -- step 2: entity-less module skip (post-shadow-drop) -----------
         let populatedEspaces =
-            bundle.Kinds |> List.map (fun k -> k.EspaceId) |> Set.ofList
-        bundle.Modules
-        |> List.filter (fun m -> not (Set.contains m.EspaceId populatedEspaces))
-        |> List.sortBy (fun m -> m.EspaceName, m.EspaceId)
-        |> List.map (fun m ->
-            { DiagnosticEntry.create
-                "adapter:OSSYS" DiagnosticSeverity.Info
-                "adapter.ossys.module.entityLess"
-                (sprintf
-                    "Module %s (espace %d) contains no entities and is skipped from the model read — nothing to publish or transfer."
-                    m.EspaceName m.EspaceId)
-              with Metadata =
-                    Map.ofList
-                        [ "espaceId", string m.EspaceId
-                          "moduleName", m.EspaceName ] })
+            survivingKinds |> List.map (fun k -> k.EspaceId) |> Set.ofList
+        let populatedModules, entityLess =
+            bundle.Modules
+            |> List.partition (fun m -> Set.contains m.EspaceId populatedEspaces)
+        let entityLessNotices =
+            entityLess
+            |> List.sortBy (fun m -> m.EspaceName, m.EspaceId)
+            |> List.map (fun m ->
+                { DiagnosticEntry.create
+                    "adapter:OSSYS" DiagnosticSeverity.Info
+                    CodeModuleEntityLess
+                    (sprintf
+                        "Module %s (espace %d) contains no entities and is skipped from the model read — nothing to publish or transfer."
+                        m.EspaceName m.EspaceId)
+                  with Metadata =
+                        Map.ofList
+                            [ "espaceId", string m.EspaceId
+                              "moduleName", m.EspaceName ] })
+        { bundle with
+            Modules    = populatedModules
+            Kinds      = survivingKinds
+            References = reaimedReferences },
+        shadowNotices @ entityLessNotices
 
     /// V1 rowset bundle → V2 Catalog. Sibling to `parseDocument` (JSON
     /// path). The flat-list bundle joins by FK ID columns at load time
@@ -750,9 +850,12 @@ module OssysRowsetReader =
     /// existing `Module.create` / `Catalog.create` aggregate-root
     /// smart constructors, so referential-integrity invariants are
     /// checked at the boundary identically to the JSON path.
-    /// Entity-less modules are SKIPPED as a named erasure (see
-    /// `entityLessModules` above — the notice producer the live read
-    /// wires so the skip is never silent).
+    /// The bundle is normalized first (`normalizeBundle` above —
+    /// inactive-shadow resolution + entity-less module skip); the
+    /// notices are surfaced by the live read, which calls
+    /// `normalizeBundle` directly, so the parse-side application here
+    /// is an idempotent re-run that guarantees EVERY consumer gets the
+    /// normalized semantics.
     ///
     /// Big-O / pillar 7 perf clause: O(N + E + A + R) for the input
     /// bundle plus O(E + A) for the three Map.ofList constructions
@@ -760,7 +863,8 @@ module OssysRowsetReader =
     /// with O(1) Map lookups; per-kind reference assembly is O(R_e)
     /// with O(1) Map lookups. Linear in the bundle's total size;
     /// matches `parseDocument`'s complexity class.
-    let parseRowsetBundle (bundle: RowsetBundle) : Result<Catalog> =
+    let parseRowsetBundle (rawBundle: RowsetBundle) : Result<Catalog> =
+        let bundle, _erasureNotices = normalizeBundle rawBundle
         let attributesByEntity =
             bundle.Attributes |> List.groupBy (fun a -> a.EntityId) |> Map.ofList
         let kindsByEspace =
@@ -831,16 +935,8 @@ module OssysRowsetReader =
               IndexColumnsByIndex  = indexColumnsByIndex
               TriggersByEntity     = triggersByEntity
               ColumnChecksByEntity = columnChecksByEntity }
-        // The entity-less skip (the erasure `entityLessModules` names):
-        // only espaces with at least one entity reach `Module.create`,
-        // whose non-empty-kinds invariant (LR1 / A39) is for CORRUPT
-        // shapes, not for the routine entity-less espaces of a real
-        // estate.
-        let populatedModules =
-            bundle.Modules
-            |> List.filter (fun m -> Map.containsKey m.EspaceId kindsByEspace)
         let moduleResults =
-            populatedModules |> Bench.iterMap "adapter.osm.parse.rowsetModule" (parseModuleRow ctx)
+            bundle.Modules |> Bench.iterMap "adapter.osm.parse.rowsetModule" (parseModuleRow ctx)
         match Result.aggregate moduleResults with
         | Ok modules ->
             Catalog.create modules []

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -10,6 +10,7 @@ open System
 open System.Diagnostics
 open System.IO
 open Projection.Core
+open Projection.Adapters.OssysSql
 open Projection.Adapters.Sql
 open Projection.Pipeline
 open Projection.Targets.SSDT
@@ -519,6 +520,11 @@ let runReverseLegTransfer
 // ---------------------------------------------------------------------------
 
 let runPeerTransfer
+    // The snapshot scope BOTH contract reads run under — the dispatcher
+    // binds it from the projection.json `model` section
+    // (`SnapshotScopeBinding.fromModel`), so the transfer reads the same
+    // modeled estate as full-export/publish (2026-07-07).
+    (contractScope: MetadataSnapshotRunner.SnapshotParameters)
     (sourceSpec: string)
     (sinkSpec: string)
     (reconcileSpecs: string list)
@@ -538,7 +544,7 @@ let runPeerTransfer
     // Acquire the two SsKey-aligned contracts (the one I/O seam this face
     // adds). An unreadable OSSYS metamodel refuses on the schema-read axis
     // (exit 6) before any gate or connection-opening work.
-    match (PeerTransfer.acquireContracts sourceSpec sinkSpec).GetAwaiter().GetResult() with
+    match (PeerTransfer.acquireContractsWith contractScope sourceSpec sinkSpec).GetAwaiter().GetResult() with
     | Error errors ->
         // The gate surface owns the copy (§5): `source.ossys.*` classifies
         // onto the schema-read axis, so the operator gets the statement +
@@ -790,7 +796,11 @@ let private probeCount (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: strin
     cmd.CommandText <- sql
     System.Convert.ToInt32 (cmd.ExecuteScalar())
 
-let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (planned: PlanAction) : int =
+let runCheckGo
+    // Same contract-read scope as `runPeerTransfer` — the go board must
+    // forecast with the contracts the live run will actually read.
+    (contractScope: MetadataSnapshotRunner.SnapshotParameters)
+    (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (planned: PlanAction) : int =
     let finish (items: GoBoard.Item list) : int =
         let board : GoBoard.Board = { Flow = flowName; From = fromLabel; To = toLabel; Items = items }
         if asJson then printfn "%s" (GoBoard.toJsonString board)
@@ -809,7 +819,7 @@ let runCheckGo (flowName: string) (fromLabel: string) (toLabel: string) (asJson:
         let items = ResizeArray<GoBoard.Item>()
         items.Add (GoBoard.item "routing" (GoBoard.Status.Green "the SsKey-aligned peer leg (both renditions physical)."))
         // -- contracts (the two OSSYS metamodel reads) ---------------------
-        match (PeerTransfer.acquireContracts sourceSpec sinkSpec).GetAwaiter().GetResult() with
+        match (PeerTransfer.acquireContractsWith contractScope sourceSpec sinkSpec).GetAwaiter().GetResult() with
         | Error errors ->
             items.Add (GoBoard.itemWith "contracts"
                 (GoBoard.Status.Red

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -234,8 +234,11 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // the face reads a contract from EACH side's OSSYS metamodel (native
         // GUID identity), gates the pair (shape / subset-FK), and drives the
         // same contract-pair engine path the reverse leg proved.
+        // The contract reads run under the projection.json `model` scope
+        // (2026-07-07) — the same modeled estate every other verb reads;
+        // an unscoped config binds to the show-me-everything default.
         withRun "projection transfer" (fun () ->
-            runPeerTransfer src sink opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
+            runPeerTransfer (SnapshotScopeBinding.fromModel shaping.Model) src sink opts.Reconcile opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE
@@ -301,7 +304,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
-    | PlanAction.CheckGo (flowName, fromLabel, toLabel, asJson, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo flowName fromLabel toLabel asJson planned)
+    | PlanAction.CheckGo (flowName, fromLabel, toLabel, asJson, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo (SnapshotScopeBinding.fromModel shaping.Model) flowName fromLabel toLabel asJson planned)
     | PlanAction.RevertScript (script, envLabel, connSpec, go, force) -> shellRun "projection revert" (if go then Shell.Go else Shell.ReadOnly) (fun () -> runRevertScript script envLabel connSpec go force)
     // explain ------------------------------------------------------------
     | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->

--- a/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LiveModelRead.fs
@@ -126,7 +126,14 @@ module LiveModelRead =
             match! MetadataSnapshotRunner.runAsyncWithOptions cnn parameters options with
             | Error es -> return Result.failure es
             | Ok snapshot ->
-                let bundle = MetadataSnapshotRunner.toBundle snapshot
+                // The bundle normalization (2026-07-07, the live partial-
+                // transfer program): inactive-shadow duplicate-kind
+                // resolution + the entity-less module skip, each a NAMED
+                // erasure. `CatalogReader.parse` re-applies the (idempotent)
+                // normalization internally; calling it here is what lets the
+                // live read surface the erasure notices.
+                let bundle, erasureNotices =
+                    OssysRowsetReader.normalizeBundle (MetadataSnapshotRunner.toBundle snapshot)
                 // F9 (audit 2026-06-17) — surface, never silently discard, every
                 // logical-vs-deployed `#ColumnReality` divergence the snapshot
                 // carries (the adapter keeps the LOGICAL value; the operator is
@@ -136,13 +143,13 @@ module LiveModelRead =
                 // auto-resolve. Since 2026-07-02 the surface is the notice
                 // rollup (one Warn envelope + the detail artifact), never a
                 // per-item stderr wall fighting the live board. Since
-                // 2026-07-07 the rollup also names each entity-less module
-                // the rowset reader SKIPS (the erasure that used to fail the
-                // whole read as `module.kinds.empty`).
+                // 2026-07-07 the rollup also names each normalization erasure
+                // (the shapes that used to fail the whole read as
+                // `module.kinds.empty` / `catalog.kinds.duplicateKey`).
                 surfaceDivergences
                     (MetadataSnapshotRunner.columnRealityDivergences snapshot
                      @ MetadataSnapshotRunner.primaryKeyDivergences snapshot
-                     @ OssysRowsetReader.entityLessModules bundle)
+                     @ erasureNotices)
                 // Slice 4 — under a pushed scope, prune reference rows
                 // whose target entity the server-side narrowing excluded
                 // (the cross-scope edges). `ModuleFilter.apply` applies

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -8,6 +8,7 @@ namespace Projection.Pipeline
 
 open System.Threading.Tasks
 open Projection.Core
+open Projection.Adapters.OssysSql
 
 /// The peer (A→A) transfer's contract + gate support: two cloud cells of ONE
 /// model whose physical `OSUSR_*` names differ per espace (the QA→UAT partial
@@ -44,15 +45,31 @@ module PeerTransfer =
     /// metamodels (D9 conn refs: `env:<var>` / `file:<path>` / raw). A failed
     /// read is the named `source.ossys.readFailed` refusal from the `Source`
     /// port, classified onto the schema-read axis (exit 6) by `Preflight`.
-    let acquireContracts (sourceConn: string) (sinkConn: string) : Task<Result<Catalog * Catalog>> =
+    ///
+    /// Scope-bearing entry point (2026-07-07) — BOTH sides read under the
+    /// same snapshot scope (the projection.json `model` binding via
+    /// `SnapshotScopeBinding.fromModel`), so the transfer's contracts see
+    /// the same modeled estate as full-export/publish. `acquireContracts`
+    /// is the zero-default sibling.
+    let acquireContractsWith
+        (parameters: MetadataSnapshotRunner.SnapshotParameters)
+        (sourceConn: string)
+        (sinkConn: string)
+        : Task<Result<Catalog * Catalog>> =
         task {
-            match! Source.read (Source.ofOssys sourceConn) with
+            match! Source.read (Source.ofOssysWith parameters sourceConn) with
             | Error es -> return Result.failure es
             | Ok sourceContract ->
-                match! Source.read (Source.ofOssys sinkConn) with
+                match! Source.read (Source.ofOssysWith parameters sinkConn) with
                 | Error es -> return Result.failure es
                 | Ok sinkContract -> return Result.success (sourceContract, sinkContract)
         }
+
+    /// Zero-default sibling — the show-me-everything `defaultParameters`
+    /// stance (the canary/mock-environment face; config-bound callers pass
+    /// their model scope through `acquireContractsWith`).
+    let acquireContracts (sourceConn: string) (sinkConn: string) : Task<Result<Catalog * Catalog>> =
+        acquireContractsWith MetadataSnapshotRunner.defaultParameters sourceConn sinkConn
 
     // ------------------------------------------------------------------
     // The shape gate — SS_KEY-keyed schema compatibility, scoped to the

--- a/sidecar/projection/src/Projection.Pipeline/Source.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Source.fs
@@ -5,6 +5,7 @@ open System.Threading.Tasks
 open Microsoft.Data.SqlClient
 open Projection.Core
 open Projection.Adapters.Osm
+open Projection.Adapters.OssysSql
 open Projection.Adapters.Sql
 open Projection.Targets.Json
 
@@ -191,13 +192,20 @@ module Source =
     /// (`CROSS_ENVIRONMENT_READINESS.md`). `conn` is a D9 connection reference
     /// (`env:<var>` / `file:<path>`). Carries ReadCatalog (the OSSYS model) +
     /// Profile (the live data — the readiness gate's dealbreaker evidence).
-    let ofOssys (conn: string) : Source =
+    ///
+    /// Scope-bearing entry point — `parameters` is the snapshot scope the
+    /// model read runs under (`SnapshotScopeBinding.fromModel` binds it from
+    /// the projection.json `model` section), so a scoped consumer (the peer
+    /// transfer's contract reads, 2026-07-07) sees the SAME modeled estate
+    /// as full-export/publish (`Compose.readConfigModel`). `ofOssys` is the
+    /// zero-default sibling (the show-me-everything `defaultParameters`).
+    let ofOssysWith (parameters: MetadataSnapshotRunner.SnapshotParameters) (conn: string) : Source =
         { Identity       = "ossys:" + conn  // LINT-ALLOW: terminal Source-identity tag string at the resolution boundary; no use-case-specific AST
           Capabilities   = Set.ofList [ ReadCatalog; Profile; Live ]
           ReadCatalog    =
             (fun () ->
                 task {
-                    try return! LiveModelRead.fromConnSpec conn
+                    try return! LiveModelRead.fromConnSpecWith parameters conn
                     with ex ->
                         return
                             Result.failureOf
@@ -222,6 +230,12 @@ module Source =
                                 (ValidationError.create "source.ossys.profileFailed"
                                     (System.String.Concat("ossys source ", conn, ": ", ex.Message)))  // LINT-ALLOW: terminal error-message composition at the source-resolution IO boundary; BCL String.Concat is the right primitive
                 }) }
+
+    /// Zero-default sibling of `ofOssysWith` — the show-me-everything
+    /// stance (`defaultParameters`): all modules, system + inactive
+    /// included. The canary/baseline face.
+    let ofOssys (conn: string) : Source =
+        ofOssysWith MetadataSnapshotRunner.defaultParameters conn
 
     /// Enrich a source with the `Profile` capability (the live / profilable
     /// form). The capability is the presence of the function — cf.

--- a/sidecar/projection/tests/Projection.Tests.Integration/EntityLessModuleReadDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/EntityLessModuleReadDockerTests.fs
@@ -12,7 +12,7 @@ namespace Projection.Tests
 // entities), which is how it shipped past the canary; this suite pins
 // it end-to-end: seed + one entity-less espace → extraction → bundle →
 // catalog parse succeeds WITHOUT the module, and the erasure is NAMED
-// (one notice from `OssysRowsetReader.entityLessModules`).
+// (one notice from `OssysRowsetReader.normalizeBundle`).
 //
 // Serial via Docker-SqlServer; blocking wait via TaskSync.
 
@@ -45,12 +45,12 @@ type EntityLessModuleReadDockerTests(fixture: EphemeralContainerFixture) =
                     match snapshotResult with
                     | Ok s -> s
                     | Error errors -> failwithf "extraction failed: %A" errors
-                let bundle = MetadataSnapshotRunner.toBundle snapshot
+                let bundle, notices =
+                    OssysRowsetReader.normalizeBundle (MetadataSnapshotRunner.toBundle snapshot)
                 // The erasure is NAMED — exactly one notice, naming the
                 // skipped module.
-                let notices = OssysRowsetReader.entityLessModules bundle
                 let notice = Assert.Single(notices)
-                Assert.Equal("adapter.ossys.module.entityLess", notice.Code)
+                Assert.Equal(OssysRowsetReader.CodeModuleEntityLess, notice.Code)
                 Assert.Contains("PortalTheme", notice.Message)
                 // ...and the catalog parse succeeds without the module —
                 // the read that used to die whole with `module.kinds.empty`.
@@ -62,5 +62,58 @@ type EntityLessModuleReadDockerTests(fixture: EphemeralContainerFixture) =
                     let names = catalog.Modules |> List.map (fun m -> Name.value m.Name)
                     Assert.DoesNotContain("PortalTheme", names)
                     Assert.Contains("AppCore", names)
+                return ()
+            }))
+
+    /// The other real-estate duplicate shape (readiness log Entry 24): an
+    /// entity MOVED between modules leaves an INACTIVE `ossys_Entity` row in
+    /// the old espace with the SAME SS_Key — under the show-me-everything
+    /// read both rows load, and carrying both used to fail the whole read
+    /// with `catalog.kinds.duplicateKey` (A4). The normalization drops the
+    /// inactive shadow as a named erasure and carries the active entity.
+    [<Fact>]
+    member _.``an inactive duplicate SS_Key entity (the moved-entity shadow) is dropped as a named erasure — the metamodel read succeeds`` () =
+        if not (Deploy.Docker.ensureRunning ()) then
+            printfn "SKIP InactiveShadow: Docker daemon not reachable."
+        else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "ShadowKind" (fun cnn _ -> task {
+                do! Deploy.executeBatch cnn (MetadataExtractionSql.readEdgeCaseSeed ())
+                // The shadow: an inactive entity in a second espace carrying
+                // City's SS_Key (bbbbbbbb-…-0002) — the trace of City having
+                // been moved out of 'AppCoreOld'. One inactive attribute rides
+                // along (the realistic leftover row shape).
+                do! Deploy.executeBatch cnn
+                        "INSERT INTO [dbo].[ossys_Espace] ([Id], [Name], [Is_System], [Is_Active], [EspaceKind], [SS_Key]) \
+                         VALUES (900, N'AppCoreOld', 0, 1, N'eSpace', '99999999-9999-4999-8999-999999999999'); \
+                         INSERT INTO [dbo].[ossys_Entity] ([Id], [Name], [Physical_Table_Name], [Espace_Id], [Is_Active], [Is_System], [Is_External], [Data_Kind], [PrimaryKey_SS_Key], [SS_Key], [Description]) \
+                         VALUES (9001, N'City', N'OSUSR_OLD_CITY', 900, 0, 0, 0, N'entity', NULL, 'bbbbbbbb-0000-0000-0000-000000000002', NULL); \
+                         INSERT INTO [dbo].[ossys_Entity_Attr] ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Physical_Column_Name], [Order_Num]) \
+                         VALUES (90011, 9001, N'Id', 'dddddddd-9999-4999-8999-000000000001', N'Identifier', 1, 0, 1, 1, N'ID', 1);"
+                let! snapshotResult =
+                    MetadataSnapshotRunner.runAsync cnn MetadataSnapshotRunner.defaultParameters
+                let snapshot =
+                    match snapshotResult with
+                    | Ok s -> s
+                    | Error errors -> failwithf "extraction failed: %A" errors
+                let bundle, notices =
+                    OssysRowsetReader.normalizeBundle (MetadataSnapshotRunner.toBundle snapshot)
+                // The shadow drop is NAMED, and dropping AppCoreOld's only
+                // entity makes the module itself entity-less — both erasures
+                // surface.
+                Assert.Contains(notices, fun n -> n.Code = OssysRowsetReader.CodeKindInactiveShadow)
+                Assert.Contains(notices, fun n -> n.Code = OssysRowsetReader.CodeModuleEntityLess)
+                let! catalogResult =
+                    CatalogReader.parse (CatalogReader.SnapshotRowsets bundle)
+                match catalogResult with
+                | Error errors -> Assert.Fail (sprintf "catalog parse failed: %A" errors)
+                | Ok catalog ->
+                    let names = catalog.Modules |> List.map (fun m -> Name.value m.Name)
+                    Assert.DoesNotContain("AppCoreOld", names)
+                    // City survives exactly once, in its active home.
+                    let cityKinds =
+                        Catalog.allKinds catalog
+                        |> List.filter (fun k -> Name.value k.Name = "City")
+                    Assert.Equal(1, List.length cityKinds)
                 return ()
             }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -20,6 +20,7 @@ namespace Projection.Tests
 open Xunit
 open Projection.Core
 open Projection.Pipeline
+open Projection.Adapters.OssysSql
 open Projection.Cli.Faces.Transfer
 
 module private GoBoardFixtures =
@@ -94,11 +95,11 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
 
                         // 1. RED — subset [Customer], City escapes, no strategy.
-                        let red1 = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
+                        let red1 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
                         Assert.Equal(5, red1)
 
                         // 2. GREEN — the SAME flow with the proposed reconcile.
-                        let green = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let green = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(0, green)
 
                         // The board's dry run NEVER writes: the sink customer
@@ -113,7 +114,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         // attribute = blocking).
                         do! GoBoardFixtures.exec snk.Admin
                                 "DELETE FROM [dbo].[ossys_Entity_Attr] WHERE [Name] = N'LastName' AND [Entity_Id] = 1000;"
-                        let red2 = runCheckGo "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let red2 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(5, red2)
                         return ()
                     }))

--- a/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OsmRowsetReaderTests.fs
@@ -1506,13 +1506,18 @@ let ``PK recovery: the fallback requires a native attribute SS_Key to compare (s
     Assert.Empty(attrs |> List.filter (fun a -> a.IsPrimaryKey))
 
 // ---------------------------------------------------------------------------
-// The entity-less-module skip (2026-07-07, the live partial-transfer catch).
-// A real estate routinely carries espaces with no entities (UI / theme /
-// service modules); V1 skips them ("Module 'X' contains no entities and
-// will be skipped"). V2's rowset path used to feed them to `Module.create`,
-// whose LR1/A39 non-empty-kinds invariant failed the WHOLE metamodel read
-// (`module.kinds.empty`). The skip is a NAMED erasure: `entityLessModules`
-// produces one Info notice per skipped module.
+// The bundle normalization (2026-07-07, the live partial-transfer catches;
+// readiness log Entries 23 + 24). A real estate routinely carries shapes the
+// canary seed lacks:
+//   * espaces with no entities (UI / theme / service modules) — V1 skips
+//     them ("Module 'X' contains no entities and will be skipped"); feeding
+//     them to `Module.create` failed the WHOLE read (`module.kinds.empty`);
+//   * inactive duplicate entities — an entity moved between modules leaves
+//     an inactive `ossys_Entity` row in the old espace with the SAME
+//     SS_Key; carrying both trips A4 (`catalog.kinds.duplicateKey`).
+// `normalizeBundle` resolves both as NAMED erasures (one Info notice each);
+// a duplicate with no single active row is carried unchanged — the A4
+// refusal stays the terminal for a genuine contradiction.
 // ---------------------------------------------------------------------------
 
 let private entityLessPortalRow : OssysRowsetTypes.ModuleRow =
@@ -1525,19 +1530,37 @@ let private entityLessPortalRow : OssysRowsetTypes.ModuleRow =
         EspaceSsKey    = None
     }
 
+let private appCoreOldRow : OssysRowsetTypes.ModuleRow =
+    { entityLessPortalRow with EspaceId = 3; EspaceName = "AppCoreOld" }
+
+let private userShadowGuid = System.Guid.Parse "aaaaaaaa-bbbb-4ccc-8ddd-000000000011"
+
+/// The inactive shadow of `userKindRow` — same entity SS_Key, different
+/// espace (AppCoreOld) + EntityId, Is_Active = 0 (the moved-entity trace).
+let private userShadowKindRow : OssysRowsetTypes.KindRow =
+    { userKindRow (Some userShadowGuid) with
+        EntityId = 99
+        EspaceId = 3
+        IsActive = false }
+
+let private normalizationBundle
+    (modules: OssysRowsetTypes.ModuleRow list)
+    (kinds: OssysRowsetTypes.KindRow list)
+    : OssysRowsetTypes.RowsetBundle =
+    {
+        Modules      = modules
+        Kinds        = kinds
+        Attributes   = [ idAttrRow None; emailAttrRow None ]
+        References   = []
+        Indexes      = []
+        IndexColumns = []
+        Triggers     = []
+        ColumnChecks = []
+    }
+
 [<Fact>]
 let ``V1 parity: an entity-less espace is skipped, not a module.kinds.empty failure of the whole read`` () =
-    let bundle : OssysRowsetTypes.RowsetBundle =
-        {
-            Modules      = [ moduleRow None; entityLessPortalRow ]
-            Kinds        = [ userKindRow None ]
-            Attributes   = [ idAttrRow None; emailAttrRow None ]
-            References   = []
-            Indexes      = []
-            IndexColumns = []
-            Triggers     = []
-            ColumnChecks = []
-        }
+    let bundle = normalizationBundle [ moduleRow None; entityLessPortalRow ] [ userKindRow None ]
     match parseSync (CatalogReader.SnapshotRowsets bundle) with
     | Error errors -> failwithf "expected Ok; got Error: %A" errors
     | Ok catalog ->
@@ -1546,22 +1569,80 @@ let ``V1 parity: an entity-less espace is skipped, not a module.kinds.empty fail
 
 [<Fact>]
 let ``the entity-less skip is a NAMED erasure: one Info notice per skipped module, none when every module is populated`` () =
-    let bundle : OssysRowsetTypes.RowsetBundle =
-        {
-            Modules      = [ moduleRow None; entityLessPortalRow ]
-            Kinds        = [ userKindRow None ]
-            Attributes   = [ idAttrRow None; emailAttrRow None ]
-            References   = []
-            Indexes      = []
-            IndexColumns = []
-            Triggers     = []
-            ColumnChecks = []
-        }
-    let notices = OssysRowsetReader.entityLessModules bundle
+    let bundle = normalizationBundle [ moduleRow None; entityLessPortalRow ] [ userKindRow None ]
+    let _, notices = OssysRowsetReader.normalizeBundle bundle
     let notice = Assert.Single(notices)
-    Assert.Equal("adapter.ossys.module.entityLess", notice.Code)
+    Assert.Equal(OssysRowsetReader.CodeModuleEntityLess, notice.Code)
     Assert.Equal(DiagnosticSeverity.Info, notice.Severity)
     Assert.Contains("PortalTheme", notice.Message)
     Assert.Equal(Some "2", Map.tryFind "espaceId" notice.Metadata)
-    let populatedOnly = { bundle with Modules = [ moduleRow None ] }
-    Assert.Empty(OssysRowsetReader.entityLessModules populatedOnly)
+    let populatedOnly = normalizationBundle [ moduleRow None ] [ userKindRow None ]
+    Assert.Empty(snd (OssysRowsetReader.normalizeBundle populatedOnly))
+
+[<Fact>]
+let ``an inactive duplicate SS_Key kind is dropped as a NAMED shadow; the active kind is carried and the read succeeds`` () =
+    let bundle =
+        normalizationBundle
+            [ moduleRow None; appCoreOldRow ]
+            [ userKindRow (Some userShadowGuid); userShadowKindRow ]
+    match parseSync (CatalogReader.SnapshotRowsets bundle) with
+    | Error errors -> failwithf "expected Ok; got Error: %A" errors
+    | Ok catalog ->
+        // Only AppCore survives — AppCoreOld's sole entity was the shadow,
+        // so it skips entity-less (the two normalization steps compose).
+        let names = catalog.Modules |> List.map (fun m -> Name.value m.Name)
+        Assert.Equal<string list>([ "AppCore" ], names)
+        Assert.Equal(1, Catalog.allKinds catalog |> List.length)
+    let _, notices = OssysRowsetReader.normalizeBundle bundle
+    Assert.Equal<string list>(
+        [ OssysRowsetReader.CodeKindInactiveShadow; OssysRowsetReader.CodeModuleEntityLess ],
+        notices |> List.map (fun n -> n.Code))
+    let shadow = notices |> List.find (fun n -> n.Code = OssysRowsetReader.CodeKindInactiveShadow)
+    Assert.Contains("AppCoreOld", shadow.Message)
+    Assert.Equal(Some "99", Map.tryFind "shadowEntityId" shadow.Metadata)
+    Assert.Equal(Some "11", Map.tryFind "survivorEntityId" shadow.Metadata)
+
+[<Fact>]
+let ``a reference aimed at a dropped shadow's EntityId re-aims at the survivor (same SS_Key, only the join id moves)`` () =
+    let bundle =
+        { normalizationBundle
+            [ moduleRow None; appCoreOldRow ]
+            [ userKindRow (Some userShadowGuid); userShadowKindRow ] with
+            References =
+                [ { AttrId              = 112
+                    RefEntityName       = "User"
+                    RefEntityId         = Some 99   // the shadow's id
+                    DeleteRuleCode      = None
+                    HasDbConstraint     = true
+                    OnUpdate            = None
+                    IsConstraintTrusted = true } ] }
+    let normalized, _ = OssysRowsetReader.normalizeBundle bundle
+    let reference = Assert.Single(normalized.References)
+    Assert.Equal(Some 11, reference.RefEntityId)
+
+[<Fact>]
+let ``two ACTIVE kinds sharing an SS_Key are carried unchanged — the A4 refusal remains the terminal for a real contradiction`` () =
+    let bundle =
+        normalizationBundle
+            [ moduleRow None; appCoreOldRow ]
+            [ userKindRow (Some userShadowGuid)
+              { userShadowKindRow with IsActive = true } ]
+    // No shadow resolution fires (no single active row to prefer)...
+    Assert.Empty(snd (OssysRowsetReader.normalizeBundle bundle))
+    // ...and the parse refuses on A4, exactly as before.
+    match parseSync (CatalogReader.SnapshotRowsets bundle) with
+    | Ok _ -> failwith "expected the A4 duplicate-kind refusal"
+    | Error errors ->
+        Assert.Contains("catalog.kinds.duplicateKey", errors |> List.map (fun e -> e.Code))
+
+[<Fact>]
+let ``normalizeBundle is idempotent: a normalized bundle re-normalizes to itself with zero notices`` () =
+    let bundle =
+        normalizationBundle
+            [ moduleRow None; appCoreOldRow; entityLessPortalRow ]
+            [ userKindRow (Some userShadowGuid); userShadowKindRow ]
+    let once, firstNotices = OssysRowsetReader.normalizeBundle bundle
+    Assert.NotEmpty firstNotices
+    let twice, secondNotices = OssysRowsetReader.normalizeBundle once
+    Assert.Empty secondNotices
+    Assert.Equal<OssysRowsetTypes.RowsetBundle>(once, twice)


### PR DESCRIPTION
## What

Follow-up to #655/#656 (same live partial-transfer run, third catch): with row-mapping and the entity-less skip fixed, the metamodel read died at catalog assembly with `catalog.kinds.duplicateKey: Catalog has Kind SsKey OssysOriginal <guid> duplicated across modules; A4 requires Kind identity to be globally unique.`

## Root cause (two-ply)

1. **The transfer's contract reads ignored the projection.json model scope.** Full-export/publish read through `readConfigModel` → `SnapshotScopeBinding.fromModel cfg.Model` (declared `model.modules` pushed down; `includeInactiveModules` default false; `onlyActiveAttributes` default true). The peer transfer's `acquireContracts` → `Source.ofOssys` → `LiveModelRead.fromConnSpec` read with `defaultParameters` — all modules, system + **inactive entities** included. The transfer saw strictly more estate than any other verb.
2. **What the wider view exposed:** an entity moved between modules leaves an *inactive* `ossys_Entity` row in the old espace with the **same SS_Key** as the active row in its new home. Loading both produces two Kinds with one SsKey → the A4 refusal kills the whole read.

## Fix 1 — scope parity

`Source.ofOssysWith` + `PeerTransfer.acquireContractsWith` are new scope-bearing siblings (zero-default `ofOssys`/`acquireContracts` delegate to them — no duplication); `runPeerTransfer` and `runCheckGo` take a `contractScope`, bound at dispatch from `SnapshotScopeBinding.fromModel shaping.Model`. The transfer and its go board now read the **same modeled estate as full-export/publish, on both sides**. Even an unscoped config now applies `onlyActiveAttributes=true` to transfer reads (the config default), pre-empting the inactive-duplicate-attribute layer beneath this one.

## Fix 2 — bundle normalization (robustness inside any scope)

The #656 entity-less skip generalizes into **`OssysRowsetReader.normalizeBundle`** — the one normalization pass every rowset parse applies (idempotent; the live read calls it directly to surface the notices):

1. **Inactive-shadow resolution** (`adapter.ossys.kind.inactiveShadow`, Info): a duplicate SS_Key with exactly one active row carries the active row, drops each inactive shadow as a named erasure (survivor/shadow ids + modules in metadata), and re-aims references from a shadow's EntityId to the survivor. Two active or all inactive → carried unchanged; the A4 refusal remains the terminal for a genuine contradiction.
2. **Entity-less module skip** (from #656), computed post-shadow-drop, so a module whose only entity was a shadow skips too.

Because normalization is parse-owned, `ModelResolution`-based verbs (emit/preview/migrate over live OSSYS) get the same protection.

## Tests

- **Pure** (`OsmRowsetReaderTests`, 41 total): shadow dropped + named with metadata pinned; reference re-aim; two-active still refuses on A4; normalization idempotent (`normalize ∘ normalize = normalize`, zero notices second pass); entity-less tests re-homed onto `normalizeBundle`.
- **Docker e2e** (`EntityLessModuleReadDockerTests`): new fact seeding an inactive `City` shadow in a second espace — extraction → normalize → parse succeeds, City carried exactly once in its active home, both erasures named.
- Rebased onto the #656 squash with an **empty content diff**, so all focused-run evidence applies to this exact tree; full sweep running, verdict to be appended to readiness-log Entry 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m