### PR TITLE
Effective transfer graph + weak-feedback cycle resolver (v5): scoped gates, object-scope grants, complete cycle handling

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -200,6 +200,7 @@ table before continuing.
 
 | Deferral | First logged | Trigger condition | Status (current; session-N tag indicates last update) |
 |---|---|---|---|
+| **Manual cycle-ordering override (V1 `CircularDependencyOptions` analogue)** | 2026-07-07 (weak-feedback resolver v5) | A real estate surfaces a cycle whose breakability is NOT inferable from schema (every edge non-nullable/cascade, but the operator knows the data arrives in a self-consistent staged order). Add as a registered `OperatorIntent Ordering` overlay keyed by SsKey, COMPOSING with the resolver — never V1's replace-it-entirely semantics. | deferred (2026-07-07) |
 | **Composition primitive `fallback`** | 2026-05-13 (Composition vocabulary cash-out) | A second strategy returns "no decision" / Defer outcome and another picks up | 0 consumers (session 25) |
 | **Composition primitive `accumulate`** | 2026-05-13 (Composition vocabulary cash-out) | A second pass needs to consume multiple-strategy decisions at once | 0 consumers (session 25) |
 | **Composition primitive `wrap`** | 2026-05-13 (Composition vocabulary cash-out) | Per-strategy diagnostics emerge (likely tied to Diagnostics writer) | 0 consumers (session 25) |
@@ -26782,3 +26783,56 @@ flood still never degrades; `processing` after threshold, `stalled` nowhere);
 dedup-vs-decision, operator-safety contract held); `ModelFidelityTests`
 (payload builder Some/None); `TtyRendererTests` (panel row + next move);
 `VoiceTotalityTests` (the new code forced same-commit).
+
+
+## 2026-07-07 — The weak-feedback cycle resolver (v5) + the resolved-cycle unsatisfiability fix; manual ordering overrides stay deferred
+
+**Decision.** `TopologicalOrderPass` v5 replaces the asymmetric-2-cycle
+resolver with `CycleResolution.weakFeedbackStrategy`: find a cycle
+(deterministic DFS); if every edge on it is non-Weak, refuse — naming
+exactly that cycle; otherwise break the smallest Weak edge on it and
+repeat until acyclic. The complete case map and invariants (I1
+soundness: broken ⊆ Weak ⊆ deferrable; I2 acyclicity on resolve; I3
+refusal ⟺ an all-strong cycle exists; I4 input-order independence; I5
+frugality — a pure weak ring breaks one edge) live in the resolver's
+docstring and are property-tested in `CycleResolutionTests`. The prior
+resolver's shapes are rows of the new map: single-weak 2-cycles and
+weak self-loops behave byte-identically; symmetric-weak 2-cycles and
+weak-bearing SCCs of any size now RESOLVE; only genuinely
+non-deferrable cycles refuse — with the exact cycle named instead of
+"SCC of size N".
+
+**The correlated fix the completeness audit surfaced.**
+`DataLoadPlan.buildWith` computed `UnbreakableCycleFks` over ALL cycle
+members — but a RESOLVED SCC deliberately stays in `Cycles` (its broken
+weak edges need phase-2 deferral), so every resolved asymmetric
+2-cycle's strong edge was flagged unbreakable and `executeGate` refused
+a load the proven order satisfies (latent: the canary estates carry
+only self-loop cycles, whose strong variant never resolves).
+`TopologicalOrder.unresolvedCycleMembers` (`BreakableEdges = []` is the
+discriminant) now feeds unsatisfiability; `cycleMembers` (all members)
+still feeds `deferredFkColumns`. The algebra: RESOLVED cycle → strong
+edges satisfied by ORDER, weak edges satisfied by DEFERRAL; UNRESOLVED
+cycle → nullable columns defer, non-nullable columns are the named
+`transfer.unbreakableCycleFk` refusal.
+
+**Deferral (indexed above).** V1's operator override
+(`CircularDependencyOptions` / `AllowedCycle` z-index positions —
+which DISABLES automatic detection wholesale and keys on
+espace-fragile physical names) is deliberately not carried. The
+resolver derives breakability from schema facts (nullability +
+OnDelete); the only case an override serves is a cycle whose
+breakability is not schema-inferable, and that trigger is now indexed.
+Conservative choice kept from V1: `Cascade` edges never break, even
+when nullable (deferral of a nullable cascade column remains legal
+when ordering resolves by other means; breaking on cascade evidence is
+not).
+
+**Witnesses.** `CycleResolutionTests` (case map + I1–I5 properties),
+`TopologicalOrderPassTests` (v5 flips: symmetric-weak resolves with the
+deterministic edge; all-weak 3-cycle breaks exactly one; all-strong
+3-cycle refuses by name), `DataLoadPlanTests` (resolved cycle →
+satisfiable + no unbreakable; unresolved → the named diagnostic),
+`DataEmissionComposerTests` (the unresolvable fixture moved to
+nullable+Restrict — strength Other with deferrable columns, preserving
+both the Alphabetical premise and the phase-2 partition law).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1029,3 +1029,45 @@ the unrelated-cycle board goes GREEN while the unscoped topology provably
 degrades on the same contract; `PeerManagedGrantTransferDockerTests` — the new
 OBJECT-scope-DML cell lands the subset with zero grant violations and no
 database-scope DML at all; both G1 promotions). Full-sweep verdict below.
+
+## Entry 26 — 2026-07-07, THE WEAK-FEEDBACK RESOLVER (v5): cycle handling made total, and the resolved-cycle refusal bug the audit caught
+
+**Why (operator-directed completeness follow-on to Entry 25):** the review of
+V1's manual cycle-ordering override (`CircularDependencyOptions` — z-index
+positions that DISABLE automatic detection wholesale, keyed on espace-fragile
+physical names) concluded V2 should overcome it with a complete resolver rather
+than carry the knob. The gap named there: the asymmetric-2-cycle resolver refused
+symmetric-weak 2-cycles and every SCC ≥ 3 — shapes the two-phase deferral can
+provably load.
+
+**The resolver (`CycleResolution.weakFeedbackStrategy`, pass v5):** find a cycle
+(deterministic DFS); every edge on it non-Weak → refuse, naming EXACTLY that
+cycle (and the remedy: make one of its FK columns nullable — it then defers);
+otherwise break the smallest Weak edge on it and repeat until acyclic. The
+complete case map (self-loops, 2-cycles asymmetric/symmetric/strong, SCCs ≥ 3
+weak-bearing/strong-cored, fused rings, cascade conservatism) is the docstring
+table; invariants I1–I5 (broken ⊆ Weak ⊆ deferrable; acyclic on resolve;
+refuse ⟺ an all-strong cycle exists; input-order independence; a pure weak ring
+breaks ONE edge) are property-tested. Manual overrides stay DEFERRED with a
+named trigger in the DECISIONS index (a cycle whose breakability is not
+schema-inferable).
+
+**The correlated catch:** `UnbreakableCycleFks` judged ALL cycle members, but a
+RESOLVED SCC deliberately stays in `Cycles` for deferral — so a resolved
+asymmetric 2-cycle's strong edge was flagged unbreakable and `executeGate`
+refused a load the proven order satisfies (latent until now: the canary estates
+only carry self-loop cycles). `TopologicalOrder.unresolvedCycleMembers` now
+feeds unsatisfiability; `cycleMembers` still feeds deferral. The algebra reads
+cleanly: resolved → strong edges satisfied by ORDER, weak by DEFERRAL;
+unresolved → nullable defers, non-nullable is the named refusal.
+
+**Also caught while here (the sweep's one red):** the per-object grant probe
+treated a MISSING sink table as zero permissions — a misleading
+`insufficientGrant` for what is a shape fact. An absent object now stays
+unprobed (database-scope fallback), and the chunk-resume crash witness holds.
+
+**Proven:** pure — `CycleResolutionTests` (case map + I1–I5 FsCheck properties),
+`TopologicalOrderPassTests` (v5 flips), `DataLoadPlanTests` (resolved →
+satisfiable; unresolved → named diagnostic), `DataEmissionComposerTests`
+(unresolvable fixture moved to nullable+Restrict, preserving both premises);
+full fast pool green. Full-sweep verdict below.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -976,3 +976,56 @@ pool 291/291 (649s), scale pool 16/16 (111s), the normalization + scope-parity t
 aboard. Three live-run catches (Entries 22-24) closed in one day; the contracts gate
 now reads a whole real estate — orphan attributes, entity-less espaces, and
 moved-entity shadows — under the same model scope every other verb honors.
+
+## Entry 25 — 2026-07-07, THE EFFECTIVE TRANSFER GRAPH: the board and the engine stop judging the whole estate
+
+**What the live run hit (the go board, post-contracts):** three related reds on a
+small declared subset — (1) `grant` STOP because the cloud principal carries
+object/column-scope DML with NO database-scope grant, and the probe read
+`fn_my_permissions(NULL,'DATABASE')` only; (2) `load order` STOP because the
+topology ran on the WHOLE sink contract, so an unrelated estate cycle degraded the
+order alphabetical; (3) dry-run `cycles` naming unbreakable-cycle FKs entirely
+outside the requested subset. The diagnosis (operator review, confirmed): an
+ABSTRACTION GAP — the engine had every ingredient of "what does this transfer
+actually touch" (LoadSet, reconciled kinds, ingestScope, the face's gateScope) but
+no reified carrier, so every consumer that predates subsets (topology, plan
+cycles, grant planning) silently evaluated the estate.
+
+**The carrier:** `TransferScope` (Core) — WriteKinds (declared or whole estate,
+minus reconciled), Nodes (write ∪ reconciled as ISOLATED graph nodes — reported,
+never ordered), and `TransferScope.topology` over the induced subgraph
+(`TopologicalOrderPass.runScopedWith` — FK edges bind only between written kinds;
+same algorithm, one graph-construction parameter). Built ONCE from the inputs
+every gate already holds; consumed by the engine's Execute gates AND the go
+board, so the forecast and the live run cannot evaluate different graphs. A full
+non-reconciling transfer is the identity scope (byte-identical; property-pinned).
+
+**Engine deltas (Execute gates, per the operator-approved review):**
+`orderedLoadGate` and `executeGate`/`UnbreakableCycleFks` judge the scoped graph
+(unrelated cycles stop refusing subset runs; a cycle THROUGH a reconciled kind
+correctly breaks — it is never written); `DeferredFkColumns` shrink to scoped
+cycle members (fewer Phase-2 UPDATEs); the slice apply (`runGoldenApply`) scopes
+to its slice's kinds; the streaming leg gets the reconciled-edge drop; synthetic
+legs unchanged (whole estate is their true graph).
+
+**Grant deltas:** `Preflight.WriteAction` gains `Update` (Phase-2 re-point and
+the MERGE lane genuinely UPDATE — INSERT never implied it; the capability survey's
+data sets follow); `plannedTransferWrites` is scope × emission (INSERT+UPDATE per
+written kind; DELETE under a wipe — previously ungated); `captureGrantEvidenceFor`
+probes per planned table at OBJECT scope (`fn_my_permissions('<obj>','OBJECT')`,
+object grain), recorded in `GrantEvidence.ProbedObjects` — a probed object's rows
+are EFFECTIVE permissions and AUTHORITATIVE (no database fallback), so **the
+pinned G1 gap closes for planned tables**: a table-level DENY refuses
+`transfer.insufficientGrant` pre-write with ZERO partial write (both pinned tests
+PROMOTED — `ReverseLegCanaryTests` L3Deny + the peer scenario 5). The go board's
+grant item renders the SAME planned-write evaluation the engine enforces —
+object-scope-only DML is a [ GO ].
+
+**Proven:** pure (`TransferScopeTests` — scoped topo ignores unrelated cycles,
+reconciled-edge drop, full-transfer identity, planned-write verbs;
+`PreflightTests` — probed-object precedence incl. the DENY-under-db-grant shape;
+`CapabilitySurveyTests` re-pinned with Update) and docker (`GoBoardDockerTests` —
+the unrelated-cycle board goes GREEN while the unscoped topology provably
+degrades on the same contract; `PeerManagedGrantTransferDockerTests` — the new
+OBJECT-scope-DML cell lands the subset with zero grant violations and no
+database-scope DML at all; both G1 promotions). Full-sweep verdict below.

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -884,15 +884,21 @@ let runCheckGo
                 (PeerTransfer.narrateEscapes escapes))
         else
             items.Add (GoBoard.item "relationships" (GoBoard.Status.Green "every relationship the subset touches is inside it or reconciled."))
-        // -- load order (the whole-estate topology) --------------------------
-        let topo = (Projection.Core.Passes.TopologicalOrderPass.runWith Projection.Core.TreatAsCycle sinkContract).Value
+        // -- load order (the EFFECTIVE transfer graph, 2026-07-07) -----------
+        // The same `TransferScope` the engine's Execute gates build:
+        // declared tables plus reconciled kinds as isolated nodes, FK
+        // edges binding only between written kinds — an unrelated estate
+        // cycle no longer reds a partial transfer's board (and no longer
+        // refuses its live run).
+        let scope = TransferScope.create sinkContract loadSet reconciledKeys
+        let topo = TransferScope.topology Projection.Core.TreatAsCycle scope sinkContract
         (match Transfer.orderedLoadGate topo with
          | Some refusal ->
              items.Add (GoBoard.itemWith "load order"
-                 (GoBoard.Status.Red ("the load order degraded to the alphabetical fallback — a live run refuses.", "make the named cycle's FK columns nullable (they then defer automatically), or transfer without the affected kinds."))
+                 (GoBoard.Status.Red ("the load order of the transferred set degraded to the alphabetical fallback — a live run refuses.", "make the named cycle's FK columns nullable (they then defer automatically), or transfer without the affected kinds."))
                  [ refusal.Message ])
          | None ->
-             items.Add (GoBoard.item "load order" (GoBoard.Status.Green "parents before children, proven (topological).")))
+             items.Add (GoBoard.item "load order" (GoBoard.Status.Green "parents before children over the transferred set, proven (topological).")))
         // -- THE DRY RUN (real reads, zero writes): the row/identity forecast -
         let shapeClean = List.isEmpty shape.Blocking
         if not shapeClean then
@@ -959,20 +965,43 @@ let runCheckGo
                  items.Add (GoBoard.itemWith "cdc"
                      (GoBoard.Status.Red (sprintf "the sink is CDC-tracked (%d table(s)) — a live run refuses without consent." tracked.Length, "run --go with --allow-cdc (the capture will see the load), or disable capture on the sink."))
                      (tracked |> List.truncate 5)))
-            (match (Preflight.captureGrantEvidence sink).GetAwaiter().GetResult() with
+            // The PLANNED-WRITE grant evaluation (2026-07-07): the same
+            // planned writes the engine's G2 gate enforces, evaluated per
+            // transferred table against object-scope EFFECTIVE permissions
+            // (database OR object grants cover; a managed-cloud principal
+            // carrying object-scope DML with no database-scope grant is a
+            // [ GO ]). Reconciled parents additionally need SELECT (the
+            // match-by-key reads them).
+            let plannedWrites = Transfer.plannedTransferWrites scope opts.Emission sinkContract
+            let readTables =
+                Catalog.allKinds sinkContract
+                |> List.filter (fun k -> Set.contains k.SsKey scope.Nodes)
+                |> List.map (fun k -> TableId.schemaText k.Physical, TableId.tableText k.Physical)
+                |> List.distinct
+            let probeTables =
+                (plannedWrites |> List.map (fun w -> w.Schema, w.Table)) @ readTables |> List.distinct
+            (match (Preflight.captureGrantEvidenceFor probeTables sink).GetAwaiter().GetResult() with
              | Error errors ->
                  items.Add (GoBoard.itemWith "grant" (GoBoard.Status.Red ("the grant probe failed.", "check the sink connection/principal; then re-run.")) (errors |> List.map (fun e -> e.Message)))
              | Ok evidence ->
-                 let missing =
-                     [ "SELECT"; "INSERT"; "UPDATE"; "DELETE" ]
-                     |> List.filter (fun p -> not (Preflight.coversPermissionAtDatabaseScope p evidence))
-                 if List.isEmpty missing then
-                     items.Add (GoBoard.itemWith "grant"
-                         (GoBoard.Status.Green "the sink principal carries database-scope SELECT/INSERT/UPDATE/DELETE.")
-                         [ "standing note: a TABLE-level DENY is invisible to this probe and would surface mid-load (the pinned G1 gap)." ])
-                 else
+                 let writeViolations =
+                     Preflight.permissionViolations plannedWrites evidence
+                     |> List.map (fun v -> sprintf "%s on %s" (Preflight.permissionName v.Action) v.Object)
+                 let readViolations =
+                     readTables
+                     |> List.filter (fun (schema, table) -> not (Preflight.coversPermissionOn schema table "SELECT" evidence))
+                     |> List.map (fun (schema, table) -> sprintf "SELECT on %s.%s" schema table)
+                 match writeViolations @ readViolations with
+                 | [] ->
                      items.Add (GoBoard.item "grant"
-                         (GoBoard.Status.Red (sprintf "the sink principal lacks database-scope %s." (String.concat ", " missing), "grant the missing permission(s) to the sink principal; then re-run."))))
+                         (GoBoard.Status.Green
+                             (sprintf
+                                 "the sink principal covers the planned writes (%d table(s), database or object scope) and SELECT on the touched set — table-level DENYs would show here."
+                                 (plannedWrites |> List.map (fun w -> w.Schema, w.Table) |> List.distinct |> List.length))))
+                 | violations ->
+                     items.Add (GoBoard.itemWith "grant"
+                         (GoBoard.Status.Red ("the sink principal does not cover the planned writes.", "grant the missing permission(s) — database scope or per-table object scope both satisfy the gate; then re-run."))
+                         (violations |> List.truncate 10)))
             // Pinned owners (2026-07-06, the single-owner program): every
             // `Table:=<key>` / `Table:Column:=<key>` rule names a sink row
             // that must EXIST — probe each against the live sink so the

--- a/sidecar/projection/src/Projection.Core/DataLoadPlan.fs
+++ b/sidecar/projection/src/Projection.Core/DataLoadPlan.fs
@@ -169,16 +169,24 @@ module DataLoadPlan =
         let loads   = loadAndSkipped |> List.map fst
         let skipped = loadAndSkipped |> List.collect snd
 
