### PR TITLE
Go board forecast: before→after data table, evidence-backed reconcile proposals, --sql plan preview

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26836,3 +26836,52 @@ satisfiable + no unbreakable; unresolved → the named diagnostic),
 `DataEmissionComposerTests` (the unresolvable fixture moved to
 nullable+Restrict — strength Other with deferrable columns, preserving
 both the Alphabetical premise and the phase-2 partition law).
+
+## 2026-07-07 — The go-board data forecast: before→after table, evidence-backed reconcile proposals, and the `--sql` plan preview
+
+**Decision.** Three semantic additions to the go board (operator-requested;
+`PARTIAL_TRANSFER_READINESS_LOG.md` Entry 27):
+
+1. **`TransferReport.Plan : DataLoadPlan option`** — the dry run's built
+   plan rides the report (`Some` on DryRun's materialized/synthetic/golden
+   legs; `None` on Execute — never retain estate-scale rows past the run —
+   and on the streaming preview, whose plan carries no rows). It exists so
+   preview surfaces derive forecasts and text realizations WITHOUT
+   re-ingesting. **`KindOutcome.RowsMatched`** carries a reconciled kind's
+   measured match count (the remap's per-kind bindings) — `RowsIngested`
+   stays 0-by-design for reconciled kinds, and the forecast's "match"
+   column must be a measurement, not an inference.
+2. **`GoBoard.ForecastLine` / `forecastTable`** (pure) render the
+   before→after table: `after = before − deletes + adds`; an unprobed count
+   renders `?` and poisons the TOTAL (never a silent 0). The face joins the
+   plan against live sink counts on a short-lived connection; WipeAndLoad
+   deletes ride the SAME `TransferResume.wipeTargets` walk the live wipe
+   takes.
+3. **`PeerTransfer.probeReconcileEvidence` / `narrateEvidence`** — each
+   escaping target's candidate reconcile columns (unique-index-backed,
+   then name-shaped TEXT attributes when no index nominates, ≤3 per
+   target) probed live: sink uniqueness + a bounded 200-value
+   parameterized sample matched into the sink; verdicts are total
+   (`Probed` strength ladder / `Unprobed reason`). **`Transfer
+   .plannedSqlPreview`** (pure) renders the same plan through
+   `StaticSeedsEmitter.emitFromPlan` — the `SliceApplyRun.emit`
+   composition: child-first wipe under replace, phase-1 in plan order,
+   phase-2 re-points — behind the new `check go <flow> --sql` opt-in,
+   written to `go-board/<flow>.planned.sql`.
+
+**Also.** The `check go` positional filter counted a value-bearing flag's
+value token as a positional (`--format json` refused as "two flow names");
+the walk now skips `--format`'s value.
+
+**Why.** The board previously narrated row counts as prose — the operator
+had to derive the target's end state. Confidence to execute comes from the
+change STATED (a table with a TOTAL row), proposals PROVEN (live evidence,
+not name-shape guesses), and the DML READABLE before authorization. All
+three reuse existing algebra (the plan carrier, the wipe walk, the A35/A36
+realization sibling) — no new write-plane semantics.
+
+**Witnesses.** `PeerTransferTests` (forecast arithmetic/alignment/
+`?`-poisoning; `plannedSqlPreview` wipe order + loadSet scoping +
+Incremental-no-wipe; `narrateEvidence` strength ladder);
+`GoBoardDockerTests` red/green/red extended (evidence lines, the table,
+the `--sql` artifact content, on the live managed-grant pair).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1080,3 +1080,63 @@ resolver-v5 witnesses all aboard, and the Release-configuration build verified
 The go board and the engine now judge the same effective transfer graph, and
 cycle handling is total over its case space with the correlated
 deferral/unsatisfiability algebra property-pinned.
+
+## Entry 27 — 2026-07-07, THE FORECAST TABLE: the board states the data change (before → after), proves its reconcile proposals, and previews the SQL
+
+**Operator request:** the forecast "gestures indirectly" at the data change —
+show the planned before and after of the target environment side by side;
+strengthen the automatic reconcile suggestions; add an option to preview the
+planned SQL.
+
+**The forecast item is now a table.** The dry run's report carries its
+`DataLoadPlan` (`TransferReport.Plan`, DryRun only — Execute never retains
+estate-scale rows past the run, and the streaming preview's plan carries no
+rows), and the face joins it against LIVE sink counts probed over a
+short-lived connection:
+
+```
+table                        before      +add     match      -del       after
+dbo.OSUSR_XABC_CUSTOMER           0         2         -         0           2
+dbo.OSUSR_XDEF_CITY               2         0         2         0           2   reconciled — matched to existing sink rows, no insert
+TOTAL                             2         2         2         0           4
+```
+
+`after = before − deletes + adds`, per row and in TOTAL; a count that will
+not probe renders `?` and poisons the totals (never a silent 0); a
+WipeAndLoad kind's `-del` is its live before-count (the wipe), scoped by the
+same `TransferResume.wipeTargets` walk the live wipe takes. `KindOutcome`
+gained `RowsMatched` (the remap's per-kind bindings) so a reconciled kind's
+"match" column is the measured match count, not an inference.
+
+**Reconcile proposals now carry LIVE evidence.** Each escaping target's
+candidate columns — the sink's single-column unique indexes, then
+name-shaped text attributes (`Name`/`Code`/`Email`/…) when no index
+nominates one, at most three per target — are probed against the actual
+pair: sink uniqueness (`COUNT` vs `COUNT DISTINCT`) plus a bounded sample
+(200 distinct source values, parameterized) matched into the sink. The
+relationships red item's detail now reads
+`evidence: reconcile 'AppCore.City:Name' (unique-indexed on the sink) —
+sink-unique; 2/2 sampled source value(s) found in the sink: a STRONG
+candidate.` — the operator pastes a PROVEN rule. A probe that cannot run is
+a NAMED `Unprobed` verdict; a pair that will not open degrades to the
+static proposals, named.
+
+**`check go <flow> --sql` writes the planned SQL.** `Transfer
+.plannedSqlPreview` renders the SAME plan the dry run built through
+`StaticSeedsEmitter.emitFromPlan` (the A35/A36 text-realization sibling of
+the live bulk lanes, the `SliceApplyRun.emit` composition): the child-first
+wipe DELETEs under strategy replace, phase-1 MERGEs in FK-safe plan order,
+then the phase-2 deferred-FK re-points — written to
+`go-board/<flow>.planned.sql` with a header naming the contract
+(AssignedBySink keys mint at run time; the artifact's values are the plan's
+source-side keys, shown for shape). An advisory board line names the path.
+
+**Also caught while here:** `check go golden --format json` REFUSED — the
+positional filter counted a value-bearing flag's value token (`json`) as a
+second flow name. The positional walk now skips `--format`'s value.
+
+**Proven:** pure — `PeerTransferTests` (forecast-table arithmetic/alignment/
+`?`-poisoning, `plannedSqlPreview` wipe order + loadSet scoping + no wipe
+under Incremental, `narrateEvidence` strength ladder); docker — the
+red/green/red board now asserts the evidence lines (STRONG, 2/2 sampled),
+the before→after table, and the `--sql` artifact's content on the live pair.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1028,7 +1028,7 @@ reconciled-edge drop, full-transfer identity, planned-write verbs;
 the unrelated-cycle board goes GREEN while the unscoped topology provably
 degrades on the same contract; `PeerManagedGrantTransferDockerTests` — the new
 OBJECT-scope-DML cell lands the subset with zero grant violations and no
-database-scope DML at all; both G1 promotions). Full-sweep verdict below.
+database-scope DML at all; both G1 promotions).
 
 ## Entry 26 — 2026-07-07, THE WEAK-FEEDBACK RESOLVER (v5): cycle handling made total, and the resolved-cycle refusal bug the audit caught
 
