### PR TITLE
Display elevation: route the go board through the View engine, then put the three unused Spectre widgets (Tree, Rule, Progress) to use

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -26994,3 +26994,66 @@ engine field (it rides the existing `tables`/`reconcile` string lists).
 **Witnesses.** `SupportingScopeTests` (bridge / desugar / resolve / the six
 verify claims / dependentEdges / completeness), `MovementSurfaceTests`
 (round-trip + named refusals), `GoBoardDockerTests` (the axis on the live pair).
+
+## 2026-07-08 — The go-board rendering elevation: the report routes through the `View` engine (responsive forecast table, the References/Dependents guarantee tree)
+
+The go board (`projection check go`) and the live-run report were the last two
+operator surfaces still on raw `printfn` + fixed-width `sprintf`. They now build
+a `View` (the Spectre-backed `REPORTING_HORIZON` substrate) and render through the
+one engine — "one substrate, many lenses", the `TtyRenderer` precedent. The pure
+`GoBoard.Board` stays the ONE substrate; the machine lens (`GoBoard.toJsonString`)
+is byte-for-byte untouched (the CI contract).
+
+**Typed carriers, additive.** `GoBoard.Item` gains a `Body : ItemBody` field
+(`Plain | Forecast of ForecastLine list * previews | Scope of ScopeGroup list *
+unaccounted`) with `forecastItem` / `scopeItem` constructors that ALSO set the
+existing flat `Detail` strings. `render` / `toJsonString` never match `Body`, so
+every existing `item` / `itemWith` site and the JSON output are unchanged. The
+carriers are primitive-typed (strings + `GoBoard.Status`) because `GoBoard`
+compiles before `SupportingScope` — the assembly boundary that kept `GoBoard`
+free of the DUs it precedes.
+
+**The forecast becomes a responsive `View.Table`.** Spectre measures its own
+columns against the terminal, so the wide physical-name columns reflow instead of
+clipping; per-cell `Status` colors `+add` green / `-del` red; a `TOTAL` row
+closes it. The free-text note drops OUT of the table to a per-row `Note` beneath
+(it never fights the table's width).
+
+**The supporting-scope axis becomes a fully-expanded hierarchy.** Grouped
+References / Dependents → per-claim `Disclosure` carrying the normalized JOIN
+edges (which payload columns point at a reference; which dependent columns point
+back), the authored intent, and — the operator's ask — the GUARANTEE a Confirmed
+claim earns. `SupportingScope.guaranteeOf` states each invariant in THE_VOICE
+register (a static-lookup identical-match reads as a stated no-op, green, so the
+operator FEELS the confidence). `SupportingScope.scopeGroups` is the ONE builder
+both the board and the live-run report project, so the guarantee tree cannot
+drift between the readiness surface and the run itself.
+
+**Board + live run.** `narrateTransferReport` is rebuilt on `View` too — the load
+plan is a responsive table, the cycle / unmatched / drop sections are
+status-glyphed `Disclosure` blocks, and a declared-scope flow closes with the
+same guarantee tree ("the invariants that held", threaded from the resolved
+supporting scope at the flow-config call site).
+
+**The width discipline (two channels, resolved independently).** The board is a
+REPORT: its proof lines (reconcile evidence, dropped rows, wipe previews) must
+print in FULL, exactly as the raw-`printfn` predecessor emitted them. So the
+`View` text cap (`RenderOptions.Width`) is unbound, and a REDIRECTED sink (pipe /
+file / capture) widens its console `Profile.Width` so Spectre never wraps a proof
+line mid-phrase. A real TTY keeps its width — the forecast `Table` reflows to the
+terminal (the responsive lens the operator asked for), long proof soft-wraps.
+The forecast `Table` auto-sizes to its own content regardless, so widening the
+redirected profile does not blow the table out. (Discovered by `GoBoardDockerTests`:
+the captured evidence substring straddled the width-100 wrap.)
+
+**One gap fixed in passing.** A `Red` item with a remedy but no detail must still
+surface the remedy in the rich lens (the plain renderer always printed it); a bare
+`Field` is reserved for the case with neither remedy nor detail.
+
+**Witnesses.** Pure — `GoBoardViewTests` (the responsive forecast render, the
+Confirmed-claim guarantee + join edge under the family tree, the green/red verdict
+next-move, `toJsonString` byte-identity under a `Body`-bearing item) +
+`SupportingScopeTests` (`guaranteeOf` per relationship + the THE_VOICE
+banned-word scan; `scopeGroups` family split with join edges). Docker —
+`GoBoardDockerTests` (the board + supporting-scope substrings survive the
+Table/tree format). Release build clean (FS3511 verified).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -27057,3 +27057,62 @@ next-move, `toJsonString` byte-identity under a `Body`-bearing item) +
 banned-word scan; `scopeGroups` family split with join edges). Docker —
 `GoBoardDockerTests` (the board + supporting-scope substrings survive the
 Table/tree format). Release build clean (FS3511 verified).
+
+## 2026-07-08 — The widget elevation: the three unused Spectre widgets (Tree, Rule, Progress) put to use, each where it honestly fits
+
+Three Spectre.Console widgets the `View` engine had never used — `Tree`, `Rule`,
+`Progress` — parked Tier 3 in `REPORTING_HORIZON.md`. Each is now in use, placed by
+where it fits the substrate honestly rather than sprayed everywhere. A cross-surface
+survey (three subagents) found the fit for each.
+
+**`Tree` — the go board's References / Dependents guarantee hierarchy, and only
+there.** New `View.Tree of headline * Status * TreeNode list` (a `TreeNode` is
+label + status + children — a leaf-or-branch of TEXT, so the Spectre `Tree` mapping
+and the `toJson` shape stay total). Rendered with connector lines (`├─`/`└─`/`│`),
+ALWAYS fully expanded. It is the counterpart to `Disclosure`, NOT a replacement:
+`Disclosure` is the depth-gated dig (the `Navigator` cursor, the `▸ N more` collapse,
+the `OpenPath` surgical reveal all ride it), and Spectre's `Tree` has no depth budget.
+So the survey's rule held — `Tree` fits exactly ONE site: a static, one-shot,
+already-fully-expanded hierarchy (the go board's scope tree, which opts out of gating
+via `boardDepth`/`Width=MaxValue`). Everywhere else (the at-scale `Comparison`
+groupings, `Lane`, `Trail`, the whole `Disclosure`/`Navigator` substrate) STAYS
+hand-rolled — a `Tree` there would regress progressive disclosure and break the
+`Navigator`/`toJson` coupling. `GoBoardView.scopeTree` now builds a `View.Tree`, the
+shared lens both the board and the live-run guarantee report project.
+
+**`Rule` — titled section dividers at the mastheads and captions.** New
+`View.Rule of title option * Status` — a full-width divider that NAMES the band it
+opens (unlike `Blank`, a mute gap). Applied at: the go board's masthead underline +
+verdict separator (tinted by the outcome); the readiness board's `cutover readiness`
+masthead + `ledger` footer; the `Bench` / `Run events` / `Flows` table captions;
+`Comparison`'s `by module` rollup header. **The width hazard the survey flagged and
+the docker run would have caught:** the go board widens a redirected sink's profile
+to 100 000 columns so proof never wraps — a full-width Spectre `Rule` there would be a
+100 000-char line. The render arm caps the rule's width to `plainWidth` when the
+profile is the widened sentinel (`> 400`), restoring it after; the forecast `Table`
+(which sizes to its own content) is unaffected.
+
+**`Progress` — a determinate bar in the live Watch, honoring §13.** The honest,
+in-discipline reading: Spectre's `Progress` widget owns the console with its OWN
+render loop (incompatible with the Watch's existing `Live` region), and its row-118
+`SpectreProgressAdapter` cash-out has an UNFIRED trigger (chapter 5.1). So rather than
+force the widget or build a premature deferred feature, the Watch's active-stage line
+gains a fixed-width determinate bar (`▇▇▇▇▇░░░░░`), driven by the already-shipped
+`summary.stageProgress` feed. It is drawn PRECISELY when a real denominator exists
+(`Total > 0`) — the honest reading of `THE_VOICE.md` §13's "never a progress bar that
+misstates"; an unknown total (a lazily-streamed producer) draws NO bar, the plain
+count-up carries it. The fill is scaled to a constant width (the R6 `Theme.meter`
+takes the TOTAL as its width, so a 30 000-row stage would draw 30 000 blocks).
+
+**One substrate, three lenses (unchanged law).** Both new `View` cases carry a
+`toJson` arm (`{kind:"rule",title?,status}`, `{kind:"tree",headline,status,nodes[]}`),
+a plain-lens fallback (Spectre's box-drawing survives NoColors), and the `Navigator`'s
+`labelOf`/`filterView` gained arms (a `Rule` filters like a leaf on its title; a `Tree`
+prunes like a `Disclosure`). A `Red` item's remedy became a red tree leaf.
+
+**Witnesses.** Pure — `ViewTests` (the `Rule` title + json + the width cap on a
+widened sink; the `Tree` connectors + fully-expanded leaves + nested json);
+`WatchTests` (a determinate stage draws a bar, an unknown total draws none, the bar is
+fixed-width). Docker — `GoBoardDockerTests` (the scope tree's substrings survive the
+`Tree` connectors; the masthead/verdict rules do not break the board). Full sweep +
+Release clean (FS3511).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1267,3 +1267,65 @@ resolve, the six verify claims, `dependentEdges`, completeness),
 also-payload / no-reason named refusals). Docker — `GoBoardDockerTests`: the
 axis confirms a declared City reference and catches a mislabeled owned-child red
 on the live managed-grant pair. Release build clean (FS3511 verified).
+
+## Entry 30 — 2026-07-08, THE RENDERING ELEVATION: the board (and the live run) route through the `View` engine — responsive forecast, per-claim guarantees, the References/Dependents tree
+
+**Operator request:** make the board rendering responsive to terminal size using
+the Spectre implementation — "really zhush it up." Print the GUARANTEE each
+references/dependents claim makes, grouped by category, so the operator FEELS the
+confidence (an identical-match static entity should read as a stated no-op, green).
+Normalize the presentation across the joins that make sense. Present the
+multi-relationship information as a hierarchical / graphical interface. Scope:
+board AND the live run; hierarchy fully expanded.
+
+**The move.** The go board and the live-run report were the last two operator
+surfaces still on raw `printfn` + fixed-width `sprintf`. Both now BUILD a `View`
+(the Spectre-backed `REPORTING_HORIZON` substrate) and render through the one
+engine — "one substrate, many lenses", the `TtyRenderer` precedent. The pure
+`GoBoard.Board` stays the ONE substrate; the machine lens (`GoBoard.toJsonString`)
+is byte-for-byte untouched (the CI contract).
+
+**Typed carriers, additive.** `GoBoard.Item` gains `Body : ItemBody`
+(`Plain | Forecast | Scope`) with `forecastItem` / `scopeItem` constructors that
+ALSO set the existing flat `Detail` strings; `render` / `toJsonString` never match
+`Body`, so every existing site and the JSON are unchanged. Primitive-typed
+carriers (strings + `Status`) because `GoBoard` compiles before `SupportingScope`
+— the assembly boundary held.
+
+**The forecast is now a responsive `View.Table`** — Spectre auto-sizes its columns
+to the terminal, so the wide physical-name columns reflow instead of clipping;
+`+add` reads green, `-del` red; a `TOTAL` row closes it; the free-text note drops
+to a per-row `Note` beneath so it never fights the table's width.
+
+**The supporting-scope axis is a fully-expanded hierarchy** — grouped References /
+Dependents → per-claim `Disclosure` carrying the normalized JOIN edges (which
+payload columns point at a reference; which dependent columns point back), the
+authored intent, and the GUARANTEE a Confirmed claim earns. `guaranteeOf` states
+each of the six invariants in THE_VOICE register: a static-lookup identical-match
+reads as "a verified no-op on the lookup", green — the confidence made explicit.
+`SupportingScope.scopeGroups` is the ONE builder both the board and the live-run
+report project, so the guarantee tree cannot drift between the readiness surface
+and the run.
+
+**The live run too.** `narrateTransferReport` is rebuilt on `View`: the load plan
+is a responsive table, the cycle / unmatched / drop sections are status-glyphed
+`Disclosure` blocks, and a declared-scope flow closes with the same guarantee tree
+("the invariants that held", threaded from the resolved supporting scope).
+
+**The width discipline the docker run taught.** The board is a REPORT — its proof
+lines (reconcile evidence, dropped rows, wipe previews) must print in FULL, exactly
+as the raw-`printfn` predecessor emitted them. So the `View` text cap is unbound,
+and a REDIRECTED sink widens its console `Profile.Width` so Spectre never wraps a
+proof line mid-phrase (the captured evidence substring had straddled the width-100
+wrap); a real TTY keeps its width so the forecast table reflows. The table
+auto-sizes to its own content regardless. One gap fixed in passing: a `Red` item
+with a remedy but no detail now still surfaces the remedy in the rich lens (the
+plain renderer always printed it).
+
+**Proven:** pure — `GoBoardViewTests` (responsive forecast render, the
+Confirmed-claim guarantee + join edge under the family tree, the green/red verdict
+next-move, `toJsonString` byte-identity under a `Body`-bearing item) +
+`SupportingScopeTests` (`guaranteeOf` per relationship + the THE_VOICE
+banned-word scan; `scopeGroups` family split with join edges); docker —
+`GoBoardDockerTests` (the board + supporting-scope substrings survive the
+Table/tree format on the live pair). Release build clean (FS3511 verified).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1329,3 +1329,56 @@ next-move, `toJsonString` byte-identity under a `Body`-bearing item) +
 banned-word scan; `scopeGroups` family split with join edges); docker —
 `GoBoardDockerTests` (the board + supporting-scope substrings survive the
 Table/tree format on the live pair). Release build clean (FS3511 verified).