+        // Unsatisfiability judges UNRESOLVED cycles only (2026-07-07, the
+        // resolver-completeness program): a strong edge inside a RESOLVED
+        // SCC is satisfied by the proven order (the resolver breaks weak
+        // edges only), so flagging it here refused loads the order
+        // handles. `members` (all cycle participants) still drives the
+        // DEFERRAL above — a resolved SCC's broken weak edges genuinely
+        // defer to phase 2.
+        let unresolvedMembers = TopologicalOrder.unresolvedCycleMembers topo
         let unbreakable =
             topo.Order
             |> List.collect (fun key ->
                 match Catalog.tryFindKind key catalog with
                 | None -> []
-                | Some k when not (Set.contains key members) -> []
+                | Some k when not (Set.contains key unresolvedMembers) -> []
                 | Some k ->
                     k.References
                     |> List.choose (fun r ->
-                        if Set.contains r.TargetKind members then
+                        if Set.contains r.TargetKind unresolvedMembers then
                             Kind.tryFindAttribute r.SourceAttribute k
                             |> Option.bind (fun a ->
                                 if a.Column.IsNullable then None

--- a/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
@@ -95,9 +95,34 @@ module TopologicalOrderPass =
             // is plugged in.
     }
 
-    let private buildGraph (selfLoops: SelfLoopPolicy) (c: Catalog) : Graph =
-        let allKinds = Catalog.allKinds c
+    /// Optional graph restriction (2026-07-07, the effective-transfer-graph
+    /// program). `Nodes` are the kinds admitted to the graph at all;
+    /// `EdgeKinds` are the kinds whose FK edges bind ordering — an edge is
+    /// kept only when BOTH endpoints are edge kinds. A node outside
+    /// `EdgeKinds` (a reconciled kind: present for reporting, never
+    /// written) rides as an ISOLATED node — no edge can enter or leave it,
+    /// so no cycle can pass through it. `None` = the whole catalog with
+    /// every edge (the historical behavior, byte-identical).
+    type GraphScope =
+        {
+            Nodes     : Set<SsKey>
+            EdgeKinds : Set<SsKey>
+        }
+
+    let private buildGraphWithin (selfLoops: SelfLoopPolicy) (scope: GraphScope option) (c: Catalog) : Graph =
+        let allKinds =
+            match scope with
+            | None -> Catalog.allKinds c
+            | Some s -> Catalog.allKinds c |> List.filter (fun k -> Set.contains k.SsKey s.Nodes)
         let presentKeys = allKinds |> List.map (fun k -> k.SsKey) |> Set.ofList
+        // Under a scope, an edge binds ordering only when BOTH endpoints
+        // are edge kinds. An FK leaving the scope is not "missing" — it is
+        // deliberately out of the ordering problem (the subset-escape gate
+        // owns reporting those edges), so it is dropped silently.
+        let edgeAdmitted (source: SsKey) (target: SsKey) : bool =
+            match scope with
+            | None -> true
+            | Some s -> Set.contains source s.EdgeKinds && Set.contains target s.EdgeKinds
 
         // Sort the iteration source by SsKey — this is the
         // permutation-invariance commitment in code.
@@ -139,6 +164,13 @@ module TopologicalOrderPass =
                     // no graph mutation, no MissingEdge entry (the
                     // target IS present — we just don't track the
                     // dependency).
+                    st
+                elif not (edgeAdmitted k.SsKey r.TargetKind) then
+                    // Scope-dropped edge: at least one endpoint is not an
+                    // edge kind (reconciled, or outside the transfer
+                    // subset). Deliberately silent here — the
+                    // subset-escape gate owns reporting edges that leave
+                    // the transferred set.
                     st
                 elif Set.contains r.TargetKind presentKeys then
                     match Map.tryFind edge st.ClassifiedEdges with
@@ -433,95 +465,108 @@ module TopologicalOrderPass =
     let private touchedEvent (key: SsKey) : LineageEvent =
         LineageEvent.forPass passName version classification key Touched
 
-    /// Parameterized form. Per session-36 — `selfLoops` selects how a
-    /// kind's reference to itself is handled during graph construction.
+    /// Order construction over a built graph — the shared core behind
+    /// `runWith` (whole catalog) and `runScopedWith` (the effective
+    /// transfer graph). Per session-36 — `selfLoops` (applied at graph
+    /// construction) selects how a kind's reference to itself is handled:
     /// `TreatAsCycle` (default) preserves pre-session-36 semantics;
-    /// `SkipSelfEdges` drops self-references during construction so
-    /// emitters whose target syntax allows inline self-FK constraints
-    /// see the kind in topological position. Same algorithm, two
-    /// projections — replaces the `RawTextEmitter.emissionOrder`
-    /// duplicate (Agent 4 #6).
-    let runWith (selfLoops: SelfLoopPolicy) (c: Catalog) : Lineage<TopologicalOrder> =
-        let graph = buildGraph selfLoops c
+    /// `SkipSelfEdges` drops self-references so emitters whose target
+    /// syntax allows inline self-FK constraints see the kind in
+    /// topological position. Same algorithm, two projections — replaces
+    /// the `RawTextEmitter.emissionOrder` duplicate (Agent 4 #6).
+    let private orderOf (graph: Graph) : TopologicalOrder =
         let sorted, unprocessed = kahnSort graph
 
-        let result =
-            if List.isEmpty unprocessed then
-                // Acyclic — the output order is the topological sort.
-                { Mode         = Topological
-                  Order        = sorted
-                  Edges        = graph.Edges
-                  MissingEdges = graph.MissingEdges
-                  Cycles       = []
-                  Diagnostics  = [
-                      sprintf "topologicalOrder v%d: %d nodes, %d edges, %d missing"
-                          version graph.Nodes.Length graph.Edges.Length graph.MissingEdges.Length
-                  ] }
-            else
-                // Cycle present. Run Tarjan's SCC on the unprocessed
-                // residue, then ask the asymmetric-2-cycle resolver
-                // which Weak edges it's willing to break.
-                let sccs = tarjanScc unprocessed graph.Adjacency
-                let resolution =
-                    applyResolver CycleResolution.asymmetric2CycleStrategy graph sccs
+        if List.isEmpty unprocessed then
+            // Acyclic — the output order is the topological sort.
+            { Mode         = Topological
+              Order        = sorted
+              Edges        = graph.Edges
+              MissingEdges = graph.MissingEdges
+              Cycles       = []
+              Diagnostics  = [
+                  sprintf "topologicalOrder v%d: %d nodes, %d edges, %d missing"
+                      version graph.Nodes.Length graph.Edges.Length graph.MissingEdges.Length
+              ] }
+        else
+            // Cycle present. Run Tarjan's SCC on the unprocessed
+            // residue, then ask the asymmetric-2-cycle resolver
+            // which Weak edges it's willing to break.
+            let sccs = tarjanScc unprocessed graph.Adjacency
+            let resolution =
+                applyResolver CycleResolution.asymmetric2CycleStrategy graph sccs
 
-                if List.isEmpty resolution.UnresolvedDiagnostics then
-                    // Every SCC resolved. Re-run Kahn on the reduced graph.
-                    let reduced = reduceGraph graph resolution.RemovedPrecedenceEdges
-                    let resorted, residue = kahnSort reduced
-                    if List.isEmpty residue then
-                        { Mode         = Topological
-                          Order        = resorted
-                          Edges        = graph.Edges
-                          MissingEdges = graph.MissingEdges
-                          // Resolved cycles stay in Cycles for audit —
-                          // they record the SCCs found and the edges
-                          // broken to resolve them.
-                          Cycles       = resolution.ResolvedDiagnostics
-                          Diagnostics  = [
-                              sprintf "topologicalOrder v%d: %d cycle(s) auto-resolved via Weak-edge removal"
-                                  version resolution.ResolvedDiagnostics.Length
-                          ] }
-                    else
-                        // Defensive: removing the resolver's chosen edges
-                        // should always make the graph acyclic, but if a
-                        // bug or unforeseen graph shape leaves residue
-                        // we degrade gracefully.
-                        let leftover = tarjanScc residue reduced.Adjacency
-                        let leftoverDiagnostics =
-                            leftover
-                            |> List.map (fun members ->
-                                { Members        = members
-                                  BreakableEdges = []
-                                  Reason         = "residual SCC after resolver; please report" })
-                        { Mode         = Alphabetical
-                          Order        = graph.Nodes
-                          Edges        = graph.Edges
-                          MissingEdges = graph.MissingEdges
-                          Cycles       = resolution.ResolvedDiagnostics @ leftoverDiagnostics
-                          Diagnostics  = [
-                              sprintf "topologicalOrder v%d: resolver left residue; alphabetical fallback"
-                                  version
-                          ] }
-                else
-                    // At least one SCC the resolver can't handle. Fall
-                    // back to alphabetical; record both the resolved and
-                    // unresolved diagnostics so callers can audit.
-                    let alphabeticalAll = graph.Nodes
-                    { Mode         = Alphabetical
-                      Order        = alphabeticalAll
+            if List.isEmpty resolution.UnresolvedDiagnostics then
+                // Every SCC resolved. Re-run Kahn on the reduced graph.
+                let reduced = reduceGraph graph resolution.RemovedPrecedenceEdges
+                let resorted, residue = kahnSort reduced
+                if List.isEmpty residue then
+                    { Mode         = Topological
+                      Order        = resorted
                       Edges        = graph.Edges
                       MissingEdges = graph.MissingEdges
-                      Cycles       = resolution.ResolvedDiagnostics @ resolution.UnresolvedDiagnostics
+                      // Resolved cycles stay in Cycles for audit —
+                      // they record the SCCs found and the edges
+                      // broken to resolve them.
+                      Cycles       = resolution.ResolvedDiagnostics
                       Diagnostics  = [
-                          sprintf "topologicalOrder v%d: %d resolved, %d unresolved; alphabetical fallback"
-                              version
-                              resolution.ResolvedDiagnostics.Length
-                              resolution.UnresolvedDiagnostics.Length
+                          sprintf "topologicalOrder v%d: %d cycle(s) auto-resolved via Weak-edge removal"
+                              version resolution.ResolvedDiagnostics.Length
                       ] }
+                else
+                    // Defensive: removing the resolver's chosen edges
+                    // should always make the graph acyclic, but if a
+                    // bug or unforeseen graph shape leaves residue
+                    // we degrade gracefully.
+                    let leftover = tarjanScc residue reduced.Adjacency
+                    let leftoverDiagnostics =
+                        leftover
+                        |> List.map (fun members ->
+                            { Members        = members
+                              BreakableEdges = []
+                              Reason         = "residual SCC after resolver; please report" })
+                    { Mode         = Alphabetical
+                      Order        = graph.Nodes
+                      Edges        = graph.Edges
+                      MissingEdges = graph.MissingEdges
+                      Cycles       = resolution.ResolvedDiagnostics @ leftoverDiagnostics
+                      Diagnostics  = [
+                          sprintf "topologicalOrder v%d: resolver left residue; alphabetical fallback"
+                              version
+                      ] }
+            else
+                // At least one SCC the resolver can't handle. Fall
+                // back to alphabetical; record both the resolved and
+                // unresolved diagnostics so callers can audit.
+                let alphabeticalAll = graph.Nodes
+                { Mode         = Alphabetical
+                  Order        = alphabeticalAll
+                  Edges        = graph.Edges
+                  MissingEdges = graph.MissingEdges
+                  Cycles       = resolution.ResolvedDiagnostics @ resolution.UnresolvedDiagnostics
+                  Diagnostics  = [
+                      sprintf "topologicalOrder v%d: %d resolved, %d unresolved; alphabetical fallback"
+                          version
+                          resolution.ResolvedDiagnostics.Length
+                          resolution.UnresolvedDiagnostics.Length
+                  ] }
 
+    let private lineageOf (graph: Graph) : Lineage<TopologicalOrder> =
         let events = graph.Nodes |> List.map touchedEvent
-        Lineage.ofValueAndEvents events result
+        Lineage.ofValueAndEvents events (orderOf graph)
+
+    let runWith (selfLoops: SelfLoopPolicy) (c: Catalog) : Lineage<TopologicalOrder> =
+        lineageOf (buildGraphWithin selfLoops None c)
+
+    /// Scoped variant (2026-07-07, the effective-transfer-graph program):
+    /// the graph restricted to `scope.Nodes`, with FK edges binding only
+    /// between `scope.EdgeKinds` members (see `GraphScope`). A subset
+    /// transfer orders — and cycle-checks — only what it actually writes;
+    /// reconciled kinds ride as isolated nodes (reported, never ordered);
+    /// an unrelated estate cycle can no longer degrade the order. Same
+    /// algorithm, one graph-construction parameter (A40).
+    let runScopedWith (selfLoops: SelfLoopPolicy) (scope: GraphScope) (c: Catalog) : Lineage<TopologicalOrder> =
+        lineageOf (buildGraphWithin selfLoops (Some scope) c)
 
     /// Run the topological-order pass with the default self-loop
     /// policy. Returns a `Lineage<TopologicalOrder>`; the catalog

--- a/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/TopologicalOrderPass.fs
@@ -59,8 +59,16 @@ module TopologicalOrderPass =
     ///       refuse 1-cycles (its name names the shape it handles);
     ///       the diagnostic surfaces for emitters that consume cycle
     ///       membership directly.
+    /// v5 — The weak-feedback resolver (2026-07-07): replaces the
+    ///       asymmetric-2-cycle strategy with `CycleResolution
+    ///       .weakFeedbackStrategy` — ANY SCC whose every cycle carries
+    ///       at least one Weak edge auto-resolves (one break per
+    ///       residual cycle); refusal fires exactly on a cycle of
+    ///       non-deferrable edges, naming its members. 2-cycle and
+    ///       self-loop behavior unchanged except symmetric weak
+    ///       2-cycles, which now resolve.
     [<Literal>]
-    let version : int = 4
+    let version : int = 5
 
     [<Literal>]
     let private passName : string = "topologicalOrder"
@@ -144,11 +152,6 @@ module TopologicalOrderPass =
         // COMBINES across the parallel set: the pair is breakable only if
         // EVERY parallel reference is Weak (a Cascade or non-nullable
         // sibling still binds the dependency).
-        let strongerOf (a: EdgeStrength) (b: EdgeStrength) : EdgeStrength =
-            match a, b with
-            | EdgeStrength.Cascade, _ | _, EdgeStrength.Cascade -> EdgeStrength.Cascade
-            | EdgeStrength.Other, _ | _, EdgeStrength.Other -> EdgeStrength.Other
-            | _ -> EdgeStrength.Weak
         let folder (state: Graph) (k: Kind) : Graph =
             // Sort references by SsKey too — same invariance commitment
             // at the inner level.
@@ -178,7 +181,7 @@ module TopologicalOrderPass =
                         // A parallel reference over an already-tracked pair:
                         // combine strength only — adjacency/indegree/Edges
                         // stay single-entry so break/reduce stays coherent.
-                        { st with ClassifiedEdges = Map.add edge (strongerOf existing strength) st.ClassifiedEdges }
+                        { st with ClassifiedEdges = Map.add edge (CycleResolution.combineStrength existing strength) st.ClassifiedEdges }
                     | None ->
                         let children =
                             Map.tryFind r.TargetKind st.Adjacency
@@ -360,10 +363,11 @@ module TopologicalOrderPass =
     // The algebra here is: enumerate SCCs (Tarjan); ask the
     // domain-supplied resolver which FK edges to break per SCC; remove
     // the precedence-graph edges; re-run Kahn. The choice of resolver
-    // is V1-flavored domain policy and lives in `CycleResolution`. This
-    // pass currently uses `CycleResolution.asymmetric2CycleStrategy`;
-    // pluggable resolvers arrive when an admire pass surfaces a need
-    // (e.g., manual cycle overrides for known fixtures).
+    // is domain policy and lives in `CycleResolution`. This pass uses
+    // `CycleResolution.weakFeedbackStrategy` (v5, 2026-07-07); manual
+    // cycle overrides stay deferred with a named trigger (a cycle whose
+    // breakability is not inferable from schema — see DECISIONS
+    // 2026-07-07).
     // -----------------------------------------------------------------------
 
     type private ResolverOutcome = {
@@ -490,11 +494,11 @@ module TopologicalOrderPass =
               ] }
         else
             // Cycle present. Run Tarjan's SCC on the unprocessed
-            // residue, then ask the asymmetric-2-cycle resolver
-            // which Weak edges it's willing to break.
+            // residue, then ask the weak-feedback resolver which
+            // edges it's willing to break.
             let sccs = tarjanScc unprocessed graph.Adjacency
             let resolution =
-                applyResolver CycleResolution.asymmetric2CycleStrategy graph sccs
+                applyResolver CycleResolution.weakFeedbackStrategy graph sccs
 
             if List.isEmpty resolution.UnresolvedDiagnostics then
                 // Every SCC resolved. Re-run Kahn on the reduced graph.

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -174,6 +174,7 @@
     <Compile Include="Passes/LogicalTableEmission.fs" />
     <Compile Include="Passes/LogicalColumnEmission.fs" />
     <Compile Include="Passes/TopologicalOrderPass.fs" />
+    <Compile Include="TransferScope.fs" />
     <!-- H-071 through H-076 pass implementations — compiled after
          ComposeState.fs; return types from the files above. -->
     <Compile Include="Passes/AdvisoryTuning.fs" />

--- a/sidecar/projection/src/Projection.Core/Strategies/CycleResolution.fs
+++ b/sidecar/projection/src/Projection.Core/Strategies/CycleResolution.fs
@@ -27,15 +27,18 @@ namespace Projection.Core
 ///   - `Other`    : not nullable + `(NoAction | SetNull | Restrict)`.
 ///                  Breaking would orphan rows; never broken.
 ///
-/// `asymmetric2CycleStrategy` is the **resolver** — V1's choice of
-/// what to do with classified edges. For 2-member SCCs with exactly
-/// one Weak edge, return that edge; otherwise (0 weak / 2+ weak / SCC
-/// size != 2), refuse to resolve.
+/// `weakFeedbackStrategy` is the **resolver** — 2026-07-07's
+/// generalization of V1's asymmetric-2-cycle heuristic (retired the
+/// same day; its behavior is the 2-cycle row of the new case map).
+/// It breaks a weak-edge feedback set in ANY SCC whose every cycle
+/// carries at least one Weak edge, and refuses — naming the exact
+/// cycle — when a cycle of non-deferrable edges exists.
 ///
-/// Both are V1 carryovers from the `EntityDependencySorter` admire
-/// (ADMIRE.md, 2026-05-07). Future strategies (manual cycle overrides,
-/// minimum-feedback-arc-set search, deferred-junction handling) live
-/// alongside in this module — never inside the pure algebra.
+/// The classifier is a V1 carryover from the `EntityDependencySorter`
+/// admire (ADMIRE.md, 2026-05-07). Future strategies (manual cycle
+/// overrides — deferred with a named trigger, DECISIONS 2026-07-07 —
+/// deferred-junction handling) live alongside in this module — never
+/// inside the pure algebra.
 [<RequireQualifiedAccess>]
 type EdgeStrength =
     | Weak
@@ -78,64 +81,139 @@ module CycleResolution =
     type Resolver =
         SsKey list -> ((SsKey * SsKey) * EdgeStrength) list -> ResolutionStep
 
-    /// V1's asymmetric-2-cycle strategy, extended (2026-07-06) with the
-    /// self-loop rule. For SCCs of size 2 with exactly one Weak edge,
-    /// returns that edge as breakable. For SCCs of size 1 (a
-    /// self-referencing kind), a Weak self-edge is breakable FOR
-    /// ORDERING: the two-phase load's deferral machinery re-points a
-    /// nullable self-FK in phase 2 regardless of order (the F1 lift,
-    /// DECISIONS 2026-06-10), and a RESOLVED SCC stays in `Cycles`, so
-    /// `cycleMembers`/`deferredFkColumns` still defer the column — only
-    /// the ORDER stops degrading. Before this rule, one nullable
-    /// self-reference anywhere (Category.Parent, Employee.Manager — the
-    /// common OutSystems shapes) refused resolution and dropped the
-    /// WHOLE catalog to the alphabetical fallback, re-ordering every
-    /// unrelated parent/child pair; a subset transfer then loaded
-    /// children before their parents and mass-dropped FK rows (found
-    /// 2026-07-06 by the peer-aligned two-environment canary). Still
-    /// refuses every other shape — 0 Weak, multiple-Weak 2-cycles,
-    /// non-Weak self-edges, larger SCCs — leaving those for the
-    /// alphabetical fallback.
-    let asymmetric2CycleStrategy : Resolver =
+    /// Combine two strengths of PARALLEL references over the same
+    /// (source, target) pair: the pair is breakable only if EVERY parallel
+    /// reference is Weak — a Cascade or non-nullable sibling still binds
+    /// the dependency. Shared by the pass's graph construction and the
+    /// resolver's defensive dedupe (2026-07-06 adversarial MEDIUM #9
+    /// lifted here so there is ONE combiner).
+    let combineStrength (a: EdgeStrength) (b: EdgeStrength) : EdgeStrength =
+        match a, b with
+        | EdgeStrength.Cascade, _ | _, EdgeStrength.Cascade -> EdgeStrength.Cascade
+        | EdgeStrength.Other, _ | _, EdgeStrength.Other -> EdgeStrength.Other
+        | _ -> EdgeStrength.Weak
+
+    /// Deterministic directed-cycle search over FK-orientation edges:
+    /// DFS with SsKey-sorted roots and adjacency; returns the EDGE LIST of
+    /// the first cycle found (including a self-edge as a 1-edge cycle),
+    /// or None when the graph is acyclic. Deterministic by construction —
+    /// the same edge set yields the same cycle regardless of input order.
+    let private findCycle (edges: (SsKey * SsKey) list) : (SsKey * SsKey) list option =
+        let adjacency =
+            edges
+            |> List.groupBy fst
+            |> List.map (fun (s, es) -> s, es |> List.map snd |> List.distinct |> List.sort)
+            |> Map.ofList
+        let nodes = edges |> List.collect (fun (s, t) -> [ s; t ]) |> List.distinct |> List.sort
+        let mutable found : (SsKey * SsKey) list option = None
+        let visited = System.Collections.Generic.HashSet<SsKey>()
+        let onStack = System.Collections.Generic.HashSet<SsKey>()
+        let rec dfs (path: SsKey list) (v: SsKey) : unit =
+            if Option.isNone found then
+                visited.Add v |> ignore
+                onStack.Add v |> ignore
+                for w in (Map.tryFind v adjacency |> Option.defaultValue []) do
+                    if Option.isNone found then
+                        if onStack.Contains w then
+                            // Back-edge (v, w) closes the cycle: the path
+                            // suffix from w to v, plus (v, w).
+                            let suffix =
+                                (v :: path)
+                                |> List.rev
+                                |> List.skipWhile (fun n -> n <> w)
+                            let cycleEdges = List.pairwise suffix @ [ (v, w) ]
+                            found <- Some cycleEdges
+                        elif not (visited.Contains w) then
+                            dfs (v :: path) w
+                onStack.Remove v |> ignore
+        for n in nodes do
+            if Option.isNone found && not (visited.Contains n) then dfs [] n
+        found
+
+    let private edgeText ((s, t): SsKey * SsKey) : string =
+        sprintf "%s -> %s" (SsKey.rootOriginal s) (SsKey.rootOriginal t)
+
+    /// The WEAK-FEEDBACK resolver (2026-07-07) — generalizes and retires
+    /// V1's asymmetric-2-cycle heuristic. THE COMPLETE CASE MAP over an
+    /// SCC's classified internal edges:
+    ///
+    ///   | SCC shape                                   | outcome |
+    ///   |---------------------------------------------|---------|
+    ///   | size 1, Weak self-edge                      | resolved — self-edge deferred (the 2026-07-06 rule, preserved) |
+    ///   | size 1, non-Weak self-edge                  | refused — a mandatory/cascade self-FK cannot defer |
+    ///   | size 2, exactly one Weak inter-edge         | resolved — that edge (V1's asymmetric arm, byte-compatible) |
+    ///   | size 2, BOTH inter-edges Weak               | resolved — one edge, deterministically chosen |
+    ///   | size 2, zero Weak                           | refused — names the non-deferrable cycle |
+    ///   | size ≥3, every cycle carries ≥1 Weak edge   | resolved — a weak feedback set, one break per residual cycle |
+    ///   | size ≥3, some all-strong cycle              | refused — names that cycle's members |
+    ///   | Cascade edges (any nullability)             | never broken — V1's structural rule stands |
+    ///
+    /// **Algorithm** (greedy weak-feedback): find a cycle (deterministic
+    /// DFS); if every edge on it is non-Weak, REFUSE naming exactly that
+    /// cycle; otherwise break the smallest Weak edge ON that cycle and
+    /// repeat until acyclic. Termination: every step removes one edge.
+    ///
+    /// **Invariants** (property-tested in `CycleResolutionTests`):
+    ///   I1 soundness  — broken ⊆ Weak: every broken edge has a nullable
+    ///                   source column, so the two-phase load defers it
+    ///                   (phase-1 NULL, phase-2 re-point).
+    ///   I2 acyclicity — on resolution, the SCC minus the broken edges is
+    ///                   acyclic (the pass's post-resolve Kahn re-run is a
+    ///                   defensive re-check, not the guarantee).
+    ///   I3 refusal precision — refuses ⟺ the SCC contains a cycle whose
+    ///                   edges are ALL non-Weak (only strong edges survive
+    ///                   removal, so a found all-strong cycle exists in the
+    ///                   original graph; conversely an all-strong cycle can
+    ///                   never be broken and is eventually found).
+    ///   I4 determinism — input-order-independent (sorted roots,
+    ///                   adjacency, and edge choice).
+    ///   I5 frugality  — breaks one edge per residual cycle, never a
+    ///                   blanket sweep of every weak edge (a pure weak
+    ///                   ring of any size breaks exactly one edge).
+    let weakFeedbackStrategy : Resolver =
         fun members internalEdges ->
-            match members with
-            | [ single ] ->
-                let weakSelfEdges =
-                    internalEdges
-                    |> List.filter (fun ((s, t), strength) ->
-                        s = single && t = single && strength = EdgeStrength.Weak)
-                    |> List.map fst
-                match weakSelfEdges with
-                | [] ->
-                    { EdgesToBreak = []
-                      Reason       = "self-referencing SCC has no Weak (nullable) self-edge to defer" }
-                | edges ->
-                    { EdgesToBreak = edges
-                      Reason       = "auto-resolved by deferring the nullable self-reference to phase 2" }
-            | [_; _] ->
-                // Self-edges are not the 2-cycle's business — a member's
-                // self-reference rides its own deferral; only the two
-                // INTER-member edges decide asymmetry here (the pre-2026-07-06
-                // semantics, preserved now that `internalEdgesOf` reports
-                // self-pairs).
-                let weakEdges =
-                    internalEdges
-                    |> List.filter (fun ((s, t), strength) -> s <> t && strength = EdgeStrength.Weak)
-                match weakEdges with
-                | [ (edge, _) ] ->
-                    { EdgesToBreak = [ edge ]
-                      Reason       = "auto-resolved by removing weak edge" }
-                | [] ->
-                    { EdgesToBreak = []
-                      Reason       = "SCC has no Weak edge to break" }
-                | _ ->
-                    { EdgesToBreak = []
-                      Reason       = "SCC has multiple Weak edges; resolver refuses to choose" }
-            | larger ->
-                { EdgesToBreak = []
-                  Reason       =
-                    sprintf "SCC of size %d; current resolver handles 2-cycles only"
-                        larger.Length }
+            let memberSet = Set.ofList members
+            // Defensive dedupe + parallel-strength combination + input-order
+            // independence (the pass already dedupes; a direct caller may not).
+            let edges =
+                internalEdges
+                |> List.filter (fun ((s, t), _) -> Set.contains s memberSet && Set.contains t memberSet)
+                |> List.groupBy fst
+                |> List.map (fun (e, xs) -> e, xs |> List.map snd |> List.reduce combineStrength)
+                |> List.sortBy fst
+            let strengthOf = Map.ofList edges
+            let rec resolve (broken: (SsKey * SsKey) list) (remaining: (SsKey * SsKey) list) : ResolutionStep =
+                match findCycle remaining with
+                | None ->
+                    match broken with
+                    | [] ->
+                        // Unreachable for a genuine SCC (Tarjan only hands
+                        // cycle-bearing components); degrade legibly.
+                        { EdgesToBreak = []
+                          Reason       = "no cycle found among the SCC's internal edges; please report" }
+                    | _ ->
+                        { EdgesToBreak = List.sort broken
+                          Reason       =
+                            sprintf "auto-resolved: %d weak (nullable) FK edge(s) deferred to phase 2 (%s)"
+                                broken.Length
+                                (broken |> List.sort |> List.truncate 3 |> List.map edgeText |> String.concat "; ") }
+                | Some cycleEdges ->
+                    let weakOnCycle =
+                        cycleEdges
+                        |> List.filter (fun e ->
+                            Map.tryFind e strengthOf = Some EdgeStrength.Weak)
+                        |> List.sort
+                    match weakOnCycle with
+                    | [] ->
+                        let cycleMembers =
+                            cycleEdges |> List.map fst |> List.distinct |> List.sort
+                        { EdgesToBreak = []
+                          Reason       =
+                            sprintf "unresolvable: a cycle of non-deferrable FK edges among [%s] — every edge on it is non-nullable or cascade; make one of its FK columns nullable (it then defers to phase 2 automatically), or transfer without these kinds"
+                                (cycleMembers |> List.map SsKey.rootOriginal |> String.concat ", ") }
+                    | chosen :: _ ->
+                        resolve (chosen :: broken) (remaining |> List.filter (fun e -> e <> chosen))
+            resolve [] (edges |> List.map fst)
 
     /// The "never resolve" strategy — refuse to break any cycle.
     /// Useful for callers that prefer the alphabetical fallback over

--- a/sidecar/projection/src/Projection.Core/StrategyRegistrations.fs
+++ b/sidecar/projection/src/Projection.Core/StrategyRegistrations.fs
@@ -99,9 +99,9 @@ module StrategyRegistrations =
           Domain = CrossCutting
           StageBinding = Pass
           Sites =
-            [ { SiteName = "asymmetric2CycleStrategy"
+            [ { SiteName = "weakFeedbackStrategy"
                 Classification = DataIntent
-                Rationale = "Asymmetric-2-cycle resolver: when a 2-cycle has exactly one Weak precedence edge, remove it to resolve. The choice is algorithm-internal (the resolver's heuristic); no operator opinion at the per-cycle level. Operator-supplied SelfLoopPolicy is a separate concern handled at TopologicalOrderPass.registered's selfLoopHandling site (OperatorIntent Ordering — Q9-trigger-fires worked example)." } ]
+                Rationale = "Weak-feedback cycle resolver (v5, 2026-07-07 — generalizes the retired asymmetric-2-cycle heuristic): break the smallest Weak (nullable, hence phase-2-deferrable) edge on each residual cycle until the SCC is acyclic; refuse — naming the exact cycle — when a cycle of non-deferrable (non-nullable / cascade) edges exists. The choice is algorithm-internal, derived entirely from schema facts (nullability + OnDelete); no operator opinion at the per-cycle level. Operator-supplied SelfLoopPolicy is a separate concern handled at TopologicalOrderPass.registered's selfLoopHandling site (OperatorIntent Ordering — Q9-trigger-fires worked example)." } ]
           Status = Active }
 
     /// All five strategy registrations in one list. Slice ζ's

--- a/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
+++ b/sidecar/projection/src/Projection.Core/TopologicalOrder.fs
@@ -244,11 +244,30 @@ module TopologicalOrder =
     /// parent levels)`. Parents not yet seen — broken edges where
     /// the cycle-resolved arrival of the cycle-participating kind
     /// precedes its broken parent in `t.Order` — contribute 0.
-    /// The set of kinds participating in an (unbroken) dependency cycle,
-    /// flattened from `Cycles`. Compute once, then pass to
-    /// `deferredFkColumns` per kind.
+    /// The set of kinds participating in ANY dependency cycle — RESOLVED
+    /// (the resolver broke weak edges; the SCC stays in `Cycles` for
+    /// audit and for exactly this membership) or UNRESOLVED. The
+    /// deferral input: a resolved SCC's broken weak edges NEED phase-2
+    /// deferral, so `deferredFkColumns` must see resolved members too.
+    /// Compute once, then pass to `deferredFkColumns` per kind.
     let cycleMembers (t: TopologicalOrder) : Set<SsKey> =
         t.Cycles
+        |> List.collect (fun c -> c.Members)
+        |> Set.ofList
+
+    /// The set of kinds participating in an UNRESOLVED cycle only —
+    /// `BreakableEdges = []` is the resolved/unresolved discriminant
+    /// (a resolved SCC records the edges it broke). The
+    /// unsatisfiability input (2026-07-07, the resolver-completeness
+    /// program): a non-nullable FK inside a RESOLVED cycle is satisfied
+    /// BY THE ORDER the resolver proved (only weak edges were broken;
+    /// every strong edge is honored), so `UnbreakableCycleFks` must
+    /// judge unresolved members only — the prior all-members
+    /// computation flagged every resolved asymmetric 2-cycle's strong
+    /// edge as unbreakable and refused a load the order satisfies.
+    let unresolvedCycleMembers (t: TopologicalOrder) : Set<SsKey> =
+        t.Cycles
+        |> List.filter (fun c -> List.isEmpty c.BreakableEdges)
         |> List.collect (fun c -> c.Members)
         |> Set.ofList
 

--- a/sidecar/projection/src/Projection.Core/TransferScope.fs
+++ b/sidecar/projection/src/Projection.Core/TransferScope.fs
@@ -1,0 +1,70 @@
+namespace Projection.Core
+
+open Projection.Core.Passes
+
+/// The EFFECTIVE TRANSFER GRAPH (2026-07-07, the go-board scoping
+/// program; readiness log Entry 25) — the reified answer to "which kinds
+/// does this transfer actually touch," built once from the three inputs
+/// every gate already holds and consumed by the engine's pre-write gates
+/// AND the go board, so the forecast and the live run cannot evaluate
+/// different graphs.
+///
+/// The rules it carries:
+///   - `WriteKinds` — the kinds the load WRITES: the declared subset (or
+///     the whole estate when no subset), minus the reconciled kinds
+///     (reconciled parents are matched against rows the sink already
+///     holds; `reclassifyReconciled` zeroes their writes).
+///   - `Nodes` — `WriteKinds` plus the reconciled kinds as ISOLATED
+///     graph nodes: they stay in the plan/report (their
+///     `ReconciledByRule` lines matter) but no FK edge can pass through
+///     them, so a cycle through a reconciled kind correctly breaks.
+///   - Ordering/cycle analysis (`topology`) runs on the induced
+///     subgraph: FK edges bind only between `WriteKinds` members. An FK
+///     leaving the write set is either reconciled (re-keyed; no ordering
+///     dependency) or refused by the subset-escape gate — never this
+///     graph's problem.
+///
+/// A full, non-reconciling transfer produces the identity scope (all
+/// kinds, all edges) — byte-identical behavior to the unscoped pass.
+type TransferScope =
+    {
+        /// Kinds the load writes (INSERT/UPDATE; DELETE under a wipe).
+        WriteKinds : Set<SsKey>
+        /// Write kinds ∪ reconciled kinds — everything the plan carries.
+        Nodes      : Set<SsKey>
+        /// Kinds reconciled against pre-existing sink rows (never written).
+        Reconciled : Set<SsKey>
+    }
+
+[<RequireQualifiedAccess>]
+module TransferScope =
+
+    /// Build the scope from the inputs every transfer gate already holds:
+    /// the catalog, the declared load set (`None` = whole estate), and
+    /// the reconciled kind set. Unknown keys (a declared or reconciled
+    /// key absent from the catalog) are dropped — the resolvers upstream
+    /// own naming those.
+    let create (catalog: Catalog) (loadSet: Set<SsKey> option) (reconciled: Set<SsKey>) : TransferScope =
+        let allKeys =
+            Catalog.allKinds catalog |> List.map (fun k -> k.SsKey) |> Set.ofList
+        let declared =
+            match loadSet with
+            | Some s -> Set.intersect s allKeys
+            | None -> allKeys
+        let reconciledPresent = Set.intersect reconciled allKeys
+        let nodes = Set.union declared reconciledPresent
+        {
+            WriteKinds = Set.difference nodes reconciledPresent
+            Nodes      = nodes
+            Reconciled = reconciledPresent
+        }
+
+    /// The load-ordering topology over the effective transfer graph —
+    /// `TopologicalOrderPass.runScopedWith` with this scope's node and
+    /// edge sets. The one derivation both the engine's Execute gates and
+    /// the go board's load-order item consume.
+    let topology (selfLoops: SelfLoopPolicy) (scope: TransferScope) (catalog: Catalog) : TopologicalOrder =
+        (TopologicalOrderPass.runScopedWith
+            selfLoops
+            { Nodes = scope.Nodes; EdgeKinds = scope.WriteKinds }
+            catalog).Value

--- a/sidecar/projection/src/Projection.Pipeline/CapabilitySurvey.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CapabilitySurvey.fs
@@ -77,12 +77,16 @@ module CapabilitySurvey =
     /// against a `schema+data` target needs ALTER/CREATE but no INSERT/DELETE, so
     /// the coarse facet would over-refuse).
     let requiredFor (grant: Grant) : Set<Capability> =
+        // UPDATE joined the data write-sets 2026-07-07 alongside
+        // `Preflight.WriteAction.Update` — the data leg's Phase-2 FK
+        // re-point and MERGE lane genuinely UPDATE; INSERT coverage never
+        // implied it.
         match grant with
         | Grant.SchemaAndData ->
-            set [ Performs Preflight.Insert; Performs Preflight.Delete
+            set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete
                   Performs Preflight.Alter; Performs Preflight.CreateTable ]
         | Grant.DataOnly ->
-            set [ Performs Preflight.Insert; Performs Preflight.Delete ]
+            set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ]
 
     /// The sink-role write capabilities a flow's shape exercises — faithful to
     /// `Command.planMovement`'s routing (the obligations matrix is the spec):