@@ -1070,4 +1070,13 @@ unprobed (database-scope fallback), and the chunk-resume crash witness holds.
 `TopologicalOrderPassTests` (v5 flips), `DataLoadPlanTests` (resolved →
 satisfiable; unresolved → named diagnostic), `DataEmissionComposerTests`
 (unresolvable fixture moved to nullable+Restrict, preserving both premises);
-full fast pool green. Full-sweep verdict below.
+full fast pool green.
+
+**Final verdict (Entries 25 + 26 together):** the full sweep PASSED IN FULL —
+fast pool 3965/3965 (35s), docker pool 293/293 (572s), scale pool 16/16 (96s),
+with the scope-parity, object-scope-grant, G1-promotion, unrelated-cycle, and
+resolver-v5 witnesses all aboard, and the Release-configuration build verified
+(the FS3511 witness caught and fixed the probe-loop shape before it shipped).
+The go board and the engine now judge the same effective transfer graph, and
+cycle handling is total over its case space with the correlated
+deferral/unsatisfiability algebra property-pinned.

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -630,7 +630,7 @@ let runPeerTransfer
     // forecast, with the red/green verdict).
     if not executeRequested then
         printfn ""
-        printfn "The go board (open decisions + row forecast + red/green verdict): projection check go <flow>"
+        printfn "The go board (open decisions + before→after forecast + red/green verdict): projection check go <flow>  [--sql writes the planned T-SQL]"
 
     // The shared contract-pair body: realization selector, execute/journal
     // gates, apparatus, engine run, narration — identical to the reverse leg,
@@ -791,16 +791,16 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
 // board is CI-able.
 // ---------------------------------------------------------------------------
 