+
+## Entry 31 — 2026-07-08, THE WIDGET ELEVATION: the three unused Spectre widgets (Tree, Rule, Progress), each placed where it honestly fits
+
+**Operator request:** an agent noted three Spectre widgets never used by the TTY —
+progress among them. Find every use case across the rendered surfaces and implement
+each fully, as seen fit.
+
+**The three, and the survey that placed them.** Three subagents cross-surveyed every
+renderable surface. The finding: a widget is worth adding only where the substrate
+already wants its shape — forcing it elsewhere regresses what the hand-rolled form
+does better.
+
+**`Tree` → exactly one site.** New `View.Tree` (+ a `TreeNode` = label + status +
+children, so the Spectre `Tree` mapping + `toJson` stay total). Connector lines
+(`├─`/`└─`/`│`), always fully expanded. The go board's References / Dependents
+guarantee hierarchy is the one clean fit — deep, static, one-shot, and already
+rendered fully-expanded with gating disabled. Everywhere else the nesting is
+depth-gated (`Disclosure`, the `Navigator` dig, the `▸ N more` collapse) or
+breadth-capped (`Lane`, `Trail`) or navigator-coupled (the at-scale `Comparison`
+groupings) — Spectre's non-gated `Tree` would regress those, so they stay hand-rolled.
+`GoBoardView.scopeTree` now builds the `Tree`, the shared lens for both the board and
+the live-run guarantee report.
+
+**`Rule` → the mastheads and captions.** New `View.Rule of title option * Status` — a
+titled divider that NAMES the band it opens. Applied at the go board masthead + a
+verdict separator tinted by the outcome; the readiness board's `cutover readiness`
+masthead + `ledger` footer; the `Bench` / `Run events` / `Flows` table captions;
+`Comparison`'s `by module` rollup. **The width hazard the docker path would have
+caught:** the board widens a redirected profile to 100 000 columns (so proof never
+wraps); a full-width rule there would be a 100 000-char line — the render arm caps it
+to `plainWidth` on the widened sentinel, leaving the content-sized forecast table
+untouched.
+
+**`Progress` → a determinate bar in the live Watch, honoring §13.** Spectre's
+`Progress` widget owns the console with its own render loop (incompatible with the
+Watch's `Live` region) and its row-118 cash-out trigger has not fired — so rather than
+force the widget or build a deferred feature early, the Watch's active-stage line
+gained a fixed-width bar (`▇▇▇▇▇░░░░░`) off the already-shipped `stageProgress` feed.
+It draws PRECISELY when a real denominator is known (`Total > 0`) — the honest reading
+of §13's "never a bar that misstates"; an unknown total draws no bar, the count-up
+carries it. Fill scaled to a constant width (the R6 meter uses the total AS its width).
+
+**One substrate, three lenses held.** Both new cases carry a `toJson` arm and a
+plain-lens fallback (Spectre box-drawing survives NoColors); the `Navigator`'s
+`labelOf`/`filterView` gained arms (a `Rule` filters on its title like a leaf; a
+`Tree` prunes like a `Disclosure`).
+
+**Proven:** pure — `ViewTests` (the `Rule` title + json + the width cap on a widened
+sink; the `Tree` connectors + fully-expanded leaves + nested json), `WatchTests` (a
+determinate stage draws a bar; an unknown total draws none; the bar is fixed-width);
+docker — `GoBoardDockerTests` (the scope tree's substrings survive the `Tree`
+connectors; the masthead/verdict rules do not break the board). Release build clean
+(FS3511 verified).

--- a/sidecar/projection/src/Projection.Cli/Comparison.fs
+++ b/sidecar/projection/src/Projection.Cli/Comparison.fs
@@ -688,8 +688,7 @@ let moduleRollup (d: CatalogDiff) : View.View list =
     if List.length perModule < 2 then []
     else
         let rows = perModule |> List.map (fun (m, n) -> [ (m, View.Neutral); (Theme.humane n, View.Neutral) ])
-        [ View.Blank
-          View.Note "by module (most-changed first)"
+        [ View.Rule(Some "by module (most-changed first)", View.Neutral)
           View.Table([ "module"; "changes" ], rows) ]
 
 let changeSurfaceScoped (chan: string option) (d: CatalogDiff) : Surface.Surface =

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -42,7 +42,16 @@ let dispositionName (d: IdentityDisposition) : string =
 /// The load-plan / cycle-FK / unmatched-identity narration, named by the transfer
 /// report's own `Names` index (populated from the engine's contract catalog;
 /// empty ⇒ `rootOriginal` fallback, byte-identical to pre-displayName behaviour).
-let narrateTransferReport (report: Transfer.TransferReport) : unit =
+/// The live-run report, rendered through the `View` engine (2026-07-08, the
+/// rendering-elevation program): the load plan becomes a responsive
+/// `View.Table` (Spectre auto-sizes it to the terminal), the cycle / unmatched
+/// / drop sections become status-glyphed `Disclosure` blocks, and — when the
+/// flow declared a `supportingScope` — the SAME References / Dependents
+/// guarantee tree the go board shows closes the report ("the invariants that
+/// held"). The verdict line stays the Voice-owned `renderVoicedTo`. `scopeGroups`
+/// is the shared `SupportingScope.scopeGroups` output (empty for a run with no
+/// declared scope — the generic `transfer` verb).
+let narrateTransferReportWithScope (report: Transfer.TransferReport) (scopeGroups: GoBoard.ScopeGroup list) : unit =
     let nm = nameOf report.Names
     // §4 Move — lead with the finding (rows moved, in dependency order); the
     // load plan rides beneath. Dependency order is the engine's guarantee that
@@ -69,72 +78,66 @@ let narrateTransferReport (report: Transfer.TransferReport) : unit =
             || k.Disposition = IdentityDisposition.ReconciledByRule)
     let verdictPayload : Voice.Payload = Map.ofList [ "rowCount", box headlineCount; "tableCount", box touched.Length ]
     TtyRenderer.renderVoicedTo Console.Out verdictCode verdictPayload
-    printfn ""
-    printfn "The load plan (%d table(s) touched):" touched.Length
-    for k in touched do
-        printfn "  %-40s %-22s ingested=%d written=%d deferred-fk-columns=%d"
-            (nm k.Kind)
-            (dispositionName k.Disposition)
-            k.RowsIngested
-            k.RowsWritten
-            (Set.count k.DeferredFkColumns)
-    if not (List.isEmpty untouched) then
-        printfn "  (%d other modeled table(s): no rows to move, not reconciled — untouched.)" untouched.Length
-    if not (List.isEmpty report.UnbreakableCycleFks) then
-        printfn ""
-        printfn
-            "%d relationship cycle(s) cannot be broken — the load cannot run as planned:"
-            report.UnbreakableCycleFks.Length
-        for u in report.UnbreakableCycleFks do
-            printfn
-                "  %s.%s → %s"
-                (nm u.Kind)
-                (Name.value u.Column)
-                (nm u.Target)
-    if not (List.isEmpty report.UnmatchedIdentities) then
-        printfn ""
-        printfn
-            "%d identity(ies) unmatched — source records with no match in the target:"
-            report.UnmatchedIdentities.Length
-        for (k, s) in report.UnmatchedIdentities do
-            printfn "  %s source '%s'" (nm k) (SourceKey.value s)
-    if not (List.isEmpty report.AmbiguousIdentities) then
-        printfn ""
-        printfn
-            "%d source record(s) had a non-unique reconcile key — the first binding was kept:"
-            report.AmbiguousIdentities.Length
-        for (k, s) in report.AmbiguousIdentities do
-            printfn "  %s source '%s'" (nm k) (SourceKey.value s)
-    if not (List.isEmpty report.AmbiguousTargetMatchKeys) then
-        printfn ""
-        printfn
-            "%d target record(s) shared a reconcile key with an older record — the oldest was kept (supply an override if the wrong one won):"
-            report.AmbiguousTargetMatchKeys.Length
-        for (k, a) in report.AmbiguousTargetMatchKeys do
-            printfn "  %s target '%s' (displaced)" (nm k) (AssignedKey.value a)
-    if not (List.isEmpty report.SkippedReferences) then
-        printfn ""
-        printfn
-            "%d row(s) dropped — a relationship points to an unmatched record:"
-            report.SkippedReferences.Length
-        for (owner, r) in report.SkippedReferences do
-            printfn
-                "  %s.%s → %s (unmatched source '%s')"
-                (nm owner)
-                (Name.value r.Column)
-                (nm r.Target)
-                (SourceKey.value r.UnresolvedSource)
-    // NM-53 — a resumable G10 no-op re-run replays the prior run's drop count
-    // (the marker persists the count, not the exact references), so the re-run
-    // is not silently clean. Surfaced explicitly as a replay, not freshly
-    // observed drops.
-    match report.ReplayedPriorDrops with
-    | Some n when n > 0 ->
-        printfn ""
-        printfn
-            "already complete; prior run dropped %d row(s) — re-surfacing that verdict (exact references not replayed)."
-            n
-    | _ -> ()
+    // The load plan as one responsive table — the engine measures each column
+    // against the terminal budget, so the wide table-name column reflows.
+    let planHeaders = [ "table"; "disposition"; "ingested"; "written"; "deferred FK" ]
+    let planRow (k: Transfer.KindOutcome) : (string * View.Status) list =
+        let deferred = Set.count k.DeferredFkColumns
+        [ nm k.Kind, View.Neutral
+          dispositionName k.Disposition, View.Neutral
+          string k.RowsIngested, (if k.RowsIngested > 0 then View.Ok else View.Neutral)
+          string k.RowsWritten, (if k.RowsWritten > 0 then View.Ok else View.Neutral)
+          string deferred, (if deferred > 0 then View.Warn else View.Neutral) ]
+    // A status-glyphed disclosure for a fault/advisory section — the headline
+    // carries the count + verdict, the rows reveal beneath (fully expanded at
+    // the board depth).
+    let section (status: View.Status) (headline: string) (rows: string list) : View.View option =
+        match rows with
+        | [] -> None
+        | _  -> Some (View.Disclosure (headline, status, rows |> List.map View.Note))
+    let blocks : View.View list =
+        [ yield View.Field ("load plan", sprintf "%d table(s) touched" touched.Length, View.Neutral)
+          yield View.Table (planHeaders, touched |> List.map planRow)
+          if not (List.isEmpty untouched) then
+              yield View.Note (sprintf "%d other modeled table(s): no rows to move, not reconciled — untouched." untouched.Length)
+          match section View.Bad
+                    (sprintf "%d relationship cycle(s) cannot be broken — the load cannot run as planned" report.UnbreakableCycleFks.Length)
+                    (report.UnbreakableCycleFks |> List.map (fun u -> sprintf "%s.%s -> %s" (nm u.Kind) (Name.value u.Column) (nm u.Target))) with
+          | Some v -> yield v | None -> ()
+          match section View.Warn
+                    (sprintf "%d identity(ies) unmatched — source records with no match in the target" report.UnmatchedIdentities.Length)
+                    (report.UnmatchedIdentities |> List.map (fun (k, s) -> sprintf "%s source '%s'" (nm k) (SourceKey.value s))) with
+          | Some v -> yield v | None -> ()
+          match section View.Warn
+                    (sprintf "%d source record(s) had a non-unique reconcile key — the first binding was kept" report.AmbiguousIdentities.Length)
+                    (report.AmbiguousIdentities |> List.map (fun (k, s) -> sprintf "%s source '%s'" (nm k) (SourceKey.value s))) with
+          | Some v -> yield v | None -> ()
+          match section View.Warn
+                    (sprintf "%d target record(s) shared a reconcile key with an older record — the oldest was kept (supply an override if the wrong one won)" report.AmbiguousTargetMatchKeys.Length)
+                    (report.AmbiguousTargetMatchKeys |> List.map (fun (k, a) -> sprintf "%s target '%s' (displaced)" (nm k) (AssignedKey.value a))) with
+          | Some v -> yield v | None -> ()
+          match section View.Bad
+                    (sprintf "%d row(s) dropped — a relationship points to an unmatched record" report.SkippedReferences.Length)
+                    (report.SkippedReferences |> List.map (fun (owner, r) -> sprintf "%s.%s -> %s (unmatched source '%s')" (nm owner) (Name.value r.Column) (nm r.Target) (SourceKey.value r.UnresolvedSource))) with
+          | Some v -> yield v | None -> ()
+          // NM-53 — a resumable G10 no-op re-run replays the prior run's drop
+          // count (the marker persists the count, not the exact references), so
+          // the re-run is not silently clean.
+          match report.ReplayedPriorDrops with
+          | Some n when n > 0 ->
+              yield View.Note (sprintf "already complete; prior run dropped %d row(s) — re-surfacing that verdict (exact references not replayed)." n)
+          | _ -> ()
+          // The guarantee tree — when the flow declared a supporting scope, the
+          // invariants that governed this run (the same lens `check go` shows).
+          if not (List.isEmpty scopeGroups) then
+              yield GoBoardView.scopeTree "supporting scope — the invariants that held" View.Ok scopeGroups [] ]
+    GoBoardView.writeView Console.Out (View.Doc blocks)
+
+/// The live-run report for the generic `transfer` verb (no declared supporting
+/// scope) — the historical one-argument entry point every caller and test still
+/// holds. Delegates to the scope-aware form with an empty guarantee tree.
+let narrateTransferReport (report: Transfer.TransferReport) : unit =
+    narrateTransferReportWithScope report []
 
 /// After a successful EXECUTE, the undo artifact (`transfer-undo.sql`,
 /// written by the engine's success tail into the revert dir) is the
@@ -480,7 +483,20 @@ let runContractPairTransfer
                     .GetAwaiter().GetResult()
         match result with
         | Ok report ->
-            narrateTransferReport report
+            // The guarantee tree for a declared-scope flow — the same References /
+            // Dependents hierarchy `check go` shows, now closing the run report
+            // (the invariants that held). Empty when no `supportingScope` was
+            // declared, so the tree only appears where it means something.
+            let scopeGroups =
+                if List.isEmpty supportingScope then []
+                else
+                    let payloadSet =
+                        match Transfer.resolveLoadSet physicalSinkContract tables with
+                        | Ok (Some s) -> s
+                        | _ -> Set.empty
+                    let baseReconciled = reconciliation |> Map.toSeq |> Seq.map fst |> Set.ofSeq
+                    SupportingScope.scopeGroups physicalSinkContract payloadSet baseReconciled supportingScope
+            narrateTransferReportWithScope report scopeGroups
             narrateUndoPointer mode revertOut
             narrateDropExit allowDrops report
         | Error errors ->
@@ -832,8 +848,13 @@ let runCheckGo
     (flowName: string) (fromLabel: string) (toLabel: string) (asJson: bool) (emitSql: bool) (planned: PlanAction) : int =
     let finish (items: GoBoard.Item list) : int =
         let board : GoBoard.Board = { Flow = flowName; From = fromLabel; To = toLabel; Items = items }
+        // The machine lens is the stable `toJsonString` CI contract (untouched);
+        // the human lens routes through `GoBoardView` — the Spectre-backed `View`
+        // engine (2026-07-08, the rendering-elevation program): the forecast reflows
+        // to the terminal width, the supporting-scope axis reveals as a fully-expanded
+        // References / Dependents tree with the per-claim guarantee named.
         if asJson then printfn "%s" (GoBoard.toJsonString board)
-        else GoBoard.render board |> List.iter (printfn "%s")
+        else GoBoardView.write Console.Out board
         GoBoard.exitCode board
     match planned with
     | PlanAction.Refused (_, e) ->
@@ -940,20 +961,33 @@ let runCheckGo
                     match v with
                     | SupportingScope.ScopeClaimVerdict.Confirmed note -> Some (sprintf "%s %s — %s (%s)" (relName e) e.Table note e.Reason)
                     | _ -> None)