@@ -98,7 +102,7 @@ module CapabilitySurvey =
     ///    so the survey requires nothing (flow validity is `planFlow`'s gate, not
     ///    the permission survey's).
     let private sinkCapabilities (targetGrant: Grant option) (source: FlowSource) : Set<Capability> =
-        let dataLoad = set [ Performs Preflight.Insert; Performs Preflight.Delete ]
+        let dataLoad = set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ]
         let schemaPublish = set [ Performs Preflight.Alter; Performs Preflight.CreateTable ]
         match targetGrant, source with
         | Some Grant.DataOnly, (FlowSource.Env _ | FlowSource.Synthetic _) -> dataLoad

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -430,39 +430,83 @@ module Preflight =
             else return acc
         }
 
+    /// One object's effective-permission probe. `Some pairs` when the
+    /// object EXISTS (its rows are authoritative — see `ProbedObjects`);
+    /// `None` when it does not: a missing table and a deny-everything
+    /// table both report zero permission rows, but absence is a SHAPE
+    /// fact (the shape gate / drift detection own it), not a grant fact —
+    /// claiming probe authority over it would misreport a missing sink
+    /// table as `insufficientGrant`, so an absent object stays UNPROBED
+    /// (database-scope fallback applies). Module-level helper so the
+    /// capture's per-object loop is one reducible `let!` (FS3511 —
+    /// a conditional `use!` inside a task-CE loop is not statically
+    /// compilable in Release).
+    let private probeObjectGrant (sink: SqlConnection) (key: string) (securable: string) : Task<(string * string) list option> =
+        task {
+            use existsCmd = sink.CreateCommand()
+            existsCmd.CommandText <- "SELECT CASE WHEN OBJECT_ID(@obj) IS NULL THEN 0 ELSE 1 END"
+            existsCmd.Parameters.AddWithValue("@obj", securable) |> ignore
+            let! existsScalar = existsCmd.ExecuteScalarAsync()
+            if System.Convert.ToInt32 existsScalar = 1 then
+                use objCmd = sink.CreateCommand()
+                objCmd.CommandText <-
+                    "SELECT permission_name FROM sys.fn_my_permissions(@obj, 'OBJECT') WHERE subentity_name = ''"
+                objCmd.Parameters.AddWithValue("@obj", securable) |> ignore
+                use! objReader = objCmd.ExecuteReaderAsync()
+                let! objPairs = readGrantRows key objReader []
+                return Some objPairs
+            else
+                return None
+        }
+
+    /// Walk the planned objects recursively — a `let!` inside a `for` in
+    /// a task CE is not statically compilable in Release (FS3511), so the
+    /// loop is the same module-level recursion shape as `readGrantRows`.
+    let rec private probeObjects
+        (sink: SqlConnection)
+        (remaining: (string * string) list)
+        (pairs: (string * string) list)
+        (probed: Set<string>)
+        : Task<GrantEvidence> =
+        task {
+            match remaining with
+            | [] -> return { Granted = Set.ofList pairs; ProbedObjects = probed }
+            | entry :: rest ->
+                let schema = fst entry
+                let table = snd entry
+                let key = sprintf "%s.%s" schema table
+                let securable = sprintf "[%s].[%s]" schema table  // LINT-ALLOW: securable-name string for fn_my_permissions/OBJECT_ID at the probe boundary; bracketed identifier text is the functions' input format
+                let! objPairs = probeObjectGrant sink key securable
+                match objPairs with
+                | Some ps -> return! probeObjects sink rest (ps @ pairs) (Set.add key probed)
+                | None    -> return! probeObjects sink rest pairs probed
+        }
+
+    /// The probe body without the exception envelope — the public capture
+    /// wraps ONE `let!` in its `try` (FS3511 discipline).
+    let private captureGrantPairs (objects: (string * string) list) (sink: SqlConnection) : Task<GrantEvidence> =
+        task {
+            if sink.State <> System.Data.ConnectionState.Open then do! sink.OpenAsync()
+            // The DATABASE-probe reader must close before the per-object
+            // probes run — one connection, no MARS.
+            let! dbPairs =
+                task {
+                    use cmd = sink.CreateCommand()
+                    cmd.CommandText <- "SELECT permission_name FROM sys.fn_my_permissions(NULL, 'DATABASE')"
+                    use! reader = cmd.ExecuteReaderAsync()
+                    return! readGrantRows "" reader []
+                }
+            return! probeObjects sink (List.distinct objects) dbPairs Set.empty
+        }
+
     /// Capture database-scope grants PLUS per-object effective permissions
     /// for the supplied `(schema, table)` list — the planned-write tables.
     /// An empty list is the historical database-scope-only capture.
     let captureGrantEvidenceFor (objects: (string * string) list) (sink: SqlConnection) : Task<Result<GrantEvidence>> =
         task {
             try
-                if sink.State <> System.Data.ConnectionState.Open then do! sink.OpenAsync()
-                // The DATABASE-probe reader must close before the per-object
-                // probes run — one connection, no MARS.
-                let! dbPairs =
-                    task {
-                        use cmd = sink.CreateCommand()
-                        cmd.CommandText <- "SELECT permission_name FROM sys.fn_my_permissions(NULL, 'DATABASE')"
-                        use! reader = cmd.ExecuteReaderAsync()
-                        return! readGrantRows "" reader []
-                    }
-                let mutable pairs = dbPairs
-                let mutable probed : Set<string> = Set.empty
-                // Single-value `for` binding (no tuple pattern in a task CE —
-                // the FS3511 Release-reducibility rule).
-                for entry in List.distinct objects do
-                    let schema = fst entry
-                    let table = snd entry
-                    let key = sprintf "%s.%s" schema table
-                    use objCmd = sink.CreateCommand()
-                    objCmd.CommandText <-
-                        "SELECT permission_name FROM sys.fn_my_permissions(@obj, 'OBJECT') WHERE subentity_name = ''"
-                    objCmd.Parameters.AddWithValue("@obj", sprintf "[%s].[%s]" schema table) |> ignore  // LINT-ALLOW: securable-name string for fn_my_permissions at the probe boundary; bracketed identifier text is the function's input format
-                    use! objReader = objCmd.ExecuteReaderAsync()
-                    let! objPairs = readGrantRows key objReader []
-                    pairs <- objPairs @ pairs
-                    probed <- Set.add key probed
-                return Ok { Granted = Set.ofList pairs; ProbedObjects = probed }
+                let! evidence = captureGrantPairs objects sink
+                return Ok evidence
             with ex ->
                 return Result.failureOf (ValidationError.create "migrate.grantProbeFailed" ex.Message)
         }