-let private probeCount (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : int =
+let private probeCount (cnn: Microsoft.Data.SqlClient.SqlConnection) (sql: string) : int64 =
     use cmd = cnn.CreateCommand()
     cmd.CommandText <- sql
-    System.Convert.ToInt32 (cmd.ExecuteScalar())
+    System.Convert.ToInt64 (cmd.ExecuteScalar())
 
 let runCheckGo
     // Same contract-read scope as `runPeerTransfer` — the go board must
     // forecast with the contracts the live run will actually read.
     (contractScope: MetadataSnapshotRunner.SnapshotParameters)
-    (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (planned: PlanAction) : int =
+    (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (emitSql: bool) (planned: PlanAction) : int =
     let finish (items: GoBoard.Item list) : int =
         let board : GoBoard.Board = { Flow = flowName; From = fromLabel; To = toLabel; Items = items }
         if asJson then printfn "%s" (GoBoard.toJsonString board)
@@ -879,9 +879,26 @@ let runCheckGo
             | Some s -> PeerTransfer.escapingFks sourceContract s reconciledKeys
             | None -> []
         if not (List.isEmpty escapes) then
+            // Live reconcile EVIDENCE (2026-07-07): each proposed reconcile
+            // column, probed against the actual pair — sink uniqueness + a
+            // sampled source→sink value match — so the operator pastes a
+            // PROVEN rule, not a guess. A pair that will not open degrades
+            // to the static (shape-derived) proposals, named.
+            let evidenceLines =
+                match (ConnectionSpec.openSpec SubstrateRole.Source "check-go-evidence-source" sourceSpec).GetAwaiter().GetResult() with
+                | Error _ -> [ "evidence: the source connection would not open — the proposals above are shape-derived only." ]
+                | Ok source ->
+                    use source = source
+                    match (ConnectionSpec.openSpec SubstrateRole.Sink "check-go-evidence-sink" sinkSpec).GetAwaiter().GetResult() with
+                    | Error _ -> [ "evidence: the sink connection would not open — the proposals above are shape-derived only." ]
+                    | Ok sink ->
+                        use sink = sink
+                        PeerTransfer.probeReconcileEvidence source sink sourceContract sinkContract escapes
+                        |> PeerTransfer.narrateEvidence
+                        |> List.map (sprintf "evidence: %s")
             items.Add (GoBoard.itemWith "relationships"
                 (GoBoard.Status.Red (sprintf "%d relationship(s) escape the subset — each needs a decision." escapes.Length, "add the proposed reconcile entr(ies) to the flow, or widen `tables`; then re-run."))
-                (PeerTransfer.narrateEscapes escapes))
+                (PeerTransfer.narrateEscapes escapes @ evidenceLines))
         else
             items.Add (GoBoard.item "relationships" (GoBoard.Status.Green "every relationship the subset touches is inside it or reconciled."))
         // -- load order (the EFFECTIVE transfer graph, 2026-07-07) -----------
@@ -927,13 +944,84 @@ let runCheckGo
                     (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
             | Ok report ->
                 let nm = nameOf report.Names
+                // The BEFORE → AFTER table (2026-07-07, the go-board
+                // forecast program): live sink counts beside the plan's
+                // adds / matches / deletes — the data change STATED, not
+                // gestured at. A short-lived sink connection probes
+                // `before`; a count that will not probe renders `?`,
+                // never a silent 0.
+                let wipeSet =
+                    match report.Plan with
+                    | Some plan when opts.Emission = EmissionMode.WipeAndLoad ->
+                        TransferResume.wipeTargets plan topo loadSet |> Set.ofList
+                    | _ -> Set.empty
+                let before : Map<SsKey, int64 option> =
+                    let keys = report.Kinds |> List.map (fun k -> k.Kind)
+                    match (ConnectionSpec.openSpec SubstrateRole.Sink "check-go-forecast" sinkSpec).GetAwaiter().GetResult() with
+                    | Error _ -> keys |> List.map (fun k -> k, None) |> Map.ofList
+                    | Ok cnn ->
+                        use cnn = cnn
+                        keys
+                        |> List.map (fun key ->
+                            match Catalog.tryFindKind key sinkContract with
+                            | None -> key, None
+                            | Some k ->
+                                key,
+                                (try Some (probeCount cnn (sprintf "SELECT COUNT_BIG(*) FROM [%s].[%s];" (TableId.schemaText k.Physical) (TableId.tableText k.Physical)))
+                                 with _ -> None))
+                        |> Map.ofList
+                let dropsByKind = report.SkippedReferences |> List.countBy fst |> Map.ofList
                 let forecastLines =
                     report.Kinds
-                    |> List.filter (fun k -> k.RowsIngested > 0 || k.Disposition = IdentityDisposition.ReconciledByRule)
-                    |> List.map (fun k -> sprintf "%s: %d row(s) will transfer (%s)" (nm k.Kind) k.RowsIngested (dispositionName k.Disposition))
+                    |> List.choose (fun k ->
+                        let beforeN = before |> Map.tryFind k.Kind |> Option.flatten
+                        let reconciled = k.Disposition = IdentityDisposition.ReconciledByRule
+                        let wiped = Set.contains k.Kind wipeSet
+                        let deletes = if wiped then (beforeN |> Option.defaultValue 0L) else 0L
+                        let drops = dropsByKind |> Map.tryFind k.Kind |> Option.defaultValue 0
+                        let note =
+                            [ if reconciled then yield "reconciled — matched to existing sink rows, no insert"
+                              if not (Set.isEmpty k.DeferredFkColumns) then yield sprintf "%d FK column(s) re-point in phase 2" (Set.count k.DeferredFkColumns)
+                              if drops > 0 then yield sprintf "%d row(s) drop (unmatched reference)" drops
+                              if wiped && Option.isNone beforeN then yield "wiped first (count unprobed)" ]
+                            |> String.concat "; "
+                        let table =
+                            match Catalog.tryFindKind k.Kind sinkContract with
+                            | Some kd -> sprintf "%s.%s" (TableId.schemaText kd.Physical) (TableId.tableText kd.Physical)
+                            | None -> nm k.Kind
+                        let line : GoBoard.ForecastLine =
+                            { Table   = table
+                              Before  = beforeN
+                              Adds    = int64 k.RowsIngested
+                              Matches = (if reconciled then Some (int64 k.RowsMatched) else None)
+                              Deletes = deletes
+                              Note    = note }
+                        if line.Adds > 0L || line.Deletes > 0L || reconciled || (wiped && Option.isNone beforeN)
+                        then Some line else None)
                 items.Add (GoBoard.itemWith "forecast"
-                    (GoBoard.Status.Green (sprintf "dry run complete — %d row(s) across %d table(s) would transfer." (report.Kinds |> List.sumBy (fun k -> k.RowsIngested)) (report.Kinds |> List.filter (fun k -> k.RowsIngested > 0) |> List.length)))
-                    forecastLines)
+                    (GoBoard.Status.Green (sprintf "dry run complete — %d row(s) across %d table(s) would transfer; before → after below." (report.Kinds |> List.sumBy (fun k -> k.RowsIngested)) (report.Kinds |> List.filter (fun k -> k.RowsIngested > 0) |> List.length)))
+                    (GoBoard.forecastTable forecastLines))
+                // THE PLANNED SQL (`--sql`, 2026-07-07): the dry run's plan
+                // rendered as the text realization's T-SQL and written
+                // beside the board — the exact DML shape, readable before
+                // anyone authorizes the run.
+                if emitSql then
+                    match report.Plan with
+                    | None ->
+                        items.Add (GoBoard.item "planned sql"
+                            (GoBoard.Status.Advisory "--sql: this dry run carried no materialized plan — no artifact written."))
+                    | Some plan ->
+                        match Transfer.plannedSqlPreview opts.Emission loadSet sinkContract topo plan with
+                        | Error errors ->
+                            items.Add (GoBoard.itemWith "planned sql"
+                                (GoBoard.Status.Advisory "--sql: the plan did not render to T-SQL — the live run is unaffected.")
+                                (errors |> List.map (fun e -> e.Message)))
+                        | Ok sql ->
+                            let path = System.IO.Path.Combine ("go-board", sprintf "%s.planned.sql" flowName)
+                            System.IO.Directory.CreateDirectory "go-board" |> ignore
+                            System.IO.File.WriteAllText (path, sql)
+                            items.Add (GoBoard.item "planned sql"
+                                (GoBoard.Status.Advisory (sprintf "written to %s — the wipe (if any), phase-1 inserts, then phase-2 FK re-points; AssignedBySink keys mint at run time." path)))
                 if not (List.isEmpty report.UnbreakableCycleFks) then
                     items.Add (GoBoard.itemWith "cycles"
                         (GoBoard.Status.Red (sprintf "%d relationship cycle(s) cannot be broken — the load cannot run as planned." report.UnbreakableCycleFks.Length, "make the cycle's FK columns nullable, or exclude the affected kinds."))

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -304,7 +304,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
             { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
     | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
-    | PlanAction.CheckGo (flowName, fromLabel, toLabel, asJson, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo (SnapshotScopeBinding.fromModel shaping.Model) flowName fromLabel toLabel asJson planned)
+    | PlanAction.CheckGo (flowName, fromLabel, toLabel, asJson, emitSql, planned) -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo (SnapshotScopeBinding.fromModel shaping.Model) flowName fromLabel toLabel asJson emitSql planned)
     | PlanAction.RevertScript (script, envLabel, connSpec, go, force) -> shellRun "projection revert" (if go then Shell.Go else Shell.ReadOnly) (fun () -> runRevertScript script envLabel connSpec go force)
     // explain ------------------------------------------------------------
     | PlanAction.ExplainDiff (a, b, asJson, depthOpt, channel, onlyModule) ->

--- a/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
+++ b/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
@@ -102,6 +102,64 @@ module GoBoard =
         w.Flush()
         System.Text.Encoding.UTF8.GetString(ms.ToArray())
 
+    /// One row of the BEFORE → AFTER data forecast (2026-07-07, the
+    /// go-board forecast program): what the sink table holds now, what the
+    /// planned run adds / matches / deletes, and what it holds after —
+    /// derived from the dry run's plan + live sink counts, never guessed.
+    type ForecastLine =
+        { /// Sink physical coordinate (`schema.table`).
+          Table   : string
+          /// Live sink row count before the run (`None` when the probe
+          /// could not run — rendered `?`, never silently 0).
+          Before  : int64 option
+          /// Rows the run INSERTs (post-drop).
+          Adds    : int64
+          /// For a reconciled kind: source rows matched to EXISTING sink
+          /// rows (no insert). `None` for non-reconciled kinds.
+          Matches : int64 option
+          /// Rows the run DELETEs first (the wipe, under strategy replace).
+          Deletes : int64
+          /// The note column: disposition, phase-2 re-points, drops.
+          Note    : string }
+
+    [<RequireQualifiedAccess>]
+    module ForecastLine =
+
+        let after (l: ForecastLine) : int64 option =
+            l.Before |> Option.map (fun b -> b - l.Deletes + l.Adds)
+
+    /// Render the forecast lines as one aligned BEFORE → AFTER table
+    /// (pure; the face supplies probed counts). Numbers right-aligned;
+    /// a totals row closes the table; `?` marks an unprobed count.
+    let forecastTable (lines: ForecastLine list) : string list =
+        if List.isEmpty lines then []
+        else
+            let num (v: int64 option) = match v with Some n -> string n | None -> "?"
+            let width =
+                lines |> List.map (fun l -> l.Table.Length) |> List.max |> max (String.length "table")
+            let row (table: string) (before: string) (adds: string) (matches: string) (deletes: string) (after: string) (note: string) =
+                sprintf "%-*s  %10s  %8s  %8s  %8s  %10s  %s" width table before adds matches deletes after note
+            let total (f: ForecastLine -> int64 option) =
+                lines |> List.fold (fun acc l -> match acc, f l with Some a, Some v -> Some (a + v) | _ -> None) (Some 0L)
+            [ yield row "table" "before" "+add" "match" "-del" "after" ""
+              for l in lines do
+                  yield row
+                      l.Table
+                      (num l.Before)
+                      (string l.Adds)
+                      (match l.Matches with Some m -> string m | None -> "-")
+                      (string l.Deletes)
+                      (num (ForecastLine.after l))
+                      l.Note
+              yield row
+                  "TOTAL"
+                  (num (total (fun l -> l.Before)))
+                  (string (lines |> List.sumBy (fun l -> l.Adds)))
+                  (string (lines |> List.sumBy (fun l -> l.Matches |> Option.defaultValue 0L)))
+                  (string (lines |> List.sumBy (fun l -> l.Deletes)))
+                  (num (total ForecastLine.after))
+                  "" ]
+
     /// Render the board as operator-facing lines: the mark column, the axis,
     /// the headline; detail lines indented beneath; the verdict at the close
     /// with the next move named.

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -527,12 +527,14 @@ type PlanAction =
     /// script path, the environment label (display), the RESOLVED conn
     /// spec, and the per-run intent flag.
     | RevertScript of script: string * envLabel: string * connSpec: string * go: bool * force: bool
-    /// `check go <flow>` — THE GO BOARD (2026-07-06, the preview-engine
-    /// program): the red/green go-readiness checklist for a data flow. The
-    /// action carries the flow's coordinates + the PLANNED action the flow
-    /// would run (the same `planFlow` derivation a real run takes, under
-    /// preview opts), so the board judges exactly what `--go` would execute.
-    | CheckGo of flow: string * fromLabel: string * toLabel: string * asJson: bool * planned: PlanAction
+    /// `check go <flow> [--sql]` — THE GO BOARD (2026-07-06, the
+    /// preview-engine program): the red/green go-readiness checklist for a
+    /// data flow. The action carries the flow's coordinates + the PLANNED
+    /// action the flow would run (the same `planFlow` derivation a real
+    /// run takes, under preview opts), so the board judges exactly what
+    /// `--go` would execute. `emitSql` (the `--sql` opt-in, 2026-07-07)
+    /// additionally writes the dry run's plan as a T-SQL preview artifact.
+    | CheckGo of flow: string * fromLabel: string * toLabel: string * asJson: bool * emitSql: bool * planned: PlanAction
     // explain ------------------------------------------------------------
     | ExplainDiff of refA: string * refB: string * asJson: bool * depth: int option * channel: string option * onlyModule: string option
     | Compare of refA: string * refB: string * asJson: bool

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -1724,7 +1724,18 @@ module Command =
                 // planning path a real run takes (preview opts), so the board
                 // judges exactly what `--go` would execute (A44: the check
                 // and the run cannot drift).
-                match rest |> List.filter (fun a -> not (a.StartsWith "--")) with
+                // Positionals skip flags AND a value-bearing flag's value
+                // token (`--format json` previously counted `json` as a
+                // second positional and refused; caught 2026-07-07).
+                let positionals =
+                    let rec walk (args: string list) =
+                        match args with
+                        | [] -> []
+                        | a :: _ :: tl when a = "--format" -> walk tl
+                        | a :: tl when a.StartsWith "--" -> walk tl
+                        | a :: tl -> a :: walk tl
+                    walk rest
+                match positionals with
                 | [ flowName ] ->
                     match Map.tryFind flowName cfg.Flows with
                     | None ->
@@ -1739,9 +1750,10 @@ module Command =
                             match rest |> List.pairwise |> List.tryFind (fun (a, _) -> a = "--format") with
                             | Some (_, v) -> v = "json"
                             | None -> false
-                        PlanAction.CheckGo (flowName, fromLabel, flow.To, asJson, (planFlow cfg flow previewOpts).Action)
+                        let emitSql = List.contains "--sql" rest
+                        PlanAction.CheckGo (flowName, fromLabel, flow.To, asJson, emitSql, (planFlow cfg flow previewOpts).Action)
                 | _ ->
-                    PlanAction.Refused (2, err "cli.check.goArgs" "projection check go: requires exactly one flow name (projection check go <flow>).")
+                    PlanAction.Refused (2, err "cli.check.goArgs" "projection check go: requires exactly one flow name (projection check go <flow> [--sql] [--format json]).")
             | "shape" :: _ ->
                 match cfg.Readiness with
                 | None ->

--- a/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
+++ b/sidecar/projection/src/Projection.Pipeline/PeerTransfer.fs
@@ -7,6 +7,7 @@ namespace Projection.Pipeline
 //   pure-core / I/O-one-layer-up split.
 
 open System.Threading.Tasks
+open Microsoft.Data.SqlClient
 open Projection.Core
 open Projection.Adapters.OssysSql
 
@@ -333,3 +334,144 @@ module PeerTransfer =
                         escapes.Length
                         (String.concat " " (narrateEscapes escapes))))
         else Result.success ()
+
+    // ------------------------------------------------------------------
+    // Reconcile-candidate EVIDENCE (2026-07-07, the go-board forecast
+    // program): each proposed reconcile column, validated against the
+    // LIVE pair — is the column unique on the sink (the duplicate-key
+    // tiebreaker never fires), and do the source's ACTUAL values find
+    // sink rows? Read-only scalar counts plus a bounded sample; a probe
+    // that cannot run degrades to a NAMED `Unprobed` verdict, never a
+    // crash and never silence.
+    // ------------------------------------------------------------------
+
+    /// Distinct source values sampled per candidate column — bounded so
+    /// the probe stays cheap on an estate-scale table, and far under the
+    /// 2100-parameter cap the match query spends them against.
+    [<Literal>]
+    let private EvidenceSampleCap = 200
+
+    [<RequireQualifiedAccess>]
+    type EvidenceVerdict =
+        /// The probe ran: sink uniqueness over non-null values + how many
+        /// sampled distinct source values found a sink row.
+        | Probed of sinkUnique: bool * sampleHits: int * sampleSize: int
+        /// The probe could not run — the reason is named, never silent.
+        | Unprobed of reason: string
+
+    /// One candidate reconcile column's live evidence.
+    type ReconcileEvidence =
+        { Target      : SsKey
+          /// `Module.Entity` — the resolvable, paste-able reconcile form.
+          TargetRef   : string
+          Column      : Name
+          /// Nominated by a single-column unique sink index (the
+          /// detector's candidates) vs proposed by name shape alone.
+          IndexBacked : bool
+          Verdict     : EvidenceVerdict }
+
+    let private sampleSourceValues (source: SqlConnection) (schema: string) (table: string) (col: string) : obj list =
+        use cmd = source.CreateCommand()
+        cmd.CommandText <- sprintf "SELECT DISTINCT TOP (%d) [%s] FROM [%s].[%s] WHERE [%s] IS NOT NULL;" EvidenceSampleCap col schema table col  // LINT-ALLOW: terminal SQL-text boundary; identifiers come from validated TableId/ColumnRealization coordinates
+        use r = cmd.ExecuteReader()
+        let rec read (acc: obj list) = if r.Read() then read (r.GetValue 0 :: acc) else List.rev acc
+        read []
+
+    /// `(non-null count, distinct count)` of the candidate column on the
+    /// sink — equal (and > 0) means the reconcile key never tiebreaks.
+    let private sinkUniqueness (sink: SqlConnection) (schema: string) (table: string) (col: string) : int64 * int64 =
+        use cmd = sink.CreateCommand()
+        cmd.CommandText <- sprintf "SELECT COUNT_BIG([%s]), COUNT_BIG(DISTINCT [%s]) FROM [%s].[%s];" col col schema table  // LINT-ALLOW: terminal SQL-text boundary; identifiers come from validated coordinates
+        use r = cmd.ExecuteReader()
+        if r.Read() then r.GetInt64 0, r.GetInt64 1 else 0L, 0L
+
+    /// How many of the sampled source values exist on the sink —
+    /// parameterized VALUES row set, one round trip.
+    let private sinkSampleHits (sink: SqlConnection) (schema: string) (table: string) (col: string) (values: obj list) : int =
+        if List.isEmpty values then 0
+        else
+            use cmd = sink.CreateCommand()
+            let rows = values |> List.mapi (fun i _ -> sprintf "(@p%d)" i) |> String.concat ","
+            cmd.CommandText <- sprintf "SELECT COUNT_BIG(*) FROM (VALUES %s) AS v(x) WHERE EXISTS (SELECT 1 FROM [%s].[%s] WHERE [%s] = v.x);" rows schema table col  // LINT-ALLOW: terminal SQL-text boundary; values ride parameters, identifiers come from validated coordinates
+            values |> List.iteri (fun i v -> cmd.Parameters.AddWithValue(sprintf "@p%d" i, v) |> ignore)
+            System.Convert.ToInt32 (cmd.ExecuteScalar())
+
+    /// The name shapes that make a non-PK TEXT attribute a plausible
+    /// business key when no unique index nominates one. Heuristic
+    /// candidates are always PROBED before proposed, and the narration
+    /// marks them "no unique index" — the evidence, not the name, carries
+    /// the recommendation.
+    let private nameShapedCandidate (a: Attribute) : bool =
+        not a.IsPrimaryKey
+        && a.Type = PrimitiveType.Text
+        && (let n = (Name.value a.Name).ToLowerInvariant()
+            [ "name"; "code"; "email"; "username"; "login"; "key"; "label"; "abbreviation"; "identifier"; "number" ]
+            |> List.exists (fun shape -> n = shape || n.EndsWith shape))
+
+    /// Probe live evidence for each escaping target's candidate reconcile
+    /// columns (index-backed first, then name-shaped; at most three per
+    /// target). Synchronous scalar reads on the two open connections —
+    /// the go board's short-lived probe pair.
+    let probeReconcileEvidence
+        (source: SqlConnection)
+        (sink: SqlConnection)
+        (sourceContract: Catalog)
+        (sinkContract: Catalog)
+        (escapes: EscapingFk list)
+        : ReconcileEvidence list =
+        escapes
+        |> List.distinctBy (fun e -> e.Target)
+        |> List.collect (fun e ->
+            match Catalog.tryFindKind e.Target sourceContract, Catalog.tryFindKind e.Target sinkContract with
+            | Some srcKind, Some sinkKind ->
+                let heuristic =
+                    sinkKind.Attributes
+                    |> List.filter nameShapedCandidate
+                    |> List.map (fun a -> a.Name)
+                    |> List.filter (fun n -> not (List.contains n e.CandidateReconcileColumns))
+                    |> List.sortBy Name.value
+                let targetRef = sprintf "%s.%s" (Name.value e.TargetModule) (Name.value e.TargetName)
+                ((e.CandidateReconcileColumns |> List.map (fun c -> c, true))
+                 @ (heuristic |> List.map (fun c -> c, false)))
+                |> List.truncate 3
+                |> List.map (fun (col, indexBacked) ->
+                    let verdict =
+                        match srcKind.Attributes |> List.tryFind (fun a -> a.Name = col),
+                              sinkKind.Attributes |> List.tryFind (fun a -> a.Name = col) with
+                        | Some srcAttr, Some sinkAttr ->
+                            try
+                                let sample =
+                                    sampleSourceValues source
+                                        (TableId.schemaText srcKind.Physical) (TableId.tableText srcKind.Physical)
+                                        (ColumnRealization.columnNameText srcAttr.Column)
+                                let kSchema, kTable = TableId.schemaText sinkKind.Physical, TableId.tableText sinkKind.Physical
+                                let kCol = ColumnRealization.columnNameText sinkAttr.Column
+                                let total, distinct = sinkUniqueness sink kSchema kTable kCol
+                                let hits = sinkSampleHits sink kSchema kTable kCol sample
+                                EvidenceVerdict.Probed (total = distinct && total > 0L, hits, sample.Length)
+                            with ex -> EvidenceVerdict.Unprobed ex.Message
+                        | _ -> EvidenceVerdict.Unprobed "the column is not present on both sides"
+                    { Target = e.Target; TargetRef = targetRef; Column = col; IndexBacked = indexBacked; Verdict = verdict })
+            | _ -> [])
+
+    /// The per-candidate evidence lines (operator-facing; the paste-able
+    /// move leads, the proof follows).
+    let narrateEvidence (evidence: ReconcileEvidence list) : string list =
+        evidence
+        |> List.map (fun ev ->
+            let paste = sprintf "reconcile '%s:%s'" ev.TargetRef (Name.value ev.Column)
+            let basis = if ev.IndexBacked then "unique-indexed on the sink" else "name-shaped, no unique index"
+            match ev.Verdict with
+            | EvidenceVerdict.Probed (sinkUnique, hits, size) ->
+                let uniq = if sinkUnique then "sink-unique" else "NOT sink-unique (duplicate values tiebreak to the oldest sink row)"
+                let sample =
+                    if size = 0 then "no non-null source values to sample"
+                    else sprintf "%d/%d sampled source value(s) found in the sink" hits size
+                let strength =
+                    if size = 0 then "unproven"
+                    elif hits < size then "PARTIAL — the unmatched source rows would halt a live reconcile"
+                    elif sinkUnique then "a STRONG candidate"
+                    else "a full match, but ambiguous"
+                sprintf "%s (%s) — %s; %s: %s." paste basis uniq sample strength
+            | EvidenceVerdict.Unprobed reason ->
+                sprintf "%s (%s) — the evidence probe could not run: %s" paste basis reason)

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -151,6 +151,10 @@ module Transfer =
             RowsIngested      : int
             DeferredFkColumns : Set<Name>
             RowsWritten       : int
+            /// For a `ReconciledByRule` kind: source rows MATCHED to
+            /// existing sink rows (the remap's bindings; no insert — the
+            /// forecast's "match" column). 0 for a non-reconciled kind.
+            RowsMatched       : int
         }
 
     type TransferReport =