+            // The hierarchical lens (2026-07-08, the rendering-elevation program):
+            // the References / Dependents claim tree — each claim with its family,
+            // normalized JOIN edges, authored reason, and the GUARANTEE a Confirmed
+            // claim earns. `SupportingScope.scopeGroups` is the SHARED pure builder
+            // the live-run report projects too, so the tree cannot drift between the
+            // readiness surface and the run itself.
+            let groups = SupportingScope.scopeGroups sinkContract payloadSet baseReconciled opts.SupportingScope
+            let unaccountedStrings =
+                unaccounted |> List.map (fun (k, r, target) ->
+                    sprintf "%s.%s -> %s escapes the payload and no supporting-scope entry classifies it" (Name.value k.Name) (Name.value r.Name) (Name.value target.Name))
             match contradictions, unaccounted with
             | [], [] ->
-                items.Add (GoBoard.itemWith "supporting scope"
+                items.Add (GoBoard.scopeItem "supporting scope"
                     (GoBoard.Status.Green (sprintf "%d supporting table(s) declared with intent; every one is borne out by a relationship, and no escaping reference is unaccounted." (List.length opts.SupportingScope)))
+                    groups
+                    []
                     confirmedLines)
             | cs, un ->
                 let detail =
                     [ for (e, reason, remedy) in cs do
                         yield sprintf "%s %s — %s" (relName e) e.Table reason
                         yield sprintf "  -> %s" remedy
-                      for (k, r, target) in un do
-                        yield sprintf "%s.%s -> %s escapes the payload and no supporting-scope entry classifies it" (Name.value k.Name) (Name.value r.Name) (Name.value target.Name) ]
-                items.Add (GoBoard.itemWith "supporting scope"
+                      yield! unaccountedStrings ]
+                items.Add (GoBoard.scopeItem "supporting scope"
                     (GoBoard.Status.Red (sprintf "%d declared intent(s) the graph contradicts, %d escaping reference(s) unaccounted." (List.length cs) (List.length un), "correct the entr(ies) named below, or classify the unaccounted reference(s); then re-run."))
+                    groups
+                    unaccountedStrings
                     detail))
         // -- schema shape ----------------------------------------------------
         let gateScope = loadSet |> Option.map (Set.union reconciledKeys)
@@ -1207,22 +1241,24 @@ let runCheckGo
                 // the operator reads their own list before the closure's.
                 let declaredKinds, broughtKinds = report.Kinds |> List.partition (fun k -> isDeclared k.Kind)
                 let forecastLines = (declaredKinds |> List.choose lineFor) @ (broughtKinds |> List.choose lineFor)