--- a/sidecar/projection/src/Projection.Pipeline/Preflight.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Preflight.fs
@@ -279,8 +279,13 @@ module Preflight =
     // -- A2 — permission pre-flight (T-VI spanning) --------------------------
 
     /// The kind of write a planned operation needs at the sink.
+    /// `Update` joined 2026-07-07 (the go-board scoping program): the
+    /// transfer's Phase-2 FK re-point and the MERGE capture lane genuinely
+    /// UPDATE — SQL Server grants do not let UPDATE "ride" INSERT, so the
+    /// prior INSERT-only gate passed sinks that then died mid-load.
     type WriteAction =
         | Insert
+        | Update
         | Delete
         | Alter
         | CreateTable
@@ -288,7 +293,7 @@ module Preflight =
     /// Every write action — the closed vocabulary, enumerated so a derived
     /// capability catalog (the capability survey) stays total over it by
     /// construction rather than by a hand-maintained parallel list.
-    let allWriteActions : WriteAction list = [ Insert; Delete; Alter; CreateTable ]
+    let allWriteActions : WriteAction list = [ Insert; Update; Delete; Alter; CreateTable ]
 
     /// One object + action the plan will perform at the sink. Built from the
     /// migrate schema differential (`ALTER`/`ADD` → Alter/CreateTable) and the
@@ -319,6 +324,17 @@ module Preflight =
     type GrantEvidence =
         {
             Granted : Set<string * string>
+            /// The object keys (`"schema.table"`) the capture probed at
+            /// OBJECT scope (2026-07-07). For a probed object,
+            /// `fn_my_permissions('<obj>', 'OBJECT')` reports the
+            /// EFFECTIVE permissions — database-scope grants inherited,
+            /// object grants added, DENYs subtracted — so the object rows
+            /// are AUTHORITATIVE and the database-scope fallback must not
+            /// apply (a table-level DENY under a database-scope GRANT
+            /// would otherwise read as covered: the pinned G1 gap).
+            /// Empty for a database-scope-only capture — the historical
+            /// evidence shape, where the fallback is all there is.
+            ProbedObjects : Set<string>
         }
 
     /// The `sys.fn_my_permissions` permission name a write action holds at. Public
@@ -327,6 +343,7 @@ module Preflight =
     let permissionName (a: WriteAction) : string =
         match a with
         | Insert      -> "INSERT"
+        | Update      -> "UPDATE"
         | Delete      -> "DELETE"
         | Alter       -> "ALTER"
         | CreateTable -> "CREATE TABLE"
@@ -334,14 +351,25 @@ module Preflight =
     let private objectKey (w: PlannedWrite) : string =
         sprintf "%s.%s" w.Schema w.Table
 
-    /// Pure: each planned write the grant does not cover at either the object
-    /// scope or the database scope (object-key ""). Deterministic — sorted by
+    /// Pure: does the captured grant cover `permission` on `schema.table`?
+    /// A probed object's rows are authoritative (effective permissions —
+    /// see `GrantEvidence.ProbedObjects`); an unprobed object falls back
+    /// to object-row OR database-scope coverage (the historical rule).
+    /// DB-free and testable.
+    let coversPermissionOn (schema: string) (table: string) (permission: string) (grant: GrantEvidence) : bool =
+        let key = sprintf "%s.%s" schema table
+        if Set.contains key grant.ProbedObjects then
+            Set.contains (key, permission) grant.Granted
+        else
+            Set.contains (key, permission) grant.Granted
+            || Set.contains ("", permission) grant.Granted
+
+    /// Pure: each planned write the grant does not cover (per
+    /// `coversPermissionOn`'s scope rules). Deterministic — sorted by
     /// object then action. DB-free and testable.
     let permissionViolations (planned: PlannedWrite list) (grant: GrantEvidence) : PermissionViolation list =
         let covered (w: PlannedWrite) =
-            let perm = permissionName w.Action
-            Set.contains (objectKey w, perm) grant.Granted
-            || Set.contains ("", perm) grant.Granted
+            coversPermissionOn w.Schema w.Table (permissionName w.Action) grant
         planned
         |> List.filter (fun w -> not (covered w))
         |> List.map (fun w -> { Object = objectKey w; Action = w.Action })
@@ -380,33 +408,69 @@ module Preflight =
 
     /// Capture the sink's effective permissions from `sys.fn_my_permissions`.
     ///
-    /// **Survey-gated (OPEN-2 / P1).** This probes the database-scope grants
-    /// today (`sys.fn_my_permissions(NULL, 'DATABASE')`), keyed under the empty
-    /// object-key. Object-scope refinement (per-table grants) lands once the
-    /// survey (P1) confirms the managed login's grant shape; the pure gate
-    /// already consumes object-keyed evidence, so only this capture changes.
-    /// Read every database-scope permission name as a `("", name)` pair (module
-    /// level so the recursive task state machine is statically compilable —
-    /// a nested `let rec` inside a `task { }` is not, FS3511).
-    let rec private readGrantRows (reader: SqlDataReader) (acc: (string * string) list) : Task<(string * string) list> =
+    /// Two probe grains (2026-07-07 — the object-scope refinement the P1
+    /// survey gated on landed under live cloud evidence: managed estates
+    /// carry object/column-scope DML with NO database-scope grant):
+    ///   - the DATABASE probe (`fn_my_permissions(NULL, 'DATABASE')`),
+    ///     keyed under the empty object-key — the historical capture;
+    ///   - one OBJECT probe per planned table
+    ///     (`fn_my_permissions('[schema].[table]', 'OBJECT')`, object
+    ///     grain only — `subentity_name = ''`; column-grain rows are a
+    ///     named residual), keyed `"schema.table"` and recorded in
+    ///     `ProbedObjects` so the pure gate treats them as authoritative
+    ///     effective permissions (DENYs visible — the G1 closure for
+    ///     planned tables).
+    /// Read every permission name under the supplied key (module level so
+    /// the recursive task state machine is statically compilable — a
+    /// nested `let rec` inside a `task { }` is not, FS3511).
+    let rec private readGrantRows (key: string) (reader: SqlDataReader) (acc: (string * string) list) : Task<(string * string) list> =
         task {
             let! hasRow = reader.ReadAsync()
-            if hasRow then return! readGrantRows reader (("", reader.GetString(0)) :: acc)
+            if hasRow then return! readGrantRows key reader ((key, reader.GetString(0)) :: acc)
             else return acc
         }
 
-    let captureGrantEvidence (sink: SqlConnection) : Task<Result<GrantEvidence>> =
+    /// Capture database-scope grants PLUS per-object effective permissions
+    /// for the supplied `(schema, table)` list — the planned-write tables.
+    /// An empty list is the historical database-scope-only capture.
+    let captureGrantEvidenceFor (objects: (string * string) list) (sink: SqlConnection) : Task<Result<GrantEvidence>> =
         task {
             try
                 if sink.State <> System.Data.ConnectionState.Open then do! sink.OpenAsync()
-                use cmd = sink.CreateCommand()
-                cmd.CommandText <- "SELECT permission_name FROM sys.fn_my_permissions(NULL, 'DATABASE')"
-                use! reader = cmd.ExecuteReaderAsync()
-                let! pairs = readGrantRows reader []
-                return Ok { Granted = Set.ofList pairs }
+                // The DATABASE-probe reader must close before the per-object
+                // probes run — one connection, no MARS.
+                let! dbPairs =
+                    task {
+                        use cmd = sink.CreateCommand()
+                        cmd.CommandText <- "SELECT permission_name FROM sys.fn_my_permissions(NULL, 'DATABASE')"
+                        use! reader = cmd.ExecuteReaderAsync()
+                        return! readGrantRows "" reader []
+                    }
+                let mutable pairs = dbPairs
+                let mutable probed : Set<string> = Set.empty
+                // Single-value `for` binding (no tuple pattern in a task CE —
+                // the FS3511 Release-reducibility rule).
+                for entry in List.distinct objects do
+                    let schema = fst entry
+                    let table = snd entry
+                    let key = sprintf "%s.%s" schema table
+                    use objCmd = sink.CreateCommand()
+                    objCmd.CommandText <-
+                        "SELECT permission_name FROM sys.fn_my_permissions(@obj, 'OBJECT') WHERE subentity_name = ''"
+                    objCmd.Parameters.AddWithValue("@obj", sprintf "[%s].[%s]" schema table) |> ignore  // LINT-ALLOW: securable-name string for fn_my_permissions at the probe boundary; bracketed identifier text is the function's input format
+                    use! objReader = objCmd.ExecuteReaderAsync()
+                    let! objPairs = readGrantRows key objReader []
+                    pairs <- objPairs @ pairs
+                    probed <- Set.add key probed
+                return Ok { Granted = Set.ofList pairs; ProbedObjects = probed }
             with ex ->
                 return Result.failureOf (ValidationError.create "migrate.grantProbeFailed" ex.Message)
         }
+
+    /// The database-scope-only capture — the historical shape (empty
+    /// `ProbedObjects`; the pure gate's database fallback applies).
+    let captureGrantEvidence (sink: SqlConnection) : Task<Result<GrantEvidence>> =
+        captureGrantEvidenceFor [] sink
 
     // -- A3 — transactional / resumable transfer (T-VI spanning) -------------
     //

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -676,27 +676,40 @@ module Transfer =
     // `transfer.connectionUnavailable`) and G2 (the sink grant covers the
     // planned INSERTs, `transfer.insufficientGrant`).
 
-    /// The writes a straight load performs at the sink: one INSERT per kind
-    /// (the FK-repoint Phase 2 is an UPDATE on the same tables INSERT covers, so
-    /// INSERT is the grant the gate requires). Deterministic — catalog order.
-    let private plannedTransferWrites (catalog: Catalog) : Preflight.PlannedWrite list =
+    /// The writes the load performs at the sink, over the EFFECTIVE transfer
+    /// scope (2026-07-07, the go-board scoping program): INSERT + UPDATE per
+    /// written kind (the Phase-2 FK re-point and the MERGE capture lane
+    /// genuinely UPDATE — a grant that covers INSERT alone dies mid-load),
+    /// plus DELETE under a WipeAndLoad (the child-first wipe was previously
+    /// ungated). Deterministic — catalog order. Public: the go board derives
+    /// its grant item from the SAME planned writes the engine's G2 gate
+    /// enforces, so the forecast and the live gate cannot disagree.
+    let plannedTransferWrites (scope: TransferScope) (emission: EmissionMode) (catalog: Catalog) : Preflight.PlannedWrite list =
         Catalog.allKinds catalog
-        |> List.map (fun k ->
-            { Preflight.Schema = TableId.schemaText k.Physical
-              Preflight.Table  = TableId.tableText k.Physical
-              Preflight.Action = Preflight.Insert })
+        |> List.filter (fun k -> Set.contains k.SsKey scope.WriteKinds)
+        |> List.collect (fun k ->
+            let write (action: Preflight.WriteAction) : Preflight.PlannedWrite =
+                { Preflight.Schema = TableId.schemaText k.Physical
+                  Preflight.Table  = TableId.tableText k.Physical
+                  Preflight.Action = action }
+            [ write Preflight.Insert; write Preflight.Update ]
+            @ (if emission = EmissionMode.WipeAndLoad then [ write Preflight.Delete ] else []))
         |> List.distinct
 
     /// G1 + G2 for an Execute transfer: probe both endpoints (connection