@@ -193,6 +197,16 @@ module Transfer =
             /// `UnresolvedReference`s are not re-listed, only the verdict-bearing
             /// count is persisted in the progress marker).
             ReplayedPriorDrops  : int option
+            /// The built load plan, carried on a DRY RUN only (2026-07-07,
+            /// the go-board forecast program): the plan already exists in
+            /// memory at report time and lets the preview surface derive the
+            /// before/after forecast table and the planned-SQL text
+            /// realization (`StaticSeedsEmitter.emitFromPlan` — the A35/A36
+            /// sibling of the live realization) without re-ingesting.
+            /// `None` on Execute (never retain estate-scale rows past the
+            /// run) and on the STREAMING dry run (its plan carries no rows —
+            /// an empty-INSERT artifact would mislead).
+            Plan                : DataLoadPlan option
             /// NM-21 — the named `synthetic.fk.unsatisfiable` events σ raised:
             /// a non-nullable FK column forced to NULL because its synthetic
             /// parent pool was empty. Surfaced here so a DryRun preview (which
@@ -696,6 +710,53 @@ module Transfer =
             @ (if emission = EmissionMode.WipeAndLoad then [ write Preflight.Delete ] else []))
         |> List.distinct
 
+    /// The planned-SQL preview (2026-07-07, the go-board forecast program):
+    /// render the DRY RUN's load plan as the T-SQL a text realization would
+    /// execute — the wipe's child-first DELETEs (WipeAndLoad only, the same
+    /// `TransferResume.wipeTargets` order the live wipe walks), then every
+    /// kind's Phase-1 MERGE in FK-safe plan order, then the Phase-2
+    /// deferred-FK re-points. PURE — the same
+    /// `StaticSeedsEmitter.emitFromPlan` realization `SliceApplyRun.emit`
+    /// composes (A35/A36: the plan is the contract; realizations are
+    /// siblings). The live run executes the SAME plan through the
+    /// bulk-write lanes; AssignedBySink surrogates mint at run time (the
+    /// capture lane binds them), so the preview's values for those kinds
+    /// are the plan's source-side keys.
+    let plannedSqlPreview
+        (emission: EmissionMode)
+        (loadSet: Set<SsKey> option)
+        (catalog: Catalog)
+        (topo: TopologicalOrder)
+        (plan: DataLoadPlan)
+        : Result<string> =
+        match Projection.Targets.Data.StaticSeedsEmitter.emitFromPlan DataEmitOptions.defaults catalog Profile.empty plan with
+        | Error emitErr ->
+            Result.failureOf (ValidationError.create "transfer.plannedSql.emit" (sprintf "%A" emitErr))
+        | Ok artifact ->
+            let map = ArtifactByKind.toMap artifact
+            let order = plan.Loads |> List.map (fun l -> l.Kind)
+            let rendered (pick: Projection.Targets.Data.DataInsertScript -> string) =
+                order |> List.choose (fun k -> Map.tryFind k map |> Option.map pick)
+            let wipe =
+                if emission = EmissionMode.WipeAndLoad then
+                    let deletes =
+                        TransferResume.wipeTargets plan topo loadSet
+                        |> List.choose (fun k -> Catalog.tryFindKind k catalog)
+                        |> List.map (fun kind -> System.String.Concat("DELETE FROM ", Render.tableQualified kind.Physical, ";\n"))  // LINT-ALLOW: terminal SQL-text boundary; the table name is a validated TableId via Render.tableQualified
+                    match deletes with
+                    | [] -> []
+                    | ds -> ("-- The wipe (strategy replace): child-first, the same order the live run deletes in.\n" :: ds) @ [ "\n" ]
+                else []
+            let header =
+                String.concat "\n"
+                    [ "-- PLANNED SQL PREVIEW — rendered from the dry run's load plan; `check go` never executes it."
+                      "-- The live run carries this same plan through the bulk-write lanes: phase-1 inserts in"
+                      "-- FK-safe order, then the phase-2 deferred-FK re-points. AssignedBySink surrogates mint"
+                      "-- at run time (the capture lane binds them) — their values below are the plan's"
+                      "-- source-side keys, shown for shape."
+                      ""; "" ]
+            Ok (String.concat "" (header :: (wipe @ rendered (fun s -> s.RenderedPhase1) @ rendered (fun s -> s.RenderedPhase2))))
+
     /// G1 + G2 for an Execute transfer: probe both endpoints (connection
     /// liveness/credential) and the sink grant against the planned writes,
     /// refusing before any write. The grant evidence is captured PER PLANNED