-                let forecastDetail =
-                    [ yield! GoBoard.forecastTable forecastLines
-                      // The rows a strategy-replace wipe would DELETE, in
-                      // full — the operator sees the actual records, not a
-                      // count. (A dropped row under replace shows in `-del`
-                      // as part of the wipe; the drop means it is NOT
-                      // re-inserted afterwards — the `+add` column is
-                      // already net of drops.)
-                      for k in report.Kinds do
+                // The rows a strategy-replace wipe would DELETE, in full — the
+                // operator sees the actual records, not a count. (A dropped row
+                // under replace shows in `-del` as part of the wipe; the drop
+                // means it is NOT re-inserted afterwards — the `+add` column is
+                // already net of drops.)
+                let wipePreviews =
+                    [ for k in report.Kinds do
                           match sinkProbes |> Map.tryFind k.Kind with
                           | Some (Some n, (_ :: _ as sample)) when n > 0L ->
                               yield ""
                               yield sprintf "wipe preview — %s (first %d of %d row(s) the wipe deletes):" (physicalIn sinkContract k.Kind) sample.Length n
                               for line in sample do yield sprintf "  %s" line
                           | _ -> () ]
-                items.Add (GoBoard.itemWith "forecast"
+                // `detail` is the plain/JSON twin (the aligned strings + previews),
+                // kept byte-identical; the typed `forecastLines`/`previews` ride in
+                // `Body` for the responsive-table lens (2026-07-08).
+                let forecastDetail = GoBoard.forecastTable forecastLines @ wipePreviews
+                items.Add (GoBoard.forecastItem "forecast"
                     (GoBoard.Status.Green
                         (sprintf "dry run complete — %d row(s) into %d declared table(s)%s; before → after below."
                             (report.Kinds |> List.sumBy (fun k -> k.RowsIngested))
@@ -1230,6 +1266,8 @@ let runCheckGo
                             (match broughtKinds |> List.choose lineFor |> List.length with
                              | 0 -> ""
                              | n -> sprintf ", %d table(s) brought along by relationships" n)))
+                    forecastLines
+                    (wipePreviews |> List.filter (fun s -> s <> ""))
                     forecastDetail)
                 // MATCH DRIFT (2026-07-08): reconcile matches IDENTITY and
                 // never rewrites data — target values are KEPT — so matched

--- a/sidecar/projection/src/Projection.Cli/GoBoardView.fs
+++ b/sidecar/projection/src/Projection.Cli/GoBoardView.fs
@@ -1,0 +1,179 @@
+module Projection.Cli.GoBoardView
+
+// THE GO BOARD, rendered through the `View` engine (2026-07-08, the
+// rendering-elevation program). The pure `GoBoard.Board` (Pipeline) is the ONE
+// substrate; this CLI builder is the RICH lens — a Spectre-backed, terminal-
+// responsive projection, sibling to `TtyRenderer`'s builders. The forecast
+// becomes a `View.Table` (Spectre auto-sizes it to the terminal width); the
+// supporting-scope axis becomes a fully-expanded hierarchy (References /
+// Dependents → per-claim guarantee + normalized join edges). JSON stays the
+// separate `GoBoard.toJsonString` contract — this touches only the human lens.
+
+open Projection.Cli.View
+open Projection.Pipeline
+
+/// The disclosure depth the board renders at. `check go` is a one-shot
+/// readiness report, so the whole tree (axis → family → claim → guarantee)
+/// reveals at once — never collapsed behind `▸ N more`. Generous so the
+/// deepest node (a guarantee line under a claim) always shows.
+let boardDepth = 6
+
+/// `GoBoard.Status` → the `View.Status` presentation (glyph + color).
+let private statusV : GoBoard.Status -> Status =
+    function
+    | GoBoard.Status.Green _    -> Ok
+    | GoBoard.Status.Advisory _ -> Warn
+    | GoBoard.Status.Red _      -> Bad
+
+/// The headline + optional remedy an item's status carries.
+let private describe (status: GoBoard.Status) : Status * string * string option =
+    match status with
+    | GoBoard.Status.Green note      -> Ok, note, None
+    | GoBoard.Status.Advisory note   -> Warn, note, None
+    | GoBoard.Status.Red (reason, r) -> Bad, reason, Some r
+
+// -- the responsive forecast table -------------------------------------------
+
+let private numOpt (v: int64 option) : string = match v with Some n -> string n | None -> "?"
+
+/// The before→after forecast as a `View.Table` — Spectre measures its own
+/// column widths against the terminal budget, so the wide physical-name columns
+/// reflow instead of clipping. `+add` reads green, `-del` red (the cell status
+/// rides the machine lens too); a TOTAL row closes it. The free-text note is
+/// NOT a column — it rides as a per-row `Note` beneath, so it never fights the
+/// table's width.
+let forecastTable (lines: GoBoard.ForecastLine list) : View =
+    let headers = [ "source (read)"; "target (written)"; "before"; "+add"; "match"; "-del"; "after" ]
+    let row (l: GoBoard.ForecastLine) : (string * Status) list =
+        [ l.Source, Neutral
+          l.Table, Neutral
+          numOpt l.Before, Neutral
+          string l.Adds, (if l.Adds > 0L then Ok else Neutral)
+          (match l.Matches with Some m -> string m | None -> "-"), Neutral
+          string l.Deletes, (if l.Deletes > 0L then Bad else Neutral)
+          numOpt (GoBoard.ForecastLine.after l), Neutral ]
+    let total (f: GoBoard.ForecastLine -> int64 option) =
+        lines |> List.fold (fun acc l -> match acc, f l with Some a, Some v -> Some (a + v) | _ -> None) (Some 0L)
+    let totalRow : (string * Status) list =
+        [ "", Neutral
+          "TOTAL", Neutral
+          numOpt (total (fun l -> l.Before)), Neutral
+          string (lines |> List.sumBy (fun l -> l.Adds)), Neutral
+          string (lines |> List.sumBy (fun l -> l.Matches |> Option.defaultValue 0L)), Neutral
+          string (lines |> List.sumBy (fun l -> l.Deletes)), Neutral
+          numOpt (total GoBoard.ForecastLine.after), Neutral ]
+    Table (headers, (lines |> List.map row) @ [ totalRow ])
+
+// -- the supporting-scope hierarchy ------------------------------------------
+
+let private familyLabel (family: string) : string =
+    match family with
+    | "references" -> "References — the payload points at these"
+    | "dependents" -> "Dependents — these point at the payload"
+    | other        -> other
+
+let private groupStatus (claims: GoBoard.ScopeClaim list) : Status =
+    if claims |> List.exists (fun c -> match c.Status with GoBoard.Status.Red _ -> true | _ -> false)
+    then Bad else Ok
+
+let private claimNode (c: GoBoard.ScopeClaim) : View =
+    let detail =
+        [ if not (List.isEmpty c.JoinEdges) then yield Note (sprintf "← %s" (String.concat ", " c.JoinEdges))
+          yield Note (sprintf "intent: %s" c.Reason)
+          match c.Status with
+          | GoBoard.Status.Green _ when c.Guarantee <> "" -> yield Note (sprintf "guarantee: %s" c.Guarantee)
+          | GoBoard.Status.Red (_, remedy)                -> yield Action remedy
+          | _ -> () ]
+    Disclosure (sprintf "%s %s" c.Relationship c.Table, statusV c.Status, detail)
+
+/// The References / Dependents claim tree as one `Disclosure` — the shared
+/// hierarchical lens both the go board and the live-run report render (the
+/// guarantee tree is built ONCE in `SupportingScope.scopeGroups`, so the two
+/// surfaces cannot disagree).
+let scopeTree (headline: string) (status: Status) (groups: GoBoard.ScopeGroup list) (unaccounted: string list) : View =
+    let families =
+        groups
+        |> List.filter (fun g -> not (List.isEmpty g.Claims))
+        |> List.map (fun g ->
+            Disclosure (sprintf "%s (%d)" (familyLabel g.Family) (List.length g.Claims),
+                        groupStatus g.Claims,
+                        g.Claims |> List.map claimNode))
+    Disclosure (headline, status, families @ (unaccounted |> List.map Note))
+
+// -- item → block ------------------------------------------------------------
+
+let private blockOfItem (i: GoBoard.Item) : View =
+    let vstatus, headline, remedy = describe i.Status
+    match i.Body with
+    | GoBoard.ItemBody.Forecast (lines, previews) ->
+        let noteLines =
+            lines
+            |> List.filter (fun l -> l.Note <> "")
+            |> List.map (fun l -> Note (sprintf "%s — %s" l.Table l.Note))
+        Disclosure (sprintf "%s — %s" i.Axis headline, vstatus,
+                    (forecastTable lines :: noteLines) @ (previews |> List.map Note))
+    | GoBoard.ItemBody.Scope (groups, unaccounted) ->
+        scopeTree (sprintf "%s — %s" i.Axis headline) vstatus groups unaccounted
+    | GoBoard.ItemBody.Plain ->
+        // The remedy is load-bearing (a Red line names the exact next move), so
+        // it must survive even when the item carries no detail — the plain lens
+        // always prints it. A bare `Field` is reserved for the case with neither
+        // a remedy nor detail (a clean pass / advisory with nothing beneath).
+        let children =
+            (match remedy with Some r -> [ Action r ] | None -> [])
+            @ (i.Detail |> List.map Note)
+        match children with
+        | [] -> Field (i.Axis, headline, vstatus)
+        | _  -> Disclosure (sprintf "%s — %s" i.Axis headline, vstatus, children)
+
+/// The whole board as one `View` — a hero, the axis blocks, and the verdict
+/// panel with the next move named (green: the `--go` command; red: the re-run
+/// imperative).
+let ofBoard (board: GoBoard.Board) : View =
+    let hero = Hero (Neutral, sprintf "THE GO BOARD — flow '%s'   %s → %s" board.Flow board.From board.To)
+    let verdict =
+        if GoBoard.isGreen board then
+            Panel ("verdict",
+                [ PanelRow.Labeled ("verdict", "GREEN — every gate passes.", Ok)
+                  PanelRow.Next (sprintf "PROJECTION_ALLOW_EXECUTE=1 projection %s --go" board.Flow) ])
+        else
+            Panel ("verdict",
+                [ PanelRow.Labeled ("verdict", sprintf "RED — %d open decision(s) / blocking fault(s)." (GoBoard.redCount board), Bad)
+                  PanelRow.Next (sprintf "resolve each [STOP] line above, then re-run projection check go %s" board.Flow) ])
+    Doc ([ hero; Blank ] @ (board.Items |> List.map blockOfItem) @ [ Blank; verdict ])
+
+/// Whether a writer is a non-terminal sink (an in-memory / file writer, or a
+/// redirected standard stream) — the same predicate `View.consoleTo` derives
+/// internally, replicated here because the board needs it to choose its width
+/// policy.
+let private redirected (writer: System.IO.TextWriter) : bool =
+    if   System.Object.ReferenceEquals(writer, System.Console.Error) then System.Console.IsErrorRedirected
+    elif System.Object.ReferenceEquals(writer, System.Console.Out)   then System.Console.IsOutputRedirected
+    else true
+
+/// The width a REDIRECTED board renders at — generous so no proof line wraps
+/// (the forecast `Table` sizes to its own content, well under this; it is only a
+/// ceiling that keeps long evidence/drop/preview lines on one line, matching the
+/// predecessor `GoBoard.render` which never wrapped). A pipe or file has no
+/// terminal to reflow to, so a wide, un-wrapped capture is the faithful form.
+let private redirectedReportWidth = 100000
+
+/// Render a report `View` to a writer through the rich lens (a redirected sink
+/// gets the plain NoColors lens; a TTY gets color + its real width).
+///
+/// Two width channels, resolved independently:
+///   - The `View` text cap (`RenderOptions.Width`) is UNBOUND: the board is a
+///     REPORT, and its proof lines must print in full — a clipped guarantee is a
+///     clipped guarantee.
+///   - The console `Profile.Width` governs Spectre's own wrapping + the forecast
+///     `Table`'s auto-sizing. A TTY keeps its real width (the table reflows to
+///     the terminal — the responsive lens the operator asked for); a redirected
+///     sink is widened so long proof lines stay on one line, exactly as the raw
+///     `printfn` predecessor emitted them.
+let writeView (writer: System.IO.TextWriter) (v: View) : unit =
+    let console = consoleTo writer
+    if redirected writer then console.Profile.Width <- redirectedReportWidth
+    writeWith { defaultOptions with Depth = boardDepth; Width = System.Int32.MaxValue } console v
+
+let write (writer: System.IO.TextWriter) (board: GoBoard.Board) : unit =
+    writeView writer (ofBoard board)

--- a/sidecar/projection/src/Projection.Cli/GoBoardView.fs
+++ b/sidecar/projection/src/Projection.Cli/GoBoardView.fs
@@ -76,29 +76,33 @@ let private groupStatus (claims: GoBoard.ScopeClaim list) : Status =
     if claims |> List.exists (fun c -> match c.Status with GoBoard.Status.Red _ -> true | _ -> false)
     then Bad else Ok
 
-let private claimNode (c: GoBoard.ScopeClaim) : View =
-    let detail =
-        [ if not (List.isEmpty c.JoinEdges) then yield Note (sprintf "← %s" (String.concat ", " c.JoinEdges))
-          yield Note (sprintf "intent: %s" c.Reason)
-          match c.Status with
-          | GoBoard.Status.Green _ when c.Guarantee <> "" -> yield Note (sprintf "guarantee: %s" c.Guarantee)
-          | GoBoard.Status.Red (_, remedy)                -> yield Action remedy
-          | _ -> () ]
-    Disclosure (sprintf "%s %s" c.Relationship c.Table, statusV c.Status, detail)
+let private leaf (status: Status) (label: string) : TreeNode = { Label = label; Status = status; Children = [] }
 
-/// The References / Dependents claim tree as one `Disclosure` — the shared
-/// hierarchical lens both the go board and the live-run report render (the
+let private claimNode (c: GoBoard.ScopeClaim) : TreeNode =
+    let leaves =
+        [ if not (List.isEmpty c.JoinEdges) then yield leaf Neutral (sprintf "← %s" (String.concat ", " c.JoinEdges))
+          yield leaf Neutral (sprintf "intent: %s" c.Reason)
+          match c.Status with
+          | GoBoard.Status.Green _ when c.Guarantee <> "" -> yield leaf Neutral (sprintf "guarantee: %s" c.Guarantee)
+          | GoBoard.Status.Red (_, remedy)                -> yield leaf Bad (sprintf "→ %s" remedy)
+          | _ -> () ]
+    { Label = sprintf "%s %s" c.Relationship c.Table; Status = statusV c.Status; Children = leaves }
+
+/// The References / Dependents claim tree as one fully-expanded `View.Tree` — the
+/// shared hierarchical lens both the go board and the live-run report render (the
 /// guarantee tree is built ONCE in `SupportingScope.scopeGroups`, so the two
-/// surfaces cannot disagree).
+/// surfaces cannot disagree). A `Tree` (not the depth-gated `Disclosure`) because
+/// the board renders it fully expanded; Spectre's connector lines read the
+/// family → claim → guarantee nesting at a glance.
 let scopeTree (headline: string) (status: Status) (groups: GoBoard.ScopeGroup list) (unaccounted: string list) : View =
     let families =
         groups
         |> List.filter (fun g -> not (List.isEmpty g.Claims))
         |> List.map (fun g ->
-            Disclosure (sprintf "%s (%d)" (familyLabel g.Family) (List.length g.Claims),
-                        groupStatus g.Claims,
-                        g.Claims |> List.map claimNode))
-    Disclosure (headline, status, families @ (unaccounted |> List.map Note))
+            { Label = sprintf "%s (%d)" (familyLabel g.Family) (List.length g.Claims)
+              Status = groupStatus g.Claims
+              Children = g.Claims |> List.map claimNode })
+    Tree (headline, status, families @ (unaccounted |> List.map (leaf Bad)))
 
 // -- item → block ------------------------------------------------------------
 
@@ -140,7 +144,11 @@ let ofBoard (board: GoBoard.Board) : View =
             Panel ("verdict",
                 [ PanelRow.Labeled ("verdict", sprintf "RED — %d open decision(s) / blocking fault(s)." (GoBoard.redCount board), Bad)
                   PanelRow.Next (sprintf "resolve each [STOP] line above, then re-run projection check go %s" board.Flow) ])
-    Doc ([ hero; Blank ] @ (board.Items |> List.map blockOfItem) @ [ Blank; verdict ])
+    // A titleless Rule underlines the masthead; a `verdict`-titled Rule (tinted by
+    // the outcome) opens the closing panel — the section breaks the raw board never
+    // had (2026-07-08, the widget-elevation program).
+    let verdictStatus = if GoBoard.isGreen board then Ok else Bad
+    Doc ([ hero; Rule (None, Neutral) ] @ (board.Items |> List.map blockOfItem) @ [ Rule (Some "verdict", verdictStatus); verdict ])
 
 /// Whether a writer is a non-terminal sink (an in-memory / file writer, or a
 /// redirected standard stream) — the same predicate `View.consoleTo` derives

--- a/sidecar/projection/src/Projection.Cli/Navigator.fs
+++ b/sidecar/projection/src/Projection.Cli/Navigator.fs
@@ -66,6 +66,8 @@ let labelOf (v: View.View) : string =
     | View.Note t -> t
     | View.Action t -> t
     | View.Blank -> ""
+    | View.Rule (title, _) -> defaultArg title ""
+    | View.Tree (h, _, _) -> h
 
 // --- The filter (L1): a PROJECTION of the tree, never a second copy ---------
 // `/` filters the dig to the branches matching a substring — the canonical
@@ -123,6 +125,20 @@ let rec filterView (q: string) (v: View.View) : View.View option =
     | View.Spark (l, _)           -> if hits q l then Some v else None
     | View.Timeline (l, _, _, _, _) -> if hits q l then Some v else None
     | View.Blank                  -> None
+    // A `Rule` is a divider: kept only when its own title matches (like a leaf),
+    // dropped otherwise (as `Blank` is) so a filtered view is not littered with
+    // section rules whose band was pruned away.
+    | View.Rule (title, _)        -> if (match title with Some t -> hits q t | None -> false) then Some v else None
+    | View.Tree (h, st, nodes)    ->
+        // A `Tree` prunes like a `Disclosure`: an OWN-headline match keeps the whole
+        // tree; else each node is pruned recursively (a node's own-label match keeps
+        // its subtree).
+        if hits q h then Some v
+        else
+            let rec filterNode (n: View.TreeNode) : View.TreeNode option =
+                if hits q n.Label then Some n
+                else match n.Children |> List.choose filterNode with [] -> None | kept -> Some { n with Children = kept }
+            match nodes |> List.choose filterNode with [] -> None | kept -> Some (View.Tree (h, st, kept))
 
 // --- The Model + the pure reducer ------------------------------------------
 

--- a/sidecar/projection/src/Projection.Cli/Projection.Cli.fsproj
+++ b/sidecar/projection/src/Projection.Cli/Projection.Cli.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Comparison.fs" />
     <Compile Include="Voice.fs" />
     <Compile Include="TtyRenderer.fs" />
+    <Compile Include="GoBoardView.fs" />
     <Compile Include="Watch.fs" />
     <Compile Include="Shell.fs" />
     <Compile Include="Intervene.fs" />

--- a/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
+++ b/sidecar/projection/src/Projection.Cli/TtyRenderer.fs
@@ -165,7 +165,7 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (series: i
             [ View.Note(shape + here) ]
     let lastCanary = match r.LastCanary with Some c -> c | None -> "—"
     View.Doc(
-        [ View.Blank
+        [ View.Rule(Some "cutover readiness", View.Neutral)
           hero
           View.Blank
           View.Meter("cutover", r.ConsecutiveGreen, r.Threshold, sprintf "%d / %d green" r.ConsecutiveGreen r.Threshold) ]
@@ -177,8 +177,8 @@ let buildReadinessView (r: RunLedger.Readiness) (recent: string list) (series: i
               "runs",
               sprintf "%d total %s %d with a round-trip verification %s last %s" r.TotalRuns Theme.dot r.CanaryRuns Theme.dot lastCanary,
               View.Neutral)
-            View.Blank
-            View.Note(sprintf "ledger    %s" ledgerPath) ])
+            View.Rule(Some "ledger", View.Neutral)
+            View.Note ledgerPath ])
 
 let renderReadinessBoardTo
     (console: IAnsiConsole)