-    /// liveness/credential) and the sink grant against the planned INSERTs,
-    /// refusing before any write. Re-codes the migrate-named refusals under the
-    /// `transfer.*` namespace so the CLI can map them to the connection/
-    /// permission exit codes. A grant-probe failure is itself a refusal (a sink
-    /// we cannot survey is a sink we will not write to blind).
+    /// liveness/credential) and the sink grant against the planned writes,
+    /// refusing before any write. The grant evidence is captured PER PLANNED
+    /// TABLE (object-scope effective permissions — managed cloud estates
+    /// carry object/column-scope DML with no database-scope grant, and a
+    /// table-level DENY is now visible pre-write: the G1 closure for planned
+    /// tables). Re-codes the migrate-named refusals under the `transfer.*`
+    /// namespace so the CLI can map them to the connection/permission exit
+    /// codes. A grant-probe failure is itself a refusal (a sink we cannot
+    /// survey is a sink we will not write to blind).
     let spanningPreflight
         (source: SqlConnection)
         (sink: SqlConnection)
-        (catalog: Catalog)
+        (planned: Preflight.PlannedWrite list)
         : Task<Result<unit>> =
         task {
             match! Preflight.connectionPreflight source sink with
@@ -705,13 +718,14 @@ module Transfer =
                     Result.failure
                         (es |> List.map (fun e -> ValidationError.create "transfer.connectionUnavailable" e.Message))
             | Ok () ->
-                match! Preflight.captureGrantEvidence sink with
+                let plannedTables = planned |> List.map (fun w -> w.Schema, w.Table) |> List.distinct
+                match! Preflight.captureGrantEvidenceFor plannedTables sink with
                 | Error es ->
                     return
                         Result.failure
                             (es |> List.map (fun e -> ValidationError.create "transfer.grantProbeFailed" e.Message))
                 | Ok grant ->
-                    match Preflight.permissionPreflight grant (plannedTransferWrites catalog) with
+                    match Preflight.permissionPreflight grant planned with
                     | Ok () -> return Ok ()
                     | Error es ->
                         return
@@ -883,16 +897,25 @@ module Transfer =
                                                 (tracked |> List.truncate 3 |> String.concat ", ")))
                     else return Ok ()
                 }
+            // The EFFECTIVE TRANSFER GRAPH (2026-07-07): the one scope value
+            // the grant gate, the topology, and (through the scoped topo) the
+            // plan's cycle analysis all consume — declared subset plus
+            // reconciled kinds as isolated nodes, FK edges binding only
+            // between written kinds. A full non-reconciling transfer is the
+            // identity scope (byte-identical to the historical whole-estate
+            // evaluation). The go board builds the SAME value.
+            let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+            let scope = TransferScope.create catalog writeOpts.LoadSet reconciledKinds
             let spanningGate : Task<Result<unit>> =
                 task {
-                    if mode = Execute then return! spanningPreflight source sink catalog
+                    if mode = Execute then
+                        return! spanningPreflight source sink (plannedTransferWrites scope writeOpts.Emission catalog)
                     else return Ok ()
                 }
             match! Preflight.all [ cdcGate; spanningGate ] with
             | Error es -> return Result.failure es
             | Ok () ->
-            let topoLineage : Lineage<TopologicalOrder> = TopologicalOrderPass.runWith TreatAsCycle catalog
-            let topo = topoLineage.Value
+            let topo = TransferScope.topology TreatAsCycle scope catalog
             // 6.B.2 — RefactorLog-aware ingestion. With a rename context,
             // ingest with the SOURCE contract (old physical columns) and
             // re-point each row's values onto the sink's names (by SsKey,
@@ -900,7 +923,6 @@ module Transfer =
             // contract B). With no rename context, source and sink share the
             // schema and ingestion uses `catalog` directly (byte-identical).
             let ingestCatalog = match ingestion with Some (c, _) -> c | None -> catalog
-            let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
             // Item 5 — the declared table subset (golden data). Restrict the
             // load to the named kinds; the catalog stays whole (FK context),
             // so non-listed sink tables are simply never written (untouched).
@@ -1149,7 +1171,8 @@ module Transfer =
                                 Result.failure
                                     (es |> List.map (fun e -> ValidationError.create "synthetic.grantProbeFailed" e.Message))
                         | Ok grant ->
-                            match Preflight.permissionPreflight grant (plannedTransferWrites catalog) with
+                            // σ loads the whole estate — the identity scope.
+                            match Preflight.permissionPreflight grant (plannedTransferWrites (TransferScope.create catalog None Set.empty) emission catalog) with
                             | Ok () -> return Ok ()
                             | Error es ->
                                 return
@@ -1249,16 +1272,24 @@ module Transfer =
             match cdcGate with
             | Error e -> return Result.failure e
             | Ok () ->
+            // A slice IS a subset load — its effective scope is the slice's
+            // own kind set (2026-07-07): the grant gate demands writes on
+            // exactly the sliced tables, and the ordering/cycle analysis
+            // runs on the induced subgraph (an unrelated estate cycle no
+            // longer blocks a two-table slice).
+            let scope =
+                TransferScope.create catalog (Some (rows |> Map.toSeq |> Seq.map fst |> Set.ofSeq)) Set.empty
             let! grantGate =
                 task {
                     if mode = Execute then
-                        match! Preflight.captureGrantEvidence sink with
+                        let planned = plannedTransferWrites scope EmissionMode.Incremental catalog
+                        match! Preflight.captureGrantEvidenceFor (planned |> List.map (fun w -> w.Schema, w.Table) |> List.distinct) sink with
                         | Error es ->
                             return
                                 Result.failure
                                     (es |> List.map (fun e -> ValidationError.create "slice.apply.grantProbeFailed" e.Message))
                         | Ok grant ->
-                            match Preflight.permissionPreflight grant (plannedTransferWrites catalog) with
+                            match Preflight.permissionPreflight grant planned with
                             | Ok () -> return Ok ()
                             | Error es ->
                                 return
@@ -1269,7 +1300,7 @@ module Transfer =
             match grantGate with
             | Error es -> return Result.failure es
             | Ok () ->
-                let topo = (TopologicalOrderPass.runWith TreatAsCycle catalog).Value
+                let topo = TransferScope.topology TreatAsCycle scope catalog
                 let plan = DataLoadPlan.build catalog topo rows SurrogateRemapContext.empty
                 let preWrite =
                     if mode = Execute then
@@ -1899,16 +1930,23 @@ module Transfer =
                                                 (tracked |> List.truncate 3 |> String.concat ", ")))
                     else return Ok ()
                 }
+            // The streaming leg refuses `--tables` at the realization
+            // selector, so its scope is the whole estate MINUS the
+            // reconciled kinds (never written; FK edges into them drop —
+            // a cycle through a reconciled kind correctly breaks). The
+            // streaming arm never wipes, so Incremental verbs.
+            let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+            let scope = TransferScope.create sinkContract None reconciledKinds
             let spanningGate : Task<Result<unit>> =
                 task {
-                    if mode = Execute then return! spanningPreflight source sink sinkContract
+                    if mode = Execute then
+                        return! spanningPreflight source sink (plannedTransferWrites scope EmissionMode.Incremental sinkContract)
                     else return Ok ()
                 }
             match! Preflight.all [ cdcGate; spanningGate ] with
             | Error es -> return Result.failure es
             | Ok () ->
-                let topo = (TopologicalOrderPass.runWith TreatAsCycle sinkContract).Value
-                let reconciledKinds = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+                let topo = TransferScope.topology TreatAsCycle scope sinkContract
                 // Reconcile the named kinds against the sink (read-only,
                 // safe in DryRun): ingest each reconciled kind's SOURCE
                 // rows (re-pointed to the sink's names — the only kinds

--- a/sidecar/projection/tests/Projection.Tests.Integration/DmlPrincipal.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/DmlPrincipal.fs
@@ -51,6 +51,26 @@ module DmlPrincipal =
     let createManaged (admin: SqlConnection) (adminConnStr: string) =
         create admin adminConnStr ManagedGrants
 
+    /// The OBJECT-SCOPE DML profile (2026-07-07 — the live-run estate shape:
+    /// object/column-scope DML, NO database-scope DML at all). Database-scope
+    /// SELECT (the metamodel/contract reads span ossys_* + sys views) plus
+    /// INSERT/UPDATE/DELETE granted PER OBJECT on every non-ossys table. A
+    /// database-scope-only grant probe reads this principal as write-less;
+    /// the planned-table object probe reads the truth.
+    let createObjectDml (admin: SqlConnection) (adminConnStr: string) : System.Threading.Tasks.Task<string * string> =
+        task {
+            let! login, connStr = create admin adminConnStr "SELECT"
+            do! Deploy.executeBatch admin
+                    (sprintf
+                        "DECLARE @sql NVARCHAR(MAX) = N''; \
+                         SELECT @sql = @sql + N'GRANT INSERT, UPDATE, DELETE ON ' + QUOTENAME(s.name) + N'.' + QUOTENAME(t.name) + N' TO [%s]; ' \
+                         FROM sys.tables t JOIN sys.schemas s ON s.schema_id = t.schema_id \
+                         WHERE t.name NOT LIKE N'ossys[_]%%'; \
+                         EXEC sys.sp_executesql @sql;"
+                        login)
+            return login, connStr
+        }
+
     /// Best-effort login cleanup (the per-run database drops with the
     /// ephemeral fixture; the LOGIN is instance-scoped and must go too).
     let dropLogin (admin: SqlConnection) (login: string) : unit =

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -63,6 +63,8 @@ module private GoBoardFixtures =
           Correction  = None
           SinkCapability = SinkLoadCapability.structural }
 
+    let value (r: Result<'a>) : 'a = Result.value r
+
     let countRows (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) : System.Threading.Tasks.Task<int> =
         task {
             use cmd = cnn.CreateCommand()
@@ -78,6 +80,23 @@ module private GoBoardFixtures =
             let! _ = cmd.ExecuteNonQueryAsync()
             return ()
         }
+
+    /// An UNRELATED, UNRESOLVABLE dependency cycle injected into a cell's
+    /// metamodel (2026-07-07, the effective-transfer-graph program):
+    /// CycleA ↔ CycleB, both FK attributes MANDATORY (non-nullable →
+    /// EdgeStrength `Other`, which the asymmetric-2-cycle resolver refuses
+    /// to break). Same SS_Keys in both cells so the contracts align; direct
+    /// `Referenced_Entity_Id` linkage; no physical tables needed — the pair
+    /// stays outside the transferred subset, so no data path touches it.
+    let unrelatedCycleBatch =
+        [ "INSERT INTO [dbo].[ossys_Entity] ([Id], [Name], [Physical_Table_Name], [Espace_Id], [Is_Active], [Is_System], [Is_External], [Data_Kind], [PrimaryKey_SS_Key], [SS_Key], [Description]) VALUES \
+             (98001, N'CycleA', N'OSUSR_CYC_A', 100, 1, 0, 0, N'entity', NULL, '000000c1-0000-4000-8000-00000000000a', NULL), \
+             (98002, N'CycleB', N'OSUSR_CYC_B', 100, 1, 0, 0, N'entity', NULL, '000000c1-0000-4000-8000-00000000000b', NULL); \
+           INSERT INTO [dbo].[ossys_Entity_Attr] ([Id], [Entity_Id], [Name], [SS_Key], [Data_Type], [Is_Mandatory], [Is_Active], [Is_AutoNumber], [Is_Identifier], [Referenced_Entity_Id], [Delete_Rule], [Physical_Column_Name], [Order_Num]) VALUES \
+             (98011, 98001, N'Id',   '000000a1-0000-4000-8000-00000000c1a1', N'Identifier', 1, 1, 1, 1, NULL,  NULL,       N'ID',  1), \
+             (98012, 98001, N'BRef', '000000a1-0000-4000-8000-00000000c1a2', N'Identifier', 1, 1, 0, 0, 98002, N'Protect', N'BID', 10), \
+             (98021, 98002, N'Id',   '000000a1-0000-4000-8000-00000000c1b1', N'Identifier', 1, 1, 1, 1, NULL,  NULL,       N'ID',  1), \
+             (98022, 98002, N'ARef', '000000a1-0000-4000-8000-00000000c1b2', N'Identifier', 1, 1, 0, 0, 98001, N'Protect', N'AID', 10);" ]
 
 [<Xunit.Collection("Docker-SqlServer")>]
 type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
@@ -116,6 +135,37 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                                 "DELETE FROM [dbo].[ossys_Entity_Attr] WHERE [Name] = N'LastName' AND [Entity_Id] = 1000;"
                         let red2 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(5, red2)
+                        return ()
+                    }))
+
+    /// The unrelated-cycle witness (2026-07-07): an UNRESOLVABLE dependency
+    /// cycle elsewhere in the estate no longer reds a partial transfer's
+    /// board — the load-order gate and the dry run's cycle report judge the
+    /// EFFECTIVE transfer graph (declared tables + reconciled parents as
+    /// isolated nodes), not the whole sink contract. The same flow that goes
+    /// green in the red/green/red scenario stays green with CycleA ↔ CycleB
+    /// (both FKs mandatory — the resolver refuses it) sitting outside the
+    /// subset in BOTH cells.
+    [<Fact>]
+    member _.``go board: an unrelated estate cycle does not block a partial transfer — load order and cycles judge the transferred set only`` () =
+        if not (GoBoardFixtures.skipIfNoDocker "GoBoardUnrelatedCycle") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "GoBoardCyc"
+                "" (GoBoardFixtures.sourceRows @ GoBoardFixtures.unrelatedCycleBatch) MockOutSystemsEnv.ManagedDml
+                "X" (GoBoardFixtures.sinkCityRows @ GoBoardFixtures.unrelatedCycleBatch) MockOutSystemsEnv.ManagedDml
+                (fun src snk ->
+                    task {
+                        // The cycle is REAL at the whole-estate grain: the
+                        // unscoped topology degrades to alphabetical on the
+                        // sink contract (the contrast that pins the fix).
+                        let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                        let (_, sinkContract) = GoBoardFixtures.value contractsR
+                        let whole = (Projection.Core.Passes.TopologicalOrderPass.runWith Projection.Core.TreatAsCycle sinkContract).Value
+                        Assert.Equal(Projection.Core.Alphabetical, whole.Mode)
+                        // ...and the board still goes GREEN for the subset.
+                        let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
+                        let green = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        Assert.Equal(0, green)
                         return ()
                     }))
 

--- a/sidecar/projection/tests/Projection.Tests.Integration/MockOutSystemsEnv.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/MockOutSystemsEnv.fs
@@ -25,6 +25,10 @@ module MockOutSystemsEnv =
         /// A `DmlPrincipal.ManagedGrants` login drives the engine — the
         /// managed-cloud envelope (no ALTER / CREATE TABLE / IDENTITY_INSERT).
         | ManagedDml
+        /// A `DmlPrincipal.createObjectDml` login drives the engine —
+        /// database-scope SELECT with OBJECT-scope I/U/D per table (the
+        /// 2026-07-07 live-run estate shape: no database-scope DML).
+        | ObjectScopeDml
 
     type MockEnv =
         { /// Admin-scope connection (setup, DENY injection, assertions).
@@ -59,6 +63,12 @@ module MockOutSystemsEnv =
                     return! body { Admin = admin; AdminConnStr = adminConnStr; EngineConnStr = adminConnStr; Login = None; EspaceKey = espaceKey }
                 | ManagedDml ->
                     let! login, restricted = DmlPrincipal.createManaged admin adminConnStr
+                    try
+                        return! body { Admin = admin; AdminConnStr = adminConnStr; EngineConnStr = restricted; Login = Some login; EspaceKey = espaceKey }
+                    finally
+                        DmlPrincipal.dropLogin admin login
+                | ObjectScopeDml ->
+                    let! login, restricted = DmlPrincipal.createObjectDml admin adminConnStr
                     try
                         return! body { Admin = admin; AdminConnStr = adminConnStr; EngineConnStr = restricted; Login = Some login; EspaceKey = espaceKey }
                     finally

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerManagedGrantTransferDockerTests.fs
@@ -21,11 +21,13 @@ namespace Projection.Tests
 //   3. Reconcile-by-key under the grant (SELECT-only touch on the target).
 //   4. OSSYS metamodel unreadable on the sink → the NAMED contract
 //      acquisition refusal (schema-read axis, exit 6) — never a raw crash.
-//   5. Object-scope DENY INSERT mid-subset: the DB-scope preflight is blind
-//      to it (G1, PINNED) — raw permission exception mid-load, upstream
-//      kinds already landed. The named-gap witness on the peer dispatch,
-//      cross-referencing the reserved promotion stub in
-//      ReverseLegBoundaryTests.
+//   5. Object-scope DENY INSERT → PROMOTED 2026-07-07: the planned-table
+//      object probe sees the DENY (effective permissions) and refuses by
+//      name pre-write with ZERO partial write (the G1 gap closed for
+//      planned tables).
+//   6. OBJECT-scope-only DML (the 2026-07-07 live-run estate shape): the
+//      planned-write evaluation is a GO with no database-scope DML at all,
+//      and the subset lands.
 //
 // Serial via Docker-SqlServer; blocking wait via TaskSync.
 
@@ -320,14 +322,14 @@ type PeerManagedGrantTransferDockerTests(fixture: EphemeralContainerFixture) =
                         return ()
                     }))
 
-    /// G1 PINNED on the peer dispatch: an object-scope DENY INSERT is
-    /// invisible to the DB-scope grant preflight — the load crashes RAW
-    /// mid-subset with the parent kind already landed (the partial-write
-    /// surprise). The promotion trigger lives with the reserved stub in
-    /// ReverseLegBoundaryTests (`object-scope DENY`); when an object-scope
-    /// probe lands, flip this to a named pre-write refusal.
+    /// G1 PROMOTED (2026-07-07 — was the pinned partial-write gap): the
+    /// grant preflight now captures evidence PER PLANNED TABLE
+    /// (`fn_my_permissions('<obj>','OBJECT')` — EFFECTIVE permissions,
+    /// DENYs subtracted), so an object-scope DENY INSERT refuses BY NAME
+    /// before any write. The parent kind no longer lands first: the sink
+    /// stays byte-untouched.
     [<Fact>]