@@ -780,7 +841,12 @@ module Transfer =
 
     // -- orchestration ------------------------------------------------------
 
-    let private reportKinds (mode: Mode) (plan: DataLoadPlan) : KindOutcome list =
+    /// Per-kind match count from the reconcile remap: the bindings a
+    /// `ReconciledByRule` kind carries (matched sink rows, no insert).
+    let private matchedOf (remap: SurrogateRemapContext) (kind: SsKey) : int =
+        remap.Assignments |> Map.tryFind kind |> Option.map Map.count |> Option.defaultValue 0
+
+    let private reportKinds (mode: Mode) (remap: SurrogateRemapContext) (plan: DataLoadPlan) : KindOutcome list =
         plan.Loads
         |> List.map (fun l ->
             // RowsIngested reflects the source-side count; for reconciled
@@ -788,12 +854,14 @@ module Transfer =
             // reconciled-kind set's source count IS the rows that became
             // the remap, not rows that get inserted. The operator-facing
             // distinction: `Rows.Length` is what would be written; for
-            // ReconciledByRule that's 0 by design.
+            // ReconciledByRule that's 0 by design — `RowsMatched` carries
+            // the matched count (the remap's bindings) instead.
             { Kind              = l.Kind
               Disposition       = l.Disposition
               RowsIngested      = l.Rows.Length
               DeferredFkColumns = l.DeferredFkColumns
-              RowsWritten       = (match mode with Execute -> l.Rows.Length | DryRun -> 0) })
+              RowsWritten       = (match mode with Execute -> l.Rows.Length | DryRun -> 0)
+              RowsMatched       = matchedOf remap l.Kind })
 
     /// The write-seam policy (Wave 3): the D10 `EmissionMode` (incremental MERGE
     /// vs operator-selected wipe-and-load) and the G10 resumability flag. The