@@ -333,7 +333,7 @@ let benchView (stats: Bench.Stats list) : View.View =
           string s.P95Ms,          View.Neutral
           string s.P99Ms,          View.Neutral
           string s.MaxMs,          View.Neutral ]
-    View.Doc [ View.Note "Bench (sorted by total time)"; View.Table(headers, stats |> List.map row) ]
+    View.Doc [ View.Rule(Some "Bench (sorted by total time)", View.Neutral); View.Table(headers, stats |> List.map row) ]
 
 /// Build the `--stat` rollup `View` (2026-07-02) — the run's §11 aggregates
 /// as one table (category / code / count / first samples' grain elided): the
@@ -348,7 +348,7 @@ let buildStatView (groups: LogSink.GroupAccumulator list) : View.View =
         groups
         |> List.sortByDescending (fun g -> g.Count)
         |> List.map row
-    View.Doc [ View.Note "Run events, rolled up (category · code · count)"; View.Table(headers, rows) ]
+    View.Doc [ View.Rule(Some "Run events, rolled up (category · code · count)", View.Neutral); View.Table(headers, rows) ]
 
 /// Build the flow-menu `View` — the no-argument `projection` answer ("the
 /// config IS the menu", THE_CLI.md §4.4), as one document the three lenses
@@ -363,7 +363,8 @@ let buildFlowMenuView (flows: (string * string * string * string) list) : View.V
           target, View.Neutral
           extras, View.Neutral ]
     View.Doc