-    member _.``peer under managed grant PINNED GAP: object-scope DENY INSERT crashes raw mid-load with a partial write (G1)`` () =
+    member _.``peer under managed grant PROMOTED (was pinned G1): object-scope DENY INSERT refuses by name pre-write — zero partial write`` () =
         if not (ManagedGrantFixtures.skipIfNoDocker "PeerManagedG1") then () else
         TaskSync.run (fun () ->
             MockOutSystemsEnv.withMockEnvPair fixture "PeerMgG1"
@@ -341,24 +343,71 @@ type PeerManagedGrantTransferDockerTests(fixture: EphemeralContainerFixture) =
                         let (srcContract, sinkContract) = ManagedGrantFixtures.value contractsR
                         let! outcome =
                             ManagedGrantFixtures.throughConnections src.EngineConnStr snk.EngineConnStr false (fun connections ->
-                                task {
-                                    try
-                                        let! r =
-                                            Transfer.runReverseLegThroughConnections
-                                                Transfer.Execute EmissionMode.Incremental false true false
-                                                [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
-                                        return Choice1Of2 r
-                                    with ex -> return Choice2Of2 ex
-                                })
+                                Transfer.runReverseLegThroughConnections
+                                    Transfer.Execute EmissionMode.Incremental false true false
+                                    [ "City"; "Customer" ] connections srcContract sinkContract Map.empty)
                         match outcome with
-                        | Choice1Of2 _ -> Assert.Fail "expected the object-scope DENY to crash the load (the pinned G1 gap)"
-                        | Choice2Of2 ex ->
-                            Assert.True(DmlPrincipal.isPermissionDenied ex, sprintf "expected the permission class, got: %s" ex.Message)
-                        // The partial write, pinned: the parent kind (City,
-                        // topologically first) already landed.
+                        | Ok _ -> Assert.Fail "expected the object-scope DENY to refuse pre-write (transfer.insufficientGrant)"
+                        | Error es ->
+                            Assert.True(
+                                es |> List.exists (fun e -> e.Code = "transfer.insufficientGrant"),
+                                sprintf "expected transfer.insufficientGrant, got %A" (es |> List.map (fun e -> e.Code)))
+                        // ZERO partial write — the refusal preceded the load;
+                        // City (topologically first) no longer lands.
                         let! cities = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
-                        Assert.Equal(2, cities)
+                        Assert.Equal(0, cities)
                         let! customers = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
                         Assert.Equal(0, customers)
+                        return ()
+                    }))
+
+    /// The 2026-07-07 live-run estate shape: OBJECT-scope I/U/D per table,
+    /// NO database-scope DML. The planned-write grant evaluation (the same
+    /// computation the go board's grant item renders) reports zero
+    /// violations — the [ GO ] — and the live engine's G2 gate passes and
+    /// lands the subset.
+    [<Fact>]
+    member _.``peer under OBJECT-scope DML (no database-scope grant): the planned-write evaluation is a GO and the subset lands`` () =
+        if not (ManagedGrantFixtures.skipIfNoDocker "PeerObjDml") then () else
+        TaskSync.run (fun () ->
+            MockOutSystemsEnv.withMockEnvPair fixture "PeerObjDml"
+                "" ManagedGrantFixtures.sourceRows MockOutSystemsEnv.ObjectScopeDml
+                "X" ManagedGrantFixtures.sinkReseed MockOutSystemsEnv.ObjectScopeDml
+                (fun src snk ->
+                    task {
+                        let! contractsR = PeerTransfer.acquireContracts src.EngineConnStr snk.EngineConnStr
+                        let (srcContract, sinkContract) = ManagedGrantFixtures.value contractsR
+                        // (a) The board's grant computation over the effective
+                        // scope: object-scope evidence covers the planned
+                        // writes — zero violations, despite fn_my_permissions
+                        // at DATABASE scope carrying no DML at all.
+                        let loadSet =
+                            Transfer.resolveLoadSet sinkContract [ "City"; "Customer" ]
+                            |> ManagedGrantFixtures.value
+                        let scope = TransferScope.create sinkContract loadSet Set.empty
+                        let planned = Transfer.plannedTransferWrites scope EmissionMode.Incremental sinkContract
+                        use! cnn = ManagedGrantFixtures.openConn snk.EngineConnStr
+                        let! evidenceR =
+                            Preflight.captureGrantEvidenceFor
+                                (planned |> List.map (fun w -> w.Schema, w.Table) |> List.distinct) cnn
+                        let evidence = ManagedGrantFixtures.value evidenceR
+                        Assert.False(Preflight.coversPermissionAtDatabaseScope "INSERT" evidence)
+                        Assert.Empty(Preflight.permissionViolations planned evidence)
+                        // (b) The live engine passes G2 under the same evidence
+                        // and the subset lands.
+                        let! report =
+                            ManagedGrantFixtures.throughConnections src.EngineConnStr snk.EngineConnStr false (fun connections ->
+                                task {
+                                    let! r =
+                                        Transfer.runReverseLegThroughConnections
+                                            Transfer.Execute EmissionMode.Incremental false true false
+                                            [ "City"; "Customer" ] connections srcContract sinkContract Map.empty
+                                    return ManagedGrantFixtures.value r
+                                })
+                        Assert.Empty(report.SkippedReferences)
+                        let! cities = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XDEF_CITY]"
+                        let! customers = ManagedGrantFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"
+                        Assert.Equal(2, cities)
+                        Assert.Equal(2, customers)
                         return ()
                     }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
@@ -684,12 +684,13 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                 })
 
     [<Fact>]
-    member this.``NAMED GAP (pinned): an object-scope DENY INSERT escapes the database-scope grant probe — the failure is a mid-load SqlException, not a preflight refusal`` () =
-        // `Preflight.captureGrantEvidence` reads sys.fn_my_permissions at
-        // DATABASE scope only (survey-gated P1 refinement). A principal with
-        // database-scope DML but a table-level DENY passes the preflight and
-        // crashes mid-load — a PARTIAL write. Pinned so the gap stays named
-        // until the object-scope probe lands; see the LE-3 report.
+    member this.``PROMOTED (was the pinned G1 gap): an object-scope DENY INSERT refuses by name pre-write — zero partial write`` () =
+        // 2026-07-07: `spanningPreflight` captures grant evidence PER
+        // PLANNED TABLE (`fn_my_permissions('<obj>','OBJECT')` — EFFECTIVE
+        // permissions, table-level DENYs subtracted), so the DENY that used
+        // to crash mid-load with upstream kinds already landed (the
+        // partial-write hazard the LE-3 report named) now refuses
+        // `transfer.insufficientGrant` before any write.
         if not (ReverseLegFixtures.skipIfNoDocker "L3Deny") then () else
         this.WithReverseLegEstates "L3Deny" ReverseLegFixtures.seedClean
             (fun src _ adminSink sinkConnStr logicalContract physicalContract ->
@@ -701,15 +702,18 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                                 (sprintf "DENY INSERT ON [dbo].[OSUSR_L3_INVOICE] TO [%s];" login)
                         use sink = new Microsoft.Data.SqlClient.SqlConnection(restrictedConnStr)
                         do! sink.OpenAsync()
-                        let! _ =
-                            Assert.ThrowsAnyAsync<Microsoft.Data.SqlClient.SqlException>(fun () ->
-                                Transfer.runWithRenames Transfer.Execute true src sink logicalContract physicalContract
-                                :> System.Threading.Tasks.Task)
-                        // The crash is mid-load: upstream kinds already landed
-                        // (the partial-write hazard the named gap documents).
+                        let! reportR =
+                            Transfer.runWithRenames Transfer.Execute true src sink logicalContract physicalContract
+                        match reportR with
+                        | Error es ->
+                            Assert.True(
+                                es |> List.exists (fun e -> e.Code = "transfer.insufficientGrant"),
+                                sprintf "expected transfer.insufficientGrant, got %A" (es |> List.map (fun e -> e.Code)))
+                        | Ok _ -> Assert.Fail "expected the object-scope DENY to refuse pre-write"
+                        // ZERO partial write — no upstream kind landed.
                         let! customers = ReverseLegFixtures.countRows adminSink "[dbo].[OSUSR_L3_CUSTOMER]"
                         let! invoices  = ReverseLegFixtures.countRows adminSink "[dbo].[OSUSR_L3_INVOICE]"
-                        Assert.Equal(2, customers)
+                        Assert.Equal(0, customers)
                         Assert.Equal(0, invoices)
                     finally
                         DmlPrincipal.dropLogin adminSink login

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
@@ -16,18 +16,18 @@ open type Projection.Pipeline.CapabilitySurvey.Capability
 [<Fact>]
 let ``requiredFor: schema+data permits the schema activities; data-only just the DML`` () =
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete
               Performs Preflight.Alter; Performs Preflight.CreateTable ],
         CapabilitySurvey.requiredFor Grant.SchemaAndData)
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete ],
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ],
         CapabilitySurvey.requiredFor Grant.DataOnly)
 
 // --- reconciliation --------------------------------------------------------
 
 [<Fact>]
 let ``reconcile: a data-only grant against a schema+data requirement misses the schema activities`` () =
-    let evidence : Preflight.GrantEvidence = { Granted = set [ ("", "INSERT"); ("", "DELETE") ] }
+    let evidence : Preflight.GrantEvidence = { Granted = set [ ("", "INSERT"); ("", "DELETE") ]; ProbedObjects = Set.empty }
     let missing = CapabilitySurvey.reconcile (CapabilitySurvey.requiredFor Grant.SchemaAndData) evidence
     Assert.Contains(Performs Preflight.Alter, missing)
     Assert.Contains(Performs Preflight.CreateTable, missing)
@@ -36,12 +36,12 @@ let ``reconcile: a data-only grant against a schema+data requirement misses the 
 [<Fact>]
 let ``reconcile: a full grant covers the schema+data requirement — nothing missing`` () =
     let evidence : Preflight.GrantEvidence =
-        { Granted = set [ ("", "INSERT"); ("", "DELETE"); ("", "ALTER"); ("", "CREATE TABLE") ] }
+        { Granted = set [ ("", "INSERT"); ("", "UPDATE"); ("", "DELETE"); ("", "ALTER"); ("", "CREATE TABLE") ]; ProbedObjects = Set.empty }
     Assert.Empty(CapabilitySurvey.reconcile (CapabilitySurvey.requiredFor Grant.SchemaAndData) evidence)
 
 [<Fact>]
 let ``reconcile: a source-read requirement misses a grant that holds no SELECT`` () =
-    let evidence : Preflight.GrantEvidence = { Granted = set [ ("", "INSERT"); ("", "DELETE") ] }
+    let evidence : Preflight.GrantEvidence = { Granted = set [ ("", "INSERT"); ("", "DELETE") ]; ProbedObjects = Set.empty }
     Assert.Equal<CapabilitySurvey.Capability list>([ Reads ], CapabilitySurvey.reconcile (set [ Reads ]) evidence)
 
 // --- the capability catalog (harvest-central) ------------------------------
@@ -49,7 +49,7 @@ let ``reconcile: a source-read requirement misses a grant that holds no SELECT``
 [<Fact>]
 let ``CapabilitySurvey.Capability.all is Reads plus every write action; permissionOf names each`` () =
     Assert.Equal<CapabilitySurvey.Capability list>(
-        [ Reads; Performs Preflight.Insert; Performs Preflight.Delete
+        [ Reads; Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete
           Performs Preflight.Alter; Performs Preflight.CreateTable ],
         CapabilitySurvey.Capability.all)
     Assert.Equal<string>("SELECT", CapabilitySurvey.Capability.permissionOf Reads)
@@ -88,7 +88,7 @@ let ``requiredBy: a cross-substrate transfer reads the source and writes the dat
     let f = Map.find "load" cfg.Flows
     Assert.Equal<Set<CapabilitySurvey.Capability>>(set [ Reads ], CapabilitySurvey.requiredBy cfg f SubstrateRole.Source)
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete ],
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ],
         CapabilitySurvey.requiredBy cfg f SubstrateRole.Sink)
 
 [<Fact>]
@@ -98,7 +98,7 @@ let ``requiredBy: a live source to a schema+data target migrates schema and data
     let cfg = cfgWith [ source; sink ] [ flow "migrate" (FlowSource.Env "staging") "uat" ]
     let f = Map.find "migrate" cfg.Flows
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete
               Performs Preflight.Alter; Performs Preflight.CreateTable ],
         CapabilitySurvey.requiredBy cfg f SubstrateRole.Sink)
 
@@ -141,7 +141,7 @@ let ``requiredOf: a place is the union of what every flow asks of it across role
         set [ Reads; Performs Preflight.Alter; Performs Preflight.CreateTable ],
         CapabilitySurvey.requiredOf cfg "staging")
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete ],
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ],
         CapabilitySurvey.requiredOf cfg "uat")
 
 [<Fact>]
@@ -180,9 +180,10 @@ let ``EnvironmentReport carries the UserDirectory P10 field (report field, not a
     Assert.True(r.UserDirectory.Found)
     Assert.True(r.UserDirectory.EmailKeyed)
     Assert.Equal(Some "dbo.OSSYS_USER", r.UserDirectory.TableName)
-    // The Capability DU is untouched — `Capability.all` is still exactly the
-    // five Reads/Performs variants (the totality stays structural).
-    Assert.Equal(5, List.length CapabilitySurvey.Capability.all)
+    // The Capability DU is untouched by P10 — `Capability.all` is exactly the
+    // Reads/Performs variants (six since Update joined the write actions,
+    // 2026-07-07; the totality stays structural).
+    Assert.Equal(6, List.length CapabilitySurvey.Capability.all)
 
 [<Fact>]
 let ``blocked: a connected place missing a required capability is blocked; an all-clear place is not`` () =
@@ -232,7 +233,7 @@ let private envArch (name: string) (archetype: Archetype option) : Projection.Pi
 
 /// A database-scope `GrantEvidence` from a permission-name list (object-key "").
 let private grantOf (perms: string list) : Preflight.GrantEvidence =
-    { Granted = perms |> List.map (fun p -> ("", p)) |> Set.ofList }
+    { Granted = perms |> List.map (fun p -> ("", p)) |> Set.ofList; ProbedObjects = Set.empty }
 
 [<Fact>]
 let ``Slice B (Part 1): the survey routes through the archetype's derived grant — an archetype-declared sink yields the SAME required set as the equivalent grant (byte-identical)`` () =
@@ -250,7 +251,7 @@ let ``Slice B (Part 1): the survey routes through the archetype's derived grant 
     let dmlSink = envArch "cloud" (Some Archetype.ManagedDml)
     let cfgD = cfgWith [ liveSource; dmlSink ] [ flow "d" (FlowSource.Env "staging") "cloud" ]
     Assert.Equal<Set<CapabilitySurvey.Capability>>(
-        set [ Performs Preflight.Insert; Performs Preflight.Delete ],
+        set [ Performs Preflight.Insert; Performs Preflight.Update; Performs Preflight.Delete ],
         CapabilitySurvey.requiredBy cfgD (Map.find "d" cfgD.Flows) SubstrateRole.Sink)
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/CycleResolutionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CycleResolutionTests.fs
@@ -77,13 +77,17 @@ let ``classify: nullable + Restrict = Other (Restrict not breakable)`` () =
     Assert.Equal<EdgeStrength>(EdgeStrength.Other, CycleResolution.classify k r)
 
 // ---------------------------------------------------------------------------
-// asymmetric2CycleStrategy — V1's resolver heuristic. Pure function of
-// SCC members + classified internal edges.
+// weakFeedbackStrategy — THE COMPLETE CASE MAP (v5, 2026-07-07; retires
+// V1's asymmetric-2-cycle heuristic). Pure function of SCC members +
+// classified internal edges. The rows below mirror the resolver's
+// docstring table; the property suite at the end pins the invariants
+// I1-I5 over generated graphs.
 // ---------------------------------------------------------------------------
 
 let private aKey = testKey "A"
 let private bKey = testKey "B"
 let private cKey = testKey "C"
+let private dKey = testKey "D"
 
 [<Fact>]
 let ``resolver: a Weak self-edge (nullable self-FK) is broken for ordering — phase 2 re-points it`` () =
@@ -92,23 +96,23 @@ let ``resolver: a Weak self-edge (nullable self-FK) is broken for ordering — p
     // the whole catalog to the alphabetical fallback — the deferral
     // machinery re-points it in phase 2 regardless of order.
     let step =
-        CycleResolution.asymmetric2CycleStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Weak ]
+        CycleResolution.weakFeedbackStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Weak ]
     Assert.Equal<(SsKey * SsKey) list>([ (aKey, aKey) ], step.EdgesToBreak)
     Assert.Contains("auto-resolved", step.Reason)
 
 [<Fact>]
 let ``resolver: a non-Weak self-edge still refuses (a mandatory self-FK cannot defer)`` () =
     let step =
-        CycleResolution.asymmetric2CycleStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Other ]
+        CycleResolution.weakFeedbackStrategy [ aKey ] [ (aKey, aKey), EdgeStrength.Other ]
     Assert.Empty(step.EdgesToBreak)
-    Assert.Contains("no Weak (nullable) self-edge", step.Reason)
+    Assert.Contains("non-deferrable", step.Reason)
 
 [<Fact>]
 let ``resolver: 2-cycle with exactly one Weak edge returns that edge`` () =
     let edges =
         [ (aKey, bKey), EdgeStrength.Weak
           (bKey, aKey), EdgeStrength.Other ]
-    let step = CycleResolution.asymmetric2CycleStrategy [ aKey; bKey ] edges
+    let step = CycleResolution.weakFeedbackStrategy [ aKey; bKey ] edges
     Assert.Equal<(SsKey * SsKey) list>([ (aKey, bKey) ], step.EdgesToBreak)
     Assert.Contains("auto-resolved", step.Reason)
 
@@ -117,18 +121,22 @@ let ``resolver: 2-cycle with no Weak edges returns empty and explains`` () =
     let edges =
         [ (aKey, bKey), EdgeStrength.Other
           (bKey, aKey), EdgeStrength.Other ]
-    let step = CycleResolution.asymmetric2CycleStrategy [ aKey; bKey ] edges
+    let step = CycleResolution.weakFeedbackStrategy [ aKey; bKey ] edges
     Assert.Empty(step.EdgesToBreak)
-    Assert.Contains("no Weak edge", step.Reason)
+    Assert.Contains("non-deferrable", step.Reason)
 
 [<Fact>]
-let ``resolver: 2-cycle with two Weak edges returns empty and refuses to choose`` () =
+let ``resolver v5: 2-cycle with two Weak edges resolves — exactly one edge broken, the smallest, deterministically`` () =
     let edges =
         [ (aKey, bKey), EdgeStrength.Weak
           (bKey, aKey), EdgeStrength.Weak ]
-    let step = CycleResolution.asymmetric2CycleStrategy [ aKey; bKey ] edges
-    Assert.Empty(step.EdgesToBreak)
-    Assert.Contains("multiple Weak edges", step.Reason)
+    let step = CycleResolution.weakFeedbackStrategy [ aKey; bKey ] edges
+    Assert.Equal<(SsKey * SsKey) list>([ (aKey, bKey) ], step.EdgesToBreak)
+    Assert.Contains("auto-resolved", step.Reason)
+    // Input-order independence (I4): the reversed edge list breaks the
+    // same edge.
+    let reversedStep = CycleResolution.weakFeedbackStrategy [ bKey; aKey ] (List.rev edges)
+    Assert.Equal<(SsKey * SsKey) list>(step.EdgesToBreak, reversedStep.EdgesToBreak)
 
 [<Fact>]
 let ``resolver: 2-cycle with Cascade alongside Weak still uses the Weak edge`` () =