@@ -1019,7 +1087,7 @@ module Transfer =
                 return
                     Result.success
                         { Mode                = mode
-                          Kinds               = reportKinds mode plan
+                          Kinds               = reportKinds mode reconciled.Remap plan
                           UnbreakableCycleFks = plan.UnbreakableCycleFks
                           UnmatchedIdentities = reconciled.Unmatched
                           AmbiguousIdentities = reconciled.Ambiguous
@@ -1031,6 +1099,7 @@ module Transfer =
                           ReplayedPriorDrops  = replayedPriorDrops
                           // NM-21 — only the σ path can raise these; ingested
                           // Transfer never draws against a synthetic pool.
+                          Plan                = (match mode with DryRun -> Some plan | Execute -> None)
                           SyntheticUnsatisfiableFks = []
                           Names = Catalog.nameIndex catalog }
         }
@@ -1216,7 +1285,7 @@ module Transfer =
                     return
                         Result.success
                             { Mode                = mode
-                              Kinds               = reportKinds mode plan
+                              Kinds               = reportKinds mode SurrogateRemapContext.empty plan
                               UnbreakableCycleFks = plan.UnbreakableCycleFks
                               UnmatchedIdentities = []
                               AmbiguousIdentities = []
@@ -1226,6 +1295,7 @@ module Transfer =
                               // Synthetic load has no resumable G10 envelope.
                               ReplayedPriorDrops  = None
                               // NM-21 — σ's named unsatisfiable-FK lineage.
+                              Plan                = (match mode with DryRun -> Some plan | Execute -> None)
                               SyntheticUnsatisfiableFks = syntheticDiags
                               Names = Catalog.nameIndex catalog }
         }
@@ -1319,7 +1389,7 @@ module Transfer =
                     return
                         Result.success
                             { Mode                = mode
-                              Kinds               = reportKinds mode plan
+                              Kinds               = reportKinds mode SurrogateRemapContext.empty plan
                               UnbreakableCycleFks = plan.UnbreakableCycleFks
                               UnmatchedIdentities = []
                               AmbiguousIdentities = []
@@ -1327,6 +1397,7 @@ module Transfer =
                               SkippedReferences   = plan.SkippedReferences @ writeSkips
                               CaptureLaneDescents = laneDescents
                               ReplayedPriorDrops  = None
+                              Plan                = (match mode with DryRun -> Some plan | Execute -> None)
                               SyntheticUnsatisfiableFks = []
                               Names = Catalog.nameIndex catalog }
         }
@@ -2021,7 +2092,8 @@ module Transfer =
                                           Disposition       = l.Disposition
                                           RowsIngested      = estimate
                                           DeferredFkColumns = l.DeferredFkColumns
-                                          RowsWritten       = 0 } :: acc
+                                          RowsWritten       = 0
+                                          RowsMatched       = matchedOf reconciled.Remap l.Kind } :: acc
                                 return List.rev acc
                             }
                         return
@@ -2037,6 +2109,7 @@ module Transfer =
                                   // Streaming DryRun: no G10 resumable replay.
                                   ReplayedPriorDrops  = None
                                   // NM-21 — streaming Transfer ingests source rows, not σ.
+                                  Plan                = None   // streaming plan carries no rows
                                   SyntheticUnsatisfiableFks = []
                                   Names = Catalog.nameIndex sourceContract }
                     else
@@ -2095,7 +2168,8 @@ module Transfer =
                                       Disposition       = l.Disposition
                                       RowsIngested      = t.Ingested
                                       DeferredFkColumns = l.DeferredFkColumns
-                                      RowsWritten       = t.Written })
+                                      RowsWritten       = t.Written
+                                      RowsMatched       = matchedOf reconciled.Remap l.Kind })
                             return
                                 Result.success
                                     { Mode                = mode
@@ -2111,6 +2185,7 @@ module Transfer =
                                       // own drops); no G10 marker replay here.
                                       ReplayedPriorDrops  = None
                                       // NM-21 — streaming Transfer ingests source rows, not σ.
+                                      Plan                = None   // streaming plan carries no rows
                                       SyntheticUnsatisfiableFks = []
                                       Names = Catalog.nameIndex sourceContract }
         }

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -65,6 +65,17 @@ module private GoBoardFixtures =
 
     let value (r: Result<'a>) : 'a = Result.value r
 
+    /// Run a board and capture what the operator would read (the render
+    /// goes to stdout) — the forecast-table / evidence assertions read it.
+    let captureBoard (f: unit -> int) : int * string =
+        let prior = System.Console.Out
+        use sw = new System.IO.StringWriter()
+        System.Console.SetOut sw
+        try
+            let exit = f ()
+            exit, sw.ToString()
+        finally System.Console.SetOut prior
+
     let countRows (cnn: Microsoft.Data.SqlClient.SqlConnection) (table: string) : System.Threading.Tasks.Task<int> =
         task {
             use cmd = cnn.CreateCommand()
@@ -114,12 +125,39 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
 
                         // 1. RED — subset [Customer], City escapes, no strategy.
-                        let red1 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] []))
+                        //    The escape's proposals now carry LIVE evidence
+                        //    (2026-07-07): each candidate reconcile column
+                        //    probed against the actual pair.
+                        let red1, redOut = GoBoardFixtures.captureBoard (fun () -> runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false false (planned (GoBoardFixtures.optsWith [ "Customer" ] [])))
                         Assert.Equal(5, red1)
+                        Assert.Contains("evidence: reconcile 'AppCore.City:Name'", redOut)
+                        Assert.Contains("sink-unique", redOut)          // Lisbon/Porto are distinct on the sink
+                        Assert.Contains("2/2 sampled source value(s) found in the sink", redOut)
+                        Assert.Contains("STRONG", redOut)
 