-        [ View.Note "Flows — the daily act is `projection <flow>` (preview by default; --go applies)."
+        [ View.Rule(Some "Flows", View.Neutral)
+          View.Note "the daily act is `projection <flow>` (preview by default; --go applies)."
           View.Table(headers, flows |> List.map row) ]
 
 let renderReadinessBoard (r: RunLedger.Readiness) (recent: string list) (series: int list) (ledgerPath: string) : unit =

--- a/sidecar/projection/src/Projection.Cli/View.fs
+++ b/sidecar/projection/src/Projection.Cli/View.fs
@@ -46,6 +46,15 @@ type PanelRow =
     /// The next-action row; the historical `action`.
     | Next of string
 
+/// One node of a `Tree` (2026-07-08, the widget-elevation program) — a labelled,
+/// status-glyphed row over its own children. Deliberately NOT a `View`: a tree
+/// node is a leaf-or-branch of TEXT, not an arbitrary block, which keeps the
+/// Spectre `Tree` mapping total (every node is exactly label + status + children)
+/// and the `toJson` shape closed. The connector-lined counterpart to the
+/// depth-gated `Disclosure`, for a static, always-fully-expanded hierarchy.
+type TreeNode =
+    { Label: string; Status: Status; Children: TreeNode list }
+
 type View =
     /// A sequence of blocks, rendered as lines (the board shape).
     | Doc of View list
@@ -100,6 +109,18 @@ type View =
     | Action of string
     /// A blank line.
     | Blank
+    /// A full-width divider with an optional left-anchored title (Spectre `Rule`) —
+    /// the titled section break (2026-07-08). Unlike `Blank` (a mute gap), a `Rule`
+    /// NAMES the band it opens; the `Status` tints the line. Width-capped on a
+    /// widened report sink so it never draws a 100 000-column line. `toJson` carries
+    /// `{title?, status}`.
+    | Rule of title: string option * Status
+    /// A fully-expanded hierarchy rendered with connector lines (Spectre `Tree`,
+    /// 2026-07-08): the always-shown counterpart to the depth-gated `Disclosure`,
+    /// for a static one-shot report tree (the go board's References / Dependents
+    /// guarantee tree). Every node is a `TreeNode` (label + status + children), so
+    /// the render + JSON stay total. NOT depth-gated — that is `Disclosure`'s job.
+    | Tree of headline: string * Status * TreeNode list
 
 // --- Status → presentation -------------------------------------------------
 
@@ -411,6 +432,34 @@ let rec private writeBlock (console: IAnsiConsole) (opts: RenderOptions) (indent
                     (Theme.muted (sprintf "%d more" (List.length detail))))
     | Note text -> safeMarkupLine console (sprintf "%s%s" lead (Theme.muted (Markup.Escape (truncateTo (opts.Width - indent.Length) text))))
     | Action text -> safeMarkupLine console (sprintf "%s%s %s" lead Theme.arrow (Theme.accent (Markup.Escape (truncateTo (opts.Width - indent.Length - 2) text))))
+    | Rule (title, st) ->
+        // The titled section divider (Spectre `Rule`). A report widens a redirected
+        // sink's profile so proof never wraps (`GoBoardView.writeView`), which would
+        // make a full-width rule a 100 000-column line — so cap the rule's width to
+        // `plainWidth` when the profile is the widened sentinel, restoring it after.
+        // The title rides the status color; a titleless rule is a plain divider. The
+        // Write is wrapped defensively (#3) like every other markup arm.
+        let saved = console.Profile.Width
+        let rule =
+            match title with
+            | Some t -> Spectre.Console.Rule(colorOf st (Markup.Escape t))
+            | None   -> Spectre.Console.Rule()
+        rule.Justification <- Justify.Left
+        console.Profile.Width <- (if saved > 400 then plainWidth else saved)
+        (try console.Write(rule) with :? System.InvalidOperationException -> console.WriteLine(defaultArg title ""))
+        console.Profile.Width <- saved
+    | Tree (headline, st, nodes) ->
+        // A fully-expanded hierarchy with connector lines (Spectre `Tree`). Every
+        // node always shows — the static counterpart to `Disclosure`'s depth-gated
+        // dig; the width cap does not apply (labels are short). The node labels are
+        // pre-styled markup (glyph + escaped text), wrapped in `Markup` renderables.
+        let mk (markup: string) : Spectre.Console.Rendering.IRenderable = Markup(markup) :> Spectre.Console.Rendering.IRenderable
+        let tree = Spectre.Console.Tree(mk (styled st headline))
+        let rec add (parent: IHasTreeNodes) (n: TreeNode) : unit =
+            let child = parent.AddNode(mk (styled n.Status n.Label))
+            for c in n.Children do add child c
+        for n in nodes do add tree n
+        (try console.Write(tree) with :? System.InvalidOperationException -> safeMarkupLine console (styled st headline))
 
 /// Render with an explicit policy (#4) — the single carrier #11 (width) and #15
 /// (breadth) read. `opts.Width` is respected verbatim (the caller owns the
@@ -588,3 +637,19 @@ let rec toJson (v: View) : JsonNode =
     | Note text -> obj [ "kind", s "note"; "text", s text ]
     | Action text -> obj [ "kind", s "action"; "text", s text ]
     | Blank -> obj [ "kind", s "blank" ]
+    | Rule (title, st) ->
+        let o = JsonObject()
+        o.["kind"] <- s "rule"
+        (match title with Some t -> o.["title"] <- s t | None -> ())
+        o.["status"] <- s (statusTag st)
+        o :> JsonNode
+    | Tree (headline, st, nodes) ->
+        // The full hierarchy rides the structure — every node, its status, its
+        // children — so a `--query` walks the tree the connectors draw.
+        let rec nodeJson (n: TreeNode) : JsonNode =
+            let ch = JsonArray()
+            for c in n.Children do ch.Add(nodeJson c)
+            obj [ "label", s n.Label; "status", s (statusTag n.Status); "children", ch ]
+        let a = JsonArray()
+        for n in nodes do a.Add(nodeJson n)
+        obj [ "kind", s "tree"; "headline", s headline; "status", s (statusTag st); "nodes", a ]

--- a/sidecar/projection/src/Projection.Cli/Watch.fs
+++ b/sidecar/projection/src/Projection.Cli/Watch.fs
@@ -363,10 +363,24 @@ module Watch =
     /// event stream cannot ground.
     let private processingText : string = "processing"
 
+    /// The determinate progress BAR (2026-07-08, the widget-elevation program) — a
+    /// fixed-width `▇▇▇▇▇░░░░░` gauge, shown ONLY when a real denominator is known.
+    /// This is the honest reading of §13's "never a progress bar that misstates": a
+    /// bar is drawn precisely when `Total > 0` (a genuine fraction), and an unknown
+    /// total (`Total <= 0`, a lazily-streamed producer) draws NO bar — the plain
+    /// count-up carries it instead. The R6 `Theme.meter` takes the TOTAL as its
+    /// width (a 300-row stage would draw 300 blocks), so the fill is scaled to a
+    /// constant `barCells` width here.
+    let private barCells = 20
+    let progressBar (p: Progress) : string =
+        if p.Total <= 0 then ""
+        else sprintf "%s " (Theme.meter (p.Done * barCells / p.Total) barCells)
+
     let progressTextQuiet (quietForMs: int64 option) (p: Progress) : string =
+        let bar = progressBar p
         let count =
             if p.Total <= 0 then sprintf "%s applied" (Theme.humane p.Done)
-            else sprintf "%s of %s" (Theme.humane p.Done) (Theme.humane p.Total)
+            else sprintf "%s%s of %s" bar (Theme.humane p.Done) (Theme.humane p.Total)
         match quietForMs with
         | Some _ ->
             // The estimate degrades HONESTLY (#20 / §13): a stage that has gone quiet drops

--- a/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
+++ b/sidecar/projection/src/Projection.Pipeline/GoBoard.fs
@@ -37,13 +37,82 @@ module GoBoard =
         /// remedy that turns the line green.
         | Red of reason: string * remedy: string
 
+    /// One row of the BEFORE → AFTER data forecast (2026-07-07, the
+    /// go-board forecast program): what the sink table holds now, what the
+    /// planned run adds / matches / deletes, and what it holds after —
+    /// derived from the dry run's plan + live sink counts, never guessed.
+    /// 2026-07-08 (the board-clarity program): the row carries BOTH
+    /// physical coordinates — the source table read and the sink table
+    /// written differ per espace on the peer leg.
+    type ForecastLine =
+        { /// Source physical coordinate (`schema.table`) — where the rows
+          /// are read from. Empty when the kind has no source side (a
+          /// wipe-only line).
+          Source  : string
+          /// Sink physical coordinate (`schema.table`) — where the change
+          /// lands; the before/after counts are THIS table's.
+          Table   : string
+          /// Live sink row count before the run (`None` when the probe
+          /// could not run — rendered `?`, never silently 0).
+          Before  : int64 option
+          /// Rows the run INSERTs (post-drop).
+          Adds    : int64
+          /// For a reconciled kind: source rows matched to EXISTING sink
+          /// rows (no insert). `None` for non-reconciled kinds.
+          Matches : int64 option
+          /// Rows the run DELETEs first (the wipe, under strategy replace).
+          Deletes : int64
+          /// The note column: disposition, phase-2 re-points, drops,
+          /// brought-along-by edges.
+          Note    : string }
+
+    /// One supporting-scope claim, normalized for the hierarchical lens
+    /// (2026-07-08, the rendering-elevation program). Primitive-typed (strings
+    /// + `Status`) so the pure `GoBoard` model stays free of the
+    /// `SupportingScope` types it compiles before; the face maps its verdicts
+    /// + join edges + guarantee onto this.
+    type ScopeClaim =
+        { /// "references" (the payload points at this) | "dependents" (points at the payload).
+          Family       : string
+          /// The relationship label — `existing-reference` … `blocked-dependent`.
+          Relationship : string
+          /// The supporting table's logical label (`Module.Entity`).
+          Table        : string
+          /// The verify verdict (Green confirmed / Red contradicted).
+          Status       : Status
+          /// The normalized join: the payload columns that point at this table
+          /// (`Order.UserId`), or the dependent's inbound edges.
+          JoinEdges    : string list
+          /// The operator's authored intent, echoed.
+          Reason       : string
+          /// The invariant a Confirmed claim earns (empty when contradicted).
+          Guarantee    : string }
+
+    /// A family grouping of claims (References / Dependents) for the tree.
+    type ScopeGroup =
+        { Family : string
+          Claims : ScopeClaim list }
+
+    /// The typed body an item carries for the RICH (Spectre `View`) lens
+    /// (2026-07-08). Additive: `Plain` is the default, so every existing
+    /// `item`/`itemWith` site and the JSON writer are untouched — `Detail`
+    /// stays the authoritative plain/JSON path; `Body` is read only by the
+    /// CLI `GoBoardView` builder.
+    type ItemBody =
+        | Plain
+        | Forecast of lines: ForecastLine list * previews: string list
+        | Scope    of groups: ScopeGroup list * unaccounted: string list
+
     type Item =
         { /// The axis label (short, stable — the operator scans these).
           Axis   : string
           Status : Status
           /// Optional per-line proof/detail beneath the headline (escaping
-          /// edges, divergence lines, unmatched identities…).
-          Detail : string list }
+          /// edges, divergence lines, unmatched identities…). The plain/JSON
+          /// lens renders these; `Body` carries the typed twin for the rich lens.
+          Detail : string list
+          /// The typed body for the Spectre `View` lens (`Plain` by default).
+          Body   : ItemBody }
 
     type Board =
         { Flow  : string
@@ -51,8 +120,19 @@ module GoBoard =
           To    : string
           Items : Item list }
 
-    let item (axis: string) (status: Status) : Item = { Axis = axis; Status = status; Detail = [] }
-    let itemWith (axis: string) (status: Status) (detail: string list) : Item = { Axis = axis; Status = status; Detail = detail }
+    let item (axis: string) (status: Status) : Item = { Axis = axis; Status = status; Detail = []; Body = ItemBody.Plain }
+    let itemWith (axis: string) (status: Status) (detail: string list) : Item = { Axis = axis; Status = status; Detail = detail; Body = ItemBody.Plain }
+
+    /// The forecast axis (2026-07-08): the typed `ForecastLine list` rides in
+    /// `Body` for the responsive-table lens; `detail` is the plain/JSON twin
+    /// (the aligned strings + wipe-preview lines) — kept byte-identical.
+    let forecastItem (axis: string) (status: Status) (lines: ForecastLine list) (previews: string list) (detail: string list) : Item =
+        { Axis = axis; Status = status; Detail = detail; Body = ItemBody.Forecast (lines, previews) }
+
+    /// The supporting-scope axis (2026-07-08): the typed `ScopeGroup list` rides
+    /// in `Body` for the hierarchical lens; `detail` is the plain/JSON twin.
+    let scopeItem (axis: string) (status: Status) (groups: ScopeGroup list) (unaccounted: string list) (detail: string list) : Item =
+        { Axis = axis; Status = status; Detail = detail; Body = ItemBody.Scope (groups, unaccounted) }
 
     let private isRed (i: Item) = match i.Status with Status.Red _ -> true | _ -> false
 
@@ -101,35 +181,6 @@ module GoBoard =
         w.WriteEndObject()
         w.Flush()
         System.Text.Encoding.UTF8.GetString(ms.ToArray())
-
-    /// One row of the BEFORE → AFTER data forecast (2026-07-07, the
-    /// go-board forecast program): what the sink table holds now, what the
-    /// planned run adds / matches / deletes, and what it holds after —
-    /// derived from the dry run's plan + live sink counts, never guessed.
-    /// 2026-07-08 (the board-clarity program): the row carries BOTH
-    /// physical coordinates — the source table read and the sink table
-    /// written differ per espace on the peer leg.
-    type ForecastLine =
-        { /// Source physical coordinate (`schema.table`) — where the rows
-          /// are read from. Empty when the kind has no source side (a
-          /// wipe-only line).
-          Source  : string
-          /// Sink physical coordinate (`schema.table`) — where the change
-          /// lands; the before/after counts are THIS table's.
-          Table   : string
-          /// Live sink row count before the run (`None` when the probe
-          /// could not run — rendered `?`, never silently 0).
-          Before  : int64 option
-          /// Rows the run INSERTs (post-drop).
-          Adds    : int64
-          /// For a reconciled kind: source rows matched to EXISTING sink
-          /// rows (no insert). `None` for non-reconciled kinds.
-          Matches : int64 option
-          /// Rows the run DELETEs first (the wipe, under strategy replace).
-          Deletes : int64
-          /// The note column: disposition, phase-2 re-points, drops,
-          /// brought-along-by edges.
-          Note    : string }
 
     [<RequireQualifiedAccess>]
     module ForecastLine =

--- a/sidecar/projection/src/Projection.Pipeline/SupportingScope.fs
+++ b/sidecar/projection/src/Projection.Pipeline/SupportingScope.fs
@@ -94,6 +94,31 @@ module SupportingScope =
         /// The graph contradicts the declaration: what is wrong + the remedy.
         | Contradicted of reason: string * remedy: string
 
+    /// The INVARIANT a Confirmed claim earns — the guarantee the operator can
+    /// rely on (2026-07-08, the rendering-elevation program). Each states, in
+    /// THE_VOICE register (stative, agentless, no pronouns, the true verb,
+    /// evidence beneath), exactly what the load will and will not do to the
+    /// target for this relationship — so a verified no-op READS as a no-op. A
+    /// Contradicted verdict earns no guarantee (empty): the claim node shows the
+    /// verdict's reason + remedy instead.
+    let guaranteeOf (r: SupportingRelationship) (v: ScopeClaimVerdict) : string =
+        match v with
+        | ScopeClaimVerdict.Contradicted _ -> ""
+        | ScopeClaimVerdict.Confirmed _ ->
+            match r with
+            | SupportingRelationship.ExistingReference _ ->
+                "Matched to the target's own rows by business key; no reference row is written — every foreign key resolves against data already present, and the reference table is left untouched."
+            | SupportingRelationship.ReferenceSeed ->
+                "Rows the target lacks are seeded; rows already present are preserved — every foreign key resolves after the seed, and no existing reference row is overwritten."
+            | SupportingRelationship.SharedAnchor _ ->
+                "Every payload reference is re-pointed to one designated target row; the referenced rows collapse to a single anchor, and no divergent reference survives the load."
+            | SupportingRelationship.StaticLookup _ ->
+                "Matched by business key and held to zero divergence — every matched pair is byte-identical, so no row on the target changes: a verified no-op on the lookup."
+            | SupportingRelationship.OwnedChild parent ->
+                sprintf "Owned by %s under the delete-rule cascade; copied with the parent and wiped with it under replace — the child rows share the parent's lifecycle exactly." parent
+            | SupportingRelationship.BlockedDependent parent ->
+                sprintf "A real dependent of %s, deliberately not harvested; the exclusion is acknowledged, so a replace-wipe does not refuse on its account and no environment-specific row is copied." parent
+
     // -- the canonical bridge: terse `reconcile` strings ARE supporting scope --
 
     /// Project the parsed terse `reconcile` entries into the unified model.
@@ -332,3 +357,81 @@ module SupportingScope =
         let covered = Set.unionMany [ payload; resolved.LoadSetAdditions; resolved.AcknowledgedExclusions ]
         TransferSubset.dependentEdges catalog payload
         |> List.filter (fun (source, _, _) -> not (Set.contains source.SsKey covered))