@@ -136,25 +144,79 @@ let ``resolver: 2-cycle with Cascade alongside Weak still uses the Weak edge`` (
     let edges =
         [ (aKey, bKey), EdgeStrength.Weak
           (bKey, aKey), EdgeStrength.Cascade ]
-    let step = CycleResolution.asymmetric2CycleStrategy [ aKey; bKey ] edges
+    let step = CycleResolution.weakFeedbackStrategy [ aKey; bKey ] edges
     Assert.Equal<(SsKey * SsKey) list>([ (aKey, bKey) ], step.EdgesToBreak)
 
 [<Fact>]
-let ``resolver: 3-cycle returns empty and notes the size`` () =
+let ``resolver v5: an all-weak 3-cycle resolves with exactly ONE broken edge (I5 — never a blanket sweep)`` () =
     let edges =
         [ (aKey, bKey), EdgeStrength.Weak
           (bKey, cKey), EdgeStrength.Weak
           (cKey, aKey), EdgeStrength.Weak ]
     let step =
-        CycleResolution.asymmetric2CycleStrategy [ aKey; bKey; cKey ] edges
-    Assert.Empty(step.EdgesToBreak)
-    Assert.Contains("size 3", step.Reason)
+        CycleResolution.weakFeedbackStrategy [ aKey; bKey; cKey ] edges
+    Assert.Equal(1, step.EdgesToBreak.Length)
+    Assert.Contains("auto-resolved", step.Reason)
 
 [<Fact>]
-let ``resolver: empty-edges 2-cycle (degenerate) returns empty`` () =
-    let step = CycleResolution.asymmetric2CycleStrategy [ aKey; bKey ] []
+let ``resolver v5: a 3-cycle with one strong edge resolves by breaking weak edges only (the strong edge is honored by order)`` () =
+    let edges =
+        [ (aKey, bKey), EdgeStrength.Weak
+          (bKey, cKey), EdgeStrength.Other
+          (cKey, aKey), EdgeStrength.Weak ]
+    let step =
+        CycleResolution.weakFeedbackStrategy [ aKey; bKey; cKey ] edges
+    Assert.Equal(1, step.EdgesToBreak.Length)
+    Assert.DoesNotContain((bKey, cKey), step.EdgesToBreak)
+
+[<Fact>]
+let ``resolver v5: an all-strong 3-cycle refuses, naming the exact cycle members`` () =
+    let edges =
+        [ (aKey, bKey), EdgeStrength.Other
+          (bKey, cKey), EdgeStrength.Cascade
+          (cKey, aKey), EdgeStrength.Other ]
+    let step =
+        CycleResolution.weakFeedbackStrategy [ aKey; bKey; cKey ] edges
     Assert.Empty(step.EdgesToBreak)
-    Assert.Contains("no Weak edge", step.Reason)
+    Assert.Contains("non-deferrable", step.Reason)
+    Assert.Contains("A", step.Reason)
+    Assert.Contains("B", step.Reason)
+    Assert.Contains("C", step.Reason)
+
+[<Fact>]
+let ``resolver v5: a strong cycle nested in a larger weak SCC refuses — the weak decorations cannot save it (I3)`` () =
+    // A <-> B strong (the poison pair) decorated with weak edges through
+    // C and D. Whatever weak edges break, the strong 2-cycle survives —
+    // refusal names it.
+    let edges =
+        [ (aKey, bKey), EdgeStrength.Other
+          (bKey, aKey), EdgeStrength.Other
+          (bKey, cKey), EdgeStrength.Weak
+          (cKey, dKey), EdgeStrength.Weak
+          (dKey, aKey), EdgeStrength.Weak ]
+    let step =
+        CycleResolution.weakFeedbackStrategy [ aKey; bKey; cKey; dKey ] edges
+    Assert.Empty(step.EdgesToBreak)
+    Assert.Contains("non-deferrable", step.Reason)
+
+[<Fact>]
+let ``resolver v5: two fused weak rings resolve — one break per residual cycle, graph acyclic after`` () =
+    // Ring 1: A -> B -> A; Ring 2: B -> C -> B. Sharing member B.
+    let edges =
+        [ (aKey, bKey), EdgeStrength.Weak
+          (bKey, aKey), EdgeStrength.Weak
+          (bKey, cKey), EdgeStrength.Weak
+          (cKey, bKey), EdgeStrength.Weak ]
+    let step =
+        CycleResolution.weakFeedbackStrategy [ aKey; bKey; cKey ] edges
+    Assert.Equal(2, step.EdgesToBreak.Length)
+    Assert.Contains("auto-resolved", step.Reason)
+
+[<Fact>]
+let ``resolver v5: empty-edges SCC (degenerate) returns empty and degrades legibly`` () =
+    let step = CycleResolution.weakFeedbackStrategy [ aKey; bKey ] []
+    Assert.Empty(step.EdgesToBreak)
+    Assert.Contains("no cycle found", step.Reason)
 
 // ---------------------------------------------------------------------------
 // neverResolve — opt-out resolver for callers that prefer alphabetical
@@ -199,3 +261,98 @@ let ``resolver shape: a custom resolver can be passed by callers`` () =
     let step = alwaysFirst [ aKey; bKey ] edges
     Assert.Equal<(SsKey * SsKey) list>([ (aKey, bKey) ], step.EdgesToBreak)
     Assert.Contains("custom", step.Reason)
+
+// ---------------------------------------------------------------------------
+// The invariant property suite (I1–I5 over generated graphs). Members are
+// P0..P3; edges are generated from raw byte triples so FsCheck shrinks
+// cleanly. Parallel strengths combine through `combineStrength` — the same
+// pre-processing the pass performs.
+// ---------------------------------------------------------------------------
+
+open FsCheck
+open FsCheck.Xunit
+
+let private pKey (i: int) : SsKey = testKey (sprintf "P%d" i)
+
+let private strengthFor (s: int) : EdgeStrength =
+    match ((s % 3) + 3) % 3 with
+    | 0 -> EdgeStrength.Weak
+    | 1 -> EdgeStrength.Other
+    | _ -> EdgeStrength.Cascade
+
+let private edgesFrom (raw: (byte * byte * byte) list) : ((SsKey * SsKey) * EdgeStrength) list =
+    raw
+    |> List.map (fun (a, b, st) ->
+        (pKey (int a % 4), pKey (int b % 4)), strengthFor (int st))
+    |> List.groupBy fst
+    |> List.map (fun (e, xs) -> e, xs |> List.map snd |> List.reduce CycleResolution.combineStrength)
+
+/// Simple acyclicity check by iterative source-elimination (Kahn) over
+/// FK-orientation edges — independent of the production algorithm.
+let private isAcyclic (edges: (SsKey * SsKey) list) : bool =
+    let rec strip (remaining: (SsKey * SsKey) list) : bool =
+        if List.isEmpty remaining then true
+        else
+            let nodes = remaining |> List.collect (fun (s, t) -> [ s; t ]) |> List.distinct
+            let withIncoming = remaining |> List.map snd |> Set.ofList
+            let sources = nodes |> List.filter (fun n -> not (Set.contains n withIncoming))
+            if List.isEmpty sources then false   // every node has an incoming edge → cycle
+            else
+                let sourceSet = Set.ofList sources
+                strip (remaining |> List.filter (fun (s, _) -> not (Set.contains s sourceSet)))
+    strip (edges |> List.filter (fun (s, t) -> s <> t))
+    && not (edges |> List.exists (fun (s, t) -> s = t))   // any self-edge is a cycle
+
+[<Property>]
+let ``I1 soundness: every edge the resolver breaks is Weak (hence nullable, hence phase-2 deferrable)`` (raw: (byte * byte * byte) list) =
+    let edges = edgesFrom raw
+    let members = [ 0 .. 3 ] |> List.map pKey
+    let step = CycleResolution.weakFeedbackStrategy members edges
+    let strengths = Map.ofList edges
+    step.EdgesToBreak
+    |> List.forall (fun e -> Map.tryFind e strengths = Some EdgeStrength.Weak)
+
+[<Property>]
+let ``I2 acyclicity: when the resolver resolves, the SCC minus the broken edges is acyclic`` (raw: (byte * byte * byte) list) =
+    let edges = edgesFrom raw
+    let members = [ 0 .. 3 ] |> List.map pKey
+    let step = CycleResolution.weakFeedbackStrategy members edges
+    List.isEmpty step.EdgesToBreak
+    || isAcyclic (edges |> List.map fst |> List.filter (fun e -> not (List.contains e step.EdgesToBreak)))
+
+[<Property>]
+let ``I3 refusal precision: the resolver refuses a cyclic graph exactly when removing every Weak edge still leaves a cycle`` (raw: (byte * byte * byte) list) =
+    let edges = edgesFrom raw
+    let members = [ 0 .. 3 ] |> List.map pKey
+    let step = CycleResolution.weakFeedbackStrategy members edges
+    let allEdges = edges |> List.map fst
+    let strongOnly =
+        edges |> List.choose (fun (e, st) -> if st <> EdgeStrength.Weak then Some e else None)
+    if isAcyclic allEdges then
+        // No cycle to resolve — the resolver breaks nothing.
+        List.isEmpty step.EdgesToBreak
+    elif isAcyclic strongOnly then
+        // Every cycle passes through a Weak edge — must resolve.
+        not (List.isEmpty step.EdgesToBreak)
+    else
+        // Some all-strong cycle — must refuse, by name.
+        List.isEmpty step.EdgesToBreak && step.Reason.Contains "non-deferrable"
+
+[<Property>]
+let ``I4 determinism: the broken set is independent of input edge order`` (raw: (byte * byte * byte) list) =
+    let edges = edgesFrom raw
+    let members = [ 0 .. 3 ] |> List.map pKey
+    let forward = CycleResolution.weakFeedbackStrategy members edges
+    let reversed = CycleResolution.weakFeedbackStrategy (List.rev members) (List.rev edges)
+    forward.EdgesToBreak = reversed.EdgesToBreak
+
+[<Property>]
+let ``I5 frugality: the resolver never breaks more Weak edges than the graph has residual cycles to break (a pure ring breaks one)`` (n: byte) =
+    // A pure weak ring of size 2..4 breaks EXACTLY one edge.
+    let size = 2 + int n % 3
+    let members = [ 0 .. size - 1 ] |> List.map pKey
+    let edges =
+        [ 0 .. size - 1 ]
+        |> List.map (fun i -> (pKey i, pKey ((i + 1) % size)), EdgeStrength.Weak)
+    let step = CycleResolution.weakFeedbackStrategy members edges
+    step.EdgesToBreak.Length = 1

--- a/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataEmissionComposerTests.fs
@@ -781,10 +781,13 @@ let private mkAcyclicLeveledCatalog () : Kind list =
     [ root; mid; leaf; indep ]
 
 /// A pair of static kinds forming a genuinely UNRESOLVABLE cycle: each
-/// holds a NULLABLE FK to the other — a 2-SCC with TWO Weak edges, which
-/// the asymmetric resolver refuses by name ("multiple Weak edges; resolver
-/// refuses to choose"). Both FK columns are nullable + same-cycle, so both
-/// defer to Phase 2 (the partition law covers both phases).
+/// holds a NULLABLE + ON DELETE RESTRICT FK to the other — strength
+/// `Other` on both edges (nullable + Restrict is never breakable), so the
+/// v5 weak-feedback resolver refuses by name. Both FK columns are still
+/// NULLABLE + same-cycle, so both defer to Phase 2 (the partition law
+/// covers both phases). Until 2026-07-07 the fixture used two Weak
+/// (nullable + NoAction) edges — the v5 resolver now RESOLVES that shape,
+/// so the unresolvable premise moves to the Restrict strength.
 let private mkStaticMutualCycleKind (name: string) (table: string) (otherName: string) : Kind =
     let kindKey = mkKey ["TestModule"; name]
     let idKey = mkKey ["TestModule"; name; "Id"]
@@ -804,7 +807,7 @@ let private mkStaticMutualCycleKind (name: string) (table: string) (otherName: s
                 { Attribute.create peerKey (mkName "PeerId") Integer with Column = ColumnRealization.create ("PEERID") (true) |> Result.value }
             ]
         References =
-            [ Reference.create (mkKey ["TestModule"; name; "RefPeer"]) (mkName "RefPeer") peerKey (mkKey ["TestModule"; otherName]) ]
+            [ { Reference.create (mkKey ["TestModule"; name; "RefPeer"]) (mkName "RefPeer") peerKey (mkKey ["TestModule"; otherName]) with OnDelete = Restrict } ]
         Indexes    = []
         Description = None
         IsActive = true

--- a/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DataLoadPlanTests.fs
@@ -111,8 +111,28 @@ let ``DataLoadPlan: nullable same-cycle FK is deferred, non-nullable is not`` ()
     Assert.True(Set.isEmpty (loadFor bKey plan).DeferredFkColumns)
 
 [<Fact>]
-let ``DataLoadPlan: non-nullable same-cycle FK surfaces as an unbreakable diagnostic`` () =
+let ``DataLoadPlan: a RESOLVED cycle's non-nullable FK is satisfied by the proven order — no unbreakable diagnostic, plan satisfiable`` () =
+    // The fixture topo's A<->B SCC is RESOLVED (BreakableEdges = [(A,B)]):
+    // the resolver broke A's weak (nullable, deferred) edge, and the order
+    // [.. A; B] honors B's strong edge — B loads after A, so B.A_ID is
+    // satisfied by ORDER, not deferral. The pre-2026-07-07 computation
+    // judged ALL cycle members and flagged B.A_ID unbreakable, refusing a
+    // load the proven order satisfies (the resolver-completeness catch).
     let plan = build Map.empty
+    Assert.True(DataLoadPlan.isSatisfiable plan)
+    Assert.Empty(plan.UnbreakableCycleFks)
+
+/// The same catalog under an UNRESOLVED A<->B cycle (BreakableEdges = [] —
+/// the resolved/unresolved discriminant): the alphabetical fallback cannot
+/// prove B's strong edge, so the non-nullable FK is genuinely unbreakable.
+let private unresolvedTopo : TopologicalOrder =
+    { topo with
+        Mode   = OrderingMode.Alphabetical
+        Cycles = [ { Members = [ aKey; bKey ]; BreakableEdges = []; Reason = "test unresolved 2-cycle" } ] }
+
+[<Fact>]
+let ``DataLoadPlan: an UNRESOLVED cycle's non-nullable FK surfaces as the unbreakable diagnostic (the nullable side does not)`` () =
+    let plan = DataLoadPlan.build catalog unresolvedTopo Map.empty SurrogateRemapContext.empty
     Assert.False(DataLoadPlan.isSatisfiable plan)
     Assert.Contains(
         plan.UnbreakableCycleFks,

--- a/sidecar/projection/tests/Projection.Tests/PreflightTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PreflightTests.fs
@@ -152,7 +152,7 @@ let ``A1: a reachable endpoint with no authenticated login is a connection viola
 // ---------------------------------------------------------------------------
 
 let private granted (pairs: (string * string) list) : Preflight.GrantEvidence =
-    { Granted = Set.ofList pairs }
+    { Granted = Set.ofList pairs; ProbedObjects = Set.empty }
 
 [<Fact>]
 let ``A2: a planned INSERT the grant covers (object scope) is not a violation`` () =
@@ -317,3 +317,53 @@ let ``G2: a transfer INSERT against a read-only sink grant is a permission viola
     match Preflight.permissionPreflight grant planned with
     | Ok () -> Assert.Fail "expected a refusal: a read-only sink would transfer zero rows and exit clean"
     | Error errs -> Assert.Contains(errs, fun (e: ValidationError) -> e.Code = "migrate.insufficientGrant")
+
+// ---------------------------------------------------------------------------
+// Object-scope grant evaluation (2026-07-07, the go-board scoping program).
+// A probed object's rows are EFFECTIVE permissions (fn_my_permissions at
+// OBJECT scope: database grants inherited, object grants added, DENYs
+// subtracted) — authoritative, no database fallback. An unprobed object
+// keeps the historical object-OR-database rule.
+// ---------------------------------------------------------------------------
+
+let private grantedProbed (pairs: (string * string) list) (probed: string list) : Preflight.GrantEvidence =
+    { Granted = Set.ofList pairs; ProbedObjects = Set.ofList probed }
+
+[<Fact>]
+let ``object scope: object-scope-only DML covers the planned writes (no database grant needed)`` () =
+    let planned =
+        [ { Preflight.Schema = "dbo"; Preflight.Table = "Customer"; Preflight.Action = Preflight.Insert }
+          { Preflight.Schema = "dbo"; Preflight.Table = "Customer"; Preflight.Action = Preflight.Update }
+          { Preflight.Schema = "dbo"; Preflight.Table = "Customer"; Preflight.Action = Preflight.Delete } ]
+    let grant =
+        grantedProbed
+            [ ("dbo.Customer", "INSERT"); ("dbo.Customer", "UPDATE"); ("dbo.Customer", "DELETE") ]
+            [ "dbo.Customer" ]
+    Assert.Empty(Preflight.permissionViolations planned grant)
+
+[<Fact>]
+let ``object scope: a probed object is authoritative — a table-level DENY under a database-scope GRANT is a violation (the G1 closure)`` () =
+    // Database-scope INSERT granted, but the probed object reports no
+    // INSERT (a DENY subtracted it from the effective set). The old
+    // object-OR-database rule would read this as covered and crash
+    // mid-load; the probed-object precedence refuses pre-write.
+    let planned = [ { Preflight.Schema = "dbo"; Preflight.Table = "Customer"; Preflight.Action = Preflight.Insert } ]
+    let grant = grantedProbed [ ("", "INSERT"); ("dbo.Customer", "SELECT") ] [ "dbo.Customer" ]
+    match Preflight.permissionViolations planned grant with
+    | [ v ] -> Assert.Equal("dbo.Customer", v.Object)
+    | other -> Assert.Fail(sprintf "expected one violation, got %A" other)
+
+[<Fact>]
+let ``object scope: an UNPROBED object keeps the database-scope fallback (historical evidence shape)`` () =
+    let planned = [ { Preflight.Schema = "dbo"; Preflight.Table = "Customer"; Preflight.Action = Preflight.Insert } ]
+    let grant = grantedProbed [ ("", "INSERT") ] []
+    Assert.Empty(Preflight.permissionViolations planned grant)
+
+[<Fact>]
+let ``object scope: coversPermissionOn agrees with the violation gate on all three shapes`` () =
+    let probedDeny = grantedProbed [ ("", "UPDATE") ] [ "dbo.T" ]
+    Assert.False(Preflight.coversPermissionOn "dbo" "T" "UPDATE" probedDeny)
+    let probedGranted = grantedProbed [ ("dbo.T", "UPDATE") ] [ "dbo.T" ]
+    Assert.True(Preflight.coversPermissionOn "dbo" "T" "UPDATE" probedGranted)
+    let unprobedDbScope = grantedProbed [ ("", "UPDATE") ] []
+    Assert.True(Preflight.coversPermissionOn "dbo" "T" "UPDATE" unprobedDbScope)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -191,6 +191,7 @@
     <Compile Include="NormalizeStaticPopulationsTests.fs" />
     <Compile Include="SymmetricClosureTests.fs" />
     <Compile Include="TopologicalOrderPassTests.fs" />
+    <Compile Include="TransferScopeTests.fs" />
     <Compile Include="IslandDetectionTests.fs" />
     <Compile Include="CascadeShockZoneTests.fs" />
     <Compile Include="JunctionDeferredTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/TopologicalOrderPassTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TopologicalOrderPassTests.fs
@@ -281,14 +281,14 @@ let ``Tarjan: SCC reason explains why the cycle stayed unresolved`` () =
     // The synthetic fixture uses non-nullable FK columns on both sides
     // of the back-reference, so the resolver classifies both edges as
     // Other and refuses to break either one. The Reason field records
-    // the class of failure.
+    // the class of failure — v5 names the non-deferrable cycle itself.
     let backRefKey = refKey ["Customer"; "Order"; "back"]
     let cyclic =
         sampleCatalog
         |> addReference customerKey orderKey backRefKey "Order_back" customerNameKey
     let result = topoRun cyclic
     let scc = result.Value.Cycles |> List.head
-    Assert.Contains("Weak edge", scc.Reason)
+    Assert.Contains("non-deferrable", scc.Reason)
 
 // ---------------------------------------------------------------------------
 // Self-loop detection (v4) — surfaced by chapter 4.1.B slice δ.
@@ -505,25 +505,31 @@ let ``resolver: 2-cycle with no Weak edges remains unresolved`` () =
     Assert.Equal(Alphabetical, result.Value.Mode)
     let diag = result.Value.Cycles |> List.head
     Assert.Empty(diag.BreakableEdges)
-    Assert.Contains("no Weak edge", diag.Reason)
+    Assert.Contains("non-deferrable", diag.Reason)
 
 [<Fact>]
-let ``resolver: 2-cycle with two Weak edges remains unresolved`` () =
-    // Both edges nullable + NoAction = Weak / Weak. Resolver refuses
-    // to choose; cycle is unresolved.
+let ``resolver v5: 2-cycle with two Weak edges resolves — one edge broken, deterministically chosen`` () =
+    // Both edges nullable + NoAction = Weak / Weak. The v5 weak-feedback
+    // resolver breaks the smallest weak edge on the found cycle (one
+    // deferral, not two — I5 frugality) and the order proves topological.
     let parent = kindWithRef "Parent" "ParentRef" (mkKey "Audit") true NoAction
     let audit  = kindWithRef "Audit"  "AuditRef"  (mkKey "Parent") true NoAction
     let cyclic : Catalog =
         { Modules = [
             { SsKey = mkKey "M"; Name = mkName "M"; Kinds = [ parent; audit ]; IsActive = true; ExtendedProperties = [] } ]; Sequences = [] }
     let result = topoRun cyclic
-    Assert.Equal(Alphabetical, result.Value.Mode)
+    Assert.Equal(Topological, result.Value.Mode)
     let diag = result.Value.Cycles |> List.head
-    Assert.Empty(diag.BreakableEdges)
-    Assert.Contains("multiple Weak edges", diag.Reason)
+    Assert.Equal(1, diag.BreakableEdges.Length)
+    Assert.Contains("auto-resolved", diag.Reason)
+    // The kept edge is honored by the order: breaking (Audit -> Parent)
+    // leaves Parent's FK to Audit, so Audit loads first. Deterministic —
+    // the smallest edge by SsKey pair breaks.
+    Assert.Equal((mkKey "Audit", mkKey "Parent"), diag.BreakableEdges.[0])
+    Assert.True(TopologicalOrder.precedes (mkKey "Audit") (mkKey "Parent") result.Value)
 
 [<Fact>]
-let ``resolver: 3-cycle remains unresolved (current resolver handles 2-cycles only)`` () =
+let ``resolver v5: an all-weak 3-cycle resolves with exactly ONE broken edge (I5 — a pure weak ring never blanket-defers)`` () =
     let a = kindWithRef "A" "AtoB" (mkKey "B") true NoAction
     let b = kindWithRef "B" "BtoC" (mkKey "C") true NoAction
     let c = kindWithRef "C" "CtoA" (mkKey "A") true NoAction
@@ -531,10 +537,25 @@ let ``resolver: 3-cycle remains unresolved (current resolver handles 2-cycles on
         { Modules = [
             { SsKey = mkKey "M"; Name = mkName "M"; Kinds = [ a; b; c ]; IsActive = true; ExtendedProperties = [] } ]; Sequences = [] }
     let result = topoRun cyclic
-    Assert.Equal(Alphabetical, result.Value.Mode)
+    Assert.Equal(Topological, result.Value.Mode)
     let diag = result.Value.Cycles |> List.head
     Assert.Equal(3, diag.Members.Length)
-    Assert.Contains("size 3", diag.Reason)
+    Assert.Equal(1, diag.BreakableEdges.Length)
+    Assert.Contains("auto-resolved", diag.Reason)
+
+[<Fact>]
+let ``resolver v5: a 3-cycle whose every edge is STRONG refuses, naming the cycle`` () =
+    let a = kindWithRef "A" "AtoB" (mkKey "B") false NoAction
+    let b = kindWithRef "B" "BtoC" (mkKey "C") false NoAction
+    let c = kindWithRef "C" "CtoA" (mkKey "A") false NoAction
+    let cyclic : Catalog =
+        { Modules = [
+            { SsKey = mkKey "M"; Name = mkName "M"; Kinds = [ a; b; c ]; IsActive = true; ExtendedProperties = [] } ]; Sequences = [] }
+    let result = topoRun cyclic
+    Assert.Equal(Alphabetical, result.Value.Mode)
+    let diag = result.Value.Cycles |> List.head
+    Assert.Empty(diag.BreakableEdges)
+    Assert.Contains("non-deferrable", diag.Reason)
 
 [<Fact>]
 let ``resolver: Cascade edges are never broken`` () =

--- a/sidecar/projection/tests/Projection.Tests/TransferScopeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferScopeTests.fs
@@ -1,0 +1,139 @@
+module Projection.Tests.TransferScopeTests
+
+open Xunit
+open Projection.Core
+open Projection.Core.Passes
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+
+let private mkKey (s: string) : SsKey = testKey s
+
+// ---------------------------------------------------------------------------
+// The EFFECTIVE TRANSFER GRAPH (2026-07-07, the go-board scoping program;
+// readiness log Entry 25). `TransferScope` reifies "which kinds does this
+// transfer actually touch"; its `topology` runs ordering/cycle analysis on
+// the induced subgraph (FK edges bind only between written kinds), so:
+//   * an unrelated estate cycle no longer degrades a subset transfer's
+//     load order or mints out-of-subset UnbreakableCycleFks;
+//   * a cycle through a RECONCILED kind (never written; FKs re-keyed to
+//     pre-existing sink rows) correctly breaks;
+//   * a full, non-reconciling transfer is the identity scope —
+//     byte-identical to the unscoped pass.
+// ---------------------------------------------------------------------------
+
+/// A kind with one non-nullable NoAction FK — EdgeStrength `Other`, which
+/// the asymmetric-2-cycle resolver refuses to break: two of these pointing
+/// at each other are an UNRESOLVABLE cycle (Mode = Alphabetical).
+let private strongRefKind (kindKey: string) (targetKey: SsKey) : Kind =
+    let attrId = mkKey (kindKey + "_Id")
+    let attrFk = mkKey (kindKey + "_Fk")
+    { SsKey = mkKey kindKey
+      Name = mkName kindKey
+      Origin = Native
+      Modality = []
+      Physical = mkTableId "dbo" kindKey
+      Attributes = [
+          { Attribute.create attrId (mkName "Id") Integer with Column = ColumnRealization.create "ID" false |> Result.value; IsPrimaryKey = true }
+          { Attribute.create attrFk (mkName "Fk") Integer with Column = ColumnRealization.create "FK" false |> Result.value } ]
+      References = [
+          Reference.create (mkKey (kindKey + "_Ref")) (mkName "ToOther") attrFk targetKey ]
+      Indexes = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
+
+let private plainKind (kindKey: string) : Kind =
+    let attrId = mkKey (kindKey + "_Id")
+    { SsKey = mkKey kindKey
+      Name = mkName kindKey
+      Origin = Native
+      Modality = []
+      Physical = mkTableId "dbo" kindKey
+      Attributes = [
+          { Attribute.create attrId (mkName "Id") Integer with Column = ColumnRealization.create "ID" false |> Result.value; IsPrimaryKey = true } ]
+      References = []; Indexes = []; Description = None; IsActive = true; Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
+
+let private catalogOf (kinds: Kind list) : Catalog =
+    { Modules = [ { SsKey = mkKey "M"; Name = mkName "M"; Kinds = kinds; IsActive = true; ExtendedProperties = [] } ]
+      Sequences = [] }
+
+/// City ← Customer (acyclic subset) alongside an UNRELATED unresolvable
+/// two-cycle (CycleA ↔ CycleB, both edges non-nullable).
+let private estateWithUnrelatedCycle : Catalog =
+    catalogOf
+        [ plainKind "City"
+          strongRefKind "Customer" (mkKey "City")
+          strongRefKind "CycleA" (mkKey "CycleB")
+          strongRefKind "CycleB" (mkKey "CycleA") ]
+
+let private subsetScope : TransferScope =
+    TransferScope.create estateWithUnrelatedCycle (Some (Set.ofList [ mkKey "City"; mkKey "Customer" ])) Set.empty
+
+[<Fact>]
+let ``an unrelated unresolvable estate cycle degrades the WHOLE-estate order (the pre-scope behavior, kept for full transfers)`` () =
+    let whole = (TopologicalOrderPass.runWith TreatAsCycle estateWithUnrelatedCycle).Value
+    Assert.Equal(Alphabetical, whole.Mode)
+    Assert.True(Option.isSome (Transfer.orderedLoadGate whole))
+
+[<Fact>]
+let ``the scoped topology ignores an unrelated estate cycle — the subset's load order proves topological`` () =
+    let topo = TransferScope.topology TreatAsCycle subsetScope estateWithUnrelatedCycle
+    Assert.Equal(Topological, topo.Mode)
+    Assert.True(Option.isNone (Transfer.orderedLoadGate topo))
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "City"; mkKey "Customer" ], Set.ofList topo.Order)
+    Assert.True(TopologicalOrder.precedes (mkKey "City") (mkKey "Customer") topo)
+
+[<Fact>]
+let ``the scoped plan mints no out-of-subset UnbreakableCycleFks — cycle lines mention only the transfer closure`` () =
+    let topo = TransferScope.topology TreatAsCycle subsetScope estateWithUnrelatedCycle
+    let plan =
+        DataLoadPlan.build estateWithUnrelatedCycle topo Map.empty SurrogateRemapContext.empty
+    Assert.Empty(plan.UnbreakableCycleFks)
+    // The unscoped topology DOES mint them — the contrast that pins the fix.
+    let whole = (TopologicalOrderPass.runWith TreatAsCycle estateWithUnrelatedCycle).Value
+    let wholePlan =
+        DataLoadPlan.build estateWithUnrelatedCycle whole Map.empty SurrogateRemapContext.empty
+    Assert.NotEmpty(wholePlan.UnbreakableCycleFks)
+
+[<Fact>]
+let ``a cycle through a RECONCILED kind breaks — the reconciled kind rides as an isolated node`` () =
+    // Customer ↔ Account, both edges strong (unresolvable whole-estate);
+    // Account reconciled → its edges drop; Customer orders freely and
+    // Account stays in the Order (its ReconciledByRule report line).
+    let estate =
+        catalogOf
+            [ strongRefKind "Customer" (mkKey "Account")
+              strongRefKind "Account" (mkKey "Customer") ]
+    let scope = TransferScope.create estate None (Set.ofList [ mkKey "Account" ])
+    let topo = TransferScope.topology TreatAsCycle scope estate
+    Assert.Equal(Topological, topo.Mode)
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "Customer"; mkKey "Account" ], Set.ofList topo.Order)
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "Customer" ], scope.WriteKinds)
+
+[<Fact>]
+let ``a full non-reconciling transfer is the identity scope — scoped and unscoped topologies agree`` () =
+    let scope = TransferScope.create estateWithUnrelatedCycle None Set.empty
+    let scoped = TransferScope.topology TreatAsCycle scope estateWithUnrelatedCycle
+    let whole = (TopologicalOrderPass.runWith TreatAsCycle estateWithUnrelatedCycle).Value
+    Assert.Equal(whole, scoped)
+
+[<Fact>]
+let ``TransferScope.create drops unknown keys and excludes reconciled kinds from the write set`` () =
+    let estate = catalogOf [ plainKind "City"; plainKind "Country" ]
+    let scope =
+        TransferScope.create
+            estate
+            (Some (Set.ofList [ mkKey "City"; mkKey "Ghost" ]))
+            (Set.ofList [ mkKey "Country"; mkKey "AlsoGhost" ])
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "City" ], scope.WriteKinds)
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "City"; mkKey "Country" ], scope.Nodes)
+    Assert.Equal<Set<SsKey>>(Set.ofList [ mkKey "Country" ], scope.Reconciled)
+
+[<Fact>]
+let ``plannedTransferWrites: INSERT+UPDATE per written kind, DELETE only under a wipe, nothing for reconciled kinds`` () =
+    let estate = catalogOf [ plainKind "City"; plainKind "Country" ]
+    let scope = TransferScope.create estate None (Set.ofList [ mkKey "Country" ])
+    let incremental = Transfer.plannedTransferWrites scope EmissionMode.Incremental estate
+    Assert.Equal<Set<string * Preflight.WriteAction>>(
+        set [ ("City", Preflight.Insert); ("City", Preflight.Update) ],
+        incremental |> List.map (fun w -> w.Table, w.Action) |> Set.ofList)
+    let wipe = Transfer.plannedTransferWrites scope EmissionMode.WipeAndLoad estate
+    Assert.Contains(wipe, fun w -> w.Table = "City" && w.Action = Preflight.Delete)
+    Assert.DoesNotContain(wipe, fun w -> w.Table = "Country")