-                        // 2. GREEN — the SAME flow with the proposed reconcile.
-                        let green = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        // 2. GREEN — the SAME flow with the proposed
+                        //    reconcile; `--sql` writes the planned artifact
+                        //    and the forecast carries the before→after table.
+                        let sqlPath = System.IO.Path.Combine("go-board", "golden.planned.sql")
+                        if System.IO.File.Exists sqlPath then System.IO.File.Delete sqlPath
+                        let green, greenOut = GoBoardFixtures.captureBoard (fun () -> runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false true (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ])))
                         Assert.Equal(0, green)
+                        // The forecast table: the customer table appears with
+                        // its adds; the reconciled city appears with matches
+                        // and no insert; a TOTAL row closes the table.
+                        Assert.Contains("before", greenOut)
+                        Assert.Contains("OSUSR_XABC_CUSTOMER", greenOut)
+                        Assert.Contains("OSUSR_XDEF_CITY", greenOut)
+                        Assert.Contains("reconciled — matched to existing sink rows", greenOut)
+                        Assert.Contains("TOTAL", greenOut)
+                        // The planned-SQL artifact: written, and it carries
+                        // the sink-side DML shape the plan would realize.
+                        Assert.True(System.IO.File.Exists sqlPath, "--sql must write go-board/golden.planned.sql")
+                        let plannedSql = System.IO.File.ReadAllText sqlPath
+                        Assert.Contains("PLANNED SQL PREVIEW", plannedSql)
+                        Assert.Contains("OSUSR_XABC_CUSTOMER", plannedSql)
+                        Assert.Contains("alice@x", plannedSql)
+                        Assert.DoesNotContain("DELETE FROM", plannedSql)   // Incremental: no wipe section
 
                         // The board's dry run NEVER writes: the sink customer
                         // table is still empty after both boards.
@@ -133,7 +171,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         // attribute = blocking).
                         do! GoBoardFixtures.exec snk.Admin
                                 "DELETE FROM [dbo].[ossys_Entity_Attr] WHERE [Name] = N'LastName' AND [Entity_Id] = 1000;"
-                        let red2 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let red2 = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(5, red2)
                         return ()
                     }))
@@ -164,7 +202,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                         Assert.Equal(Projection.Core.Alphabetical, whole.Mode)
                         // ...and the board still goes GREEN for the subset.
                         let planned opts = PlanAction.TransferPeer (src.EngineConnStr, snk.EngineConnStr, opts, false)
-                        let green = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
+                        let green = runCheckGo MetadataSnapshotRunner.defaultParameters "golden" "cloud-qa" "cloud-uat" false false (planned (GoBoardFixtures.optsWith [ "Customer" ] [ "AppCore.City:Name" ]))
                         Assert.Equal(0, green)
                         return ()
                     }))