+
+    // -- the hierarchical lens: the References / Dependents claim tree ----------
+
+    /// The relationship's config label (`existing-reference` … `blocked-dependent`).
+    let relationshipLabel (r: SupportingRelationship) : string =
+        match r with
+        | SupportingRelationship.ExistingReference _ -> "existing-reference"
+        | SupportingRelationship.ReferenceSeed        -> "reference-seed"
+        | SupportingRelationship.SharedAnchor _       -> "shared-anchor"
+        | SupportingRelationship.StaticLookup _       -> "static-lookup"
+        | SupportingRelationship.OwnedChild _         -> "owned-child"
+        | SupportingRelationship.BlockedDependent _   -> "blocked-dependent"
+
+    /// The family a relationship belongs to: "references" (the payload points AT
+    /// this table) or "dependents" (this table points at the payload).
+    let familyOf (r: SupportingRelationship) : string =
+        match r with
+        | SupportingRelationship.ExistingReference _
+        | SupportingRelationship.ReferenceSeed
+        | SupportingRelationship.SharedAnchor _
+        | SupportingRelationship.StaticLookup _ -> "references"
+        | SupportingRelationship.OwnedChild _
+        | SupportingRelationship.BlockedDependent _ -> "dependents"
+
+    /// The typed References / Dependents hierarchy for the rich lens (2026-07-08,
+    /// the rendering-elevation program) — the ONE builder both the go board
+    /// (`check go`) and the live-run report project, so the guarantee tree can
+    /// never drift between the readiness surface and the run itself. Each claim
+    /// carries its verify status, the normalized JOIN edges (which payload columns
+    /// point at a reference; which dependent columns point back at the payload),
+    /// the authored reason, and the guarantee a Confirmed claim earns. Primitive
+    /// carriers (`GoBoard.ScopeClaim`/`ScopeGroup`) so the assembly boundary holds
+    /// — `GoBoard` compiles first and knows nothing of these DUs.
+    let scopeGroups
+        (catalog: Catalog)
+        (payload: Set<SsKey>)
+        (reconciled: Set<SsKey>)
+        (entries: SupportingScopeEntry list)
+        : GoBoard.ScopeGroup list =
+        let colOf (k: Kind) (r: Reference) : string =
+            k.Attributes
+            |> List.tryFind (fun a -> a.SsKey = r.SourceAttribute)
+            |> Option.map (fun a -> Name.value a.Name)
+            |> Option.defaultValue (Name.value r.Name)
+        let escaping = TransferSubset.escapingEdges catalog payload reconciled
+        let dependents = TransferSubset.dependentEdges catalog payload
+        let joinEdgesFor (e: SupportingScopeEntry) : string list =
+            match tryResolveTable catalog e.Table with
+            | None -> []
+            | Some k ->
+                match familyOf e.Relationship with
+                | "references" ->
+                    escaping
+                    |> List.filter (fun (_, _, target) -> target.SsKey = k.SsKey)
+                    |> List.map (fun (src, r, _) -> sprintf "%s.%s" (Name.value src.Name) (colOf src r))
+                    |> List.distinct
+                | _ ->
+                    dependents
+                    |> List.filter (fun (source, _, _) -> source.SsKey = k.SsKey)
+                    |> List.map (fun (source, r, target) -> sprintf "%s.%s -> %s" (Name.value source.Name) (colOf source r) (Name.value target.Name))
+                    |> List.distinct
+        let claims : GoBoard.ScopeClaim list =
+            verify catalog payload reconciled entries
+            |> List.map (fun (e, v) ->
+                let status =
+                    match v with
+                    | ScopeClaimVerdict.Confirmed note -> GoBoard.Status.Green note
+                    | ScopeClaimVerdict.Contradicted (reason, remedy) -> GoBoard.Status.Red (reason, remedy)
+                { Family = familyOf e.Relationship
+                  Relationship = relationshipLabel e.Relationship
+                  Table = e.Table
+                  Status = status
+                  JoinEdges = joinEdgesFor e
+                  Reason = e.Reason
+                  Guarantee = guaranteeOf e.Relationship v })
+        [ { GoBoard.ScopeGroup.Family = "references"; GoBoard.ScopeGroup.Claims = claims |> List.filter (fun c -> c.Family = "references") }
+          { GoBoard.ScopeGroup.Family = "dependents"; GoBoard.ScopeGroup.Claims = claims |> List.filter (fun c -> c.Family = "dependents") } ]
+        |> List.filter (fun g -> not (List.isEmpty g.Claims))

--- a/sidecar/projection/tests/Projection.Tests/GoBoardViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/GoBoardViewTests.fs
@@ -1,0 +1,76 @@
+module Projection.Tests.GoBoardViewTests
+
+// The go board's RICH lens (2026-07-08, the rendering-elevation program): the
+// pure `GoBoard.Board` projected through the Spectre-backed `View` engine —
+// the responsive forecast table and the fully-expanded References / Dependents
+// guarantee tree. Pure: renders to an in-memory writer (the redirected =
+// NoColors, width-100 lens), asserts the operator-facing substrings survive.
+// The machine lens (`GoBoard.toJsonString`) stays the separate CI contract —
+// its byte-identity under a Body-bearing item is pinned here too.
+
+open Xunit
+open Projection.Pipeline
+open Projection.Cli
+
+let private render (board: GoBoard.Board) : string =
+    use sw = new System.IO.StringWriter()
+    GoBoardView.write sw board
+    sw.ToString()
+
+let private forecastLine src tbl before adds matches deletes note : GoBoard.ForecastLine =
+    { Source = src; Table = tbl; Before = before; Adds = adds; Matches = matches; Deletes = deletes; Note = note }
+
+[<Fact>]
+let ``ofBoard: the forecast renders as a table with the add cells and a TOTAL row`` () =
+    let lines = [ forecastLine "dbo.SRC" "dbo.DST" (Some 10L) 5L None 0L "brought along by Order.CityId" ]
+    let board : GoBoard.Board =
+        { Flow = "f"; From = "a"; To = "b"
+          Items = [ GoBoard.forecastItem "forecast" (GoBoard.Status.Green "dry run complete") lines [] (GoBoard.forecastTable lines) ] }
+    let out = render board
+    Assert.Contains("+add", out)          // a short header cell — no wrap risk at width 100
+    Assert.Contains("TOTAL", out)         // the totals row closes the table
+    Assert.Contains("dbo.SRC", out)       // the source physical name
+    Assert.Contains("dbo.DST", out)       // the sink physical name
+
+[<Fact>]
+let ``ofBoard: a Confirmed scope claim renders its guarantee and join edge under the family tree`` () =
+    let claim : GoBoard.ScopeClaim =
+        { Family = "references"; Relationship = "static-lookup"; Table = "Ref.Currency"
+          Status = GoBoard.Status.Green "held identical"; JoinEdges = [ "Order.CurrencyId" ]
+          Reason = "currencies are identical across environments"
+          Guarantee = "held to zero divergence — a verified no-op on the lookup." }
+    let groups = [ { GoBoard.ScopeGroup.Family = "references"; GoBoard.ScopeGroup.Claims = [ claim ] } ]
+    let board : GoBoard.Board =
+        { Flow = "f"; From = "a"; To = "b"
+          Items = [ GoBoard.scopeItem "supporting scope" (GoBoard.Status.Green "all borne out") groups [] [] ] }
+    let out = render board
+    Assert.Contains("References", out)          // the family headline
+    Assert.Contains("static-lookup", out)       // the relationship label
+    Assert.Contains("Ref.Currency", out)        // the supporting table
+    Assert.Contains("guarantee:", out)          // the invariant is labeled
+    Assert.Contains("no-op on the lookup", out) // ...and stated
+    Assert.Contains("Order.CurrencyId", out)    // the normalized join edge
+
+[<Fact>]
+let ``ofBoard: a green verdict names the --go command; a red one names the re-run`` () =
+    let green : GoBoard.Board =
+        { Flow = "golden"; From = "a"; To = "b"; Items = [ GoBoard.item "routing" (GoBoard.Status.Green "ok") ] }
+    Assert.Contains("--go", render green)
+    let red : GoBoard.Board =
+        { Flow = "golden"; From = "a"; To = "b"; Items = [ GoBoard.item "routing" (GoBoard.Status.Red ("blocked", "fix it")) ] }
+    let redOut = render red
+    Assert.Contains("check go", redOut)
+    Assert.Contains("fix it", redOut)           // the red item's remedy is surfaced
+
+[<Fact>]
+let ``toJsonString: a Body-bearing item renders JSON identical to a plain item with the same detail`` () =
+    // The Body carrier is invisible to the machine lens — JSON reads Axis +
+    // Status + Detail only. A `scopeItem` and an `itemWith` with the same
+    // Detail must produce byte-identical JSON (the CI contract is stable).
+    let detail = [ "line one"; "line two" ]
+    let groups = [ { GoBoard.ScopeGroup.Family = "references"; GoBoard.ScopeGroup.Claims = [] } ]
+    let bodyBoard : GoBoard.Board =
+        { Flow = "f"; From = "a"; To = "b"; Items = [ GoBoard.scopeItem "scope" (GoBoard.Status.Green "ok") groups [ "x" ] detail ] }
+    let plainBoard : GoBoard.Board =
+        { Flow = "f"; From = "a"; To = "b"; Items = [ GoBoard.itemWith "scope" (GoBoard.Status.Green "ok") detail ] }
+    Assert.Equal(GoBoard.toJsonString plainBoard, GoBoard.toJsonString bodyBoard)

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="ExplainViewTests.fs" />
     <Compile Include="NavigatorTests.fs" />
     <Compile Include="TtyRendererTests.fs" />
+    <Compile Include="GoBoardViewTests.fs" />
     <Compile Include="InterveneTests.fs" />
     <Compile Include="RelaxationStoreTests.fs" />
     <Compile Include="VoiceTotalityTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/SupportingScopeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SupportingScopeTests.fs
@@ -174,3 +174,45 @@ let ``completeness: City reference covers the escape; AuditLog stays an unaccoun
     // Acknowledge AuditLog → fully accounted.
     let r2 = SupportingScope.resolve catalog (entries @ [ { Table = "App.AuditLog"; Relationship = SupportingScope.SupportingRelationship.BlockedDependent "App.Order"; Reason = "r" } ]) |> mustOk
     Assert.Empty(SupportingScope.unaccountedDependents catalog payload r2)
+
+// -- the guarantee statements + the hierarchical builder ----------------------
+// (2026-07-08, the rendering-elevation program.)
+
+let private everyRelationship : SupportingScope.SupportingRelationship list =
+    [ SupportingScope.SupportingRelationship.ExistingReference "Name"
+      SupportingScope.SupportingRelationship.ReferenceSeed
+      SupportingScope.SupportingRelationship.SharedAnchor ("7", None)
+      SupportingScope.SupportingRelationship.StaticLookup "IsoCode"
+      SupportingScope.SupportingRelationship.OwnedChild "App.Order"
+      SupportingScope.SupportingRelationship.BlockedDependent "App.Order" ]
+
+[<Fact>]
+let ``guaranteeOf: every Confirmed relationship earns a non-empty invariant; a Contradicted one earns none`` () =
+    for r in everyRelationship do
+        Assert.False(System.String.IsNullOrWhiteSpace(SupportingScope.guaranteeOf r (SupportingScope.ScopeClaimVerdict.Confirmed "x")))
+        Assert.Equal("", SupportingScope.guaranteeOf r (SupportingScope.ScopeClaimVerdict.Contradicted ("reason", "remedy")))
+
+[<Fact>]
+let ``guaranteeOf: the invariants stay in THE_VOICE register — no first/second-person pronouns`` () =
+    // The register (THE_VOICE): stative, agentless, no pronouns. A leaked
+    // "you"/"we"/"our" would break the operator-facing voice contract.
+    let banned = [ " you "; " your "; " we "; " our "; " us "; " i "; "please" ]
+    for r in everyRelationship do
+        let g = (" " + SupportingScope.guaranteeOf r (SupportingScope.ScopeClaimVerdict.Confirmed "x") + " ").ToLowerInvariant()
+        for b in banned do
+            Assert.False(g.Contains(b), sprintf "guarantee leaked '%s': %s" b g)
+
+[<Fact>]
+let ``scopeGroups: references and dependents split, each claim carrying its join edges and a guarantee`` () =
+    let entries : SupportingScope.SupportingScopeEntry list =
+        [ { Table = "App.City";      Relationship = SupportingScope.SupportingRelationship.ExistingReference "Name"; Reason = "match the target's cities" }
+          { Table = "App.OrderLine"; Relationship = SupportingScope.SupportingRelationship.OwnedChild "App.Order"; Reason = "lines belong to the order" } ]
+    let groups = SupportingScope.scopeGroups catalog payload Set.empty entries
+    Assert.Equal<Set<string>>(Set.ofList [ "references"; "dependents" ], groups |> List.map (fun g -> g.Family) |> Set.ofList)
+    let refClaim = (groups |> List.find (fun g -> g.Family = "references")).Claims |> List.head
+    Assert.Equal("existing-reference", refClaim.Relationship)
+    Assert.Contains("Order.CityId", refClaim.JoinEdges)                          // the normalized join: which payload column points here
+    Assert.False(System.String.IsNullOrWhiteSpace refClaim.Guarantee)
+    let depClaim = (groups |> List.find (fun g -> g.Family = "dependents")).Claims |> List.head
+    Assert.Equal("owned-child", depClaim.Relationship)
+    Assert.Contains("OrderLine.OrderId", depClaim.JoinEdges |> String.concat " ")  // the inbound edge back at the payload