### PR DESCRIPTION
## What

Two operator-directed programs from the live partial-transfer run, sharing one theme: the gates judge **what the transfer actually touches**, and the cycle machinery is **complete over its case space**.

## Part 1 — the effective transfer graph (`TransferScope`)

Three go-board catches resolved through one reified abstraction (per the approved review): the board and the engine's Execute gates were evaluating the whole sink estate.

- **`TransferScope`** (Core): write kinds (declared minus reconciled), reconciled kinds as isolated nodes; `TransferScope.topology` orders the induced subgraph via `TopologicalOrderPass.runScopedWith`. Board and engine consume the same value — the forecast cannot disagree with the live run.
- **Grant** — planned-write evaluation replaces the database-scope-only check: `WriteAction` gains `Update`; `plannedTransferWrites` is scope × emission (DELETE gated under a wipe); `captureGrantEvidenceFor` probes each planned table at OBJECT scope with probed objects **authoritative** (effective permissions). Acceptance: object-scope I/U/D on the transfer tables → `[ GO ]` (witnessed by the new `ObjectScopeDml` mock cell). **G1 promoted**: table-level DENYs refuse `transfer.insufficientGrant` pre-write, zero partial write (both pinned tests flipped). A **missing** sink table stays unprobed — shape fact, not grant fact.
- **Load order / cycles** — unrelated estate cycles no longer red the board, refuse the run, or mint out-of-subset `UnbreakableCycleFks`; a cycle through a reconciled kind correctly breaks. Witnessed: the unscoped topology provably degrades on the same contract while the board goes green.

## Part 2 — the weak-feedback resolver (pass v5) + the correlated algebra fix

The completeness follow-on ("a 2-cycle where both edges are Weak, or an SCC of size ≥3 with breakable edges — map and handle all invariants and cases"):

- **`CycleResolution.weakFeedbackStrategy`** (retires the asymmetric-2-cycle heuristic): find a cycle (deterministic DFS); every edge non-Weak → refuse **naming exactly that cycle**; else break the smallest Weak edge on it and repeat until acyclic. The complete case map is the docstring table; invariants are FsCheck-property-tested: **I1** broken ⊆ Weak ⊆ phase-2-deferrable; **I2** acyclic on resolve; **I3** refuse ⟺ an all-strong cycle exists; **I4** input-order independence; **I5** a pure weak ring breaks exactly one edge. Symmetric-weak 2-cycles and weak-bearing SCCs of any size now resolve; single-weak 2-cycles and weak self-loops are byte-identical to v4.
- **The correlated catch the audit surfaced**: `UnbreakableCycleFks` judged *all* cycle members, but resolved SCCs deliberately stay in `Cycles` for deferral — so a resolved asymmetric 2-cycle's strong edge was flagged unbreakable and `executeGate` refused a load the proven order satisfies. `TopologicalOrder.unresolvedCycleMembers` (`BreakableEdges = []` discriminant) now feeds unsatisfiability; `cycleMembers` still feeds deferral. The algebra: resolved → strong edges satisfied by ORDER, weak by DEFERRAL; unresolved → nullable defers, non-nullable is the named refusal.
- **V1's manual cycle-ordering override deliberately not carried** (`CircularDependencyOptions` disables automatic detection wholesale and keys on espace-fragile physical names): deferred with a named trigger in the DECISIONS Active-deferrals index — a cycle whose breakability is not schema-inferable. Cascade edges stay unbreakable (V1's conservative rule), even when nullable.

## Unchanged by design

Synthetic loads (whole estate), full non-reconciling transfers (identity scope, property-pinned), `subsetEscapeGate`, gate precedence, `SelfLoopPolicy`/`JunctionDeferral`.

## Tests

Pure: `TransferScopeTests`, `CycleResolutionTests` (case map + I1–I5 properties), `TopologicalOrderPassTests` v5 flips, `DataLoadPlanTests` resolved/unresolved split, `PreflightTests` probed-object precedence incl. DENY-under-database-grant, `CapabilitySurveyTests` re-pinned with Update. Docker: unrelated-cycle green board, `ObjectScopeDml` cell, both G1 promotions, chunk-resume crash witness preserved. Release-configuration build verified (FS3511). Full-sweep verdict lands in readiness-log Entries 25–26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m