--- a/sidecar/projection/tests/Projection.Tests/NarrationDisplayTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NarrationDisplayTests.fs
@@ -65,7 +65,7 @@ let ``transfer load-plan narration names the table by Name (the report's Names i
     let kindK = SsKey.ossysOriginal (System.Guid("d0000000-0000-0000-0000-000000000006"))
     let report : Transfer.TransferReport =
         { Mode                     = Transfer.DryRun
-          Kinds                    = [ { Kind = kindK; Disposition = IdentityDisposition.AssignedBySink; RowsIngested = 5; DeferredFkColumns = Set.empty; RowsWritten = 5 } ]
+          Kinds                    = [ { Kind = kindK; Disposition = IdentityDisposition.AssignedBySink; RowsIngested = 5; DeferredFkColumns = Set.empty; RowsWritten = 5; RowsMatched = 0 } ]
           UnbreakableCycleFks      = []
           UnmatchedIdentities      = []
           AmbiguousIdentities      = []
@@ -73,6 +73,7 @@ let ``transfer load-plan narration names the table by Name (the report's Names i
           SkippedReferences        = []
           CaptureLaneDescents      = []
           ReplayedPriorDrops       = None
+          Plan                     = None
           SyntheticUnsatisfiableFks = []
           Names                    = Map.ofList [ kindK, "Orders" ] }
     let out = capture (fun () -> Faces.Transfer.narrateTransferReport report)

--- a/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/PeerTransferTests.fs
@@ -370,3 +370,86 @@ let ``classify: the peer gates carry their own exits (shape 5; subset-FK 9; ossy
     Assert.Equal((5, Preflight.ShapeDivergence), Preflight.classify "transfer.peer.shapeDivergence")
     Assert.Equal((9, Preflight.SubsetFkEscape), Preflight.classify "transfer.peer.subsetFkEscapes")
     Assert.Equal((6, Preflight.SchemaReadFailed), Preflight.classify "source.ossys.readFailed")
+
+// --- the go-board FORECAST table + planned-SQL preview + reconcile evidence ---
+// (2026-07-07, the go-board forecast program)
+
+[<Fact>]
+let ``GoBoard.ForecastLine.after: before - deletes + adds; unprobed stays unprobed`` () =
+    let line : GoBoard.ForecastLine =
+        { Table = "dbo.T"; Before = Some 10L; Adds = 5L; Matches = None; Deletes = 10L; Note = "" }
+    Assert.Equal(Some 5L, GoBoard.ForecastLine.after line)
+    Assert.Equal(None, GoBoard.ForecastLine.after { line with Before = None })
+
+[<Fact>]
+let ``GoBoard.forecastTable: header + rows + TOTAL; ? marks unprobed; - marks non-reconciled match; totals go unprobed when any row is`` () =
+    let lines : GoBoard.ForecastLine list =
+        [ { Table = "dbo.OSUSR_BBB_CUSTOMER"; Before = Some 10L; Adds = 5L;  Matches = None;    Deletes = 10L; Note = "wiped first" }
+          { Table = "dbo.OSUSR_BBB_CITY";     Before = Some 3L;  Adds = 0L;  Matches = Some 3L; Deletes = 0L;  Note = "reconciled" } ]
+    let t = GoBoard.forecastTable lines
+    Assert.Equal(4, List.length t) // header + 2 rows + TOTAL
+    let tokens (row: string) = row.Split([|' '|], System.StringSplitOptions.RemoveEmptyEntries)
+    Assert.Equal<string[]>([| "table"; "before"; "+add"; "match"; "-del"; "after" |], tokens t.[0])
+    Assert.Equal<string[]>([| "dbo.OSUSR_BBB_CUSTOMER"; "10"; "5"; "-"; "10"; "5"; "wiped"; "first" |], tokens t.[1])
+    Assert.Equal<string[]>([| "dbo.OSUSR_BBB_CITY"; "3"; "0"; "3"; "0"; "3"; "reconciled" |], tokens t.[2])
+    Assert.Equal<string[]>([| "TOTAL"; "13"; "5"; "3"; "10"; "8" |], tokens t.[3])
+    // an unprobed row renders ? and poisons the TOTAL's before/after (never a silent 0)
+    let withUnprobed = lines @ [ { Table = "dbo.OSUSR_BBB_ORDER"; Before = None; Adds = 7L; Matches = None; Deletes = 0L; Note = "" } ]
+    let t2 = GoBoard.forecastTable withUnprobed
+    Assert.Equal<string[]>([| "dbo.OSUSR_BBB_ORDER"; "?"; "7"; "-"; "0"; "?" |], tokens t2.[3])
+    Assert.Equal<string[]>([| "TOTAL"; "?"; "12"; "3"; "10"; "?" |], tokens t2.[4])
+    Assert.Empty(GoBoard.forecastTable [])
+
+[<Fact>]
+let ``Transfer.plannedSqlPreview: child-first wipe (loadSet-scoped), then phase-1 in plan order; the header names the contract`` () =
+    let topo = (Projection.Core.Passes.TopologicalOrderPass.runWith TreatAsCycle sinkCell).Value
+    let rowOf (ident: string) (values: (string * string) list) : StaticRow =
+        { Identifier = SsKey.synthesizedComposite "PEER_ROW" [ ident ] |> Result.value
+          Values     = values |> List.map (fun (k, v) -> nm k, v) |> Map.ofList }
+    let rows =
+        Map.ofList
+            [ kKey "City",     [ rowOf "c1" [ "Id", "1"; "Name", "Lisbon" ] ]
+              kKey "Customer", [ rowOf "u1" [ "Id", "1"; "Email", "a@b.c"; "CityId", "1" ] ] ]
+    let plan = DataLoadPlan.build sinkCell topo rows SurrogateRemapContext.empty
+    match Transfer.plannedSqlPreview EmissionMode.WipeAndLoad (Some (keys [ "City"; "Customer" ])) sinkCell topo plan with
+    | Error es -> Assert.Fail (es |> List.map (fun e -> e.Message) |> String.concat "; ")
+    | Ok sql ->
+        Assert.Contains("PLANNED SQL PREVIEW", sql)
+        // the wipe: child-first (Customer before City), scoped to the loadSet (no Order wipe)
+        let delCustomer = sql.IndexOf "DELETE FROM [dbo].[OSUSR_BBB_CUSTOMER]"
+        let delCity     = sql.IndexOf "DELETE FROM [dbo].[OSUSR_BBB_CITY]"
+        Assert.True(delCustomer >= 0 && delCity >= 0, "both wipe DELETEs present")
+        Assert.True(delCustomer < delCity, "the wipe deletes children before parents")
+        Assert.DoesNotContain("DELETE FROM [dbo].[OSUSR_BBB_ORDER]", sql)
+        // phase 1 follows the wipe, parents before children, rows realized
+        let insCity     = sql.IndexOf "OSUSR_BBB_CITY]"
+        Assert.Contains("Lisbon", sql)
+        Assert.True(delCity < sql.LastIndexOf "OSUSR_BBB_CITY", "the City load renders after the wipe")
+        Assert.True(sql.LastIndexOf "OSUSR_BBB_CITY" < sql.LastIndexOf "OSUSR_BBB_CUSTOMER", "phase 1 loads parents before children")
+        ignore insCity
+    // Incremental renders no wipe
+    match Transfer.plannedSqlPreview EmissionMode.Incremental (Some (keys [ "City"; "Customer" ])) sinkCell topo plan with
+    | Error es -> Assert.Fail (es |> List.map (fun e -> e.Message) |> String.concat "; ")
+    | Ok sql -> Assert.DoesNotContain("DELETE FROM", sql)
+
+[<Fact>]
+let ``PeerTransfer.narrateEvidence: the paste-able move leads; strength named; an unprobed candidate carries its reason`` () =
+    let ev (col: string) (indexBacked: bool) (verdict: PeerTransfer.EvidenceVerdict) : PeerTransfer.ReconcileEvidence =
+        { Target = kKey "City"; TargetRef = "AppCore.City"; Column = nm col; IndexBacked = indexBacked; Verdict = verdict }
+    let lines =
+        PeerTransfer.narrateEvidence
+            [ ev "Name"  true  (PeerTransfer.EvidenceVerdict.Probed (true, 12, 12))
+              ev "Label" false (PeerTransfer.EvidenceVerdict.Probed (false, 3, 12))
+              ev "Code"  true  (PeerTransfer.EvidenceVerdict.Probed (false, 12, 12))
+              ev "Alias" true  (PeerTransfer.EvidenceVerdict.Probed (true, 0, 0))
+              ev "Tag"   true  (PeerTransfer.EvidenceVerdict.Unprobed "login failed") ]
+    Assert.StartsWith("reconcile 'AppCore.City:Name'", lines.[0])
+    Assert.Contains("sink-unique", lines.[0])
+    Assert.Contains("12/12", lines.[0])
+    Assert.Contains("STRONG", lines.[0])
+    Assert.Contains("unique-indexed", lines.[0])
+    Assert.Contains("PARTIAL", lines.[1])
+    Assert.Contains("name-shaped", lines.[1])
+    Assert.Contains("ambiguous", lines.[2])
+    Assert.Contains("unproven", lines.[3])
+    Assert.Contains("could not run: login failed", lines.[4])

--- a/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
@@ -28,6 +28,7 @@ let private reportWithReplay (replayed: int option) : Transfer.TransferReport =
       SkippedReferences   = []
       CaptureLaneDescents = []
       ReplayedPriorDrops  = replayed
+      Plan                = None
       SyntheticUnsatisfiableFks = []
       Names = Map.empty }
 


### PR DESCRIPTION
## What

The go board's forecast now **states the planned data change** in the target environment instead of gesturing at it (operator request; `PARTIAL_TRANSFER_READINESS_LOG.md` Entry 27, `DECISIONS.md` 2026-07-07).

## The before→after table

The dry run's report now carries its built plan (`TransferReport.Plan : DataLoadPlan option` — DryRun only; Execute never retains estate-scale rows past the run, and the streaming preview's plan carries no rows), and `KindOutcome.RowsMatched` carries a reconciled kind's **measured** match count (the remap's per-kind bindings). The face joins the plan against live sink counts probed on a short-lived connection and renders them through the new pure `GoBoard.ForecastLine`/`forecastTable`:

```
table                        before      +add     match      -del       after
dbo.OSUSR_XABC_CUSTOMER           0         2         -         0           2
dbo.OSUSR_XDEF_CITY               2         0         2         0           2   reconciled — matched to existing sink rows, no insert
TOTAL                             2         2         2         0           4
```

`after = before − deletes + adds`, per row and in TOTAL; an unprobed count renders `?` and poisons the totals (never a silent 0); a WipeAndLoad kind's `-del` is its live before-count, scoped by the **same** `TransferResume.wipeTargets` walk the live wipe takes.

## Evidence-backed reconcile proposals

Each escaping target's candidate reconcile columns — the sink's single-column unique indexes, then name-shaped text attributes (`Name`/`Code`/`Email`/…) when no index nominates one, at most three per target — are probed against the **live pair**: sink uniqueness (`COUNT` vs `COUNT DISTINCT`) plus a bounded 200-value parameterized sample matched into the sink. The relationships red item now reads:

```
evidence: reconcile 'AppCore.City:Name' (unique-indexed on the sink) — sink-unique; 2/2 sampled source value(s) found in the sink: a STRONG candidate.
```

Verdicts are total (`Probed` strength ladder: STRONG / full-match-but-ambiguous / PARTIAL / unproven; `Unprobed reason`); a pair that will not open degrades to the static proposals, named.

## `check go <flow> --sql`

The new pure `Transfer.plannedSqlPreview` renders the same plan the dry run built through `StaticSeedsEmitter.emitFromPlan` — the A35/A36 text-realization sibling of the live bulk lanes, the `SliceApplyRun.emit` composition: child-first wipe DELETEs under strategy replace, phase-1 MERGEs in FK-safe plan order, then the phase-2 deferred-FK re-points — written to `go-board/<flow>.planned.sql` with a header naming the contract (AssignedBySink keys mint at run time; the artifact's values are the plan's source-side keys, shown for shape).

**Also fixed:** `check go <flow> --format json` refused — the positional filter counted the flag's value token as a second flow name; the walk now skips `--format`'s value.

## Tests

Pure: `PeerTransferTests` — forecast arithmetic/alignment/`?`-poisoning; `plannedSqlPreview` wipe order + loadSet scoping + Incremental-no-wipe; `narrateEvidence` strength ladder (fast pool 3969/3969). Docker: the red/green/red board scenario extended to assert the evidence lines (STRONG, 2/2 sampled), the before→after table, and the `--sql` artifact's DML content on the live managed-grant pair (GoBoard suite 3/3). Release-configuration build verified (FS3511).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m)_