--- a/sidecar/projection/tests/Projection.Tests/ViewTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ViewTests.fs
@@ -608,3 +608,58 @@ let ``View: the readiness board renders the changeset sparkline beside the dots 
         |> Seq.map (fun b -> nonNull (b.GetProperty("kind").GetString())) |> Seq.toList
     Assert.Contains("spark", kinds)     // the changeset trend joined the board
     Assert.Contains("dots", kinds)      // beside the canary dots
+
+// --- the widget-elevation cases: Rule + Tree (2026-07-08) -------------------
+
+[<Fact>]
+let ``View: a titled Rule renders a divider carrying its title, and carries {title,status} in json`` () =
+    let v = View.Rule(Some "cutover readiness", View.Neutral)
+    let p = plain v
+    Assert.Contains("cutover readiness", p)   // the title rides the divider
+    Assert.Contains("─", p)                    // the rule line (box-drawing survives NoColors)
+    let j = json v
+    Assert.Equal("rule", j.GetProperty("kind").GetString())
+    Assert.Equal("cutover readiness", j.GetProperty("title").GetString())
+    Assert.Equal("neutral", j.GetProperty("status").GetString())
+
+[<Fact>]
+let ``View: a Rule caps its width on a widened report sink (never a 100k-column line)`` () =
+    // The go board widens a redirected profile to 100_000 so proof never wraps; a
+    // full-width rule there would be a 100_000-char line. The render arm caps it.
+    use sw = new StringWriter()
+    let console =
+        AnsiConsole.Create(
+            AnsiConsoleSettings(Ansi = AnsiSupport.No, ColorSystem = ColorSystemSupport.NoColors, Out = AnsiConsoleOutput(sw)))
+    console.Profile.Width <- 100000
+    View.writeWith { View.defaultOptions with Width = System.Int32.MaxValue } console (View.Rule(Some "verdict", View.Neutral))
+    let longestLine = sw.ToString().Split('\n') |> Array.map (fun l -> l.TrimEnd().Length) |> Array.max
+    Assert.True(longestLine <= 120, sprintf "rule ran to %d columns" longestLine)
+
+[<Fact>]
+let ``View: a Tree renders connector lines fully expanded and carries the nested nodes in json`` () =
+    let v =
+        View.Tree("supporting scope", View.Ok,
+            [ { Label = "References (1)"; Status = View.Ok
+                Children = [ { Label = "existing-reference City"; Status = View.Ok
+                               Children = [ { Label = "guarantee: no reference row is written."; Status = View.Neutral; Children = [] } ] } ] }
+              { Label = "Dependents (1)"; Status = View.Bad
+                Children = [ { Label = "owned-child City"; Status = View.Bad; Children = [] } ] } ])
+    // pretty/plain lens — connector lines + every node fully expanded (not depth-gated)
+    let p = plain v
+    Assert.Contains("supporting scope", p)
+    Assert.Contains("References (1)", p)
+    Assert.Contains("existing-reference City", p)
+    Assert.Contains("guarantee: no reference row is written.", p)   // the deepest leaf shows
+    Assert.Contains("Dependents (1)", p)
+    Assert.True([ "├"; "└"; "│" ] |> List.exists p.Contains, sprintf "no tree connector in %s" p)
+    // json lens — SAME value: the full nested hierarchy + per-node status
+    let j = json v
+    Assert.Equal("tree", j.GetProperty("kind").GetString())
+    Assert.Equal("ok", j.GetProperty("status").GetString())
+    let nodes = j.GetProperty("nodes").EnumerateArray() |> Seq.toList
+    Assert.Equal(2, nodes.Length)
+    let refs = nodes |> List.find (fun n -> nonNull (n.GetProperty("label").GetString()) = "References (1)")
+    let child = refs.GetProperty("children").EnumerateArray() |> Seq.head
+    Assert.Equal("existing-reference City", child.GetProperty("label").GetString())
+    let deps = nodes |> List.find (fun n -> nonNull (n.GetProperty("label").GetString()) = "Dependents (1)")
+    Assert.Equal("bad", deps.GetProperty("status").GetString())

--- a/sidecar/projection/tests/Projection.Tests/WatchTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WatchTests.fs
@@ -331,6 +331,22 @@ let ``Watch progress: an unknown total is a plain count-up — no fraction, no e
     Assert.DoesNotContain("remaining", text)
 
 [<Fact>]
+let ``Watch progress: a determinate stage draws a bar; an unknown total draws NONE (§13 honesty)`` () =
+    // The bar is drawn precisely when a real fraction exists (Total > 0) — the
+    // honest reading of §13's "never a bar that misstates".
+    let determinate = Watch.progressText { Done = 150; Total = 300; ElapsedMs = 4000L }
+    Assert.Contains("▇", determinate)                 // filled cells
+    Assert.Contains("░", determinate)                 // empty cells (150/300 → half)
+    Assert.Contains("150 of 300", determinate)        // the count still rides beside the bar
+    // an unknown denominator draws no bar — the count-up carries it alone
+    let indeterminate = Watch.progressText { Done = 142; Total = 0; ElapsedMs = 3000L }
+    Assert.DoesNotContain("▇", indeterminate)
+    Assert.DoesNotContain("░", indeterminate)
+    // the bar is fixed-width (not `Total` blocks) — a 30 000-row stage is not 30 000 cells
+    let huge = Watch.progressBar { Done = 15000; Total = 30000; ElapsedMs = 1000L }
+    Assert.True(huge.Trim().Length <= 24, sprintf "bar was %d cells wide" (huge.Trim().Length))
+
+[<Fact>]
 let ``Watch progress: a quiet active stage degrades the estimate to 'processing', not a frozen countdown (#20, amended 2026-07-06)`` () =
     let p : Watch.Progress = { Done = 142; Total = 300; ElapsedMs = 4000L }
     // live: the honest estimate shows


### PR DESCRIPTION
Two sequential programs on the operator display, both on the `View` ADT engine ("one substrate, many lenses"). The second builds on the first, so they ship together.

---

# Part 1 — Rendering elevation: the go board (and the live run) through the `View` engine

The go board (`projection check go`) and the live transfer report were the last two surfaces still on raw `printfn` + fixed-width `sprintf`. Both now **build a `View`** (Spectre-backed, `Profile.Width`-responsive) and render through the one engine. The pure `GoBoard.Board` stays the substrate; the machine lens (`GoBoard.toJsonString`) is **byte-for-byte untouched**.

- **Typed carriers** on `GoBoard.Item` (`Body: ItemBody = Plain | Forecast | Scope`), additive — `render`/`toJsonString` never match `Body`, so every existing site and the JSON are unchanged.
- **Forecast → responsive `View.Table`** (reflows to the terminal; `+add` green, `-del` red; TOTAL row; the note drops to a per-row `Note`).
- **Supporting-scope axis → a per-claim guarantee hierarchy** — `SupportingScope.guaranteeOf` states each of six invariants in THE_VOICE register (a static-lookup identical-match reads as a stated green no-op). `SupportingScope.scopeGroups` is the one builder both the board and the live run project.
- **`narrateTransferReport` rebuilt on `View`** — responsive load-plan table + status-glyphed `Disclosure` blocks + the guarantee tree ("the invariants that held").
- **Width discipline** — a redirected sink widens its profile so proof never wraps mid-phrase (a docker-caught fix); a TTY keeps its width so the table reflows.

# Part 2 — Widget elevation: Tree, Rule, Progress

Three Spectre widgets the engine had never used, parked Tier 3 in `REPORTING_HORIZON.md`. A cross-surface survey (three subagents) placed each where the substrate already wants its shape.

### `Tree` — the go board's References / Dependents guarantee hierarchy, and only there
New `View.Tree` (+ a `TreeNode` = label + status + children, so the Spectre `Tree` mapping and `toJson` stay total). Connector lines (`├─`/`└─`/`│`), **always fully expanded**. It is the counterpart to `Disclosure`, not a replacement — `Disclosure` is the depth-gated dig (the `Navigator` cursor, the `▸ N more` collapse, the `OpenPath` reveal all ride it), and Spectre's `Tree` has no depth budget. So `Tree` fits exactly one site: a static, one-shot, already-fully-expanded hierarchy. Everywhere else (the at-scale `Comparison` groupings, `Lane`, `Trail`, the whole `Disclosure`/`Navigator` substrate) stays hand-rolled.

### `Rule` — titled section dividers at the mastheads and captions
New `View.Rule of title option * Status` — a divider that **names** the band it opens. Applied at: the go board masthead underline + a verdict separator tinted by the outcome; the readiness board's `cutover readiness` masthead + `ledger` footer; the `Bench` / `Run events` / `Flows` table captions; `Comparison`'s `by module` rollup. **Width hazard handled:** the board widens a redirected profile to 100 000 columns so proof never wraps — a full-width rule there would be a 100 000-char line, so the render arm caps the rule to `plainWidth` on the widened sentinel (the content-sized forecast table is untouched).

### `Progress` — a determinate bar in the live Watch, honoring §13
Spectre's `Progress` widget owns the console with its own render loop (incompatible with the Watch's existing `Live` region), and its row-118 cash-out has an **unfired trigger** (chapter 5.1). So rather than force the widget or build a deferred feature early, the Watch's active-stage line gains a fixed-width bar (`▇▇▇▇▇░░░░░`) off the already-shipped `summary.stageProgress` feed. It draws **precisely when a real denominator exists** (`Total > 0`) — the honest reading of `THE_VOICE.md` §13's "never a bar that misstates"; an unknown total draws no bar, the count-up carries it. Fill scaled to a constant width (the R6 meter uses the total AS its width).

**One substrate, three lenses held** — both new cases carry a `toJson` arm and a plain-lens fallback (Spectre box-drawing survives NoColors); the `Navigator`'s `labelOf`/`filterView` gained arms (a `Rule` filters on its title like a leaf; a `Tree` prunes like a `Disclosure`).

---

## Compatibility
`Body` is additive (`Plain` default); the JSON CI contract and every existing board site are byte-identical. The two new `View` cases are additive to the DU; the only exhaustive-match site that needed arms was `Navigator` (`labelOf`/`filterView`).

## Testing
- **Pure:** `GoBoardViewTests`, `SupportingScopeTests` (`guaranteeOf` + `scopeGroups`), `ViewTests` (the `Rule` title/json/width-cap; the `Tree` connectors/expansion/nested json), `WatchTests` (a determinate stage draws a bar; an unknown total draws none; the bar is fixed-width).
- **Docker:** `GoBoardDockerTests` — the board + supporting-scope substrings survive the Table/tree/rule format on the live managed-grant pair.
- **Full sweep green:** fast (35s), docker (521s), scale (82s) — all exit 0; Release build verified (FS3511 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfpRY2fSEDoxTQYhgSxE7m