### PR TITLE
Partial-transfer hardening: Tier-0/1 correctness landmines & destructive-write gates

### DIFF
--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1692,3 +1692,30 @@ transfer (no subset) stays strict estate-wide. `alignForMode` resolves the
 declared `tables` against the source (names are rewrite-invariant) and the face
 / board pass it in — so an unrelated drifted table can no longer block a scoped
 transfer, while the transferred set is still held to the strict-clone bar.
+
+**Hardening (multi-agent review) — the identity re-keying can no longer silently
+corrupt or be silently dropped.** Three adversarial reviews confirmed the pass's
+core safe (bypass surface, reconcile/align SsKey-space consistency, board/engine
+parity, `toLogicalShape` completeness, determinism, feature-interaction matrix)
+and surfaced two defects, both now closed:
+
+- **Identity injectivity.** `align` guarded sink-side ambiguity but trusted
+  source-side and map-value uniqueness; `Map.ofList` on source-keyed pairs would
+  launder a many-to-one VALUE collision (two source identities → one sink) into
+  duplicate SsKeys that `CatalogDiff` silently collapses (rows vanish). Reachable
+  from config (`alignMap: {A: Shared, B: Shared}`). Now refused two ways: a
+  value-injectivity guard in `align` (`alignment.identityCollision` — the run-time
+  net over module/entity/attribute/reference/index/sequence collisions) and a
+  parse-time `cli.config.alignMapNotInjective`. A clean clone is 1:1, so neither
+  fires on a genuine clone.
+- **Silent drop on mis-route.** `alignment: by-name` is consumed only on the
+  `UpPeer` route; a by-name flow that forgot `rendition: physical` routed to the
+  name-blind leg and dropped `alignMap` silently. `resolveFlowSpec` now refuses
+  `cli.flow.alignmentNotPeer` when a by-name flow is not a physical→physical peer.
+
+Plus: the shape-divergence refusal renders facet names cleanly (no `%A`); the
+three best-effort by-name loops collapsed to one helper. New tests pin the
+strict-scope-*bites* path, the collision + mis-route + FK-escape + sequence
+refusals/behaviors, the `AlignmentMode` round-trip, and — at the live seam — the
+FK re-point at ROW level (reseed the sink identities, then assert no verbatim and
+no dangling FK), the one hazard the pass exists to prevent.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1719,3 +1719,15 @@ strict-scope-*bites* path, the collision + mis-route + FK-escape + sequence
 refusals/behaviors, the `AlignmentMode` round-trip, and — at the live seam — the
 FK re-point at ROW level (reseed the sink identities, then assert no verbatim and
 no dangling FK), the one hazard the pass exists to prevent.
+
+**Board forecast ⇔ execute on one seam.** The go board's dry run went through
+`runReverseLegThroughConnections` (the zero-default sibling) while the live run
+used `...With`, so the forecast omitted the flow's SEED kinds, acknowledged
+EXCLUSIONS, `foreignRefs` ack, and the sink's IDENTITY POLICY — a board could red
+(or mis-forecast rows) where execute would proceed, and vice versa. The dry run
+now calls the SAME `runReverseLegThroughConnectionsWith` entry with the SAME
+resolved supporting-scope (`SupportingScope.resolve`, the canonical resolver the
+live face uses) + `opts.ForeignRefs` + `opts.SinkCapability.IdentityPolicy` —
+board and engine read the same fact (two-traversal parity). Behavior-identical for
+flows that use none of these (empty scope / structural sink → the two calls are
+the same), so the whole existing board suite is unchanged.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1682,3 +1682,13 @@ is opt-in and DEFENSIVE:
   re-mints every `SS_Key` GUID): the un-aligned pair refuses `shapeDivergence`,
   the name-aligned pair reads as one shape and lands the subset with the FK
   re-pointed by identity.
+
+**Refinement (same day) — strictness is subset-scoped.** `align` now takes the
+resolved load scope: an entity actually being transferred must be a clean clone
+(name + strict shape) or the pass refuses; a neighbor in a mapped module is
+re-keyed by name where it uniquely matches (so FK targets stay consistent) but a
+name/shape mismatch there is NOT a refusal (its data is not moving). A full
+transfer (no subset) stays strict estate-wide. `alignForMode` resolves the
+declared `tables` against the source (names are rewrite-invariant) and the face
+/ board pass it in — so an unrelated drifted table can no longer block a scoped
+transfer, while the transferred set is still held to the strict-clone bar.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1641,3 +1641,44 @@ streaming write-ahead intent protocol (T0.4's core duplication window).
 
 The partial-transfer hardening program (Tier-0/1 + the shared harness + the four
 docker witnesses + the streaming intent protocol) is complete on this branch.
+
+### Addendum — cloned-module (name-aligned) peer leg (2026-07-09)
+
+A NEW secondary case: two CLONED modules — an espace cloned into a
+differently-named module whose entities are same-named with identical
+attributes, but which are DISTINCT OSSYS entities (different native-GUID
+`SsKey`s). The existing peer leg pairs by SsKey equality end to end (shape gate,
+rename map, `DataLoadPlan.buildWith`), so a clone reads as all-removed/all-added
+— the shape gate refuses, and a bypass would load `[]` for every kind. Support
+is opt-in and DEFENSIVE:
+
+- **`NameAlignment.align` (new pure pass, `Projection.Pipeline`).** Rewrites the
+  SOURCE contract's SsKey-bearing fields (module / kind / attribute / reference /
+  index) to the SINK's corresponding SsKeys, matched BY NAME within an
+  operator-declared source→sink MODULE map, keeping physical coordinates / types
+  / structure. After the pass the pair is SsKey-aligned, so the entire existing
+  engine runs UNCHANGED (the aligned clone diffs to zero — the core pure witness).
+  Shape is judged on the espace-safe logical shape (`Readiness.toLogicalShape`),
+  so a physical default-constraint-name difference is not a false divergence.
+- **Named refusals.** `alignment.module.unmatched` (short-circuit),
+  `alignment.entity.unmatched` / `.ambiguous`, `alignment.attribute.unmatched` /
+  `.shapeDivergence` (STRICT — any `AttributeFacet` difference), and the
+  config-parse `alignment.mode.unknown`. FK targets with no sink counterpart keep
+  their source SsKey and fall to the existing T0.3 out-of-contract gate — no new
+  code. Entity/attribute mismatches are collected into one report.
+- **Identity basis is A1-BOUNDED.** Name-derived identity is materially weaker
+  than the native GUID; the mode is entered only by explicit opt-in
+  (`alignment: "by-name"` + `alignMap` on the flow, threaded like `foreignRefs`),
+  never auto-detected (a mis-wired pair must not silently "align by name"). Peer
+  leg only; the rendition reverse leg keeps `by-sskey`.
+- **Placement.** The pass runs at the PEER FACE (`Faces/Transfer.fs`), rebinding
+  the acquired source before the SsKey-keyed gates, and identically in the go
+  board's `TransferPeer` branch (board/engine two-traversal parity) — no change
+  to `WriteOptions` / `runCore` / the runner.
+- **Proof.** `NameAlignmentTests` (10 pure: the diff-to-zero + shape-gate-Ok
+  witness, FK re-point by identity, every refusal, determinism) + the A44
+  round-trip for `alignment`/`alignMap` + a live docker witness
+  (`ClonedModuleTransferDockerTests` over `OssysSeedBuilder.asClonedModule`, which
+  re-mints every `SS_Key` GUID): the un-aligned pair refuses `shapeDivergence`,
+  the name-aligned pair reads as one shape and lands the subset with the FK
+  re-pointed by identity.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1502,3 +1502,80 @@ guarantee is held to its literal promise (full detail in `DECISIONS 2026-07-09`)
 
 Pure suites green (Reconciliation +8, TransferImpact +10, delete-scope gate +3); Release clean.
 Docker witnesses for `--impact` and the static-lookup board case are the named follow-on.
+
+---
+
+## 2026-07-09 — Audit follow-on: cross-environment mis-key landmines, identity-insert gate, fail-closed revert, journal durability, unproven-refusal witnesses
+
+A multi-agent audit of the transfer engine / gates / resume-revert / test estate
+surfaced a cluster of Tier-0 correctness landmines (silent mis-key on exit 0) and
+Tier-1 destructive-write authorization holes. This entry records the slices landed
+(each committed with tests; Release FS3511-clean; pure pool + transfer docker
+classes green on the warm container). The remaining audit items are the named
+follow-on at the bottom.
+
+- **T0.1 — collation-parity reconcile match.** The Core reconcile match indexed
+  business keys ORDINALLY while the sink and the go-board evidence probe match
+  under the sink's `CI_AS` collation. Same fact, two rulers: a source key the
+  board previewed GREEN the engine could drop (exit-9 on a green board), or a
+  `FallbackToAssigned` pin silently re-keyed every ordinal-missed FK to the owner.
+  A new named `Reconciliation.matchKey` (case-fold + trailing-trim; blankness still
+  decided on the raw value) folds both the sink index and the source lookup for
+  `MatchByColumn`/`MatchByColumns`, so engine and board agree by construction.
+  Accent- and leading-space-sensitivity preserved; a per-column collation contract
+  for non-default collations is the named follow-on.
+- **T0.2 — fail-loud duplicate sink key (NM-58).** A duplicate reconcile key on
+  the SINK re-keyed every matching source FK onto the oldest row, silently
+  displacing the rest, on exit 0. `AmbiguousTargetMatchKeys` now counts in
+  `droppedRowCount`/`hasDrops` (exit 9, cleared by `--allow-drops` or a
+  `ManualOverride`), symmetric with NM-51's duplicate SOURCE key; the go-board
+  forecast reads the same field (two-traversal).
+- **T0.4 — capture-journal durability.** `append` now fsyncs (`Flush(true)`); the
+  docstring NAMES the at-least-once window honestly (sink commits first, then the
+  append — a crash between re-writes/re-mints the chunk on resume) instead of
+  asserting atomicity; the write-ahead intent protocol that closes the window is
+  the named follow-on. `load` and `openResumeIndex` now tolerate a torn TRAILING
+  line (mid-crash partial, keyed on the missing closing newline) instead of
+  throwing and wedging resume/revert; a newline-terminated corrupt line still
+  throws (the not-silently-lossy contract holds).
+- **T1.5 — identity-insert gated by signoff.** Identity-insert (explicit source
+  PKs into an IDENTITY column under `KeepIdentity`) was a first-class `WriteMode`
+  gated NOWHERE — the engine's signoff refusal fired only for `WipeAndLoad`. The
+  engine now refuses `transfer.writeSignoff.ungreenlit` when the plan performs
+  identity-insert without the flow greenlighting it, on ANY Execute (the merge
+  path too). Detection is plan-derivable (`Transfer.identityInsertTables`:
+  a `PreservedFromSource` load onto an IDENTITY-PK kind), so board and engine gate
+  one fact. Breaking by design (like the 2026-07-08 signoff program); the NM-40
+  test-only rename seams pre-greenlight it (inert under `Structural`), production
+  routes through `runReverseLegThroughConnectionsWith`'s real signoff. The go board
+  is env→env-scoped (AssignedBySink) and never drives an identity-insert flow, so
+  no board twin here (the reverse-leg probe sheet is that surface).
+- **T1.7 — fail-closed revert wrong-sink guard.** `projection revert` deletes BY
+  KEY in whatever `--against` resolves to. The guard was fail-OPEN: a header-less
+  script proceeded with a note, and only `database=` was compared. A pure
+  `TransferRevert.guardVerdict` now refuses a header-less script
+  (`revert.headerMissing`) and a `server=` OR `database=` mismatch
+  (`revert.sinkMismatch`, server via `sink.DataSource`); `--force` overrides. The
+  face is thin (parse + decide + render).
+- **T1.9 — honest `fresh` impact text.** The `fresh` signoff prose claimed the
+  target is "assumed empty ... overwritten without a diff", milder than the act
+  (fresh performs the SAME full child-first wipe as replace). Corrected so
+  greenlighting `fresh` is not misled about the blast radius.
+- **Witnesses — two shipped guarantees pinned by name.** `staticLookupRefusalOf`
+  made public: the pure pool now witnesses `transfer.staticLookup.diverged` (a
+  divergent static-lookup refuses; a clean one passes). `orderedLoadGate` gains a
+  witness: an alphabetical-degraded order refuses `transfer.loadOrderUnproven`.
+
+**Proven:** Release FS3511-clean; pure pool 4073+; docker `PeerAlignedTransfer`,
+`PeerManagedGrant`, `GoBoardDocker`, `TransferCanary`, `ReverseLegCanary` all green.
+PR #663.
+
+**Named follow-on (the remaining audit items):** T1.6 (route `--allow-drops`/
+`--allow-cdc` through the durable signoff layer); T1.8 (mirror the WipeAndLoad
+populated-sink refusal at the incremental seam — the merge-into-populated
+duplication hole); T1.10 (signoff arm on the streaming reverse-leg path —
+defense-in-depth, needs threading signoffs into the streaming signature); T0.3
+(surface out-of-contract FK escapes as a named condition — needs an acknowledgement
+path, since platform-`User` FK ubiquity makes a hard refusal too broad); the shared
+two-environment peer fixture; and docker witnesses for `--impact`, the
+static-lookup board case, and `supportingScope.inboundOrphan`.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1579,3 +1579,23 @@ defense-in-depth, needs threading signoffs into the streaming signature); T0.3
 path, since platform-`User` FK ubiquity makes a hard refusal too broad); the shared
 two-environment peer fixture; and docker witnesses for `--impact`, the
 static-lookup board case, and `supportingScope.inboundOrphan`.
+
+### Addendum — T1.6 + T0.3 landed (same session)
+
+- **T1.6 — drops/cdc via the durable signoff.** Row loss / CDC-flood is now
+  acknowledged by the `--allow-drops`/`--allow-cdc` flag OR the flow's durable
+  `Drops`/`Cdc` signoff (`Transfer.dropsAcknowledged`/`cdcAcknowledged`). `runCore`
+  folds the signoff into the effective flags so the pre-write gates and the face's
+  exit code read one acknowledgement — closing the "scripted `--go --allow-drops`
+  drops rows with nothing durable to audit" gap. Streaming keeps flag-only (noted).
+- **T0.3 — out-of-contract FK escapes refused; durable `foreignRefs` ack.** An
+  in-subset FK to a NON-User kind absent from the acquired contract loaded the raw
+  source surrogate (a silent cross-wire). The engine now refuses
+  `transfer.subsetFkEscapes.targetOutOfContract` unless the flow declares the
+  reference stable in `foreignRefs` (a first-class, A44-round-tripping config field
+  threaded onto `WriteOptions.ForeignRefsAcknowledged`); the platform-User path is
+  excluded (`Reference.IsUserFk`). Widening the acquisition is the other remedy.
+
+Remaining named follow-on: T1.8 (incremental populated-sink refusal), T1.10
+(streaming signoff arm), the shared two-environment fixture, and docker witnesses
+for `--impact` / the static-lookup board / `supportingScope.inboundOrphan`.

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1599,3 +1599,27 @@ static-lookup board case, and `supportingScope.inboundOrphan`.
 Remaining named follow-on: T1.8 (incremental populated-sink refusal), T1.10
 (streaming signoff arm), the shared two-environment fixture, and docker witnesses
 for `--impact` / the static-lookup board / `supportingScope.inboundOrphan`.
+
+### Addendum — T1.10 + T1.8 + the shared harness landed (same session)
+
+- **T1.10 — streaming signoff arm.** `runStreamingReconcilingWithRenames` now
+  threads the flow's `signoffs` and carries the same identity-insert gate runCore
+  does, so the materialized and streaming gate blocks cannot drift. Inert on
+  today's sink-mint streaming plan; a guard for a future preserve-keys path.
+- **T1.8 — populated-sink refusal.** A merge/Incremental Execute into a sink that
+  already holds rows in the transferred set now refuses
+  `transfer.incremental.populatedSink` at the live-write seam — mirroring the go
+  board's `re-run` axis over the same `populated` fact — instead of silently
+  re-minting (duplicating) AssignedBySink rows. The escape is `strategy: replace`.
+  The `re-run honesty` canary that pinned the old duplication is updated to the
+  refusal. WipeAndLoad and first-loads are unaffected.
+- **T3 — shared two-cell harness + witnesses.** `PeerEstateHarness.run2Cell`
+  bootstraps two SsKey-aligned cells (source `OSUSR_*` / sink `OSUSR_X*`), reads
+  both OSSYS contracts, and hands them to a body — a new two-cell witness is one
+  call. Landed two docker witnesses over it for the shipped-but-unproven engine
+  refusals: `transfer.supportingScope.inboundOrphan` and (peer-path)
+  `transfer.incremental.populatedSink`.
+
+Remaining named follow-on: docker witnesses for `check go --impact` and the
+static-lookup board case (the `PeerEstateHarness` makes these cheap now); the
+streaming write-ahead intent protocol (T0.4's core duplication window).

--- a/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
+++ b/sidecar/projection/PARTIAL_TRANSFER_READINESS_LOG.md
@@ -1623,3 +1623,21 @@ for `--impact` / the static-lookup board / `supportingScope.inboundOrphan`.
 Remaining named follow-on: docker witnesses for `check go --impact` and the
 static-lookup board case (the `PeerEstateHarness` makes these cheap now); the
 streaming write-ahead intent protocol (T0.4's core duplication window).
+
+### Addendum — the remaining follow-ons closed (same session)
+
+- **Docker witnesses over the shared harness** — the shipped-but-unproven engine
+  guarantees now fire against a live pair (`PeerWitnessDockerTests`):
+  `transfer.supportingScope.inboundOrphan`, `transfer.incremental.populatedSink`,
+  `transfer.staticLookup.diverged`, and `TransferImpact`'s add/delete/change/
+  unchanged classification against a real two-DB delta (`readKindRows` added to
+  `PeerEstateHarness`).
+- **B — the streaming write-ahead intent protocol** (T0.4's core) — a chunk is
+  journaled INTENT (fsync'd) BEFORE the sink write and COMPLETE after; a crash
+  between leaves an IN-DOUBT chunk the resume path probes (sink row count vs the
+  kind's completed-chunk total) — non-committed → safe re-write; maybe-committed →
+  refuse `transfer.resume.chunkInDoubt`. The silent re-mint / duplication window
+  is closed; normal resume is preserved (ReverseLegStreaming green).
+
+The partial-transfer hardening program (Tier-0/1 + the shared harness + the four
+docker witnesses + the streaming intent protocol) is complete on this branch.

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -189,8 +189,11 @@ let private parseReconcileInputs
 /// dropped FK-orphan rows or left reconciled-kind sources unmatched surfaces
 /// a distinct non-zero exit unless the operator declared the drops
 /// acceptable via --allow-drops; the dropped/unmatched kinds are narrated.
-let private narrateDropExit (allowDrops: bool) (report: Transfer.TransferReport) : int =
-    let dropCode = Transfer.exitCodeForReport allowDrops report
+let private narrateDropExit (allowDrops: bool) (signoffs: WriteSignoff.WriteApproval list) (report: Transfer.TransferReport) : int =
+    // T1.6 — the drop-set is accepted by --allow-drops OR the flow's durable
+    // `Drops` signoff; the exit code reads the SAME acknowledgement the engine's
+    // pre-write gate does, so a config-greenlit run does not then exit-9.
+    let dropCode = Transfer.exitCodeForReport (Transfer.dropsAcknowledged allowDrops signoffs) report
     if dropCode <> 0 then
         TtyRenderer.renderVoicedTo Console.Error "transfer.rowsDropped"
             (Map.ofList [ "droppedCount", box (Transfer.droppedRowCount report) ] : Voice.Payload)
@@ -299,7 +302,7 @@ let runTransfer
         | Ok report ->
             narrateTransferReport report
             narrateUndoPointer mode revertOut
-            narrateDropExit allowDrops report
+            narrateDropExit allowDrops [] report
         | Error errors ->
             printErrors Console.Error errors
             // A1 — single-source the refusal exit through `Preflight.refusalOf`
@@ -502,7 +505,7 @@ let runContractPairTransfer
                     SupportingScope.scopeGroups physicalSinkContract payloadSet baseReconciled supportingScope
             narrateTransferReportWithScope report scopeGroups
             narrateUndoPointer mode revertOut
-            narrateDropExit allowDrops report
+            narrateDropExit allowDrops signoff report
         | Error errors ->
             printErrors Console.Error errors
             (Preflight.refusalOf errors).ExitCode

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -486,7 +486,7 @@ let runContractPairTransfer
                 // policy the materialized branch consumes (`revertAuto`/`revertOut`
                 // derived above via `RevertPolicy.toEngine`): a mid-stream crash
                 // reverts (auto) or scripts (script) the partial sink-minted rows.
-                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.StaticLookupKinds revertAuto revertOut)
+                (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.StaticLookupKinds signoff revertAuto revertOut)
                     .GetAwaiter().GetResult()
             | ReverseLegRealization.Materialized ->
                 (Transfer.runReverseLegThroughConnectionsWith sinkCapability.IdentityPolicy mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.SeedKinds resolvedScope.AcknowledgedExclusions signoff resolvedScope.StaticLookupKinds (Set.ofList foreignRefs) revertAuto revertOut)

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -713,16 +713,11 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
     let allLines =
         System.IO.File.ReadAllLines scriptPath
         |> Array.map (fun l -> l.Trim())
-    // The provenance header the artifact writer stamps (the wrong-sink
-    // guard): `-- projection:<kind> server=<s> database=<db> generated=<t>`.
-    let stampedDatabase =
-        allLines
-        |> Array.tryPick (fun l ->
-            if l.StartsWith "-- projection:" then
-                l.Split(' ')
-                |> Array.tryPick (fun tok ->
-                    if tok.StartsWith "database=" then Some (tok.Substring 9) else None)
-            else None)
+    // The provenance the artifact writer stamps (the wrong-sink guard):
+    // `-- projection:<kind> server=<s> database=<db> generated=<t>`. Parsed
+    // purely by `TransferRevert.parseProvenance`; the fail-closed verdict is
+    // `TransferRevert.guardVerdict` (checked below, once the sink resolves).
+    let provenance = TransferRevert.parseProvenance allLines
     let statements =
         allLines
         |> Array.filter (fun l ->
@@ -779,23 +774,18 @@ let runRevertScript (scriptPath: string) (envLabel: string) (connSpec: string) (
             6
         | Ok sink ->
             use sink = sink
-            // THE WRONG-SINK GUARD (2026-07-06, the final-pass critique's
-            // top finding): the artifact deletes BY KEY in whatever database
-            // --against resolves to. The header stamped at capture time
-            // names the database the keys belong to; a mismatch refuses by
-            // name (--force is the deliberate override — e.g. a restored
-            // copy under a new name). A header-less artifact (pre-stamp)
-            // proceeds with a printed note, never a refusal.
-            match stampedDatabase with
-            | Some stamped when not (System.String.Equals(stamped, sink.Database, System.StringComparison.OrdinalIgnoreCase)) && not force ->
-                TtyRenderer.renderVoicedError
-                    (ValidationError.create "revert.sinkMismatch"
-                        (sprintf "this undo was captured against database '%s', but --against resolves to '%s'. Re-point --against at the environment the transfer wrote, or pass --force if the database was deliberately renamed/restored." stamped sink.Database))
+            // THE WRONG-SINK GUARD (2026-07-06; fail-CLOSED 2026-07-09): the
+            // artifact deletes BY KEY in whatever server/database --against
+            // resolves to. `guardVerdict` refuses a server- OR database-mismatch
+            // AND a header-less script (which can no longer be verified) — only
+            // --force proceeds past it. The single most destructive standalone
+            // verb defaults to refuse, not proceed.
+            match TransferRevert.guardVerdict force provenance sink.DataSource sink.Database with
+            | Some refusal ->
+                TtyRenderer.renderVoicedError refusal
                 dumpBench "revert"
                 7
-            | _ ->
-            if Option.isNone stampedDatabase then
-                printfn "  (note: the script carries no provenance header — cannot verify it matches this sink.)"
+            | None ->
             // ONE transaction: the undo lands whole or not at all (the
             // child-first order means FKs never block; a mid-script failure
             // rolls the earlier deletes back rather than leaving a

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -584,6 +584,11 @@ let runPeerTransfer
     // 2026-07-09 (T0.3) — the flow's `foreignRefs`: acknowledged out-of-contract
     // references, threaded to `WriteOptions.ForeignRefsAcknowledged`.
     (foreignRefs: string list)
+    // 2026-07-09 — the peer contracts' IDENTITY BASIS + the cloned-module
+    // source→sink module map. `ByName` runs `NameAlignment.align` over the
+    // acquired source contract before the SsKey-keyed gates (see below).
+    (alignment: AlignmentMode)
+    (alignMap: Map<string, string>)
     (userMapPath: string option)
     (executeRequested: bool)
     (allowCdc: bool)
@@ -615,7 +620,20 @@ let runPeerTransfer
         TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
         dumpBench "transfer"
         (Preflight.refusalOf errors).ExitCode
-    | Ok (sourceContract, sinkContract) ->
+    | Ok (acquiredSource, sinkContract) ->
+
+    // Cloned-module alignment (2026-07-09). `by-sskey` (default) is identity —
+    // the two contracts already align on native GUIDs. `by-name` rewrites the
+    // SOURCE contract's SsKeys to the sink's by name (within `alignMap`) so the
+    // downstream SsKey-keyed gates + engine run UNCHANGED; a mismatch refuses
+    // BY NAME (`alignment.*`) here, before any gate or connection work. Rebind
+    // `sourceContract` to the aligned catalog — every consumer below sees it.
+    match NameAlignment.alignForMode alignment alignMap acquiredSource sinkContract with
+    | Error errors ->
+        TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
+        dumpBench "transfer"
+        (Preflight.refusalOf errors).ExitCode
+    | Ok sourceContract ->
 
     // Resolve the gate inputs: the declared subset (against the SOURCE
     // contract — the same resolver the engine uses) and the reconciled kind
@@ -885,8 +903,25 @@ let runCheckGo
                      "check the connection reference and the principal's SELECT on the ossys_* tables; then re-run."))
                 (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
             finish (List.ofSeq items)
-        | Ok (sourceContract, sinkContract) ->
-        items.Add (GoBoard.item "contracts" (GoBoard.Status.Green "both metamodels read; identities align by SS_KEY."))
+        | Ok (acquiredSource, sinkContract) ->
+        // Cloned-module alignment (2026-07-09) — the board aligns at the SAME
+        // point the engine does (two-traversal parity): `by-name` rewrites the
+        // source contract's SsKeys to the sink's by name before the SsKey-keyed
+        // axes below; a mismatch reds the board `alignment.*` with its detail.
+        match NameAlignment.alignForMode opts.Alignment opts.AlignMap acquiredSource sinkContract with
+        | Error errors ->
+            items.Add (GoBoard.itemWith "contracts"
+                (GoBoard.Status.Red
+                    ("the two estates do not align by name for the declared cloned-module map.",
+                     "fix the flow's `alignMap` (source module -> sink module) or the entities' names/shape; then re-run."))
+                (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
+            finish (List.ofSeq items)
+        | Ok sourceContract ->
+        items.Add
+            (GoBoard.item "contracts"
+                (match opts.Alignment with
+                 | AlignmentMode.BySsKey -> GoBoard.Status.Green "both metamodels read; identities align by SS_KEY."
+                 | AlignmentMode.ByName  -> GoBoard.Status.Green "both metamodels read; identities aligned BY NAME (cloned modules) — name-derived, so A1-bounded."))
         // Supporting scope (2026-07-08, the business-intent program): the
         // typed vocabulary desugars onto the EFFECTIVE subset the downstream
         // axes judge — the payload is `opts.Tables` alone; owned-child /

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -628,7 +628,7 @@ let runPeerTransfer
     // downstream SsKey-keyed gates + engine run UNCHANGED; a mismatch refuses
     // BY NAME (`alignment.*`) here, before any gate or connection work. Rebind
     // `sourceContract` to the aligned catalog — every consumer below sees it.
-    match NameAlignment.alignForMode alignment alignMap acquiredSource sinkContract with
+    match NameAlignment.alignForMode alignment alignMap tables acquiredSource sinkContract with
     | Error errors ->
         TtyRenderer.renderGate "projection transfer (peer)" (Preflight.refusalOf errors)
         dumpBench "transfer"
@@ -904,11 +904,22 @@ let runCheckGo
                 (errors |> List.map (fun e -> sprintf "%s: %s" e.Code e.Message)))
             finish (List.ofSeq items)
         | Ok (acquiredSource, sinkContract) ->
+        // Supporting scope (2026-07-08, the business-intent program): the
+        // typed vocabulary desugars onto the EFFECTIVE subset the downstream
+        // axes judge — the payload is `opts.Tables` alone; owned-child /
+        // reference-seed expand the written set, the reference family expands
+        // the reconcile set. The dedicated axis below verifies each declared
+        // intent against the graph. Computed HERE (before alignment) because the
+        // effective subset is also name-alignment's strict scope.
+        let scopeDesugar = SupportingScope.desugarToStrings opts.SupportingScope
+        let effectiveTables = opts.Tables @ scopeDesugar.ExtraTables
+        let effectiveReconcile = opts.Reconcile @ scopeDesugar.ExtraReconcile
         // Cloned-module alignment (2026-07-09) — the board aligns at the SAME
         // point the engine does (two-traversal parity): `by-name` rewrites the
-        // source contract's SsKeys to the sink's by name before the SsKey-keyed
-        // axes below; a mismatch reds the board `alignment.*` with its detail.
-        match NameAlignment.alignForMode opts.Alignment opts.AlignMap acquiredSource sinkContract with
+        // source contract's SsKeys to the sink's by name (strict over the
+        // transferred `effectiveTables`) before the SsKey-keyed axes below; a
+        // mismatch reds the board `alignment.*` with its detail.
+        match NameAlignment.alignForMode opts.Alignment opts.AlignMap effectiveTables acquiredSource sinkContract with
         | Error errors ->
             items.Add (GoBoard.itemWith "contracts"
                 (GoBoard.Status.Red
@@ -922,15 +933,6 @@ let runCheckGo
                 (match opts.Alignment with
                  | AlignmentMode.BySsKey -> GoBoard.Status.Green "both metamodels read; identities align by SS_KEY."
                  | AlignmentMode.ByName  -> GoBoard.Status.Green "both metamodels read; identities aligned BY NAME (cloned modules) — name-derived, so A1-bounded."))
-        // Supporting scope (2026-07-08, the business-intent program): the
-        // typed vocabulary desugars onto the EFFECTIVE subset the downstream
-        // axes judge — the payload is `opts.Tables` alone; owned-child /
-        // reference-seed expand the written set, the reference family expands
-        // the reconcile set. The dedicated axis below verifies each declared
-        // intent against the graph.
-        let scopeDesugar = SupportingScope.desugarToStrings opts.SupportingScope
-        let effectiveTables = opts.Tables @ scopeDesugar.ExtraTables
-        let effectiveReconcile = opts.Reconcile @ scopeDesugar.ExtraReconcile
         // -- the declared subset -------------------------------------------
         match Transfer.resolveLoadSet sourceContract effectiveTables with
         | Error errors ->

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -1673,9 +1673,12 @@ let runCheckGo
                  | WriteSignoff.ScopeMismatch (reason, remedy) -> GoBoard.Status.Red (reason, remedy)
              items.Add (GoBoard.itemWith "signoff" status (wipedTables |> List.map (sprintf "wipes %s")))
          | EmissionMode.Incremental ->
-             // Upsert-only — no destructive wipe, so no signoff is required for the
-             // write strategy (drops / cdc / identity-insert / delete-scope carry
-             // their own acknowledgements).
+             // Upsert-only — no destructive wipe, so no wipe greenlight is required.
+             // Identity-insert (the FullRights reverse-leg path, not this env→env
+             // board) is gated at the ENGINE over the plan-derived
+             // `identityInsertTables` (T1.5, `transfer.writeSignoff.ungreenlit`);
+             // the go board is env→env-scoped (AssignedBySink), so it never drives
+             // an identity-insert flow — the reverse-leg probe sheet is its surface.
              items.Add (GoBoard.item "signoff" (GoBoard.Status.Green "no destructive wipe — merge/incremental is upsert-only; no write-mode greenlight required.")))
         // The guided-plan pointer (2026-07-08): the go board VERDICTS readiness;
         // `check plan` walks the strategy options + the WHY of each. Advisory, so it

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -364,6 +364,9 @@ let runContractPairTransfer
     // engine's `WriteOptions.Signoffs` so a destructive Execute refuses BY
     // NAME (`transfer.writeSignoff.ungreenlit`) until the mode is greenlit.
     (signoff: WriteSignoff.WriteApproval list)
+    // 2026-07-09 (T0.3) — the flow's `foreignRefs`: acknowledged out-of-contract
+    // references, threaded to `WriteOptions.ForeignRefsAcknowledged`.
+    (foreignRefs: string list)
     (userMapPath: string option)
     (executeRequested: bool)
     (allowCdc: bool)
@@ -486,7 +489,7 @@ let runContractPairTransfer
                 (Transfer.runStreamingReverseLegThroughConnections mode allowCdc allowDrops journal connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.StaticLookupKinds revertAuto revertOut)
                     .GetAwaiter().GetResult()
             | ReverseLegRealization.Materialized ->
-                (Transfer.runReverseLegThroughConnectionsWith sinkCapability.IdentityPolicy mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.SeedKinds resolvedScope.AcknowledgedExclusions signoff resolvedScope.StaticLookupKinds revertAuto revertOut)
+                (Transfer.runReverseLegThroughConnectionsWith sinkCapability.IdentityPolicy mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnoreSet resolvedScope.SeedKinds resolvedScope.AcknowledgedExclusions signoff resolvedScope.StaticLookupKinds (Set.ofList foreignRefs) revertAuto revertOut)
                     .GetAwaiter().GetResult()
         match result with
         | Ok report ->
@@ -524,6 +527,9 @@ let runReverseLegTransfer
     (reconcileIgnore: string list)
     (supportingScope: SupportingScope.SupportingScopeEntry list)
     (signoff: WriteSignoff.WriteApproval list)
+    // 2026-07-09 (T0.3) — the flow's `foreignRefs`: acknowledged out-of-contract
+    // references, threaded to `WriteOptions.ForeignRefsAcknowledged`.
+    (foreignRefs: string list)
     (userMapPath: string option)
     (executeRequested: bool)
     (allowCdc: bool)
@@ -541,7 +547,7 @@ let runReverseLegTransfer
     let scopeDesugar = SupportingScope.desugarToStrings supportingScope
     runContractPairTransfer "projection move (reverse leg)"
         sourceSpec sinkSpec logicalSourceContract physicalSinkContract
-        (reconcileSpecs @ scopeDesugar.ExtraReconcile) reconcileIgnore supportingScope signoff userMapPath executeRequested allowCdc allowDrops
+        (reconcileSpecs @ scopeDesugar.ExtraReconcile) reconcileIgnore supportingScope signoff foreignRefs userMapPath executeRequested allowCdc allowDrops
         emission resumable streaming journalDirectory (tables @ scopeDesugar.ExtraTables)
         revertPolicy revertDir sinkCapability
 
@@ -575,6 +581,9 @@ let runPeerTransfer
     (reconcileIgnore: string list)
     (supportingScope: SupportingScope.SupportingScopeEntry list)
     (signoff: WriteSignoff.WriteApproval list)
+    // 2026-07-09 (T0.3) — the flow's `foreignRefs`: acknowledged out-of-contract
+    // references, threaded to `WriteOptions.ForeignRefsAcknowledged`.
+    (foreignRefs: string list)
     (userMapPath: string option)
     (executeRequested: bool)
     (allowCdc: bool)
@@ -691,7 +700,7 @@ let runPeerTransfer
     // with the peer pair as the contracts and the peer label on the prose.
     runContractPairTransfer "projection transfer (peer)"
         sourceSpec sinkSpec sourceContract sinkContract
-        reconcileSpecs reconcileIgnore supportingScope signoff userMapPath executeRequested allowCdc allowDrops
+        reconcileSpecs reconcileIgnore supportingScope signoff foreignRefs userMapPath executeRequested allowCdc allowDrops
         emission resumable streaming journalDirectory tables
         revertPolicy revertDir sinkCapability
 

--- a/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Transfer.fs
@@ -1098,18 +1098,18 @@ let runCheckGo
          | None ->
              items.Add (GoBoard.item "load order" (GoBoard.Status.Green "parents before children over the transferred set, proven (topological).")))
         // -- THE DRY RUN (real reads, zero writes): the row/identity forecast -
-        // The static-lookup kinds (2026-07-09): the dry run threads them so the
-        // engine computes the AIRTIGHT identity into `report.StaticLookupDivergences`
-        // — the same set the live Execute reads (the two-traversal). Bound before
-        // the dry run so the forecast branch below reuses it for the axis.
-        let staticLookupKeys : Set<SsKey> =
-            opts.SupportingScope
-            |> List.choose (fun e ->
-                match e.Relationship with
-                | SupportingScope.SupportingRelationship.StaticLookup _ ->
-                    SupportingScope.tryResolveTable sinkContract e.Table |> Option.map (fun k -> k.SsKey)
-                | _ -> None)
-            |> Set.ofList
+        // The dry run forecasts EXACTLY what Execute writes (two-traversal parity):
+        // it goes through the SAME `runReverseLegThroughConnectionsWith` entry with
+        // the SAME resolved supporting-scope the live run threads — seed kinds,
+        // acknowledged exclusions, static lookups (`SupportingScope.resolve`, the
+        // canonical resolver the live face at `runContractPairTransfer` uses) plus
+        // the flow's `foreignRefs` ack and the sink's identity policy. Bound before
+        // the dry run; the forecast axis below reuses `staticLookupKeys`.
+        let boardScope =
+            match SupportingScope.resolve sinkContract opts.SupportingScope with
+            | Ok r -> r
+            | Error _ -> SupportingScope.empty
+        let staticLookupKeys : Set<SsKey> = boardScope.StaticLookupKinds
         let shapeClean = List.isEmpty shape.Blocking
         if not shapeClean then
             items.Add (GoBoard.item "forecast" (GoBoard.Status.Red ("not run — the shape divergence above would make the read/write plan unreliable.", "resolve the shape line, then re-run for the row forecast.")))
@@ -1130,9 +1130,11 @@ let runCheckGo
                         opts.ReconcileIgnore
                         |> List.choose (fun n -> match Name.create n with Ok v -> Some v | Error _ -> None)
                         |> Set.ofList
-                    (Transfer.runReverseLegThroughConnections
-                        Transfer.DryRun opts.Emission false true false
-                        effectiveTables connections sourceContract sinkContract reconciliation ignoreSet [] staticLookupKeys)
+                    (Transfer.runReverseLegThroughConnectionsWith
+                        opts.SinkCapability.IdentityPolicy Transfer.DryRun opts.Emission false true false
+                        effectiveTables connections sourceContract sinkContract reconciliation ignoreSet
+                        boardScope.SeedKinds boardScope.AcknowledgedExclusions [] boardScope.StaticLookupKinds
+                        (Set.ofList opts.ForeignRefs) false None)
                         .GetAwaiter().GetResult()
             match dryRun () with
             | Error errors ->

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -242,7 +242,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // (2026-07-07) — the same modeled estate every other verb reads;
         // an unscoped config binds to the show-me-everything default.
         withRun "projection transfer" (fun () ->
-            runPeerTransfer (SnapshotScopeBinding.fromModel shaping.Model) src sink opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.ForeignRefs opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
+            runPeerTransfer (SnapshotScopeBinding.fromModel shaping.Model) src sink opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.ForeignRefs opts.Alignment opts.AlignMap opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -242,7 +242,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // (2026-07-07) — the same modeled estate every other verb reads;
         // an unscoped config binds to the show-me-everything default.
         withRun "projection transfer" (fun () ->
-            runPeerTransfer (SnapshotScopeBinding.fromModel shaping.Model) src sink opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
+            runPeerTransfer (SnapshotScopeBinding.fromModel shaping.Model) src sink opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.ForeignRefs opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability)
     | PlanAction.RunReverseLeg (model, modelOssys, src, sink, opts, execute) ->
         // G2 routed the B→A legacy reverse leg distinctly; J3 (the contract
         // source) is CLOSED — the two SsKey-aligned contracts are the ONE
@@ -253,7 +253,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         // align — the original residual's premise, now honored structurally).
         needCatalog modelOssys model (fun cat ->
             withRun "projection reverse-leg" (fun () ->
-                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability))
+                runReverseLegTransfer src sink (CatalogRendition.logical cat) (CatalogRendition.physical cat) opts.Reconcile opts.ReconcileIgnore opts.SupportingScope opts.Signoff opts.ForeignRefs opts.Rekey execute opts.AllowCdc (opts.Declaration = DeclareAll) opts.Emission opts.Resumable opts.Streaming opts.Journal opts.Tables opts.RevertPolicy opts.RevertDir opts.SinkCapability))
     | PlanAction.MigrateWithData (model, modelOssys, sink, src, opts) ->
         needCatalog modelOssys model (fun cat -> withShaped shaping cat (fun shapedCat ->
             withRun "projection migrate --with-data" (fun () ->

--- a/sidecar/projection/src/Projection.Core/CatalogDiff.fs
+++ b/sidecar/projection/src/Projection.Core/CatalogDiff.fs
@@ -370,6 +370,14 @@ module CatalogDiff =
           Facet.ofLens AttributeFacet.DefaultValue (Facet.lens (fun (a: Attribute) -> (a.DefaultValue, a.DefaultName)) (fun (dv, dn) a -> { a with DefaultValue = dv; DefaultName = dn }))
           Facet.ofLens AttributeFacet.Computed    (Facet.lens (fun (a: Attribute) -> a.Computed) (fun v a -> { a with Computed = v })) ]
 
+    /// The changed column-shape facets between two attributes — the SAME
+    /// comparator `between` uses (the private `attributeFacets` lens table), lifted
+    /// public so a name-aligning pass (`NameAlignment.align`) judges "identical
+    /// attribute shape" by the exact facets the diff detects, not a hand-rolled
+    /// re-derivation. Empty ⇒ the two attributes' emitted columns are identical.
+    let attributeShapeFacets (a: Attribute) (b: Attribute) : Set<AttributeFacet> =
+        Facet.changed attributeFacets a b
+
     /// The empty channel diff — all four fields empty — over any change type.
     let private emptyChannelDiff<'change> : ChannelDiff<'change> =
         { Added = Set.empty; Removed = Set.empty; Renamed = Map.empty; Reshaped = [] }

--- a/sidecar/projection/src/Projection.Core/Reconciliation.fs
+++ b/sidecar/projection/src/Projection.Core/Reconciliation.fs
@@ -132,6 +132,28 @@ type ReconciliationStrategy =
 [<RequireQualifiedAccess>]
 module Reconciliation =
 
+    /// COLLATION PARITY (2026-07-09, the transfer-hardening program) — the one
+    /// named policy under which a business-key value is compared for a MATCH.
+    ///
+    /// The sink matches reconcile keys under its column collation (the managed-
+    /// cloud default `SQL_Latin1_General_CP1_CI_AS`: case-insensitive, trailing-
+    /// whitespace-insensitive), and the go board's `sinkUniqueness` /
+    /// `sinkSampleHits` probes read the sink through that SAME collation. The Core
+    /// match indexed values with F# structural (ORDINAL) equality, so the two
+    /// traversals could disagree on the same fact: a source key the board previews
+    /// GREEN (collation-matched) the engine dropped (ordinal-missed → an exit-9
+    /// refusal on a green board), and a `FallbackToAssigned` pin silently re-keyed
+    /// every ordinal-missed FK to the pinned owner. Folding both the sink index and
+    /// the source lookup through `matchKey` makes engine and board agree BY
+    /// CONSTRUCTION over the default-collation axes: case-fold (invariant culture)
+    /// + trailing-whitespace trim. Accent- and leading-space-sensitivity are
+    /// PRESERVED (the `_AS` axis, and leading space is significant under `=`); a
+    /// per-column collation contract for non-default collations is the named
+    /// follow-on. Blankness (`isKey`) is decided on the RAW value — a
+    /// whitespace-only key is "no key" before normalization ever runs.
+    let matchKey (v: string) : string =
+        v.TrimEnd().ToLowerInvariant()
+
     /// Reconcile one kind's Source surrogates to pre-existing Sink
     /// surrogates by the operator ruleset. `pkColumn` is the surrogate
     /// (PK) column whose value is the Source / Assigned key. A Source row
@@ -184,8 +206,13 @@ module Reconciliation =
                     sinkRows
                     |> List.choose (fun r ->
                         match Map.tryFind col r.Values, Map.tryFind pkColumn r.Values with
+                        // Index under the collation-parity `matchKey` (case-fold +
+                        // trailing-trim) so two sink rows differing only by case /
+                        // trailing space collide here exactly as they do under the
+                        // sink's `CI_AS` collation — the loser becomes an
+                        // `ambiguousTarget` below, matching the board's DISTINCT probe.
                         | Some matchValue, Some sinkSurrogate when isKey matchValue ->
-                            Some (matchValue, AssignedKey.ofString sinkSurrogate)
+                            Some (matchKey matchValue, AssignedKey.ofString sinkSurrogate)
                         | _ -> None)
                 let sinkIndex =
                     sinkPairs
@@ -199,7 +226,7 @@ module Reconciliation =
                     |> Map.ofList
                 fun _ row ->
                     match Map.tryFind col row.Values with
-                    | Some mv when isKey mv -> Map.tryFind mv sinkIndex
+                    | Some mv when isKey mv -> Map.tryFind (matchKey mv) sinkIndex
                     | _                     -> None
             | ReconciliationStrategy.MatchByColumns cols ->
                 // The COMPOSITE-key sibling of `MatchByColumn`: match on the
@@ -212,7 +239,10 @@ module Reconciliation =
                     if not (List.isEmpty cols)
                        && List.length present = List.length cols
                        && List.forall isKey present
-                    then Some present
+                    // Each component folded through the collation-parity `matchKey`
+                    // (blankness decided on the raw value above) so a composite key
+                    // matches under the same `CI_AS` axes as its single-column sibling.
+                    then Some (present |> List.map matchKey)
                     else None
                 let sinkIndex =
                     sinkRows

--- a/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
@@ -103,14 +103,39 @@ module CaptureJournal =
 
     /// Every journaled chunk, indexed by (kind root, chunk index). A
     /// missing or empty journal is an empty index (a fresh run).
+    ///
+    /// Torn-trailing-line tolerance (2026-07-09): a crash mid-append can leave a
+    /// half-written FINAL line with NO closing newline (the append fsyncs, but a
+    /// kill between the write and the fsync — or a torn multi-block record — is
+    /// still possible at EOF). Such a partial trailing line is SKIPPED, not thrown
+    /// on, so a hard crash never wedges resume/revert behind a hand-truncation.
+    /// A newline-TERMINATED line is complete: a corrupt one throws even when last
+    /// (real corruption, not an expected mid-crash partial) — the tolerance is
+    /// keyed on the missing trailing newline, matching `openResumeIndex`'s
+    /// byte-scan, never on mere position.
     let load (journal: CaptureJournal) : Dictionary<string * int, ChunkRecord> =
         let index = Dictionary<string * int, ChunkRecord>()
         if File.Exists journal.FilePath then
-            for line in File.ReadLines journal.FilePath do
-                if not (System.String.IsNullOrWhiteSpace line) then
-                    match JsonSerializer.Deserialize<ChunkRecord> line with
-                    | null -> ()
-                    | record -> index[(record.Kind, record.ChunkIx)] <- record
+            let text = File.ReadAllText journal.FilePath
+            if text.Length > 0 then
+                // A trailing newline means the final record is complete; its
+                // absence means the last non-empty line is a torn partial.
+                let endsClean = text.EndsWith "\n"
+                let lines = text.Split '\n'
+                let lastIx = lines.Length - 1
+                lines
+                |> Array.iteri (fun i line ->
+                    if not (System.String.IsNullOrWhiteSpace line) then
+                        let isTornTrailing = i = lastIx && not endsClean
+                        let recordOpt =
+                            try
+                                match JsonSerializer.Deserialize<ChunkRecord> line with
+                                | null   -> None
+                                | record -> Some record
+                            with _ when isTornTrailing -> None   // torn partial — skip, do not wedge
+                        match recordOpt with
+                        | Some record -> index[(record.Kind, record.ChunkIx)] <- record
+                        | None        -> ())
         index
 
     /// The NDJSON line separator (the `append` writes `Serialize record + "\n"`).
@@ -142,9 +167,11 @@ module CaptureJournal =
     /// each `(kind root, chunk index)` to its line's START offset WITHOUT
     /// retaining the parsed record (only enough is deserialized to read the key).
     /// A re-appended key takes the LATEST offset (last-write-wins — mirrors
-    /// `load`). Blank / literal-`null` lines are skipped; a corrupt line throws
-    /// (the same not-silently-lossy contract `load` carries). A missing journal
-    /// is an empty index (a fresh run).
+    /// `load`). Blank / literal-`null` lines are skipped. An INTERIOR corrupt line
+    /// (newline-terminated, so complete) throws — the not-silently-lossy contract.
+    /// A torn TRAILING line (a mid-crash partial at EOF, with no final newline) is
+    /// SKIPPED, not thrown on, so a hard crash never wedges resume behind a
+    /// hand-truncation (2026-07-09). A missing journal is an empty index (fresh run).
     let openResumeIndex (journal: CaptureJournal) : ResumeIndex =
         let offsets = System.Collections.Generic.Dictionary<string * int, int64>()
         if File.Exists journal.FilePath then
@@ -153,27 +180,36 @@ module CaptureJournal =
             let lineBytes = System.Collections.Generic.List<byte>()
             let mutable lineStart = 0L
             let mutable bufStart = 0L
-            let recordLine () =
+            // `tolerant` distinguishes an interior line (newline-terminated →
+            // complete → strict) from the trailing line (no final newline → a
+            // possible mid-crash partial → skip on parse failure).
+            let recordLine (tolerant: bool) =
                 if lineBytes.Count > 0 then
                     let line = System.Text.Encoding.UTF8.GetString(lineBytes.ToArray())
                     if not (System.String.IsNullOrWhiteSpace line) then
-                        match JsonSerializer.Deserialize<ChunkRecord> line with
-                        | null   -> ()
-                        | record -> offsets[(record.Kind, record.ChunkIx)] <- lineStart
+                        let recordOpt =
+                            try
+                                match JsonSerializer.Deserialize<ChunkRecord> line with
+                                | null   -> None
+                                | record -> Some record
+                            with _ when tolerant -> None
+                        match recordOpt with
+                        | Some record -> offsets[(record.Kind, record.ChunkIx)] <- lineStart
+                        | None        -> ()
                 lineBytes.Clear()
             let mutable read = fs.Read(buf, 0, buf.Length)
             while read > 0 do
                 for i in 0 .. read - 1 do
                     if buf.[i] = NewlineByte then
-                        recordLine ()
+                        recordLine false
                         lineStart <- bufStart + int64 i + 1L
                     else
                         lineBytes.Add buf.[i]
                 bufStart <- bufStart + int64 read
                 read <- fs.Read(buf, 0, buf.Length)
-            // A trailing line with no final newline (the append always writes one,
-            // so this is normally empty — but tolerate a hand-truncated file).
-            recordLine ()
+            // The trailing line has no final newline (the append always writes one,
+            // so this is normally empty) — tolerate a torn/hand-truncated partial.
+            recordLine true
         { IndexFilePath = journal.FilePath; Offsets = offsets }
 
     /// Resolve one journaled chunk by `(kind root, chunk index)`, re-reading and
@@ -188,16 +224,28 @@ module CaptureJournal =
             | null   -> None
             | record -> Some record
 
-    /// Append one completed chunk. The write is flushed on close, so a
-    /// crash AFTER the append never re-executes the chunk and a crash
-    /// DURING the chunk never journals it — the chunk's sink statement
-    /// (one MERGE / one bulk batch) is the atomic commit point. This
-    /// positioning IS the grain's WriteAdmit (R3 / RI-3): the completed
-    /// sink statement is the external witness, proven by control flow —
-    /// a ceremonial `Ledger.writeAdmit` here would assert nothing the
-    /// append's position does not already.
+    /// Append one completed chunk, FSYNC'd before returning (`Flush(true)`), so
+    /// the record is durable on disk — closing the "the OS write-back buffer
+    /// never flushed → silent last-record loss" window `File.AppendAllText` left
+    /// open (2026-07-09).
+    ///
+    /// The ordering is AT-LEAST-ONCE, and this names the window rather than
+    /// asserting atomicity: the chunk's sink statement (one MERGE / one bulk
+    /// batch) commits FIRST (`TransferRun`), THEN this append records it. A crash
+    /// in that window — sink committed, append not yet durable — leaves the chunk
+    /// journaled-as-absent, so resume RE-writes it; for an `AssignedBySink` kind
+    /// that re-mints, i.e. duplicates. The write-ahead intent protocol that closes
+    /// the window (journal the chunk fingerprint BEFORE the sink write; on resume
+    /// treat a journaled-unconfirmed chunk as maybe-committed and probe / MERGE
+    /// idempotently on a deterministic capture key) is the named follow-on. This
+    /// card makes the durability honest and the window documented, not silent.
+    /// The append's position remains the grain's WriteAdmit (R3 / RI-3) for a
+    /// clean run — the completed sink statement is the external witness.
     let append (journal: CaptureJournal) (record: ChunkRecord) : unit =
-        File.AppendAllText(journal.FilePath, JsonSerializer.Serialize record + "\n")
+        use fs = new FileStream(journal.FilePath, FileMode.Append, FileAccess.Write, FileShare.Read)
+        let bytes = System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize record + "\n")
+        fs.Write(bytes, 0, bytes.Length)
+        fs.Flush(true)   // fsync — the record is on disk before control returns
 
     // -- L2: the journal grain on the ledger contract (R3 / RI-3) ------------
 

--- a/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
+++ b/sidecar/projection/src/Projection.Pipeline/CaptureJournal.fs
@@ -247,6 +247,42 @@ module CaptureJournal =
         fs.Write(bytes, 0, bytes.Length)
         fs.Flush(true)   // fsync — the record is on disk before control returns
 
+    // -- T0.4 write-ahead intent (2026-07-09) — close the at-least-once window ---
+    // A chunk is journaled TWICE: an INTENT record (WrittenCount = `IntentPending`)
+    // fsync'd BEFORE the sink write, then the COMPLETE record (WrittenCount ≥ 0,
+    // pairs) fsync'd after. `load`/`openResumeIndex` are last-write-wins per
+    // (kind, chunkIx), so a clean chunk resolves to its COMPLETE record; a crash
+    // between the two leaves only the INTENT — an IN-DOUBT chunk the resume path
+    // probes rather than silently re-mints.
+
+    /// The `WrittenCount` sentinel marking an INTENT (attempted-but-unconfirmed)
+    /// record. Negative, so it never collides with a real written count (≥ 0).
+    let IntentPending : int = -1
+
+    /// A record is COMPLETE (its sink write is confirmed) iff its written count is
+    /// non-negative; an INTENT record carries `IntentPending`.
+    let isComplete (record: ChunkRecord) : bool = record.WrittenCount >= 0
+
+    /// The write-ahead INTENT record for a chunk about to be written — the
+    /// fingerprint fields only, no pairs (the assigned identities are not known
+    /// until the sink write returns).
+    let intentRecord (kind: string) (chunkIx: int) (firstPk: string) (lastPk: string) (rawCount: int) : ChunkRecord =
+        { Kind = kind; ChunkIx = chunkIx; FirstPk = firstPk; LastPk = lastPk
+          RawCount = rawCount; WrittenCount = IntentPending; Pairs = [||] }
+
+    /// The total rows a kind's COMPLETED chunks wrote, per the resume index — the
+    /// sink row count expected for the kind if an in-doubt chunk did NOT commit
+    /// (the streaming load starts empty; T1.8 forbids incremental into a populated
+    /// sink). Reads one record per journaled chunk of the kind; INTENT records
+    /// (unconfirmed) contribute nothing.
+    let completedWrittenCountForKind (index: ResumeIndex) (kindRoot: string) : int =
+        index.Offsets
+        |> Seq.filter (fun kv -> fst kv.Key = kindRoot)
+        |> Seq.sumBy (fun kv ->
+            match JsonSerializer.Deserialize<ChunkRecord> (readLineAt index.IndexFilePath kv.Value) with
+            | null   -> 0
+            | record -> if isComplete record then record.WrittenCount else 0)
+
     // -- L2: the journal grain on the ledger contract (R3 / RI-3) ------------
 
     /// The chunk's SOURCE fingerprint — what `Ledger.resumeAdmit` compares

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -163,6 +163,9 @@ type MovementSpec =
         /// 2026-07-08 — the flow's `reconcileIgnore` audit columns (shared
         /// attribute names the matched-pair diff skips).
         ReconcileIgnore : string list
+        /// 2026-07-09 (T0.3) — acknowledged out-of-contract references
+        /// (`OwnerKind.ReferenceName`), declared environment-stable.
+        ForeignRefs : string list
         /// 2026-07-08 — the typed supporting-scope vocabulary (owned children,
         /// references, anchors, lookups, blocked dependents). Empty = none.
         SupportingScope : SupportingScope.SupportingScopeEntry list
@@ -232,6 +235,7 @@ module MovementSpec =
             Rekey       = None
             Reconcile   = []
             ReconcileIgnore = []
+            ForeignRefs = []
             SupportingScope = []
             Signoff     = []
             Tables      = []
@@ -297,6 +301,10 @@ type Flow =
         /// UpdatedOn). One global list beside `reconcile`, applied to
         /// every reconciled kind. Empty = diff every non-key column.
         ReconcileIgnore : string list
+        /// 2026-07-09 (T0.3) — acknowledged OUT-OF-CONTRACT references
+        /// (`OwnerKind.ReferenceName` each), declared environment-stable so the
+        /// engine's `subsetForeignRefsGate` does not refuse them.
+        ForeignRefs : string list
         /// 2026-07-08 (the business-intent program) — the typed vocabulary
         /// for the SUPPORTING (non-payload) rows a partial transfer touches:
         /// owned children, seeded/matched references, shared anchors, static
@@ -443,6 +451,9 @@ type LoadOpts =
         /// 2026-07-08 — audit columns the reconciled-kind matched-pair
         /// diff ignores (shared attribute names; from `reconcileIgnore`).
         ReconcileIgnore : string list
+        /// 2026-07-09 (T0.3) — acknowledged out-of-contract references
+        /// (`OwnerKind.ReferenceName`), declared environment-stable.
+        ForeignRefs : string list
         /// 2026-07-08 — the typed supporting-scope vocabulary; the face
         /// desugars it onto `Tables`/`Reconcile` + the seed/exclusion sets.
         SupportingScope : SupportingScope.SupportingScopeEntry list

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -166,6 +166,12 @@ type MovementSpec =
         /// 2026-07-09 (T0.3) — acknowledged out-of-contract references
         /// (`OwnerKind.ReferenceName`), declared environment-stable.
         ForeignRefs : string list
+        /// 2026-07-09 — the peer contracts' IDENTITY BASIS (`by-sskey` default /
+        /// `by-name` for cloned modules). `ByName` runs the name-alignment pass.
+        Alignment : AlignmentMode
+        /// 2026-07-09 — the cloned-module source→sink MODULE correspondence
+        /// (`by-name` only): source-module-name → sink-module-name.
+        AlignMap : Map<string, string>
         /// 2026-07-08 — the typed supporting-scope vocabulary (owned children,
         /// references, anchors, lookups, blocked dependents). Empty = none.
         SupportingScope : SupportingScope.SupportingScopeEntry list
@@ -236,6 +242,8 @@ module MovementSpec =
             Reconcile   = []
             ReconcileIgnore = []
             ForeignRefs = []
+            Alignment   = AlignmentMode.BySsKey
+            AlignMap    = Map.empty
             SupportingScope = []
             Signoff     = []
             Tables      = []
@@ -305,6 +313,14 @@ type Flow =
         /// (`OwnerKind.ReferenceName` each), declared environment-stable so the
         /// engine's `subsetForeignRefsGate` does not refuse them.
         ForeignRefs : string list
+        /// 2026-07-09 — the peer contracts' IDENTITY BASIS. `by-sskey` (default)
+        /// = renditions of one model / GUID-stable read. `by-name` = CLONED
+        /// modules (same-named entities, distinct native GUIDs) — the peer face
+        /// runs `NameAlignment.align` over `AlignMap` before the SsKey gates.
+        Alignment : AlignmentMode
+        /// 2026-07-09 — the cloned-module source→sink MODULE correspondence,
+        /// honored only under `by-name`: source-module-name → sink-module-name.
+        AlignMap : Map<string, string>
         /// 2026-07-08 (the business-intent program) — the typed vocabulary
         /// for the SUPPORTING (non-payload) rows a partial transfer touches:
         /// owned children, seeded/matched references, shared anchors, static
@@ -454,6 +470,11 @@ type LoadOpts =
         /// 2026-07-09 (T0.3) — acknowledged out-of-contract references
         /// (`OwnerKind.ReferenceName`), declared environment-stable.
         ForeignRefs : string list
+        /// 2026-07-09 — the peer contracts' identity basis (`by-name` runs the
+        /// cloned-module name-alignment pass at the face).
+        Alignment : AlignmentMode
+        /// 2026-07-09 — the cloned-module source→sink module correspondence.
+        AlignMap : Map<string, string>
         /// 2026-07-08 — the typed supporting-scope vocabulary; the face
         /// desugars it onto `Tables`/`Reconcile` + the seed/exclusion sets.
         SupportingScope : SupportingScope.SupportingScopeEntry list

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -867,7 +867,20 @@ module ProjectionConfig =
                             Result.failureOf (err "cli.config.alignmentNoMap" (sprintf "flow '%s' sets alignment 'by-name' but declares no 'alignMap' — name-alignment needs the source->sink module correspondence." name))
                         | AlignmentMode.BySsKey, false ->
                             Result.failureOf (err "cli.config.alignMapWithoutByName" (sprintf "flow '%s' declares an 'alignMap' but alignment is not 'by-name' — set \"alignment\": \"by-name\" to use it, or remove the map." name))
-                        | _ -> Result.success (mode, map)
+                        | AlignmentMode.ByName, false ->
+                            // The map must be ONE-TO-ONE on the sink side: two source
+                            // modules pointed at one sink would collapse two source
+                            // identities onto one sink identity and silently drop the
+                            // second module's rows. Refuse here (the pass's
+                            // `alignment.identityCollision` is the run-time net).
+                            let oversubscribed =
+                                map |> Map.toList |> List.map snd
+                                |> List.countBy (fun v -> v.ToLowerInvariant())
+                                |> List.choose (fun (v, n) -> if n > 1 then Some v else None)
+                            if List.isEmpty oversubscribed then Result.success (mode, map)
+                            else
+                                Result.failureOf (err "cli.config.alignMapNotInjective" (sprintf "flow '%s' 'alignMap' points more than one source module at the same sink module (%s) — the correspondence must be one-to-one." name (String.concat ", " oversubscribed)))
+                        | AlignmentMode.BySsKey, true -> Result.success (mode, map)
                     | Error e1, Error e2 -> Result.failure (e1 @ e2)
                     | Error es, _ | _, Error es -> Result.failure es
                 match parseFlowScope name el, parseFlowShape name el, parseFlowShaping el, reconcileR, parseFlowStrategy name el, parseSupportingScope name tables el, parseSignoff name el, alignmentR with
@@ -1790,6 +1803,15 @@ module Command =
     /// environments; the per-run intent finishes it. Pure; env-resolution
     /// failures are `Error` (the grant gate is a `planFlow` refusal).
     let resolveFlowSpec (cfg: ProjectionConfig) (flow: Flow) (opts: FlowRunOpts) : Result<MovementSpec> =
+        // by-name alignment is consumed ONLY on the peer leg (`UpPeer` — both
+        // endpoints `rendition: physical`). Any other route drops `alignMap`
+        // silently and a live run would cross-wire the clone the pass exists to
+        // align. Refuse here, where the direction is known (the parser cannot see
+        // renditions). Total-decision discipline: a declared safety feature is
+        // never silently downgraded.
+        if flow.Alignment = AlignmentMode.ByName && directionOf cfg flow <> MovementDirection.UpPeer then
+            Result.failureOf (err "cli.flow.alignmentNotPeer" (sprintf "flow '%s' sets alignment 'by-name' but is not a peer (env->env) move with both endpoints 'rendition: physical' — set both renditions to physical, or remove the by-name alignment." flow.Name))
+        else
         match Map.tryFind flow.To cfg.Environments with
         | None ->
             Result.failureOf (err "cli.flow.toUnknown" (sprintf "flow '%s' target environment '%s' is not defined." flow.Name flow.To))

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -820,12 +820,25 @@ module ProjectionConfig =
                                 | Some s when not (String.IsNullOrWhiteSpace s) -> yield s.Trim()
                                 | _ -> () ]
                     | _ -> []
+                // T0.3 (2026-07-09) — the acknowledged OUT-OF-CONTRACT references
+                // (each `OwnerKind.ReferenceName`), declared environment-stable so
+                // `subsetForeignRefsGate` does not refuse them. Same shape as
+                // `reconcileIgnore`: a plain string array.
+                let foreignRefs =
+                    match el.TryGetProperty "foreignRefs" with
+                    | true, r when r.ValueKind = JsonValueKind.Array ->
+                        [ for v in r.EnumerateArray() do
+                            if v.ValueKind = JsonValueKind.String then
+                                match Option.ofObj (v.GetString()) with
+                                | Some s when not (String.IsNullOrWhiteSpace s) -> yield s.Trim()
+                                | _ -> () ]
+                    | _ -> []
                 match parseFlowScope name el, parseFlowShape name el, parseFlowShaping el, reconcileR, parseFlowStrategy name el, parseSupportingScope name tables el, parseSignoff name el with
                 | Error es, _, _, _, _, _, _ | _, Error es, _, _, _, _, _ | _, _, Error es, _, _, _, _ | _, _, _, Error es, _, _, _ | _, _, _, _, Error es, _, _ | _, _, _, _, _, Error es, _ | _, _, _, _, _, _, Error es -> Result.failure es
                 | Ok scope, Ok shape, Ok shaping, Ok reconcile, Ok strategy, Ok supportingScope, Ok signoff ->
                     Result.success
                         { Name = name; From = parseFlowSource el; To = toEnv; Rekey = getString el "rekey"
-                          Tables = tables; Reconcile = reconcile; ReconcileIgnore = reconcileIgnore; SupportingScope = supportingScope; Signoff = signoff; Scope = scope; Shape = shape; Shaping = shaping
+                          Tables = tables; Reconcile = reconcile; ReconcileIgnore = reconcileIgnore; ForeignRefs = foreignRefs; SupportingScope = supportingScope; Signoff = signoff; Scope = scope; Shape = shape; Shaping = shaping
                           // AUDIT (config-primary) — the flow's declared execution profile.
                           Strategy = strategy
                           Resumable = getBool el "resumable"
@@ -1126,6 +1139,12 @@ module ProjectionConfig =
             let a = JsonArray()
             for r in flow.ReconcileIgnore do a.Add(JsonValue.Create r)
             o.["reconcileIgnore"] <- a)
+        // T0.3 — the acknowledged out-of-contract references (empty default
+        // round-trips through the absent arm, mirroring `reconcileIgnore`).
+        (if not (List.isEmpty flow.ForeignRefs) then
+            let a = JsonArray()
+            for r in flow.ForeignRefs do a.Add(JsonValue.Create r)
+            o.["foreignRefs"] <- a)
         // 2026-07-08 — the supporting-scope entries render in a fixed field
         // order (relationship, table, per-relationship payload, reason) so the
         // round-trip `parse ∘ render = id` holds on the canonical DOM.
@@ -1343,6 +1362,7 @@ module Command =
           Emission    = emissionOf spec.Strategy
           Reconcile   = spec.Reconcile
           ReconcileIgnore = spec.ReconcileIgnore
+          ForeignRefs = spec.ForeignRefs
           SupportingScope = spec.SupportingScope
           Signoff     = spec.Signoff
           Rekey       = spec.Rekey
@@ -1826,6 +1846,7 @@ module Command =
                         // the spec into the transfer leg's `LoadOpts.Reconcile`.
                         Reconcile = flow.Reconcile
                         ReconcileIgnore = flow.ReconcileIgnore
+                        ForeignRefs = flow.ForeignRefs
                         SupportingScope = flow.SupportingScope
                         Signoff  = flow.Signoff
                         Tables   = flow.Tables

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -856,7 +856,18 @@ module ProjectionConfig =
                             Result.failureOf (err "cli.config.alignMapShape" (sprintf "flow '%s' 'alignMap' must be an object of \"sourceModule\": \"sinkModule\" strings." name))
                         | _ -> Result.success Map.empty
                     match modeR, mapR with
-                    | Ok mode, Ok map -> Result.success (mode, map)
+                    | Ok mode, Ok map ->
+                        // The mode and the map must AGREE — a set-but-inert config
+                        // is a silent footgun: `by-name` with no map would fall
+                        // through to a misleading downstream shape refusal, and a
+                        // map under `by-sskey` would be silently ignored. Refuse BY
+                        // NAME at parse so the operator's intent is unambiguous.
+                        match mode, Map.isEmpty map with
+                        | AlignmentMode.ByName, true ->
+                            Result.failureOf (err "cli.config.alignmentNoMap" (sprintf "flow '%s' sets alignment 'by-name' but declares no 'alignMap' — name-alignment needs the source->sink module correspondence." name))
+                        | AlignmentMode.BySsKey, false ->
+                            Result.failureOf (err "cli.config.alignMapWithoutByName" (sprintf "flow '%s' declares an 'alignMap' but alignment is not 'by-name' — set \"alignment\": \"by-name\" to use it, or remove the map." name))
+                        | _ -> Result.success (mode, map)
                     | Error e1, Error e2 -> Result.failure (e1 @ e2)
                     | Error es, _ | _, Error es -> Result.failure es
                 match parseFlowScope name el, parseFlowShape name el, parseFlowShaping el, reconcileR, parseFlowStrategy name el, parseSupportingScope name tables el, parseSignoff name el, alignmentR with

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -833,12 +833,38 @@ module ProjectionConfig =
                                 | Some s when not (String.IsNullOrWhiteSpace s) -> yield s.Trim()
                                 | _ -> () ]
                     | _ -> []
-                match parseFlowScope name el, parseFlowShape name el, parseFlowShaping el, reconcileR, parseFlowStrategy name el, parseSupportingScope name tables el, parseSignoff name el with
-                | Error es, _, _, _, _, _, _ | _, Error es, _, _, _, _, _ | _, _, Error es, _, _, _, _ | _, _, _, Error es, _, _, _ | _, _, _, _, Error es, _, _ | _, _, _, _, _, Error es, _ | _, _, _, _, _, _, Error es -> Result.failure es
-                | Ok scope, Ok shape, Ok shaping, Ok reconcile, Ok strategy, Ok supportingScope, Ok signoff ->
+                // 2026-07-09 — the peer contracts' identity basis + the
+                // cloned-module MODULE correspondence. `alignment` defaults to
+                // `by-sskey` (byte-identical); an unknown token refuses
+                // `alignment.mode.unknown`. `alignMap` is a source→sink module
+                // object, honored only under `by-name`.
+                let alignmentR : Result<AlignmentMode * Map<string, string>> =
+                    let modeR =
+                        match getString el "alignment" with
+                        | None -> Result.success AlignmentMode.BySsKey
+                        | Some tok -> AlignmentMode.parse tok
+                    let mapR =
+                        match el.TryGetProperty "alignMap" with
+                        | true, m when m.ValueKind = JsonValueKind.Object ->
+                            [ for p in m.EnumerateObject() do
+                                if p.Value.ValueKind = JsonValueKind.String then
+                                    match Option.ofObj (p.Value.GetString()) with
+                                    | Some s when not (String.IsNullOrWhiteSpace s) -> yield p.Name.Trim(), s.Trim()
+                                    | _ -> () ]
+                            |> Map.ofList |> Result.success
+                        | true, m when m.ValueKind <> JsonValueKind.Null ->
+                            Result.failureOf (err "cli.config.alignMapShape" (sprintf "flow '%s' 'alignMap' must be an object of \"sourceModule\": \"sinkModule\" strings." name))
+                        | _ -> Result.success Map.empty
+                    match modeR, mapR with
+                    | Ok mode, Ok map -> Result.success (mode, map)
+                    | Error e1, Error e2 -> Result.failure (e1 @ e2)
+                    | Error es, _ | _, Error es -> Result.failure es
+                match parseFlowScope name el, parseFlowShape name el, parseFlowShaping el, reconcileR, parseFlowStrategy name el, parseSupportingScope name tables el, parseSignoff name el, alignmentR with
+                | Error es, _, _, _, _, _, _, _ | _, Error es, _, _, _, _, _, _ | _, _, Error es, _, _, _, _, _ | _, _, _, Error es, _, _, _, _ | _, _, _, _, Error es, _, _, _ | _, _, _, _, _, Error es, _, _ | _, _, _, _, _, _, Error es, _ | _, _, _, _, _, _, _, Error es -> Result.failure es
+                | Ok scope, Ok shape, Ok shaping, Ok reconcile, Ok strategy, Ok supportingScope, Ok signoff, Ok (alignment, alignMap) ->
                     Result.success
                         { Name = name; From = parseFlowSource el; To = toEnv; Rekey = getString el "rekey"
-                          Tables = tables; Reconcile = reconcile; ReconcileIgnore = reconcileIgnore; ForeignRefs = foreignRefs; SupportingScope = supportingScope; Signoff = signoff; Scope = scope; Shape = shape; Shaping = shaping
+                          Tables = tables; Reconcile = reconcile; ReconcileIgnore = reconcileIgnore; ForeignRefs = foreignRefs; Alignment = alignment; AlignMap = alignMap; SupportingScope = supportingScope; Signoff = signoff; Scope = scope; Shape = shape; Shaping = shaping
                           // AUDIT (config-primary) — the flow's declared execution profile.
                           Strategy = strategy
                           Resumable = getBool el "resumable"
@@ -1145,6 +1171,15 @@ module ProjectionConfig =
             let a = JsonArray()
             for r in flow.ForeignRefs do a.Add(JsonValue.Create r)
             o.["foreignRefs"] <- a)
+        // 2026-07-09 — the identity basis + module map. The `by-sskey` /
+        // empty-map defaults round-trip through the absent arms (mirroring
+        // `foreignRefs`), so only a `by-name` flow renders these.
+        (if flow.Alignment <> AlignmentMode.BySsKey then
+            o.["alignment"] <- JsonValue.Create (AlignmentMode.serialize flow.Alignment))
+        (if not (Map.isEmpty flow.AlignMap) then
+            let mo = JsonObject()
+            for KeyValue (src, snk) in flow.AlignMap do mo.[src] <- JsonValue.Create snk
+            o.["alignMap"] <- mo)
         // 2026-07-08 — the supporting-scope entries render in a fixed field
         // order (relationship, table, per-relationship payload, reason) so the
         // round-trip `parse ∘ render = id` holds on the canonical DOM.
@@ -1363,6 +1398,8 @@ module Command =
           Reconcile   = spec.Reconcile
           ReconcileIgnore = spec.ReconcileIgnore
           ForeignRefs = spec.ForeignRefs
+          Alignment   = spec.Alignment
+          AlignMap    = spec.AlignMap
           SupportingScope = spec.SupportingScope
           Signoff     = spec.Signoff
           Rekey       = spec.Rekey
@@ -1847,6 +1884,8 @@ module Command =
                         Reconcile = flow.Reconcile
                         ReconcileIgnore = flow.ReconcileIgnore
                         ForeignRefs = flow.ForeignRefs
+                        Alignment = flow.Alignment
+                        AlignMap = flow.AlignMap
                         SupportingScope = flow.SupportingScope
                         Signoff  = flow.Signoff
                         Tables   = flow.Tables

--- a/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
+++ b/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
@@ -72,11 +72,40 @@ module AlignmentMode =
 [<RequireQualifiedAccess>]
 module NameAlignment =
 
-    let private nameEq (a: Name) (b: Name) : bool =
-        System.String.Equals(Name.value a, Name.value b, System.StringComparison.OrdinalIgnoreCase)
-
     let private strEq (a: string) (b: string) : bool =
         System.String.Equals(a, b, System.StringComparison.OrdinalIgnoreCase)
+
+    let private nameEq (a: Name) (b: Name) : bool = strEq (Name.value a) (Name.value b)
+
+    /// Operator-facing name for a changed attribute facet — THE_VOICE register,
+    /// no raw `%A` reflection output in a refusal message.
+    let private facetName (f: AttributeFacet) : string =
+        match f with
+        | AttributeFacet.DataType     -> "data type"
+        | AttributeFacet.Nullability  -> "nullability"
+        | AttributeFacet.PrimaryKey   -> "primary-key flag"
+        | AttributeFacet.Length       -> "length"
+        | AttributeFacet.Precision    -> "precision"
+        | AttributeFacet.Scale        -> "scale"
+        | AttributeFacet.Identity     -> "identity flag"
+        | AttributeFacet.DefaultValue -> "default value"
+        | AttributeFacet.Computed     -> "computed expression"
+
+    /// Best-effort by-name correspondence into `pairs`: each source element that
+    /// UNIQUELY name-matches a sink element contributes its SsKey pair; no match
+    /// is silently skipped (the identity-collision guard below catches any
+    /// many-to-one). Shared by the reference / index / sequence channels.
+    let private addByNameInto
+        (pairs: ResizeArray<SsKey * SsKey>)
+        (nameOf: 'a -> Name)
+        (keyOf: 'a -> SsKey)
+        (srcs: 'a list)
+        (snks: 'a list)
+        : unit =
+        for s in srcs do
+            match snks |> List.tryFind (fun t -> nameEq (nameOf t) (nameOf s)) with
+            | Some t -> pairs.Add (keyOf s, keyOf t)
+            | None -> ()
 
     // -- the identity rewriters — apply the source→sink map at every SsKey-bearing
     //    field; any SsKey NOT in the map (an unmapped module, a `DerivedFrom`
@@ -229,37 +258,49 @@ module NameAlignment =
                                 pairs.Add (srcAttr.SsKey, sinkAttr.SsKey)
                             else
                                 let facetText =
-                                    facets |> Set.toList |> List.map (sprintf "%A") |> String.concat ", "
+                                    facets |> Set.toList |> List.map facetName |> String.concat ", "
                                 entityErrors.Add
                                     (ValidationError.create "alignment.attribute.shapeDivergence"
                                         (System.String.Concat
                                             [ Name.value srcKind.Name; "."; Name.value srcAttr.Name
                                               " differs from the sink on: "; facetText
                                               " — a cloned entity's attributes must be identical." ]))
-                    // references — best-effort name match (no refusal); a source-only
-                    // reference keeps its SsKey and falls to the FK gates downstream.
-                    for srcRef in srcKind.References do
-                        match sinkKind.References |> List.tryFind (fun r -> nameEq r.Name srcRef.Name) with
-                        | Some sinkRef -> pairs.Add (srcRef.SsKey, sinkRef.SsKey)
-                        | None -> ()
-                    // indexes — best-effort name match (no refusal).
-                    for srcIdx in srcKind.Indexes do
-                        match sinkKind.Indexes |> List.tryFind (fun i -> nameEq i.Name srcIdx.Name) with
-                        | Some sinkIdx -> pairs.Add (srcIdx.SsKey, sinkIdx.SsKey)
-                        | None -> ()
+                    // references + indexes — best-effort name match (no refusal); a
+                    // source-only one keeps its SsKey and falls to the FK gates.
+                    addByNameInto pairs (fun (r: Reference) -> r.Name) (fun r -> r.SsKey) srcKind.References sinkKind.References
+                    addByNameInto pairs (fun (i: Index) -> i.Name) (fun i -> i.SsKey) srcKind.Indexes sinkKind.Indexes
 
-        // sequences are catalog-level — best-effort name match (no refusal).
-        for srcSeq in srcL.Sequences do
-            match snkL.Sequences |> List.tryFind (fun s -> nameEq s.Name srcSeq.Name) with
-            | Some sinkSeq -> pairs.Add (srcSeq.SsKey, sinkSeq.SsKey)
-            | None -> ()
+        // Sequences are catalog-level (no module linkage), so this is a
+        // best-effort by-name re-key across the whole catalog — the identity
+        // collision guard below is what keeps it safe.
+        addByNameInto pairs (fun (s: Sequence) -> s.Name) (fun s -> s.SsKey) srcL.Sequences snkL.Sequences
 
         if entityErrors.Count > 0 then Result.failure (List.ofSeq entityErrors) else
 
-        // -- 3. Rewrite the source catalog through the correspondence map. Any
-        //    unmapped SsKey passes through, so unmapped modules ride unchanged.
-        let map = pairs |> List.ofSeq |> Map.ofList
-        Result.success (rewriteCatalog map source)
+        // -- 3. Guard IDENTITY INJECTIVITY, then rewrite. `pairs` is keyed on the
+        //    unique SOURCE SsKey, so `Map.ofList` would silently launder a
+        //    many-to-one VALUE collision (two source identities → one sink
+        //    identity — e.g. two modules pointed at one sink, or a duplicated
+        //    entity/attribute name) into duplicate SsKeys that `CatalogDiff`
+        //    then collapses (rows vanish). Refuse instead: a clean clone is 1:1,
+        //    so this never fires on a genuine clone.
+        let assoc = pairs |> List.ofSeq
+        let collisions =
+            assoc
+            |> List.groupBy snd
+            |> List.choose (fun (sinkKey, srcs) ->
+                if List.length srcs > 1 then Some (sinkKey, List.length srcs) else None)
+        if not (List.isEmpty collisions) then
+            Result.failure
+                (collisions
+                 |> List.map (fun (sinkKey, n) ->
+                     ValidationError.create "alignment.identityCollision"
+                        (System.String.Concat
+                            [ string n; " source identities align to one sink identity '"
+                              SsKey.rootOriginal sinkKey
+                              "' — the correspondence is not injective (two modules mapped to one, or a duplicated entity/attribute name)." ])))
+        else
+            Result.success (rewriteCatalog (Map.ofList assoc) source)
 
     /// The mode router — the ONE call the peer face and the go board both make so
     /// they align on the SAME fact (board/engine two-traversal parity). `BySsKey`

--- a/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
+++ b/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
@@ -118,8 +118,20 @@ module NameAlignment =
             Sequences = c.Sequences |> List.map (fun s -> { s with SsKey = remap m s.SsKey }) }
 
     /// Rewrite `source` so its SsKeys equal `sink`'s by name, within `alignMap`
-    /// (source-module-name → sink-module-name). See the module docstring.
-    let align (alignMap: Map<string, string>) (source: Catalog) (sink: Catalog) : Result<Catalog> =
+    /// (source-module-name → sink-module-name). `strictScope` is the set of
+    /// SOURCE entity SsKeys actually being transferred (the resolved load set):
+    /// an entity in it must be a CLEAN clone (name + strict shape) or the pass
+    /// refuses; an entity OUTSIDE it (an unrelated table in a mapped module) is
+    /// still re-keyed by name where it uniquely matches — so FK targets stay
+    /// consistent — but a name/shape mismatch there is NOT a refusal (its data
+    /// is not moving). `None` = a full transfer: strict over the whole estate.
+    /// See the module docstring.
+    let align
+        (alignMap: Map<string, string>)
+        (strictScope: Set<SsKey> option)
+        (source: Catalog)
+        (sink: Catalog)
+        : Result<Catalog> =
         // An empty map is not identity — under `ByName` it would silently no-op
         // and hand a misleading shape refusal downstream. Refuse BY NAME so a
         // programmatic caller (and the config path's mirror guard) fail loud.
@@ -137,6 +149,12 @@ module NameAlignment =
         // applies verbatim to the RAW `source` rewritten at the end.
         let srcL = Readiness.toLogicalShape source
         let snkL = Readiness.toLogicalShape sink
+        // Is this source entity being transferred (⇒ strict), or merely a
+        // neighbor in a mapped module (⇒ best-effort re-key, never a refusal)?
+        let isStrict (k: Kind) : bool =
+            match strictScope with
+            | None -> true
+            | Some keys -> Set.contains k.SsKey keys
         // -- 1. Module correspondence. Validate each declared pair has BOTH
         //    sides; a missing side short-circuits (nothing else is meaningful).
         let moduleErrors = ResizeArray<ValidationError>()
@@ -167,35 +185,46 @@ module NameAlignment =
         for (srcMod, sinkMod) in modulePairs do
             pairs.Add (srcMod.SsKey, sinkMod.SsKey)
             for srcKind in srcMod.Kinds do
+                let strict = isStrict srcKind
                 let candidates = sinkMod.Kinds |> List.filter (fun k -> nameEq k.Name srcKind.Name)
                 match candidates with
                 | [] ->
-                    entityErrors.Add
-                        (ValidationError.create "alignment.entity.unmatched"
-                            (System.String.Concat
-                                [ "entity '"; Name.value srcKind.Name; "' (source module '"
-                                  Name.value srcMod.Name; "') has no same-named entity in the mapped sink module '"
-                                  Name.value sinkMod.Name; "'." ]))
+                    // No correspondent. Strict (transferred) ⇒ refuse; a neighbor
+                    // ⇒ leave it unmapped (an in-scope FK to it becomes an
+                    // out-of-contract escape the T0.3 gate owns).
+                    if strict then
+                        entityErrors.Add
+                            (ValidationError.create "alignment.entity.unmatched"
+                                (System.String.Concat
+                                    [ "entity '"; Name.value srcKind.Name; "' (source module '"
+                                      Name.value srcMod.Name; "') has no same-named entity in the mapped sink module '"
+                                      Name.value sinkMod.Name; "'." ]))
                 | _ :: _ :: _ ->
-                    entityErrors.Add
-                        (ValidationError.create "alignment.entity.ambiguous"
-                            (System.String.Concat
-                                [ "entity '"; Name.value srcKind.Name; "' matches "
-                                  string (List.length candidates); " entities in the mapped sink module '"
-                                  Name.value sinkMod.Name; "' — the correspondence is ambiguous." ]))
+                    // Ambiguous. Strict ⇒ refuse (cannot re-key the transferred
+                    // entity); a neighbor ⇒ skip (leave unmapped rather than guess).
+                    if strict then
+                        entityErrors.Add
+                            (ValidationError.create "alignment.entity.ambiguous"
+                                (System.String.Concat
+                                    [ "entity '"; Name.value srcKind.Name; "' matches "
+                                      string (List.length candidates); " entities in the mapped sink module '"
+                                      Name.value sinkMod.Name; "' — the correspondence is ambiguous." ]))
                 | [ sinkKind ] ->
                     pairs.Add (srcKind.SsKey, sinkKind.SsKey)
-                    // attributes — strict shape via the shared diff comparator.
+                    // attributes — strict shape (transferred entity) via the shared
+                    // diff comparator; a neighbor re-keys by name without a shape
+                    // check (the shape gate judges only the transferred set).
                     for srcAttr in srcKind.Attributes do
                         match sinkKind.Attributes |> List.tryFind (fun a -> nameEq a.Name srcAttr.Name) with
                         | None ->
-                            entityErrors.Add
-                                (ValidationError.create "alignment.attribute.unmatched"
-                                    (System.String.Concat
-                                        [ Name.value srcKind.Name; "."; Name.value srcAttr.Name
-                                          " has no same-named attribute on the matched sink entity." ]))
+                            if strict then
+                                entityErrors.Add
+                                    (ValidationError.create "alignment.attribute.unmatched"
+                                        (System.String.Concat
+                                            [ Name.value srcKind.Name; "."; Name.value srcAttr.Name
+                                              " has no same-named attribute on the matched sink entity." ]))
                         | Some sinkAttr ->
-                            let facets = CatalogDiff.attributeShapeFacets srcAttr sinkAttr
+                            let facets = if strict then CatalogDiff.attributeShapeFacets srcAttr sinkAttr else Set.empty
                             if Set.isEmpty facets then
                                 pairs.Add (srcAttr.SsKey, sinkAttr.SsKey)
                             else
@@ -234,13 +263,19 @@ module NameAlignment =
 
     /// The mode router — the ONE call the peer face and the go board both make so
     /// they align on the SAME fact (board/engine two-traversal parity). `BySsKey`
-    /// is identity (`Ok source`, byte-identical to today); `ByName` runs the pass.
+    /// is identity (`Ok source`, byte-identical to today); `ByName` resolves the
+    /// declared `tables` subset against the source (the strict scope — an empty
+    /// subset is a full transfer, strict estate-wide) and runs the pass. Names
+    /// are rewrite-invariant, so resolving against the raw source is sound.
     let alignForMode
         (mode: AlignmentMode)
         (alignMap: Map<string, string>)
+        (tables: string list)
         (source: Catalog)
         (sink: Catalog)
         : Result<Catalog> =
         match mode with
         | AlignmentMode.BySsKey -> Result.success source
-        | AlignmentMode.ByName  -> align alignMap source sink
+        | AlignmentMode.ByName  ->
+            Transfer.resolveLoadSet source tables
+            |> Result.bind (fun strictScope -> align alignMap strictScope source sink)

--- a/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
+++ b/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
@@ -1,0 +1,238 @@
+namespace Projection.Pipeline
+
+open Projection.Core
+
+/// The IDENTITY BASIS a peer transfer aligns its two contracts on.
+///
+///   - `BySsKey` — the two contracts are two RENDITIONS of ONE authored model
+///     (or one model read from two environments whose native OSSYS GUIDs are
+///     preserved by LifeTime). Identity is the native `OssysOriginal` GUID and
+///     is EQUAL across the pair; every existing peer/reverse-leg operation keys
+///     on that. Default — byte-identical to the established legs.
+///   - `ByName` — the two contracts are CLONED MODULES: distinct OSSYS entities
+///     (different native GUIDs) that are SAME-NAMED with identical attributes.
+///     Identity is derived from the logical NAME, so it is A1-BOUNDED (a rename
+///     on either side breaks it) — materially weaker than `BySsKey`. Entered
+///     only by explicit operator opt-in (`alignment: "by-name"`), never
+///     auto-detected: a genuinely mis-wired pair (wrong environment) whose GUIDs
+///     diverged by accident must NOT be silently "aligned by name."
+[<RequireQualifiedAccess>]
+type AlignmentMode =
+    | BySsKey
+    | ByName
+
+/// Parse / render for the flow-config `alignment` token (A44: the config word
+/// and the DU are one round-trip). Lenient on case/whitespace at the parse
+/// boundary; an unknown token refuses BY NAME.
+[<RequireQualifiedAccess>]
+module AlignmentMode =
+
+    let serialize (mode: AlignmentMode) : string =
+        match mode with
+        | AlignmentMode.BySsKey -> "by-sskey"
+        | AlignmentMode.ByName  -> "by-name"
+
+    let parse (token: string) : Result<AlignmentMode> =
+        match (token.Trim()).ToLowerInvariant() with
+        | "by-sskey" -> Result.success AlignmentMode.BySsKey
+        | "by-name"  -> Result.success AlignmentMode.ByName
+        | other ->
+            Result.failureOf
+                (ValidationError.create "alignment.mode.unknown"
+                    (System.String.Concat
+                        [ "unknown alignment mode '"; other; "' — expected 'by-sskey' or 'by-name'." ]))
+
+/// THE cloned-module alignment pass (2026-07-09). Rewrites the SOURCE contract's
+/// SsKey-bearing identity fields to the SINK's corresponding SsKeys, matched BY
+/// NAME within an operator-declared source→sink MODULE correspondence, keeping
+/// physical coordinates / types / structure UNCHANGED. After the pass the two
+/// contracts are SsKey-aligned, so the entire existing engine
+/// (`CatalogDiff.between`, `RenameProjection`, `PeerTransfer.shapeGate`,
+/// reconcile, FK re-point, `TransferScope`, the write loop) runs UNCHANGED — for
+/// a true clone the logical names are identical, so the rename map is empty and
+/// the aligned pair diffs to zero. (`CatalogDiff` compares no physical
+/// column-NAME facet, so the `OSUSR_*` prefix difference never registers.)
+///
+/// DEFENSIVE — progressively verifies each dependent concern and refuses BY NAME
+/// where the alignment cannot be established safely:
+///   - `alignment.module.unmatched`      — a declared module pair is missing a side.
+///   - `alignment.entity.ambiguous`      — the mapped sink module holds >1 same-named entity.
+///   - `alignment.entity.unmatched`      — a source entity has no counterpart on the sink.
+///   - `alignment.attribute.unmatched`   — a source attribute is absent on the matched sink kind.
+///   - `alignment.attribute.shapeDivergence` — a name-matched attribute pair differs on ≥1
+///     `AttributeFacet` (STRICT — via the shared `CatalogDiff.attributeShapeFacets` comparator).
+/// Entity/attribute mismatches are COLLECTED (independent — one report for a large
+/// clone); the module-correspondence check short-circuits (nothing downstream is
+/// meaningful without it).
+///
+/// FK targets / references / indexes with no sink counterpart are NOT a refusal:
+/// their source SsKey passes through unchanged, so an in-contract escape is caught
+/// by the existing subset-FK gate and an out-of-contract one by the T0.3
+/// `subsetForeignRefsGate`.
+[<RequireQualifiedAccess>]
+module NameAlignment =
+
+    let private nameEq (a: Name) (b: Name) : bool =
+        System.String.Equals(Name.value a, Name.value b, System.StringComparison.OrdinalIgnoreCase)
+
+    let private strEq (a: string) (b: string) : bool =
+        System.String.Equals(a, b, System.StringComparison.OrdinalIgnoreCase)
+
+    // -- the identity rewriters — apply the source→sink map at every SsKey-bearing
+    //    field; any SsKey NOT in the map (an unmapped module, a `DerivedFrom`
+    //    inverse reference, an out-of-contract FK target) passes through unchanged.
+
+    let private remap (m: Map<SsKey, SsKey>) (k: SsKey) : SsKey =
+        Map.tryFind k m |> Option.defaultValue k
+
+    let private rewriteAttribute (m: Map<SsKey, SsKey>) (a: Attribute) : Attribute =
+        { a with SsKey = remap m a.SsKey }
+
+    let private rewriteReference (m: Map<SsKey, SsKey>) (r: Reference) : Reference =
+        { r with
+            SsKey           = remap m r.SsKey
+            SourceAttribute = remap m r.SourceAttribute
+            TargetKind      = remap m r.TargetKind }
+
+    let private rewriteIndex (m: Map<SsKey, SsKey>) (i: Index) : Index =
+        { i with
+            SsKey           = remap m i.SsKey
+            Columns         = i.Columns |> List.map (fun c -> { c with Attribute = remap m c.Attribute })
+            IncludedColumns = i.IncludedColumns |> List.map (remap m) }
+
+    let private rewriteKind (m: Map<SsKey, SsKey>) (k: Kind) : Kind =
+        { k with
+            SsKey      = remap m k.SsKey
+            Attributes = k.Attributes |> List.map (rewriteAttribute m)
+            References = k.References |> List.map (rewriteReference m)
+            Indexes    = k.Indexes    |> List.map (rewriteIndex m) }
+
+    let private rewriteModule (m: Map<SsKey, SsKey>) (mo: Module) : Module =
+        { mo with
+            SsKey = remap m mo.SsKey
+            Kinds = mo.Kinds |> List.map (rewriteKind m) }
+
+    let private rewriteCatalog (m: Map<SsKey, SsKey>) (c: Catalog) : Catalog =
+        { c with
+            Modules   = c.Modules   |> List.map (rewriteModule m)
+            Sequences = c.Sequences |> List.map (fun s -> { s with SsKey = remap m s.SsKey }) }
+
+    /// Rewrite `source` so its SsKeys equal `sink`'s by name, within `alignMap`
+    /// (source-module-name → sink-module-name). See the module docstring.
+    let align (alignMap: Map<string, string>) (source: Catalog) (sink: Catalog) : Result<Catalog> =
+        // Match + shape-check on the ESPACE-SAFE logical shape — the SAME
+        // normalization the shape gate uses (`Readiness.toLogicalShape`): it
+        // blanks the physical-realization artifacts (default-constraint NAME,
+        // triggers, column checks) that OutSystems derives from the physical
+        // table name and that legitimately differ between cells. SsKeys and
+        // logical names are preserved, so the correspondence map built here
+        // applies verbatim to the RAW `source` rewritten at the end.
+        let srcL = Readiness.toLogicalShape source
+        let snkL = Readiness.toLogicalShape sink
+        // -- 1. Module correspondence. Validate each declared pair has BOTH
+        //    sides; a missing side short-circuits (nothing else is meaningful).
+        let moduleErrors = ResizeArray<ValidationError>()
+        let modulePairs = ResizeArray<Module * Module>()   // (source module, sink module)
+        for KeyValue (srcModName, sinkModName) in alignMap do
+            let srcMod  = srcL.Modules |> List.tryFind (fun m -> strEq (Name.value m.Name) srcModName)
+            let sinkMod = snkL.Modules |> List.tryFind (fun m -> strEq (Name.value m.Name) sinkModName)
+            match srcMod, sinkMod with
+            | Some s, Some k -> modulePairs.Add (s, k)
+            | None, _ ->
+                moduleErrors.Add
+                    (ValidationError.create "alignment.module.unmatched"
+                        (System.String.Concat
+                            [ "the align map names source module '"; srcModName
+                              "', which is not present in the source estate." ]))
+            | _, None ->
+                moduleErrors.Add
+                    (ValidationError.create "alignment.module.unmatched"
+                        (System.String.Concat
+                            [ "the align map maps source module '"; srcModName; "' to sink module '"
+                              sinkModName; "', which is not present in the sink estate." ]))
+        if moduleErrors.Count > 0 then Result.failure (List.ofSeq moduleErrors) else
+
+        // -- 2. Per mapped pair: name-match entities + attributes (strict shape),
+        //    building ONE source→sink SsKey map; collect all mismatches.
+        let entityErrors = ResizeArray<ValidationError>()
+        let pairs = ResizeArray<SsKey * SsKey>()
+        for (srcMod, sinkMod) in modulePairs do
+            pairs.Add (srcMod.SsKey, sinkMod.SsKey)
+            for srcKind in srcMod.Kinds do
+                let candidates = sinkMod.Kinds |> List.filter (fun k -> nameEq k.Name srcKind.Name)
+                match candidates with
+                | [] ->
+                    entityErrors.Add
+                        (ValidationError.create "alignment.entity.unmatched"
+                            (System.String.Concat
+                                [ "entity '"; Name.value srcKind.Name; "' (source module '"
+                                  Name.value srcMod.Name; "') has no same-named entity in the mapped sink module '"
+                                  Name.value sinkMod.Name; "'." ]))
+                | _ :: _ :: _ ->
+                    entityErrors.Add
+                        (ValidationError.create "alignment.entity.ambiguous"
+                            (System.String.Concat
+                                [ "entity '"; Name.value srcKind.Name; "' matches "
+                                  string (List.length candidates); " entities in the mapped sink module '"
+                                  Name.value sinkMod.Name; "' — the correspondence is ambiguous." ]))
+                | [ sinkKind ] ->
+                    pairs.Add (srcKind.SsKey, sinkKind.SsKey)
+                    // attributes — strict shape via the shared diff comparator.
+                    for srcAttr in srcKind.Attributes do
+                        match sinkKind.Attributes |> List.tryFind (fun a -> nameEq a.Name srcAttr.Name) with
+                        | None ->
+                            entityErrors.Add
+                                (ValidationError.create "alignment.attribute.unmatched"
+                                    (System.String.Concat
+                                        [ Name.value srcKind.Name; "."; Name.value srcAttr.Name
+                                          " has no same-named attribute on the matched sink entity." ]))
+                        | Some sinkAttr ->
+                            let facets = CatalogDiff.attributeShapeFacets srcAttr sinkAttr
+                            if Set.isEmpty facets then
+                                pairs.Add (srcAttr.SsKey, sinkAttr.SsKey)
+                            else
+                                let facetText =
+                                    facets |> Set.toList |> List.map (sprintf "%A") |> String.concat ", "
+                                entityErrors.Add
+                                    (ValidationError.create "alignment.attribute.shapeDivergence"
+                                        (System.String.Concat
+                                            [ Name.value srcKind.Name; "."; Name.value srcAttr.Name
+                                              " differs from the sink on: "; facetText
+                                              " — a cloned entity's attributes must be identical." ]))
+                    // references — best-effort name match (no refusal); a source-only
+                    // reference keeps its SsKey and falls to the FK gates downstream.
+                    for srcRef in srcKind.References do
+                        match sinkKind.References |> List.tryFind (fun r -> nameEq r.Name srcRef.Name) with
+                        | Some sinkRef -> pairs.Add (srcRef.SsKey, sinkRef.SsKey)
+                        | None -> ()
+                    // indexes — best-effort name match (no refusal).
+                    for srcIdx in srcKind.Indexes do
+                        match sinkKind.Indexes |> List.tryFind (fun i -> nameEq i.Name srcIdx.Name) with
+                        | Some sinkIdx -> pairs.Add (srcIdx.SsKey, sinkIdx.SsKey)
+                        | None -> ()
+
+        // sequences are catalog-level — best-effort name match (no refusal).
+        for srcSeq in srcL.Sequences do
+            match snkL.Sequences |> List.tryFind (fun s -> nameEq s.Name srcSeq.Name) with
+            | Some sinkSeq -> pairs.Add (srcSeq.SsKey, sinkSeq.SsKey)
+            | None -> ()
+
+        if entityErrors.Count > 0 then Result.failure (List.ofSeq entityErrors) else
+
+        // -- 3. Rewrite the source catalog through the correspondence map. Any
+        //    unmapped SsKey passes through, so unmapped modules ride unchanged.
+        let map = pairs |> List.ofSeq |> Map.ofList
+        Result.success (rewriteCatalog map source)
+
+    /// The mode router — the ONE call the peer face and the go board both make so
+    /// they align on the SAME fact (board/engine two-traversal parity). `BySsKey`
+    /// is identity (`Ok source`, byte-identical to today); `ByName` runs the pass.
+    let alignForMode
+        (mode: AlignmentMode)
+        (alignMap: Map<string, string>)
+        (source: Catalog)
+        (sink: Catalog)
+        : Result<Catalog> =
+        match mode with
+        | AlignmentMode.BySsKey -> Result.success source
+        | AlignmentMode.ByName  -> align alignMap source sink

--- a/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
+++ b/sidecar/projection/src/Projection.Pipeline/NameAlignment.fs
@@ -120,6 +120,14 @@ module NameAlignment =
     /// Rewrite `source` so its SsKeys equal `sink`'s by name, within `alignMap`
     /// (source-module-name → sink-module-name). See the module docstring.
     let align (alignMap: Map<string, string>) (source: Catalog) (sink: Catalog) : Result<Catalog> =
+        // An empty map is not identity — under `ByName` it would silently no-op
+        // and hand a misleading shape refusal downstream. Refuse BY NAME so a
+        // programmatic caller (and the config path's mirror guard) fail loud.
+        if Map.isEmpty alignMap then
+            Result.failureOf
+                (ValidationError.create "alignment.mapEmpty"
+                    "name-alignment requires a non-empty source->sink module map.")
+        else
         // Match + shape-check on the ESPACE-SAFE logical shape — the SAME
         // normalization the shape gate uses (`Readiness.toLogicalShape`): it
         // blanks the physical-realization artifacts (default-constraint NAME,

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -70,6 +70,7 @@
     <Compile Include="EjectRun.fs" />
     <Compile Include="ReportRun.fs" />
     <Compile Include="TransferSpec.fs" />
+    <Compile Include="NameAlignment.fs" />
     <Compile Include="PeerTransfer.fs" />
     <Compile Include="GoBoard.fs" />
     <Compile Include="SupportingScope.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/TransferRevert.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRevert.fs
@@ -24,6 +24,58 @@ module TransferRevert =
         sprintf "-- projection:%s server=%s database=%s generated=%s"
             artifactKind sink.DataSource sink.Database (System.DateTime.UtcNow.ToString "o") // LINT-ALLOW: terminal artifact-header text; DataSource/Database are SqlClient-provided identifiers at this terminal file boundary
 
+    /// The provenance an undo artifact carries — the sink it was captured against.
+    /// `HasHeader` is whether the `-- projection:` line is present at all (a
+    /// header-less script cannot be verified); `Server` / `Database` are the
+    /// stamped coordinates, each `None` when the token is absent (a legacy header
+    /// that predates the `server=` token still verifies on `database=`).
+    type Provenance =
+        { HasHeader : bool
+          Server    : string option
+          Database  : string option }
+
+    /// Parse the wrong-sink provenance from an undo script's lines. Pure — the
+    /// face reads the file, this decides. Reads the FIRST `-- projection:` line.
+    let parseProvenance (lines: string seq) : Provenance =
+        let header =
+            lines
+            |> Seq.map (fun (l: string) -> l.Trim())
+            |> Seq.tryFind (fun l -> l.StartsWith "-- projection:")
+        match header with
+        | None -> { HasHeader = false; Server = None; Database = None }
+        | Some h ->
+            let tok (prefix: string) : string option =
+                h.Split(' ')
+                |> Array.tryPick (fun t -> if t.StartsWith prefix then Some (t.Substring prefix.Length) else None)
+            { HasHeader = true; Server = tok "server="; Database = tok "database=" }
+
+    /// THE WRONG-SINK GUARD verdict (2026-07-09, fail-CLOSED) — a `revert` deletes
+    /// BY KEY in whatever `--against` resolves to, the single most destructive
+    /// standalone act, so the guard defaults to REFUSE, not proceed:
+    ///  - a HEADER-LESS script cannot be verified — refuse `revert.headerMissing`
+    ///    (the prior behavior proceeded with only a printed note — fail-OPEN);
+    ///  - a stamped `database=` OR `server=` that disagrees with the live sink —
+    ///    refuse `revert.sinkMismatch` (server is now checked too, not just the
+    ///    database, so a same-named DB on a different server no longer passes).
+    /// `--force` is the deliberate override (a restored/renamed copy). Total.
+    let guardVerdict (force: bool) (prov: Provenance) (sinkServer: string) (sinkDatabase: string) : ValidationError option =
+        let eq (a: string) (b: string) = System.String.Equals(a, b, System.StringComparison.OrdinalIgnoreCase)
+        if force then None
+        elif not prov.HasHeader then
+            Some (ValidationError.create "revert.headerMissing"
+                    (sprintf "this undo script carries no provenance header, so the environment it was captured against cannot be verified — it would DELETE BY KEY in whatever --against resolves to (server '%s', database '%s'). Re-generate the undo from a current transfer, or pass --force to delete against this sink anyway." sinkServer sinkDatabase))
+        else
+            match prov.Database with
+            | Some d when not (eq d sinkDatabase) ->
+                Some (ValidationError.create "revert.sinkMismatch"
+                        (sprintf "this undo was captured against database '%s', but --against resolves to '%s'. Re-point --against at the environment the transfer wrote, or pass --force if the database was deliberately renamed/restored." d sinkDatabase))
+            | _ ->
+                match prov.Server with
+                | Some s when not (eq s sinkServer) ->
+                    Some (ValidationError.create "revert.sinkMismatch"
+                            (sprintf "this undo was captured against server '%s', but --against resolves to '%s'. Re-point --against at the environment the transfer wrote, or pass --force if the server was deliberately changed." s sinkServer))
+                | _ -> None
+
     /// Build A — the child-first `DELETE`-by-captured-key revert script for a
     /// failed load. For each `AssignedBySink` kind, in the REVERSE of the
     /// parent-first insert order (children first, so an FK never blocks a delete),

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -2355,6 +2355,13 @@ module Transfer =
         // 2026-07-09 — the static-lookup kinds asserted identical across the
         // environments; a divergence refuses `transfer.staticLookup.diverged`.
         (staticLookupKinds: Set<SsKey>)
+        // 2026-07-09 (T1.10) — the flow's write-signoff greenlights. Defense-in-
+        // depth mirroring `runCore`: the streaming plan is sink-mint (AssignedBySink)
+        // and the selector refuses WipeAndLoad, so no destructive mode is reachable
+        // TODAY — but the identity-insert arm is present so a future preserve-keys
+        // streaming path cannot write explicit keys ungated (the runCore/streaming
+        // gate blocks no longer drift).
+        (signoffs: WriteSignoff.WriteApproval list)
         (journalDirectory: string option)
         // D — the streaming arm of the data-leg compensating-undo (M23 on the
         // estate-scale path). On a mid-stream crash the partial sink-minted rows
@@ -2451,10 +2458,28 @@ module Transfer =
                     else None
                 let staticLookupRefusal =
                     if mode = Execute then staticLookupRefusalOf sinkContract staticLookupDivs else None
-                match preWrite, staticLookupRefusal with
-                | Some refusal, _ -> return Result.failureOf refusal
-                | _, Some refusal -> return Result.failureOf refusal
-                | None, None ->
+                // T1.10 — defense-in-depth: the same identity-insert gate runCore
+                // carries, so streaming and materialized cannot drift. Inert today
+                // (the streaming plan is sink-mint), a guard for a future path.
+                let identityInsertRefusal =
+                    if mode = Execute then
+                        match identityInsertTables sinkContract plan with
+                        | [] -> None
+                        | idTables ->
+                            match WriteSignoff.verify "the flow" signoffs WriteSignoff.WriteMode.IdentityInsert idTables with
+                            | WriteSignoff.Confirmed _ -> None
+                            | WriteSignoff.Missing (reason, _) ->
+                                Some (ValidationError.create "transfer.writeSignoff.ungreenlit"
+                                    (sprintf "explicit identity keys are written but not greenlit — %s Declare it in the flow's `signoff` array (run `check go` for the exact edit) before authorizing the run." reason))
+                            | WriteSignoff.ScopeMismatch (reason, _) ->
+                                Some (ValidationError.create "transfer.writeSignoff.ungreenlit"
+                                    (sprintf "the identity-insert signoff does not cover the write — %s Widen the signoff's `tables` (or run `check go`) before authorizing the run." reason))
+                    else None
+                match preWrite, identityInsertRefusal, staticLookupRefusal with
+                | Some refusal, _, _ -> return Result.failureOf refusal
+                | _, Some refusal, _ -> return Result.failureOf refusal
+                | _, _, Some refusal -> return Result.failureOf refusal
+                | None, None, None ->
                     if mode <> Execute then
                         // Phase 4 — the movement DryRun preview. Estimate
                         // each kind's rows-would-move with a cheap exact
@@ -2604,7 +2629,7 @@ module Transfer =
         // The straight load supplies the inert revert levers (`false None`) the
         // caller did not name — D's compensating-undo is reachable only through the
         // reconciling / reverse-leg faces that carry the per-environment policy.
-        runStreamingReconcilingWithRenames mode allowCdc false source sink sourceContract sinkContract Map.empty Set.empty Set.empty journalDirectory false None
+        runStreamingReconcilingWithRenames mode allowCdc false source sink sourceContract sinkContract Map.empty Set.empty Set.empty [] journalDirectory false None
 
     /// The streaming reverse leg through the `TransferConnections`
     /// apparatus (D9) — the bounded-memory sibling of
@@ -2631,6 +2656,9 @@ module Transfer =
         // 2026-07-09 — the static-lookup kinds asserted identical across the
         // environments; a divergence refuses `transfer.staticLookup.diverged`.
         (staticLookupKinds: Set<SsKey>)
+        // 2026-07-09 (T1.10) — the flow's write-signoff greenlights (defense-in-
+        // depth; the streaming identity-insert gate reads them).
+        (signoffs: WriteSignoff.WriteApproval list)
         // D — the per-environment revert policy, collapsed at the RunFaces face
         // (`RevertPolicy.toEngine`) to (autoRevert, dir); previously only the
         // materialized reverse-leg face consumed them.
@@ -2646,7 +2674,7 @@ module Transfer =
                 | Error es -> return Result.failure es
                 | Ok sink ->
                     use sink = sink
-                    return! runStreamingReconcilingWithRenames mode allowCdc allowDrops source sink logicalSourceContract physicalSinkContract reconciliation reconcileIgnore staticLookupKinds journalDirectory autoRevert revertDir
+                    return! runStreamingReconcilingWithRenames mode allowCdc allowDrops source sink logicalSourceContract physicalSinkContract reconciliation reconcileIgnore staticLookupKinds signoffs journalDirectory autoRevert revertDir
         }
 
     /// Run a *reconciling* Transfer — the operator's headline case

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -725,6 +725,29 @@ module Transfer =
                             "%d relationship(s) escape the declared table subset (their rows would keep SOURCE-environment references): %s. Reconcile each target against the sink's rows, or widen the subset."
                             escapes.Length (String.concat "; " escapes)))
 
+    /// T0.3 (2026-07-09) — the OUT-OF-CONTRACT foreign-reference gate. An in-subset
+    /// FK to a NON-User kind ABSENT from the acquired contract loads the raw source
+    /// surrogate into the sink (a silent cross-environment mis-key — runbook live
+    /// hotspot #1). `escapingEdges` skips these, so refuse BY NAME unless the flow
+    /// declares the reference environment-stable in `foreignRefs` (the durable,
+    /// auditable ack). Fail-closed; the platform-User path is excluded upstream in
+    /// `outOfContractEscapes` (the User-reflow re-points it). No load-set (a full
+    /// transfer) has no out-of-contract escapes by definition.
+    let subsetForeignRefsGate (catalog: Catalog) (loadSet: Set<SsKey> option) (reconciled: Set<SsKey>) (acknowledged: Set<string>) : ValidationError option =
+        match loadSet with
+        | None -> None
+        | Some set ->
+            let unacked =
+                TransferSubset.outOfContractEscapes catalog set reconciled
+                |> List.filter (fun (owner, r) -> not (Set.contains (TransferSubset.foreignRefToken owner r) acknowledged))
+            if List.isEmpty unacked then None
+            else
+                let tokens = unacked |> List.map (fun (owner, r) -> TransferSubset.foreignRefToken owner r)
+                Some (ValidationError.create
+                        "transfer.subsetFkEscapes.targetOutOfContract"
+                        (sprintf "%d reference(s) target a kind OUTSIDE the acquired contract; their rows would keep SOURCE-environment surrogates (a silent cross-wire): %s. Declare each environment-stable in the flow's `foreignRefs`, or widen the acquisition to include the target's espace."
+                            unacked.Length (String.concat "; " tokens)))
+
     /// T1.5 (2026-07-09) — the plan-derivable IDENTITY-INSERT detection. A load
     /// whose disposition is `PreservedFromSource` onto a kind with an IDENTITY PK
     /// writes explicit source keys straight into the identity column (SqlBulkCopy
@@ -1133,11 +1156,17 @@ module Transfer =
           /// missing rows) reds the go board and refuses a live Execute
           /// (`transfer.staticLookup.diverged`). Empty (the `def` default) asserts
           /// nothing. Sourced from `SupportingScope.resolve`'s `StaticLookupKinds`.
-          StaticLookupKinds : Set<SsKey> }
+          StaticLookupKinds : Set<SsKey>
+          /// 2026-07-09 (T0.3) — the operator's `foreignRefs`: the acknowledged
+          /// OUT-OF-CONTRACT references (each `OwnerKind.ReferenceName`), declared
+          /// environment-stable so `subsetForeignRefsGate` does not refuse them.
+          /// Empty (the `def` default) means every out-of-contract escape is a
+          /// pre-write refusal (`transfer.subsetFkEscapes.targetOutOfContract`).
+          ForeignRefsAcknowledged : Set<string> }
 
     [<RequireQualifiedAccess>]
     module WriteOptions =
-        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None; IdentityPolicy = IdentityPolicy.Structural; RetrustForeignKeys = true; AutoRevert = false; RevertArtifactDir = None; ReconcileIgnore = Set.empty; SeedKinds = Set.empty; AcknowledgedExclusions = Set.empty; Signoffs = []; StaticLookupKinds = Set.empty }
+        let def : WriteOptions = { Emission = EmissionMode.Incremental; Resumable = false; LoadSet = None; IdentityPolicy = IdentityPolicy.Structural; RetrustForeignKeys = true; AutoRevert = false; RevertArtifactDir = None; ReconcileIgnore = Set.empty; SeedKinds = Set.empty; AcknowledgedExclusions = Set.empty; Signoffs = []; StaticLookupKinds = Set.empty; ForeignRefsAcknowledged = Set.empty }
         let resumable : WriteOptions = { def with Resumable = true }
         let ofEmission (mode: EmissionMode) : WriteOptions = { def with Emission = mode }
 
@@ -1283,9 +1312,12 @@ module Transfer =
                             match subsetEscapeGate catalog writeOpts.LoadSet reconciledKinds with
                             | Some refusal -> Some refusal
                             | None ->
-                                match validatePinnedOwners reconciled with
+                                match subsetForeignRefsGate catalog writeOpts.LoadSet reconciledKinds writeOpts.ForeignRefsAcknowledged with
                                 | Some refusal -> Some refusal
-                                | None         -> validateUserMap allowDrops reconciled
+                                | None ->
+                                    match validatePinnedOwners reconciled with
+                                    | Some refusal -> Some refusal
+                                    | None         -> validateUserMap allowDrops reconciled
                 else None
             // The inbound-orphan gate (2026-07-08): a replace-wipe of a payload
             // parent fails (FK 547) if an out-of-payload dependent still holds
@@ -2877,6 +2909,9 @@ module Transfer =
         // 2026-07-09 — the static-lookup kinds asserted identical across the
         // environments; a divergence refuses `transfer.staticLookup.diverged`.
         (staticLookupKinds: Set<SsKey>)
+        // 2026-07-09 (T0.3) — the acknowledged out-of-contract references
+        // (`OwnerKind.ReferenceName`), so `subsetForeignRefsGate` does not refuse.
+        (foreignRefsAck: Set<string>)
         (autoRevert: bool)
         (revertDir: string option)
         : Task<Result<TransferReport>> =
@@ -2895,7 +2930,7 @@ module Transfer =
                     | Error es -> return Result.failure es
                     | Ok sink ->
                         use sink = sink
-                        return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renamesByKind)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy; AutoRevert = autoRevert; RevertArtifactDir = revertDir; ReconcileIgnore = reconcileIgnore; SeedKinds = seedKinds; AcknowledgedExclusions = acknowledgedExclusions; Signoffs = signoffs; StaticLookupKinds = staticLookupKinds }
+                        return! runCore mode allowCdc allowDrops source sink physicalSinkContract reconciliation (Some (logicalSourceContract, renamesByKind)) { WriteOptions.ofEmission emission with Resumable = resumable; LoadSet = loadSet; IdentityPolicy = identityPolicy; AutoRevert = autoRevert; RevertArtifactDir = revertDir; ReconcileIgnore = reconcileIgnore; SeedKinds = seedKinds; AcknowledgedExclusions = acknowledgedExclusions; Signoffs = signoffs; StaticLookupKinds = staticLookupKinds; ForeignRefsAcknowledged = foreignRefsAck }
         }
 
     /// The structural-policy reverse leg (byte-identical; the ManagedDml cloud
@@ -2922,7 +2957,7 @@ module Transfer =
         // board reds on a diverged lookup; a straight load passes `Set.empty`).
         (staticLookupKinds: Set<SsKey>)
         : Task<Result<TransferReport>> =
-        runReverseLegThroughConnectionsWith IdentityPolicy.Structural mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnore Set.empty Set.empty signoffs staticLookupKinds false None
+        runReverseLegThroughConnectionsWith IdentityPolicy.Structural mode emission resumable allowCdc allowDrops tables connections logicalSourceContract physicalSinkContract reconciliation reconcileIgnore Set.empty Set.empty signoffs staticLookupKinds Set.empty false None
 
     // -- 6.A.1: the drop-set is fail-loud, not exit-0 -----------------------
     //

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -1338,6 +1338,42 @@ module Transfer =
                         | None -> return None
                     else return None
                 }
+            // T1.8 (2026-07-09) — the populated-sink gate. A merge/Incremental
+            // Execute into a sink that already holds rows in the transferred set
+            // RE-MINTS every AssignedBySink row (fresh identities each run), silently
+            // DUPLICATING them — the runbook's admitted re-run hazard, previously
+            // board-only. Refuse BY NAME at the live-write seam over the SAME
+            // `populated` fact the go board's `re-run` axis reads (the two-traversal),
+            // so a scripted `--go` that skips `check go` cannot duplicate. The escape
+            // is `strategy: replace` (wipe-then-load, idempotent) or clearing the
+            // subset — exactly the board's remedy. Probes the sink, so it lives
+            // outside the pure preWrite.
+            let! populatedSinkRefusal =
+                task {
+                    if mode = Execute && writeOpts.Emission = EmissionMode.Incremental then
+                        // The subset kinds the board's re-run axis probes: the
+                        // declared load-set, or (a full transfer) every kind minus
+                        // the reconciled ones (matched, never inserted).
+                        let subsetKinds =
+                            match writeOpts.LoadSet with
+                            | Some s -> Catalog.allKinds catalog |> List.filter (fun k -> Set.contains k.SsKey s)
+                            | None   -> Catalog.allKinds catalog |> List.filter (fun k -> not (Set.contains k.SsKey reconciledKinds))
+                        let mutable populated : string list = []
+                        for k in subsetKinds do
+                            use cmd = sink.CreateCommand()
+                            cmd.CommandText <-
+                                sprintf "SELECT COUNT_BIG(*) FROM [%s].[%s];" (TableId.schemaText k.Physical) (TableId.tableText k.Physical)  // LINT-ALLOW: terminal SQL-text boundary; validated TableId coordinates (mirrors countKindRows)
+                            let! scalar = cmd.ExecuteScalarAsync()
+                            let n = int (unbox<int64> scalar)
+                            if n > 0 then populated <- sprintf "%s: %d row(s)" (Name.value k.Name) n :: populated
+                        match List.rev populated with
+                        | []   -> return None
+                        | rows ->
+                            return Some
+                                (ValidationError.create "transfer.incremental.populatedSink"
+                                    (sprintf "the sink already holds rows in the transferred set and the strategy is merge/incremental — a re-run would DUPLICATE sink-minted rows: %s. Set \"strategy\": \"replace\" on the flow (wipe-the-subset-then-load, idempotent), or clear the subset first." (String.concat "; " rows)))
+                    else return None
+                }
             // The write-signoff gate (2026-07-08): a destructive WipeAndLoad is
             // REFUSED at the live-write seam until the flow greenlights the mode
             // (`replace`/`fresh`) in its `signoff` — and, when a table scope is
@@ -1396,13 +1432,14 @@ module Transfer =
                             Some (ValidationError.create "transfer.writeSignoff.ungreenlit"
                                 (sprintf "the identity-insert signoff does not cover the write — %s Widen the signoff's `tables` (or run `check go`) before authorizing the run." reason))
                 else None
-            match preWrite, inboundRefusal, signoffRefusal, identityInsertRefusal, staticLookupRefusal with
-            | Some refusal, _, _, _, _ -> return Result.failureOf refusal
-            | _, Some refusal, _, _, _ -> return Result.failureOf refusal
-            | _, _, Some refusal, _, _ -> return Result.failureOf refusal
-            | _, _, _, Some refusal, _ -> return Result.failureOf refusal
-            | _, _, _, _, Some refusal -> return Result.failureOf refusal
-            | None, None, None, None, None ->
+            match preWrite, inboundRefusal, populatedSinkRefusal, signoffRefusal, identityInsertRefusal, staticLookupRefusal with
+            | Some refusal, _, _, _, _, _ -> return Result.failureOf refusal
+            | _, Some refusal, _, _, _, _ -> return Result.failureOf refusal
+            | _, _, Some refusal, _, _, _ -> return Result.failureOf refusal
+            | _, _, _, Some refusal, _, _ -> return Result.failureOf refusal
+            | _, _, _, _, Some refusal, _ -> return Result.failureOf refusal
+            | _, _, _, _, _, Some refusal -> return Result.failureOf refusal
+            | None, None, None, None, None, None ->
                 // Option C — snapshot the AS-DEPLOYED FK trust BEFORE the load, so
                 // the post-load restore re-validates only the FKs the bulk load
                 // strips (a NoCheckFk decision — untrusted as-deployed — is absent

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -725,6 +725,27 @@ module Transfer =
                             "%d relationship(s) escape the declared table subset (their rows would keep SOURCE-environment references): %s. Reconcile each target against the sink's rows, or widen the subset."
                             escapes.Length (String.concat "; " escapes)))
 
+    /// T1.5 (2026-07-09) — the plan-derivable IDENTITY-INSERT detection. A load
+    /// whose disposition is `PreservedFromSource` onto a kind with an IDENTITY PK
+    /// writes explicit source keys straight into the identity column (SqlBulkCopy
+    /// `KeepIdentity`) — the `WriteSignoff.WriteMode.IdentityInsert` act, which can
+    /// collide with keys the target already minted. Under the default `Structural`
+    /// policy identity PKs classify `AssignedBySink` (the sink mints), so this is
+    /// empty; a `FullRights` / `PreferPreservedKeys` sink is where it arises.
+    /// Returns the logical table names touched (for the signoff scope check), so
+    /// board and engine gate the SAME plan-derived fact — the two-traversal.
+    let identityInsertTables (catalog: Catalog) (plan: DataLoadPlan) : string list =
+        plan.Loads
+        |> List.choose (fun load ->
+            if load.Disposition = IdentityDisposition.PreservedFromSource then
+                match Catalog.tryFindKind load.Kind catalog with
+                | Some kind when kind.Attributes |> List.exists (fun a -> a.IsPrimaryKey && a.IsIdentity) ->
+                    Some (Name.value kind.Name)
+                | _ -> None
+            else None)
+        |> List.distinct
+        |> List.sort
+
     /// 2026-07-06 (the phase-2 adversarial review, MEDIUM #10): an Execute
     /// whose load order fell back to the ALPHABETICAL degrade (an
     /// unresolvable dependency cycle anywhere in the estate) would load
@@ -1302,12 +1323,34 @@ module Transfer =
             // the SAME `report.StaticLookupDivergences` — the two-traversal.
             let staticLookupRefusal =
                 if mode = Execute then staticLookupRefusalOf catalog staticLookupDivs else None
-            match preWrite, inboundRefusal, signoffRefusal, staticLookupRefusal with
-            | Some refusal, _, _, _ -> return Result.failureOf refusal
-            | _, Some refusal, _, _ -> return Result.failureOf refusal
-            | _, _, Some refusal, _ -> return Result.failureOf refusal
-            | _, _, _, Some refusal -> return Result.failureOf refusal
-            | None, None, None, None ->
+            // The identity-insert gate (2026-07-09, T1.5): a load that writes
+            // explicit source PKs into an IDENTITY column (a PreservedFromSource
+            // identity-PK kind — the FullRights / PreferPreservedKeys path) is a
+            // destructive mode distinct from the wipe, and was gated NOWHERE. It
+            // fires on ANY Execute (WipeAndLoad OR Incremental/merge), so the merge
+            // path is covered too. Mirrors the go board's axis over the same
+            // plan-derived `identityInsertTables` — the two-traversal.
+            let identityInsertRefusal =
+                if mode = Execute then
+                    match identityInsertTables catalog plan with
+                    | [] -> None
+                    | idTables ->
+                        match WriteSignoff.verify "the flow" writeOpts.Signoffs WriteSignoff.WriteMode.IdentityInsert idTables with
+                        | WriteSignoff.Confirmed _ -> None
+                        | WriteSignoff.Missing (reason, _) ->
+                            Some (ValidationError.create "transfer.writeSignoff.ungreenlit"
+                                (sprintf "explicit identity keys are written but not greenlit — %s Declare it in the flow's `signoff` array (run `check go` for the exact edit) before authorizing the run." reason))
+                        | WriteSignoff.ScopeMismatch (reason, _) ->
+                            Some (ValidationError.create "transfer.writeSignoff.ungreenlit"
+                                (sprintf "the identity-insert signoff does not cover the write — %s Widen the signoff's `tables` (or run `check go`) before authorizing the run." reason))
+                else None
+            match preWrite, inboundRefusal, signoffRefusal, identityInsertRefusal, staticLookupRefusal with
+            | Some refusal, _, _, _, _ -> return Result.failureOf refusal
+            | _, Some refusal, _, _, _ -> return Result.failureOf refusal
+            | _, _, Some refusal, _, _ -> return Result.failureOf refusal
+            | _, _, _, Some refusal, _ -> return Result.failureOf refusal
+            | _, _, _, _, Some refusal -> return Result.failureOf refusal
+            | None, None, None, None, None ->
                 // Option C — snapshot the AS-DEPLOYED FK trust BEFORE the load, so
                 // the post-load restore re-validates only the FKs the bulk load
                 // strips (a NoCheckFk decision — untrusted as-deployed — is absent
@@ -1707,7 +1750,17 @@ module Transfer =
         : Task<Result<TransferReport>> =
         let renamesByKind =
             RenameProjection.renames diff |> RenameProjection.renameMapByKind
-        runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renamesByKind)) { WriteOptions.def with IdentityPolicy = identityPolicy }
+        // NM-40 test-only seam: pre-greenlight identity-insert so the reverse-leg
+        // canaries exercise the LOAD mechanics without re-declaring the signoff at
+        // every call site. Inert under `Structural` (no PreservedFromSource identity
+        // kind → the gate never consults it); the gate's own refusal is witnessed by
+        // the pure + docker identity-insert tests, not here. Production routes
+        // through `runReverseLegThroughConnectionsWith`, which threads the flow's
+        // real `signoff` (T1.5).
+        runCore mode allowCdc false source sink sinkContract Map.empty (Some (sourceContract, renamesByKind))
+            { WriteOptions.def with
+                IdentityPolicy = identityPolicy
+                Signoffs = [ WriteSignoff.greenlit WriteSignoff.WriteMode.IdentityInsert ] }
 
     let runWithRenamesWith
         (identityPolicy: IdentityPolicy)

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -2062,7 +2062,7 @@ module Transfer =
                     |> Option.bind (fun index ->
                         CaptureJournal.tryFindRecord index (SsKey.rootOriginal load.Kind) chunkIx)
                 match journaled with
-                | Some record ->
+                | Some record when CaptureJournal.isComplete record ->
                     // L2 — the journal grain's ResumeAdmit (R3 / RI-3): the
                     // live source slice recomputes the fingerprint; admission
                     // replays the journaled pairs into the shared remap
@@ -2075,43 +2075,79 @@ module Transfer =
                         return Result.success ((Verified.value admitted).WrittenCount, [], [], lane)
                     | Error drift ->
                         return Result.failureOf (sourceDriftRefusal load.Kind drift)
-                | None ->
-                    // PL-9 (S16): every chunk-invariant piece below arrives
-                    // staged on the KindWriteLane; the chunk only applies.
-                    let remapped = wl.RepointChunk chunkRaw
-                    let skips = remapped.Skipped |> List.map (fun u -> load.Kind, u)
-                    let! laneOutcome =
+                | inDoubtOrFresh ->
+                    // T0.4 — a fresh chunk (`None`) OR an INTENT-only, IN-DOUBT
+                    // chunk (`Some` with `WrittenCount = IntentPending`): a prior
+                    // run fsync'd the write-ahead intent but crashed before the
+                    // COMPLETE record. Probe whether that attempt committed — a sink
+                    // count equal to the kind's completed-chunk total means it did
+                    // NOT (safe to re-write), more means it may have partially
+                    // committed and resume cannot rebuild the sink-minted identities
+                    // (refuse by name, never a silent re-mint / duplication).
+                    let! inDoubtRefusal =
                         task {
-                            match load.Disposition with
-                            | IdentityDisposition.AssignedBySink ->
-                                match wl.IdentityCapture with
-                                | Some _ when not (Set.contains load.Kind fkTargetKinds) ->
-                                    do! Bulk.copyRowsSinkMinted sink kind.Physical (wl.CellRowsNoId remapped.Rows)
-                                    return [], lane, []
-                                | Some (_, capture) ->
-                                    let! outcome = capture lane remapped.Rows
-                                    let pairs, succeeded, descents = outcome
-                                    pairs |> List.iter (fun (src, assigned) -> PackedSurrogateRemap.capture load.Kind src assigned remap)
-                                    return pairs, succeeded, descents
-                                | None ->
+                            match inDoubtOrFresh with
+                            | None -> return None
+                            | Some _ ->
+                                let expectedBefore =
+                                    journalIndex
+                                    |> Option.map (fun idx -> CaptureJournal.completedWrittenCountForKind idx (SsKey.rootOriginal load.Kind))
+                                    |> Option.defaultValue 0
+                                let! actualNow = countKindRows sink kind
+                                if actualNow = expectedBefore then return None
+                                else
+                                    return Some
+                                        (ValidationError.create "transfer.resume.chunkInDoubt"
+                                            (sprintf "chunk %d of %s was attempted but never confirmed, and the sink now holds %d row(s) vs the %d its completed chunks wrote — it may have partially committed, and resume cannot rebuild the sink-minted identities. Re-run with strategy: replace, or clear %s on the sink and resume." chunkIx (Name.value kind.Name) actualNow expectedBefore (Name.value kind.Name)))
+                        }
+                    match inDoubtRefusal with
+                    | Some refusal -> return Result.failureOf refusal
+                    | None ->
+                        // Write-ahead INTENT (fsync'd) BEFORE the sink write, so a
+                        // crash in the write→complete window leaves an in-doubt
+                        // record the probe above catches — not a silent re-mint.
+                        journal
+                        |> Option.iter (fun j ->
+                            CaptureJournal.append j
+                                (CaptureJournal.intentRecord (SsKey.rootOriginal load.Kind) chunkIx firstPk lastPk rawCount))
+                        // PL-9 (S16): every chunk-invariant piece below arrives
+                        // staged on the KindWriteLane; the chunk only applies.
+                        let remapped = wl.RepointChunk chunkRaw
+                        let skips = remapped.Skipped |> List.map (fun u -> load.Kind, u)
+                        let! laneOutcome =
+                            task {
+                                match load.Disposition with
+                                | IdentityDisposition.AssignedBySink ->
+                                    match wl.IdentityCapture with
+                                    | Some _ when not (Set.contains load.Kind fkTargetKinds) ->
+                                        do! Bulk.copyRowsSinkMinted sink kind.Physical (wl.CellRowsNoId remapped.Rows)
+                                        return [], lane, []
+                                    | Some (_, capture) ->
+                                        let! outcome = capture lane remapped.Rows
+                                        let pairs, succeeded, descents = outcome
+                                        pairs |> List.iter (fun (src, assigned) -> PackedSurrogateRemap.capture load.Kind src assigned remap)
+                                        return pairs, succeeded, descents
+                                    | None ->
+                                        do! Bulk.copyRows sink kind.Physical (wl.CellRows remapped.Rows)
+                                        return [], lane, []
+                                | _ ->
                                     do! Bulk.copyRows sink kind.Physical (wl.CellRows remapped.Rows)
                                     return [], lane, []
-                            | _ ->
-                                do! Bulk.copyRows sink kind.Physical (wl.CellRows remapped.Rows)
-                                return [], lane, []
-                        }
-                    let pairs, succeededLane, descents = laneOutcome
-                    journal
-                    |> Option.iter (fun j ->
-                        CaptureJournal.append j
-                            { Kind = SsKey.rootOriginal load.Kind
-                              ChunkIx = chunkIx
-                              FirstPk = firstPk
-                              LastPk = lastPk
-                              RawCount = rawCount
-                              WrittenCount = List.length remapped.Rows
-                              Pairs = pairs |> List.map (fun (src, assigned) -> [| src; assigned |]) |> List.toArray })
-                    return Result.success (List.length remapped.Rows, descents, skips, succeededLane)
+                            }
+                        let pairs, succeededLane, descents = laneOutcome
+                        // COMPLETE record (fsync'd) — last-write-wins over the intent,
+                        // so a clean chunk resolves to this on the next resume.
+                        journal
+                        |> Option.iter (fun j ->
+                            CaptureJournal.append j
+                                { Kind = SsKey.rootOriginal load.Kind
+                                  ChunkIx = chunkIx
+                                  FirstPk = firstPk
+                                  LastPk = lastPk
+                                  RawCount = rawCount
+                                  WrittenCount = List.length remapped.Rows
+                                  Pairs = pairs |> List.map (fun (src, assigned) -> [| src; assigned |]) |> List.toArray })
+                        return Result.success (List.length remapped.Rows, descents, skips, succeededLane)
             }
 
         // One-chunk ingest PREFETCH: chunk N+1 starts pulling from the

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -2876,6 +2876,7 @@ module Transfer =
         report.SkippedReferences.Length
         + report.UnmatchedIdentities.Length
         + report.AmbiguousIdentities.Length   // NM-51
+        + report.AmbiguousTargetMatchKeys.Length   // NM-58 (2026-07-09 — symmetry with NM-51)
         + (report.ReplayedPriorDrops |> Option.defaultValue 0)   // NM-53
 
     /// Whether a completed run lost any rows (the drop-set is non-empty).
@@ -2888,6 +2889,14 @@ module Transfer =
         not (List.isEmpty report.SkippedReferences)
         || not (List.isEmpty report.UnmatchedIdentities)
         || not (List.isEmpty report.AmbiguousIdentities)   // NM-51
+        // NM-58 (2026-07-09) — a duplicate reconcile key on the SINK re-keys every
+        // matching source FK onto the oldest sink row, silently displacing the
+        // rest. Symmetric with NM-51 (the duplicate SOURCE key): both are
+        // reconcile-key ambiguity that mis-attributes identities, so both are
+        // fail-loud (exit 9) and cleared by the same `--allow-drops` acknowledgement
+        // (or a `ManualOverride` pinning the right winner). The go-board forecast
+        // reads the same report field, so board and engine red the same fact.
+        || not (List.isEmpty report.AmbiguousTargetMatchKeys)   // NM-58
         || (report.ReplayedPriorDrops |> Option.exists (fun n -> n > 0))   // NM-53
 
     /// The exit-code policy for a *completed* (Ok) Transfer. A clean run is

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -955,7 +955,10 @@ module Transfer =
     /// declared `static-lookup` whose dataset is NOT identical across the
     /// environments (value drift, an extra sink row, or a missing row). `None`
     /// when every declared lookup is clean.
-    let private staticLookupRefusalOf (catalog: Catalog) (divs: StaticLookupDivergence list) : ValidationError option =
+    // Public (not private) so the pure pool witnesses `transfer.staticLookup.diverged`
+    // BY NAME — the 6.A.1 pattern: one pure decision the go board, the engine, and
+    // the fast pool all share.
+    let staticLookupRefusalOf (catalog: Catalog) (divs: StaticLookupDivergence list) : ValidationError option =
         match divs |> List.filter (fun d -> not d.IsClean) with
         | [] -> None
         | dirty ->

--- a/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferRun.fs
@@ -1141,6 +1141,17 @@ module Transfer =
         let resumable : WriteOptions = { def with Resumable = true }
         let ofEmission (mode: EmissionMode) : WriteOptions = { def with Emission = mode }
 
+    /// T1.6 (2026-07-09) — drops / cdc acknowledgement is EITHER the ephemeral
+    /// `--allow-drops` / `--allow-cdc` flag OR the flow's DURABLE `signoff` (the
+    /// `Drops` / `Cdc` WriteMode), so a flow pre-authorizes the loss / CDC-flood in
+    /// config (auditable: `approvedBy` / `date`) instead of only on the command
+    /// line. The pre-write gates (cdcGate, validateUserMap) and the post-write exit
+    /// code read the SAME acknowledgement — one fact, no drift.
+    let dropsAcknowledged (allowDrops: bool) (signoffs: WriteSignoff.WriteApproval list) : bool =
+        allowDrops || Set.contains WriteSignoff.WriteMode.Drops (WriteSignoff.approvedModes signoffs)
+    let cdcAcknowledged (allowCdc: bool) (signoffs: WriteSignoff.WriteApproval list) : bool =
+        allowCdc || Set.contains WriteSignoff.WriteMode.Cdc (WriteSignoff.approvedModes signoffs)
+
     let private runCore
         (mode: Mode)
         (allowCdc: bool)
@@ -1153,6 +1164,12 @@ module Transfer =
         (writeOpts: WriteOptions)
         : Task<Result<TransferReport>> =
         task {
+            // T1.6 — fold the flow's durable `Drops` / `Cdc` signoff into the
+            // effective flags, so every gate below (cdcGate, validateUserMap) treats
+            // a config-declared acknowledgement exactly as the ephemeral flag. The
+            // caller computes the same fold for the exit code (`dropsAcknowledged`).
+            let allowCdc = cdcAcknowledged allowCdc writeOpts.Signoffs
+            let allowDrops = dropsAcknowledged allowDrops writeOpts.Signoffs
             // Wave-3 slice 3.1 — CDC pre-flight gate. Only an Execute run that
             // writes to the sink is at risk; DryRun and `allowCdc = true` skip
             // the check. The refusal is fail-loud (a structured error), never a

--- a/sidecar/projection/src/Projection.Pipeline/TransferSubset.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TransferSubset.fs
@@ -33,6 +33,42 @@ module TransferSubset =
                     |> Option.map (fun target -> (kind, r, target))))
         |> List.sortBy (fun (k, r, _) -> Name.value k.Name, Name.value r.Name)
 
+    /// T0.3 (2026-07-09) — the OUT-OF-CONTRACT escaping edges: an in-subset FK
+    /// whose target kind is ABSENT from the acquired contract entirely (not just
+    /// out of the subset). `escapingEdges` deliberately SKIPS these ("the model's
+    /// own diagnostic"), but that silence is the hazard: the column is neither
+    /// re-pointed (write-time repoint covers only AssignedBySink kinds) nor
+    /// reconciled, so it loads the RAW SOURCE-environment surrogate into the sink,
+    /// cross-wired to whatever sink row owns that id. A platform-`User` FK
+    /// (`IsUserFk`) is EXCLUDED — the User-reflow / reconcile machinery re-points
+    /// it — so this surfaces only the genuine hazard: a NON-User target outside the
+    /// contract. `(owning kind, the reference)` — there is no target Kind to carry
+    /// (it is not in the contract). Deterministic: sorted by (kind, reference).
+    let outOfContractEscapes
+        (contract: Catalog)
+        (loadSet: Set<SsKey>)
+        (reconciled: Set<SsKey>)
+        : (Kind * Reference) list =
+        Catalog.allKinds contract
+        |> List.filter (fun k -> Set.contains k.SsKey loadSet)
+        |> List.collect (fun kind ->
+            kind.References
+            |> List.choose (fun r ->
+                if Set.contains r.TargetKind loadSet
+                   || Set.contains r.TargetKind reconciled
+                   || r.IsUserFk                                        // User-reflow re-points it
+                   || (Catalog.tryFindKind r.TargetKind contract).IsSome // in-contract escape → the existing gate
+                then None
+                else Some (kind, r)))
+        |> List.sortBy (fun (k, r) -> Name.value k.Name, Name.value r.Name)
+
+    /// The stable acknowledgement token for an out-of-contract escape — the
+    /// referencing side (`OwnerKind.ReferenceName`), which is fully nameable (the
+    /// owner is in the contract) even though the target is not. The flow's
+    /// `foreignRefs` array lists these to declare the references environment-stable.
+    let foreignRefToken (owner: Kind) (reference: Reference) : string =
+        sprintf "%s.%s" (Name.value owner.Name) (Name.value reference.Name)
+
     /// The INBOUND mirror of `escapingEdges` (2026-07-08, the business-intent
     /// program): every FK edge from an OUT-of-payload kind INTO the payload —
     /// the discovered dependents that `owned-child` / `blocked-dependent`

--- a/sidecar/projection/src/Projection.Pipeline/WriteSignoff.fs
+++ b/sidecar/projection/src/Projection.Pipeline/WriteSignoff.fs
@@ -88,7 +88,7 @@ module WriteSignoff =
         | WriteMode.Replace ->
             "Every row in the transferred subset is deleted child-first, then reloaded — a target row absent from the source is removed, not preserved."
         | WriteMode.Fresh ->
-            "The target is assumed empty: every source row inserts, nothing is matched, and no losses are computed — a non-empty target's divergent rows are overwritten without a diff."
+            "Fresh assumes an empty target, but the run performs the SAME destructive act as replace: every row in the transferred subset is deleted child-first, then reloaded — a populated target is fully wiped, not diffed. Greenlighting `fresh` authorizes that wipe."
         | WriteMode.Drops ->
             "Rows whose foreign key points at an unmatched record are dropped — they do not load, and the count is reported, never recovered."
         | WriteMode.Cdc ->

--- a/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
@@ -34,9 +34,10 @@ type ClonedModuleTransferDockerTests(fixture: EphemeralContainerFixture) =
                 match PeerTransfer.shapeGate subset srcContract sinkContract with
                 | Ok _ -> failwith "un-aligned cloned contracts must not read as one shape"
                 | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.peer.shapeDivergence")
-                // Align AppCore's identities across by name, then run the peer engine.
+                // Align AppCore's identities across by name (strict over the
+                // transferred City/Customer subset), then run the peer engine.
                 let alignMap = Map.ofList [ "AppCore", "AppCore" ]
-                let aligned = NameAlignment.align alignMap srcContract sinkContract |> value
+                let aligned = NameAlignment.alignForMode AlignmentMode.ByName alignMap [ "City"; "Customer" ] srcContract sinkContract |> value
                 // The aligned pair now reads as one shape over the subset.
                 match PeerTransfer.shapeGate subset aligned sinkContract with
                 | Error es -> failwithf "the aligned pair must read as one shape: %A" (es |> List.map (fun e -> e.Code))

--- a/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
@@ -42,16 +42,27 @@ type ClonedModuleTransferDockerTests(fixture: EphemeralContainerFixture) =
                 match PeerTransfer.shapeGate subset aligned sinkContract with
                 | Error es -> failwithf "the aligned pair must read as one shape: %A" (es |> List.map (fun e -> e.Code))
                 | Ok _ -> ()
+                // Reseed the sink IDENTITY ranges away from the source surrogates
+                // (City→501+, Customer→901+) so a verbatim FK copy CANNOT pass — only
+                // a genuine remap through sink-minted keys satisfies the join below.
+                do! Deploy.executeBatch sink reseedSinkIdentities
                 let! r =
                     throughConnections srcConnStr sinkConnStr false (fun connections ->
                         Transfer.runReverseLegThroughConnections
                             Transfer.Execute EmissionMode.Incremental false true false
                             [ "City"; "Customer" ] connections aligned sinkContract Map.empty Set.empty [] Set.empty)
                 let _ = value r     // the name-aligned load succeeds
-                // The subset rows land in the CLONE sink (its own physical layout),
-                // the Customer→City FK re-pointed through sink-minted keys.
+                // The subset rows land in the CLONE sink (its own physical layout).
                 let! cities = countRows sink "[dbo].[OSUSR_XDEF_CITY]"
                 let! customers = countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
                 Assert.Equal(2, cities)
                 Assert.Equal(2, customers)
+                // The Customer→City FK is re-pointed through sink-minted keys, NOT
+                // copied verbatim: no customer keeps a source CityId (1/2), and no
+                // customer dangles (every CITYID resolves to a sink City row).
+                let! verbatimFks = countRows sink "[dbo].[OSUSR_XABC_CUSTOMER] WHERE [CITYID] IN (1, 2)"
+                Assert.Equal(0, verbatimFks)
+                let! danglingFks =
+                    countRows sink "[dbo].[OSUSR_XABC_CUSTOMER] c WHERE NOT EXISTS (SELECT 1 FROM [dbo].[OSUSR_XDEF_CITY] ci WHERE ci.[ID] = c.[CITYID])"
+                Assert.Equal(0, danglingFks)
             })

--- a/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ClonedModuleTransferDockerTests.fs
@@ -1,0 +1,56 @@
+namespace Projection.Tests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open PeerEstateHarness
+
+// The cloned-module (name-aligned) peer leg at the LIVE seam (2026-07-09).
+// Cell B is a CLONE of cell A's estate — same logical entity/attribute names +
+// structure, but every native GUID `SS_Key` RE-MINTED (`OssysSeedBuilder.
+// asClonedModule`), so the two contracts share NO identity and cannot align by
+// SsKey. `NameAlignment.align` re-keys the source's identities to the sink's BY
+// NAME; the SAME peer engine the SsKey-aligned witnesses use then lands the
+// rows with FKs re-pointed. Contrast `PeerAlignedTransferDockerTests` (same-GUID
+// cells). Serial via the Docker-SqlServer collection.
+[<Xunit.Collection("Docker-SqlServer")>]
+type ClonedModuleTransferDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    /// A subset transfer between two CLONED modules: the raw contracts share no
+    /// SsKey (the shape gate refuses), but after `NameAlignment.align` maps the
+    /// AppCore identities across by name, the City/Customer subset loads into the
+    /// clone sink with the FK re-pointed by identity.
+    [<Fact>]
+    member _.``witness: a subset transfer between cloned modules aligns by name and lands rows with FKs re-pointed`` () =
+        if not (skipIfNoDocker "ClonedModule") then () else
+        run2CellWith fixture "ClonedModule" (OssysSeedBuilder.asClonedModule "X") (fun src sink srcConnStr sinkConnStr srcContract sinkContract ->
+            task {
+                do! Deploy.executeBatch src sourceRows
+                // Control: WITHOUT alignment the re-minted clone shares no identity
+                // with the source, so the shape gate reads every subset entity as
+                // absent and refuses — the by-SsKey leg genuinely cannot do this.
+                let subset = Transfer.resolveLoadSet srcContract [ "City"; "Customer" ] |> value
+                match PeerTransfer.shapeGate subset srcContract sinkContract with
+                | Ok _ -> failwith "un-aligned cloned contracts must not read as one shape"
+                | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.peer.shapeDivergence")
+                // Align AppCore's identities across by name, then run the peer engine.
+                let alignMap = Map.ofList [ "AppCore", "AppCore" ]
+                let aligned = NameAlignment.align alignMap srcContract sinkContract |> value
+                // The aligned pair now reads as one shape over the subset.
+                match PeerTransfer.shapeGate subset aligned sinkContract with
+                | Error es -> failwithf "the aligned pair must read as one shape: %A" (es |> List.map (fun e -> e.Code))
+                | Ok _ -> ()
+                let! r =
+                    throughConnections srcConnStr sinkConnStr false (fun connections ->
+                        Transfer.runReverseLegThroughConnections
+                            Transfer.Execute EmissionMode.Incremental false true false
+                            [ "City"; "Customer" ] connections aligned sinkContract Map.empty Set.empty [] Set.empty)
+                let _ = value r     // the name-aligned load succeeds
+                // The subset rows land in the CLONE sink (its own physical layout),
+                // the Customer→City FK re-pointed through sink-minted keys.
+                let! cities = countRows sink "[dbo].[OSUSR_XDEF_CITY]"
+                let! customers = countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
+                Assert.Equal(2, cities)
+                Assert.Equal(2, customers)
+            })

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -47,7 +47,7 @@ module private GoBoardFixtures =
         { Declaration = DeclareNone
           Emission    = EmissionMode.Incremental
           Reconcile   = reconcile
-          ReconcileIgnore = []; SupportingScope = []; Signoff = []
+          ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []
           Rekey       = None
           AllowCdc    = false
           Resumable   = false
@@ -336,7 +336,7 @@ type GoBoardDockerTests(fixture: EphemeralContainerFixture) =
                                 Transfer.runReverseLegThroughConnectionsWith
                                     IdentityPolicy.Structural Transfer.Execute EmissionMode.Incremental false true false
                                     [ "Customer" ] connections srcContract sinkContract reconciliation Set.empty Set.empty Set.empty
-                                    [] Set.empty false (Some undoDir)
+                                    [] Set.empty Set.empty false (Some undoDir)
                             let report = Result.value runR
                             Assert.Equal(2, report.Kinds |> List.sumBy (fun k -> k.RowsWritten))
                             let! customersAfter = GoBoardFixtures.countRows snk.Admin "[dbo].[OSUSR_XABC_CUSTOMER]"

--- a/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/GoBoardDockerTests.fs
@@ -47,7 +47,7 @@ module private GoBoardFixtures =
         { Declaration = DeclareNone
           Emission    = EmissionMode.Incremental
           Reconcile   = reconcile
-          ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []
+          ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []
           Rekey       = None
           AllowCdc    = false
           Resumable   = false

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
@@ -103,13 +103,17 @@ module PeerEstateHarness =
             return! body connections
         }
 
-    /// THE shared combinator: bootstrap the two ephemeral cells, seed both OSSYS
-    /// metamodels, read both SsKey-aligned contracts, and hand
+    /// The sink-seed-parameterized combinator: bootstrap the two ephemeral cells,
+    /// seed the source OSSYS metamodel and the sink via `sinkSeed` (applied to the
+    /// source seed), read both contracts, and hand
     /// `(src, sink, srcConnStr, sinkConnStr, srcContract, sinkContract)` to the
-    /// body. Source/sink DATA is the body's job (each witness declares its own).
-    let run2Cell
+    /// body. `run2Cell` fixes `sinkSeed` to the espace-key shift (SsKey-aligned
+    /// renditions); the cloned-module witness passes `asClonedModule` (re-minted
+    /// GUIDs — the pair aligns by NAME, not SsKey).
+    let run2CellWith
         (fixture: EphemeralContainerFixture)
         (label: string)
+        (sinkSeed: string -> string)
         (body: SqlConnection -> SqlConnection -> string -> string -> Catalog -> Catalog -> Task<'a>)
         : 'a =
         TaskSync.run (fun () ->
@@ -119,9 +123,20 @@ module PeerEstateHarness =
                     return!
                         fixture.WithEphemeralDatabase (label + "Sink") (fun sink sinkConnStr ->
                             task {
-                                do! Deploy.executeBatch sink (seedSink ())
+                                do! Deploy.executeBatch sink (sinkSeed (seedSource ()))
                                 let! srcContractR = contractOf src
                                 let! sinkContractR = contractOf sink
                                 return! body src sink srcConnStr sinkConnStr (value srcContractR) (value sinkContractR)
                             })
                 }))
+
+    /// THE shared combinator: bootstrap the two ephemeral cells, seed both OSSYS
+    /// metamodels (the sink via the espace-key shift — SsKey-aligned renditions),
+    /// read both contracts, and hand them to the body. Source/sink DATA is the
+    /// body's job (each witness declares its own).
+    let run2Cell
+        (fixture: EphemeralContainerFixture)
+        (label: string)
+        (body: SqlConnection -> SqlConnection -> string -> string -> Catalog -> Catalog -> Task<'a>)
+        : 'a =
+        run2CellWith fixture label (OssysSeedBuilder.withEspaceKey "X") body

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
@@ -65,6 +65,33 @@ module PeerEstateHarness =
         Catalog.allKinds contract
         |> List.find (fun k -> System.String.Equals(Name.value k.Name, name, System.StringComparison.OrdinalIgnoreCase))
 
+    /// Read a kind's live rows into `StaticRow`s (Values keyed by the LOGICAL
+    /// attribute Name, so two SsKey-aligned cells' rows compare directly) — the
+    /// shape `TransferImpact.Inputs` consumes, mirroring the go board's
+    /// `--impact` read.
+    let readKindRows (cnn: SqlConnection) (kind: Kind) : Task<StaticRow list> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT * FROM [%s].[%s];" (TableId.schemaText kind.Physical) (TableId.tableText kind.Physical)  // LINT-ALLOW: terminal test-SQL boundary; validated TableId coordinates
+            use! r = cmd.ExecuteReaderAsync()
+            let ord = [ for i in 0 .. r.FieldCount - 1 -> r.GetName i, i ] |> Map.ofList
+            let acc = System.Collections.Generic.List<StaticRow>()
+            let mutable go = true
+            while go do
+                let! more = r.ReadAsync()
+                if more then
+                    let values =
+                        kind.Attributes
+                        |> List.choose (fun a ->
+                            match Map.tryFind (ColumnRealization.columnNameText a.Column) ord with
+                            | Some i -> Some (a.Name, (if r.IsDBNull i then "" else string (r.GetValue i)))
+                            | None -> None)
+                        |> Map.ofList
+                    acc.Add { Identifier = kind.SsKey; Values = values }
+                else go <- false
+            return List.ofSeq acc
+        }
+
     /// The apparatus over the two ephemeral databases (D9 `ConnectionRef.Raw`).
     let throughConnections (srcConnStr: string) (sinkConnStr: string) (reconcile: bool) (body: TransferConnections -> Task<'a>) : Task<'a> =
         task {

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerEstateHarness.fs
@@ -1,0 +1,100 @@
+namespace Projection.Tests
+
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Projection.Core
+open Projection.Adapters.OssysSql
+open Projection.Pipeline
+
+/// THE SHARED two-environment peer-estate harness (2026-07-09, T3).
+///
+/// Two ephemeral OSSYS cells — a SOURCE (`OSUSR_*`) and a SINK (`OSUSR_X*`, the
+/// espace-key shift) — bootstrapped, seeded with their metamodels, OSSYS-read
+/// into two SsKey-aligned `Catalog` contracts, and wired into
+/// `TransferConnections`. Extracted from the pattern `PeerAlignedTransferDockerTests`
+/// and `PeerManagedGrantTransferDockerTests` hand-roll inline, so a NEW two-cell
+/// witness is one `run2Cell` call: the harness bootstraps + reads the contracts,
+/// and the body declares its own source/sink DATA + the transfer + the assertions.
+/// The espace-invariance canary proved the two cells READ as one shape; this
+/// harness is where a witness MOVES data between them.
+module PeerEstateHarness =
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let value (r: Result<'a>) : 'a = Result.value r
+
+    /// Cell A seed: the edge-case OSSYS estate (metamodel + empty `OSUSR_*`).
+    let seedSource () : string = MetadataExtractionSql.readEdgeCaseSeed ()
+
+    /// Cell B seed: the sibling espace cell — every `OSUSR_*` physical name
+    /// shifted to `OSUSR_X*` (GUIDs / logical names / structure held fixed).
+    let seedSink () : string = (seedSource ()) |> OssysSeedBuilder.withEspaceKey "X"
+
+    /// Reseed the sink's IDENTITY ranges away from the source surrogates so a
+    /// verbatim FK copy cannot pass — only a genuine remap through sink-minted
+    /// keys satisfies the join assertions.
+    let reseedSinkIdentities : string =
+        "DBCC CHECKIDENT ('[dbo].[OSUSR_XDEF_CITY]', RESEED, 500); \
+         DBCC CHECKIDENT ('[dbo].[OSUSR_XABC_CUSTOMER]', RESEED, 900);"
+
+    /// Deterministic SOURCE rows: two cities (surrogates 1/2 via IDENTITY_INSERT)
+    /// and two customers pointing at them.
+    let sourceRows : string =
+        "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON; \
+         INSERT INTO [dbo].[OSUSR_DEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (1, N'Lisbon', 1), (2, N'Porto', 1); \
+         SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] OFF; \
+         SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] ON; \
+         INSERT INTO [dbo].[OSUSR_ABC_CUSTOMER] ([ID],[EMAIL],[FIRSTNAME],[LASTNAME],[CITYID]) VALUES \
+             (10, N'alice@x', N'Alice', N'Almeida', 1), (11, N'bob@x', N'Bob', N'Barbosa', 2); \
+         SET IDENTITY_INSERT [dbo].[OSUSR_ABC_CUSTOMER] OFF;"
+
+    /// The OSSYS-read contract for one cell — the production acquisition path.
+    let contractOf (cnn: SqlConnection) : Task<Result<Catalog>> = LiveModelRead.fromConnection cnn
+
+    let countRows (cnn: SqlConnection) (table: string) : Task<int> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sprintf "SELECT COUNT_BIG(*) FROM %s;" table  // LINT-ALLOW: terminal test-SQL boundary; table is a test literal
+            let! scalar = cmd.ExecuteScalarAsync()
+            return int (unbox<int64> scalar)
+        }
+
+    let kindByLogicalName (contract: Catalog) (name: string) : Kind =
+        Catalog.allKinds contract
+        |> List.find (fun k -> System.String.Equals(Name.value k.Name, name, System.StringComparison.OrdinalIgnoreCase))
+
+    /// The apparatus over the two ephemeral databases (D9 `ConnectionRef.Raw`).
+    let throughConnections (srcConnStr: string) (sinkConnStr: string) (reconcile: bool) (body: TransferConnections -> Task<'a>) : Task<'a> =
+        task {
+            let srcSub : Substrate =
+                { Environment = Projection.Core.Environment.Qa; Role = SubstrateRole.Source; ConnectionRef = ConnectionRef.Raw srcConnStr }
+            let sinkSub : Substrate =
+                { Environment = Projection.Core.Environment.Uat; Role = SubstrateRole.Sink; ConnectionRef = ConnectionRef.Raw sinkConnStr }
+            let connections = TransferConnections.create srcSub sinkSub reconcile |> value
+            return! body connections
+        }
+
+    /// THE shared combinator: bootstrap the two ephemeral cells, seed both OSSYS
+    /// metamodels, read both SsKey-aligned contracts, and hand
+    /// `(src, sink, srcConnStr, sinkConnStr, srcContract, sinkContract)` to the
+    /// body. Source/sink DATA is the body's job (each witness declares its own).
+    let run2Cell
+        (fixture: EphemeralContainerFixture)
+        (label: string)
+        (body: SqlConnection -> SqlConnection -> string -> string -> Catalog -> Catalog -> Task<'a>)
+        : 'a =
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase (label + "Src") (fun src srcConnStr ->
+                task {
+                    do! Deploy.executeBatch src (seedSource ())
+                    return!
+                        fixture.WithEphemeralDatabase (label + "Sink") (fun sink sinkConnStr ->
+                            task {
+                                do! Deploy.executeBatch sink (seedSink ())
+                                let! srcContractR = contractOf src
+                                let! sinkContractR = contractOf sink
+                                return! body src sink srcConnStr sinkConnStr (value srcContractR) (value sinkContractR)
+                            })
+                }))

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
@@ -98,3 +98,39 @@ type PeerWitnessDockerTests(fixture: EphemeralContainerFixture) =
                 | Ok _ -> failwith "a diverged static-lookup dataset must refuse at the live seam"
                 | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.staticLookup.diverged")
             })
+
+    /// `check go --impact` (`TransferImpact`) — the add/delete/change/unchanged
+    /// classification against a REAL two-DB delta (pinned pure against hand-built
+    /// rows; here it reads live rows and classifies). City is matched by NAME under
+    /// a wipe: source {Lisbon, Porto, Faro} vs sink {Lisbon, Porto(ISACTIVE flipped),
+    /// Madrid} ⇒ Faro Added, Madrid Deleted, Porto Changed, Lisbon Unchanged.
+    [<Fact>]
+    member _.``witness: TransferImpact classifies a real two-DB delta (add/delete/change/unchanged)`` () =
+        if not (skipIfNoDocker "PeerImpact") then () else
+        run2Cell fixture "PeerImpact" (fun src sink srcConnStr sinkConnStr srcContract sinkContract ->
+            task {
+                do! Deploy.executeBatch src
+                        "SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] ON; INSERT INTO [dbo].[OSUSR_DEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (1, N'Lisbon', 1), (2, N'Porto', 1), (3, N'Faro', 1); SET IDENTITY_INSERT [dbo].[OSUSR_DEF_CITY] OFF;"
+                do! Deploy.executeBatch sink
+                        "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1), (502, N'Porto', 0), (503, N'Madrid', 1); SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF;"
+                let sinkCity = kindByLogicalName sinkContract "City"
+                let srcCity  = kindByLogicalName srcContract "City"
+                let nameAttr = sinkCity.Attributes |> List.find (fun a -> ColumnRealization.columnNameText a.Column = "NAME")
+                let! before = readKindRows sink sinkCity   // the sink's current rows
+                let! after  = readKindRows src srcCity      // the rows the transfer would load
+                let inputs : TransferImpact.Inputs =
+                    { Catalog      = sinkContract
+                      Scope        = Set.ofList [ sinkCity.SsKey ]
+                      Reconciled   = Set.empty
+                      Wiped        = Set.ofList [ sinkCity.SsKey ]
+                      BusinessKeys = Map.ofList [ sinkCity.SsKey, nameAttr.Name ]
+                      Before       = Map.ofList [ sinkCity.SsKey, before ]
+                      After        = Map.ofList [ sinkCity.SsKey, after ]
+                      Ignore       = Set.empty
+                      Roles        = Map.empty }
+                let impact = TransferImpact.build "witness" "replace" inputs
+                Assert.Equal(1, impact.Totals.Added)     // Faro
+                Assert.Equal(1, impact.Totals.Deleted)   // Madrid
+                Assert.Equal(1, impact.Totals.Changed)   // Porto (ISACTIVE flipped)
+                Assert.Equal(1, impact.Totals.Unchanged) // Lisbon
+            })

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
@@ -1,0 +1,68 @@
+namespace Projection.Tests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open PeerEstateHarness
+
+// Docker witnesses over the SHARED two-cell peer harness (`PeerEstateHarness`,
+// T3) — engine refusals the audit flagged as shipped-but-unproven at the live
+// seam. Each is one `run2Cell` call: the harness bootstraps the two SsKey-aligned
+// cells; the body declares its own data + the transfer + the by-name assertion.
+// Serial via the Docker-SqlServer collection.
+[<Xunit.Collection("Docker-SqlServer")>]
+type PeerWitnessDockerTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    /// `transfer.supportingScope.inboundOrphan` — a replace-wipe of an in-payload
+    /// parent (City) refuses when an OUT-of-payload dependent (Customer) already
+    /// holds referencing rows on the sink; wiping the parent would orphan them
+    /// (FK 547). Pinned pure elsewhere; here it fires against a live pair.
+    [<Fact>]
+    member _.``witness: a WipeAndLoad whose subset parent is referenced by an out-of-subset sink dependent refuses transfer.supportingScope.inboundOrphan`` () =
+        if not (skipIfNoDocker "PeerInboundOrphan") then () else
+        run2Cell fixture "PeerInbound" (fun src sink srcConnStr sinkConnStr srcContract sinkContract ->
+            task {
+                do! Deploy.executeBatch src sourceRows
+                // The sink already holds a Customer (out of the [City] subset)
+                // referencing a City row — a replace-wipe of City would orphan it.
+                do! Deploy.executeBatch sink
+                        "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1); SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF; \
+                         SET IDENTITY_INSERT [dbo].[OSUSR_XABC_CUSTOMER] ON; INSERT INTO [dbo].[OSUSR_XABC_CUSTOMER] ([ID],[EMAIL],[FIRSTNAME],[LASTNAME],[CITYID]) VALUES (901, N'carol@x', N'Carol', N'Costa', 501); SET IDENTITY_INSERT [dbo].[OSUSR_XABC_CUSTOMER] OFF;"
+                let! r =
+                    throughConnections srcConnStr sinkConnStr false (fun connections ->
+                        Transfer.runReverseLegThroughConnections
+                            Transfer.Execute EmissionMode.WipeAndLoad false true false
+                            [ "City" ] connections srcContract sinkContract Map.empty Set.empty [] Set.empty)
+                match r with
+                | Ok _ -> failwith "the replace-wipe must refuse — a sink dependent references the wiped parent"
+                | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.supportingScope.inboundOrphan")
+                // The sink is untouched — City 501 still present (the wipe never ran).
+                let! cities = countRows sink "[dbo].[OSUSR_XDEF_CITY]"
+                Assert.Equal(1, cities)
+            })
+
+    /// `transfer.incremental.populatedSink` (T1.8) — a second merge/Incremental
+    /// Execute into a populated sink refuses (it would re-mint every AssignedBySink
+    /// row, duplicating them), on the peer path.
+    [<Fact>]
+    member _.``witness: a second Incremental Execute into a populated peer sink refuses transfer.incremental.populatedSink`` () =
+        if not (skipIfNoDocker "PeerPopulated") then () else
+        run2Cell fixture "PeerPopulated" (fun src sink srcConnStr sinkConnStr srcContract sinkContract ->
+            task {
+                do! Deploy.executeBatch src sourceRows
+                let runOnce () =
+                    throughConnections srcConnStr sinkConnStr false (fun connections ->
+                        Transfer.runReverseLegThroughConnections
+                            Transfer.Execute EmissionMode.Incremental false true false
+                            [ "City"; "Customer" ] connections srcContract sinkContract Map.empty Set.empty [] Set.empty)
+                let! first = runOnce ()
+                let _ = value first     // the first load into the empty sink succeeds
+                let! second = runOnce ()
+                match second with
+                | Ok _ -> failwith "the second Incremental Execute into a populated sink must refuse (T1.8)"
+                | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.incremental.populatedSink")
+                // No duplication — the sink holds exactly the first load's 2 customers.
+                let! customers = countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
+                Assert.Equal(2, customers)
+            })

--- a/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/PeerWitnessDockerTests.fs
@@ -66,3 +66,35 @@ type PeerWitnessDockerTests(fixture: EphemeralContainerFixture) =
                 let! customers = countRows sink "[dbo].[OSUSR_XABC_CUSTOMER]"
                 Assert.Equal(2, customers)
             })
+
+    /// `transfer.staticLookup.diverged` — a kind declared `static-lookup` (reference
+    /// data asserted IDENTICAL across the environments, matched by a business key)
+    /// refuses at the live seam when the datasets differ. Here the sink holds an
+    /// EXTRA city the source does not (so every source city still MATCHES — no
+    /// unmatched drop precedes it — but the set is not identical). Pinned pure in
+    /// ReconciliationTests / TransferRefusalTests; here it fires against a live pair.
+    [<Fact>]
+    member _.``witness: a static-lookup kind whose sink dataset diverges refuses transfer.staticLookup.diverged`` () =
+        if not (skipIfNoDocker "PeerStaticLookup") then () else
+        run2Cell fixture "PeerStaticLookup" (fun src sink srcConnStr sinkConnStr srcContract sinkContract ->
+            task {
+                do! Deploy.executeBatch src sourceRows
+                // The sink's City reference data is a SUPERSET (Lisbon/Porto match
+                // the source; Madrid is extra) — every source city matches (no
+                // unmatched), but the datasets are NOT identical.
+                do! Deploy.executeBatch sink
+                        "SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] ON; INSERT INTO [dbo].[OSUSR_XDEF_CITY] ([ID],[NAME],[ISACTIVE]) VALUES (501, N'Lisbon', 1), (502, N'Porto', 1), (503, N'Madrid', 1); SET IDENTITY_INSERT [dbo].[OSUSR_XDEF_CITY] OFF;"
+                let cityKind = kindByLogicalName sinkContract "City"
+                let cityNameAttr =
+                    cityKind.Attributes |> List.find (fun a -> ColumnRealization.columnNameText a.Column = "NAME")
+                let reconciliation = Map.ofList [ cityKind.SsKey, ReconciliationStrategy.MatchByColumn cityNameAttr.Name ]
+                let staticLookup = Set.ofList [ cityKind.SsKey ]
+                let! r =
+                    throughConnections srcConnStr sinkConnStr true (fun connections ->
+                        Transfer.runReverseLegThroughConnections
+                            Transfer.Execute EmissionMode.Incremental false true false
+                            [ "Customer" ] connections srcContract sinkContract reconciliation Set.empty [] staticLookup)
+                match r with
+                | Ok _ -> failwith "a diverged static-lookup dataset must refuse at the live seam"
+                | Error es -> Assert.Contains(es, fun (e: ValidationError) -> e.Code = "transfer.staticLookup.diverged")
+            })

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -38,8 +38,10 @@
     <Compile Include="VerifyDataIntegrationTests.fs" />
     <Compile Include="IngestionIntegrationTests.fs" />
     <Compile Include="TransferCanaryTests.fs" />
+    <Compile Include="PeerEstateHarness.fs" />
     <Compile Include="PeerAlignedTransferDockerTests.fs" />
     <Compile Include="PeerManagedGrantTransferDockerTests.fs" />
+    <Compile Include="PeerWitnessDockerTests.fs" />
     <Compile Include="GoBoardDockerTests.fs" />
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="PeerAlignedTransferDockerTests.fs" />
     <Compile Include="PeerManagedGrantTransferDockerTests.fs" />
     <Compile Include="PeerWitnessDockerTests.fs" />
+    <Compile Include="ClonedModuleTransferDockerTests.fs" />
     <Compile Include="GoBoardDockerTests.fs" />
     <Compile Include="ReverseLegCanaryTests.fs" />
     <Compile Include="ReverseLegScaleTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
@@ -580,11 +580,13 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                 })
 
     [<Fact>]
-    member this.``re-run honesty: a second Incremental Execute into a populated sink DUPLICATES AssignedBySink rows (the named open question, pinned)`` () =
-        // The data path is INSERT-based and the sink mints fresh surrogates,
-        // so an Incremental re-run cannot collide on the PK — it duplicates.
-        // Today's honest modes are WipeAndLoad (D10) or the G10 resumable
-        // marker; this pin keeps the gap named until idempotent re-run lands.
+    member this.``re-run honesty (T1.8): a second Incremental Execute into a populated sink REFUSES by name, not duplicates — the sink is untouched`` () =
+        // The data path is INSERT-based and the sink mints fresh surrogates, so an
+        // Incremental re-run used to DUPLICATE (4 customers / 8 payments). T1.8
+        // closes that: the second run refuses `transfer.incremental.populatedSink`
+        // at the live-write seam (mirroring the go board's re-run axis) and leaves
+        // the sink untouched — the first run's 2 / 4 rows. The idempotent path is
+        // `strategy: replace` (WipeAndLoad, D10).
         if not (ReverseLegFixtures.skipIfNoDocker "L3Rerun") then () else
         this.WithReverseLegEstates "L3Rerun" ReverseLegFixtures.seedClean
             (fun src _ sink _ logicalContract physicalContract ->
@@ -594,11 +596,16 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                     let! firstR = runLeg ()
                     let _ = ReverseLegFixtures.value firstR
                     let! secondR = runLeg ()
-                    let _ = ReverseLegFixtures.value secondR
+                    match secondR with
+                    | Ok _ -> failwith "the second Incremental Execute into a populated sink must refuse (T1.8), not duplicate"
+                    | Error errs ->
+                        Assert.Contains(errs, fun (e: ValidationError) -> e.Code = "transfer.incremental.populatedSink")
+                    // the refused re-run wrote nothing — the sink still holds exactly
+                    // the first run's rows (no duplication).
                     let! customers = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_CUSTOMER]"
                     let! payments  = ReverseLegFixtures.countRows sink "[dbo].[OSUSR_L3_PAYMENT]"
-                    Assert.Equal(4, customers)
-                    Assert.Equal(8, payments)
+                    Assert.Equal(2, customers)
+                    Assert.Equal(4, payments)
                 })
 
     // ------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegStreamingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegStreamingTests.fs
@@ -201,7 +201,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.Execute true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty None false None
+                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty [] None false None
                     let report = ReverseLegFixtures.value reportR
                     Assert.Empty(report.SkippedReferences)
                     Assert.Empty(report.UnmatchedIdentities)
@@ -243,7 +243,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.Execute true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty None false None
+                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty [] None false None
                     // AC-I5 / NM-31 on the streaming arm: a PRE-write refusal by
                     // name, not a post-write drop.
                     match reportR with
@@ -283,7 +283,7 @@ type ReverseLegStreamingTests(fixture: EphemeralContainerFixture) =
                     let! reportR =
                         Transfer.runStreamingReconcilingWithRenames
                             Transfer.DryRun true false src sink
-                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty None false None
+                            logicalContract physicalContract this.reconcileCustomerByEmail Set.empty Set.empty [] None false None
                     let report = ReverseLegFixtures.value reportR
                     Assert.Equal(Transfer.DryRun, report.Mode)
 

--- a/sidecar/projection/tests/Projection.Tests.Integration/TransferCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/TransferCanaryTests.fs
@@ -589,7 +589,7 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
                                         try
                                             let! _ =
                                                 Transfer.runStreamingReconcilingWithRenames
-                                                    Transfer.Execute true false src sink contract contract Map.empty Set.empty Set.empty
+                                                    Transfer.Execute true false src sink contract contract Map.empty Set.empty Set.empty []
                                                     (Some journalDir) false (Some dir)
                                             return false
                                         with _ -> return true
@@ -631,7 +631,7 @@ type TransferCanaryTests(fixture: EphemeralContainerFixture) =
                                         try
                                             let! _ =
                                                 Transfer.runStreamingReconcilingWithRenames
-                                                    Transfer.Execute true false src sink contract contract Map.empty Set.empty Set.empty
+                                                    Transfer.Execute true false src sink contract contract Map.empty Set.empty Set.empty []
                                                     (Some journalDir) true None
                                             return false
                                         with _ -> return true

--- a/sidecar/projection/tests/Projection.Tests.Support/OssysSeedBuilder.fs
+++ b/sidecar/projection/tests/Projection.Tests.Support/OssysSeedBuilder.fs
@@ -26,3 +26,31 @@ module OssysSeedBuilder =
     /// preserves the espace key, so both cells carry the SAME physical
     /// names. (Deliberately named so a test declares which case it proves.)
     let sameEspace (seed: string) : string = seed
+
+    /// The CLONED-module transform (2026-07-09). A cloned espace is a DISTINCT
+    /// OutSystems module — same logical entity/attribute names and structure,
+    /// but every native GUID `SS_Key` re-minted (the clone is a different set of
+    /// OSSYS rows). Contrast `withEspaceKey`, which KEEPS GUIDs and only shifts
+    /// the physical prefix (renditions of ONE model); this re-mints so the two
+    /// cells share NO identity and cannot align by SsKey — the case
+    /// `NameAlignment.align` (by name) exists for.
+    ///
+    /// Every distinct `uniqueidentifier` literal is mapped through ONE
+    /// deterministic old→new function (`MD5(oldGuid + cloneKey)`), applied
+    /// UNIFORMLY — so an entity's `PrimaryKey_SS_Key` still equals its PK
+    /// attribute's `SS_Key`, and a reference's `Referenced_*_SS_Key` still
+    /// resolves (internal graph consistency preserved), while nothing collides
+    /// with the source. The physical prefix is then shifted via `withEspaceKey`,
+    /// so the clone's `OSUSR_*` names match the sibling espace cell's — the
+    /// physical layout is a sibling; only the identities are new.
+    let asClonedModule (cloneKey: string) (seed: string) : string =
+        let guidRx =
+            System.Text.RegularExpressions.Regex(
+                @"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}")
+        let remint (oldGuid: string) : string =
+            use md5 = System.Security.Cryptography.MD5.Create()
+            let bytes =
+                md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(oldGuid.ToLowerInvariant() + "|clone|" + cloneKey))
+            (System.Guid bytes).ToString()
+        let reminted = guidRx.Replace(seed, fun m -> remint m.Value)
+        withEspaceKey cloneKey reminted

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
@@ -61,7 +61,7 @@ let private env (name: string) (grant: Grant option) : Projection.Pipeline.Envir
     { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None; AtomicDeploy = None; Revert = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
-    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
 
 let private cfgWith (envs: Projection.Pipeline.Environment list) (flows: Flow list) : ProjectionConfig =
     { ProjectionConfig.empty with

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTests.fs
@@ -61,7 +61,7 @@ let private env (name: string) (grant: Grant option) : Projection.Pipeline.Envir
     { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None; AtomicDeploy = None; Revert = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
-    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
 
 let private cfgWith (envs: Projection.Pipeline.Environment list) (flows: Flow list) : ProjectionConfig =
     { ProjectionConfig.empty with

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
@@ -28,7 +28,7 @@ let private env (name: string) (grant: Grant option) : Projection.Pipeline.Envir
     { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None; AtomicDeploy = None; Revert = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
-    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
 
 let private representativeConfig : ProjectionConfig =
     { ProjectionConfig.empty with

--- a/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CapabilitySurveyTotalityTests.fs
@@ -28,7 +28,7 @@ let private env (name: string) (grant: Grant option) : Projection.Pipeline.Envir
     { Name = name; Access = Access.Direct (ConnectionRef.EnvVar (name + "_CONN")); Grant = grant; Store = None; Rendition = None; Archetype = None; AtomicDeploy = None; Revert = None }
 
 let private flow (name: string) (from: FlowSource) (toEnv: string) : Flow =
-    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    { Name = name; From = from; To = toEnv; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
 
 let private representativeConfig : ProjectionConfig =
     { ProjectionConfig.empty with

--- a/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
@@ -132,6 +132,26 @@ let ``load: a corrupt (non-JSON) line throws — the resume surface is not silen
         File.AppendAllText(CaptureJournal.filePath j, "this-is-not-json\n")
         Assert.ThrowsAny<exn>(fun () -> CaptureJournal.load j |> ignore) |> ignore)
 
+// -- torn trailing line (2026-07-09): a mid-crash partial with NO closing --
+// newline is SKIPPED, not thrown on, so a hard crash never wedges resume /
+// revert behind a hand-truncation. The tolerance is keyed on the missing
+// trailing newline (a newline-terminated corrupt line is complete → still
+// throws, per the test above), never on mere position.
+
+[<Fact>]
+let ``load: a TORN trailing line (no closing newline) is skipped; prior chunks still load`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "5" 5 [||])
+        CaptureJournal.append j (chunk "OS_USER" 1 "6" "10" 5 [||])
+        // Simulate a crash mid-append: a half-written final record, no newline.
+        File.AppendAllText(CaptureJournal.filePath j, "{\"Kind\":\"OS_USER\",\"ChunkIx\":2,\"First")
+        let loaded = CaptureJournal.load j
+        Assert.Equal(2, loaded.Count)
+        Assert.True(loaded.ContainsKey(("OS_USER", 0)))
+        Assert.True(loaded.ContainsKey(("OS_USER", 1)))
+        Assert.False(loaded.ContainsKey(("OS_USER", 2))))
+
 // -- L2: the journal grain on the ledger contract (R3 / RI-3) --------------
 // The contract instance over REAL journal records: the chain form, the
 // resume point, drift detection, and the effectful remap fold adapted at
@@ -221,6 +241,19 @@ let ``ResumeIndex: blank and literal-null lines are skipped; valid records still
         let index = CaptureJournal.openResumeIndex j
         Assert.True((CaptureJournal.tryFindRecord index "OS_USER" 0).IsSome)
         Assert.True((CaptureJournal.tryFindRecord index "OS_USER" 1).IsSome))
+
+[<Fact>]
+let ``ResumeIndex: a TORN trailing line (no closing newline) is skipped; prior chunks still resolve`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "5" 5 [||])
+        CaptureJournal.append j (chunk "OS_USER" 1 "6" "10" 5 [||])
+        // A crash mid-append: a half-written final record with no closing newline.
+        File.AppendAllText(CaptureJournal.filePath j, "{\"Kind\":\"OS_USER\",\"ChunkIx\":2,\"First")
+        let index = CaptureJournal.openResumeIndex j
+        Assert.True((CaptureJournal.tryFindRecord index "OS_USER" 0).IsSome)
+        Assert.True((CaptureJournal.tryFindRecord index "OS_USER" 1).IsSome)
+        Assert.Equal(None, CaptureJournal.tryFindRecord index "OS_USER" 2))
 
 [<Fact>]
 let ``ResumeIndex: byte offsets stay correct across multi-byte UTF-8 lines`` () =

--- a/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CaptureJournalTests.fs
@@ -311,3 +311,45 @@ let ``R3: journaled pairs rebuild the remap through replay — the effectful fol
     Assert.Equal(Some "9002", PackedSurrogateRemap.tryFind remap testKind "2")
     Assert.Equal(Some "9003", PackedSurrogateRemap.tryFind remap testKind "3")
     Assert.Equal(None, PackedSurrogateRemap.tryFind remap testKind "4")
+
+// -- T0.4 write-ahead intent (2026-07-09): the two-record protocol that closes --
+// the at-least-once window. A chunk is journaled INTENT (before the sink write)
+// then COMPLETE (after); a crash between leaves an in-doubt intent the resume
+// path probes rather than silently re-minting.
+
+[<Fact>]
+let ``T0.4 intent: an intent record is not complete; a written record is`` () =
+    Assert.False(CaptureJournal.isComplete (CaptureJournal.intentRecord "OS_USER" 0 "1" "5" 5))
+    Assert.True(CaptureJournal.isComplete (chunk "OS_USER" 0 "1" "5" 5 [||]))
+
+[<Fact>]
+let ``T0.4 intent: a COMPLETE record appended after its intent wins (last-write); load sees it complete`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (CaptureJournal.intentRecord "OS_USER" 0 "1" "50" 50)
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "50" 50 [| [| "1"; "9001" |] |])
+        let loaded = CaptureJournal.load j
+        Assert.True(CaptureJournal.isComplete loaded[("OS_USER", 0)])
+        Assert.Equal(50, loaded[("OS_USER", 0)].WrittenCount))
+
+[<Fact>]
+let ``T0.4 intent: an intent with NO following complete stays IN-DOUBT (a crash in the write→complete window)`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "50" 50 [| [| "1"; "9001" |] |])   // chunk 0 complete
+        CaptureJournal.append j (CaptureJournal.intentRecord "OS_USER" 1 "51" "100" 50)   // chunk 1 attempted, crashed
+        let loaded = CaptureJournal.load j
+        Assert.True(CaptureJournal.isComplete loaded[("OS_USER", 0)])
+        Assert.False(CaptureJournal.isComplete loaded[("OS_USER", 1)]))
+
+[<Fact>]
+let ``T0.4 intent: completedWrittenCountForKind sums complete chunks and excludes the in-doubt intent`` () =
+    withTempDir (fun dir ->
+        let j = CaptureJournal.create dir "plan-A"
+        CaptureJournal.append j (chunk "OS_USER" 0 "1" "50" 50 [||])                      // 50 written
+        CaptureJournal.append j (chunk "OS_USER" 1 "51" "80" 30 [||])                     // 30 written
+        CaptureJournal.append j (CaptureJournal.intentRecord "OS_USER" 2 "81" "100" 20)   // in-doubt, excluded
+        CaptureJournal.append j (chunk "OS_ORDER" 0 "1" "5" 5 [||])                       // different kind, excluded
+        let index = CaptureJournal.openResumeIndex j
+        Assert.Equal(80, CaptureJournal.completedWrittenCountForKind index "OS_USER")
+        Assert.Equal(5, CaptureJournal.completedWrittenCountForKind index "OS_ORDER"))

--- a/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
@@ -84,7 +84,7 @@ let private genVariant : Gen<ProjectionConfig * Flow> =
             | OriginDraw.NoData    -> FlowSource.NoData, [ sink ]
             | OriginDraw.Synthetic -> FlowSource.Synthetic (Some "file:p.profile.json", None), [ sink ]
             | OriginDraw.FromEnv   -> FlowSource.Env "src", [ src; sink ]
-        let flow = { Name = "v"; From = from; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+        let flow = { Name = "v"; From = from; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = scope; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
         let cfg =
             { ProjectionConfig.empty with
                 Environments = envs |> List.map (fun e -> e.Name, e) |> Map.ofList
@@ -161,7 +161,7 @@ let ``A44 clause 1 — the flow execution profile round-trips (strategy/resumabl
           Some Strategy.Fresh, true, true, Some "j2" ]
     for (strat, resumable, streaming, journal) in profiles do
         let flow =
-            { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []
+            { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []
               Scope = Some Scope.Data; Shape = None; Shaping = None
               Strategy = strat; Resumable = resumable; Streaming = streaming; Journal = journal }
         let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
@@ -179,12 +179,33 @@ let ``A44 clause 1 — the flow's foreignRefs (T0.3) round-trips (parse ∘ rend
         |> List.map (fun e -> e.Name, e) |> Map.ofList
     let flow =
         { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []
-          ForeignRefs = [ "AuditKind.CreatedBySystem"; "Ledger.PostedByService" ]; SupportingScope = []; Signoff = []
+          ForeignRefs = [ "AuditKind.CreatedBySystem"; "Ledger.PostedByService" ]; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []
           Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
     let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
     match ProjectionConfig.parse (ProjectionConfig.render cfg) with
     | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
     | Error es -> Assert.Fail(sprintf "foreignRefs round-trip failed: %A" es)
+
+[<Fact>]
+let ``A44 clause 1 — the flow's alignment mode + module map (by-name) round-trips (parse ∘ render = id)`` () =
+    // The cloned-module identity basis is a movement-vocabulary citizen: a
+    // `by-name` flow with a non-empty `alignMap` renders and re-parses to the
+    // same flow (expressible ⇔ reachable), so the peer face's alignment routing
+    // is fully config-addressable.
+    let baseEnvs =
+        [ directEnv "sink" None None; directEnv "src" None None ]
+        |> List.map (fun e -> e.Name, e) |> Map.ofList
+    let flow =
+        { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []
+          ForeignRefs = []
+          Alignment = AlignmentMode.ByName
+          AlignMap = Map.ofList [ "CustomerClone", "Customer"; "OrdersClone", "Orders" ]
+          SupportingScope = []; Signoff = []
+          Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
+    match ProjectionConfig.parse (ProjectionConfig.render cfg) with
+    | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
+    | Error es -> Assert.Fail(sprintf "alignment round-trip failed: %A" es)
 
 [<Fact>]
 let ``A44 clause 1 — the synthetic policy block round-trips (parse ∘ render = id)`` () =
@@ -275,7 +296,7 @@ let ``A44 clause 1 — renderFlow ∘ parseFlow = id on every from × scope × s
         for shape in shapeOpts do
           for tables in tableSets do
             for rekey in [ None; Some "file:users.csv" ] do
-              let flow = { Name = "f"; From = from; To = "sink"; Rekey = rekey; Tables = tables; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = shape; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+              let flow = { Name = "f"; From = from; To = "sink"; Rekey = rekey; Tables = tables; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = scope; Shape = shape; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
               let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
               match ProjectionConfig.parse (ProjectionConfig.render cfg) with
               | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
@@ -335,7 +356,7 @@ let ``A44 clause 3 — the reverse leg (B→A) routes to RunReverseLeg; a peer (
                 // J3 — the reverse leg renders its contracts from the authored
                 // model, so the legacy variant carries one (plan-time gate).
                 Shaping = { ProjectionConfig.empty.Shaping with Model = { ProjectionConfig.empty.Shaping.Model with Path = Some "model.json" } } }
-        let flow = { Name = "leg"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+        let flow = { Name = "leg"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
         cfg, flow
     let legacyCfg, legacyFlow = mk Rendition.Logical Rendition.Physical
     Assert.Equal(MovementDirection.UpLegacy, (Command.resolveFlowSpec legacyCfg legacyFlow commit |> mustOk).Direction)

--- a/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementIsomorphismTests.fs
@@ -84,7 +84,7 @@ let private genVariant : Gen<ProjectionConfig * Flow> =
             | OriginDraw.NoData    -> FlowSource.NoData, [ sink ]
             | OriginDraw.Synthetic -> FlowSource.Synthetic (Some "file:p.profile.json", None), [ sink ]
             | OriginDraw.FromEnv   -> FlowSource.Env "src", [ src; sink ]
-        let flow = { Name = "v"; From = from; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+        let flow = { Name = "v"; From = from; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
         let cfg =
             { ProjectionConfig.empty with
                 Environments = envs |> List.map (fun e -> e.Name, e) |> Map.ofList
@@ -161,13 +161,30 @@ let ``A44 clause 1 — the flow execution profile round-trips (strategy/resumabl
           Some Strategy.Fresh, true, true, Some "j2" ]
     for (strat, resumable, streaming, journal) in profiles do
         let flow =
-            { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []
+            { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []
               Scope = Some Scope.Data; Shape = None; Shaping = None
               Strategy = strat; Resumable = resumable; Streaming = streaming; Journal = journal }
         let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
         match ProjectionConfig.parse (ProjectionConfig.render cfg) with
         | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
         | Error es -> Assert.Fail(sprintf "round-trip failed for %A: %A" flow es)
+
+[<Fact>]
+let ``A44 clause 1 — the flow's foreignRefs (T0.3) round-trips (parse ∘ render = id)`` () =
+    // The out-of-contract acknowledgement is a movement-vocabulary citizen: a
+    // non-empty `foreignRefs` renders and re-parses to the same flow (expressible
+    // ⇔ reachable), so the durable ack the engine reads is config-addressable.
+    let baseEnvs =
+        [ directEnv "sink" None None; directEnv "src" None None ]
+        |> List.map (fun e -> e.Name, e) |> Map.ofList
+    let flow =
+        { Name = "f"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []
+          ForeignRefs = [ "AuditKind.CreatedBySystem"; "Ledger.PostedByService" ]; SupportingScope = []; Signoff = []
+          Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
+    match ProjectionConfig.parse (ProjectionConfig.render cfg) with
+    | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
+    | Error es -> Assert.Fail(sprintf "foreignRefs round-trip failed: %A" es)
 
 [<Fact>]
 let ``A44 clause 1 — the synthetic policy block round-trips (parse ∘ render = id)`` () =
@@ -258,7 +275,7 @@ let ``A44 clause 1 — renderFlow ∘ parseFlow = id on every from × scope × s
         for shape in shapeOpts do
           for tables in tableSets do
             for rekey in [ None; Some "file:users.csv" ] do
-              let flow = { Name = "f"; From = from; To = "sink"; Rekey = rekey; Tables = tables; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = shape; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+              let flow = { Name = "f"; From = from; To = "sink"; Rekey = rekey; Tables = tables; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = scope; Shape = shape; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
               let cfg = { ProjectionConfig.empty with Environments = baseEnvs; Flows = Map.ofList [ "f", flow ] }
               match ProjectionConfig.parse (ProjectionConfig.render cfg) with
               | Ok back -> Assert.Equal<Flow>(flow, Map.find "f" back.Flows)
@@ -318,7 +335,7 @@ let ``A44 clause 3 — the reverse leg (B→A) routes to RunReverseLeg; a peer (
                 // J3 — the reverse leg renders its contracts from the authored
                 // model, so the legacy variant carries one (plan-time gate).
                 Shaping = { ProjectionConfig.empty.Shaping with Model = { ProjectionConfig.empty.Shaping.Model with Path = Some "model.json" } } }
-        let flow = { Name = "leg"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+        let flow = { Name = "leg"; From = FlowSource.Env "src"; To = "sink"; Rekey = None; Tables = []; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = Some Scope.Data; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
         cfg, flow
     let legacyCfg, legacyFlow = mk Rendition.Logical Rendition.Physical
     Assert.Equal(MovementDirection.UpLegacy, (Command.resolveFlowSpec legacyCfg legacyFlow commit |> mustOk).Direction)

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -1305,6 +1305,29 @@ let ``config refuses a malformed flow reconcile entry, named (J2)`` () =
     Assert.Contains("cli.config.flowReconcileShape", errCodes (ProjectionConfig.parse json))
 
 [<Fact>]
+let ``config refuses an unknown alignment token, named`` () =
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignment": "by-guid" } } }"""
+    Assert.Contains("alignment.mode.unknown", errCodes (ProjectionConfig.parse json))
+
+[<Fact>]
+let ``config refuses by-name alignment with no module map, named`` () =
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignment": "by-name" } } }"""
+    Assert.Contains("cli.config.alignmentNoMap", errCodes (ProjectionConfig.parse json))
+
+[<Fact>]
+let ``config refuses an alignMap without by-name alignment, named`` () =
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignMap": { "AppCore": "AppCoreClone" } } } }"""
+    Assert.Contains("cli.config.alignMapWithoutByName", errCodes (ProjectionConfig.parse json))
+
+[<Fact>]
+let ``config parses a by-name flow with a module map`` () =
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignment": "by-name", "alignMap": { "AppCore": "AppCoreClone" } } } }"""
+    let cfg = ProjectionConfig.parse json |> mustOk
+    let flow = Map.find "g" cfg.Flows
+    Assert.Equal(AlignmentMode.ByName, flow.Alignment)
+    Assert.Equal<Map<string,string>>(Map.ofList [ "AppCore", "AppCoreClone" ], flow.AlignMap)
+
+[<Fact>]
 let ``flow reconcile threads onto the spec and into the transfer's LoadOpts (J2)`` () =
     match specOf "golden" commit with
     | Ok s -> Assert.Equal<string list>([ "OSUSR_RC_USER:EMAIL" ], s.Reconcile)

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -458,7 +458,7 @@ let private liveDev = Destination.Live (ConnectionRef.EnvVar "DEV_CONN")
 let private baseLive = MovementSpec.forDestination liveDev
 let private defaultOpts : LoadOpts =
     { Declaration = DeclareNone; Emission = EmissionMode.Incremental
-      Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Atomic = false; RevertPolicy = RevertPolicy.def; RevertDir = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None; Correction = None; SinkCapability = SinkLoadCapability.structural }
+      Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Atomic = false; RevertPolicy = RevertPolicy.def; RevertDir = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None; Correction = None; SinkCapability = SinkLoadCapability.structural }
 
 [<Fact>]
 let ``planMovement: --fresh selects WipeAndLoad on the transfer path`` () =
@@ -684,7 +684,7 @@ let ``flow golden: the table subset is honored on the transfer opts (item 5)`` (
 
 [<Fact>]
 let ``flow tables on a non-transfer action is noted (data-transfer leg only)`` () =
-    let bt = { Name = "bt"; From = FlowSource.Model; To = "onprem-uat"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    let bt = { Name = "bt"; From = FlowSource.Model; To = "onprem-uat"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
     Assert.Contains((Command.planFlow flowCfg bt preview).Notes, fun (n: string) -> n.Contains "data-transfer leg only")
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -458,7 +458,7 @@ let private liveDev = Destination.Live (ConnectionRef.EnvVar "DEV_CONN")
 let private baseLive = MovementSpec.forDestination liveDev
 let private defaultOpts : LoadOpts =
     { Declaration = DeclareNone; Emission = EmissionMode.Incremental
-      Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Atomic = false; RevertPolicy = RevertPolicy.def; RevertDir = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None; Correction = None; SinkCapability = SinkLoadCapability.structural }
+      Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Rekey = None; AllowCdc = false; Resumable = false; Streaming = false; Journal = None; Atomic = false; RevertPolicy = RevertPolicy.def; RevertDir = None; Store = None; Env = None; Tables = []; Seed = None; Scale = None; Correction = None; SinkCapability = SinkLoadCapability.structural }
 
 [<Fact>]
 let ``planMovement: --fresh selects WipeAndLoad on the transfer path`` () =
@@ -684,7 +684,7 @@ let ``flow golden: the table subset is honored on the transfer opts (item 5)`` (
 
 [<Fact>]
 let ``flow tables on a non-transfer action is noted (data-transfer leg only)`` () =
-    let bt = { Name = "bt"; From = FlowSource.Model; To = "onprem-uat"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
+    let bt = { Name = "bt"; From = FlowSource.Model; To = "onprem-uat"; Rekey = None; Tables = [ "Customer" ]; Reconcile = []; ReconcileIgnore = []; ForeignRefs = []; Alignment = AlignmentMode.BySsKey; AlignMap = Map.empty; SupportingScope = []; Signoff = []; Scope = None; Shape = None; Shaping = None; Strategy = None; Resumable = false; Streaming = false; Journal = None }
     Assert.Contains((Command.planFlow flowCfg bt preview).Notes, fun (n: string) -> n.Contains "data-transfer leg only")
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MovementSurfaceTests.fs
@@ -1328,6 +1328,54 @@ let ``config parses a by-name flow with a module map`` () =
     Assert.Equal<Map<string,string>>(Map.ofList [ "AppCore", "AppCoreClone" ], flow.AlignMap)
 
 [<Fact>]
+let ``config refuses a non-injective alignMap (two source modules -> one sink), named`` () =
+    // Two clones merged into one sink would collapse two identities onto one and
+    // silently drop the second module's rows — refuse at parse.
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignment": "by-name", "alignMap": { "Sales_A": "Shared", "Sales_B": "Shared" } } } }"""
+    Assert.Contains("cli.config.alignMapNotInjective", errCodes (ProjectionConfig.parse json))
+
+[<Fact>]
+let ``config refuses a malformed alignMap (not an object of strings), named`` () =
+    let json = """{ "environments": { "uat": { "access": "docker" } }, "flows": { "g": { "to": "uat", "alignment": "by-name", "alignMap": [ "AppCore" ] } } }"""
+    Assert.Contains("cli.config.alignMapShape", errCodes (ProjectionConfig.parse json))
+
+[<Fact>]
+let ``resolveFlowSpec refuses a by-name flow that is not a physical->physical peer move, named`` () =
+    // logical -> physical routes to the reverse leg (UpLegacy), which ignores
+    // alignMap — the guard refuses instead of silently dropping it.
+    let cfg =
+        ProjectionConfig.parse """
+        {
+          "environments": {
+            "onprem-legacy": { "access": "direct", "conn": "env:L", "rendition": "logical" },
+            "cloud-uat":     { "access": "direct", "conn": "env:U", "grant": "data", "rendition": "physical" }
+          },
+          "flows": { "misrouted": { "from": "onprem-legacy", "to": "cloud-uat", "alignment": "by-name", "alignMap": { "AppCore": "AppCoreClone" } } },
+          "model": "model.json"
+        }
+        """ |> mustOk
+    Assert.Contains("cli.flow.alignmentNotPeer", errCodes (Command.resolveFlowSpec cfg (Map.find "misrouted" cfg.Flows) previewOpts))
+
+[<Fact>]
+let ``resolveFlowSpec accepts a by-name flow on a physical->physical peer move`` () =
+    let cfg =
+        ProjectionConfig.parse """
+        {
+          "environments": {
+            "cloud-peer": { "access": "direct", "conn": "env:P", "rendition": "physical" },
+            "cloud-uat":  { "access": "direct", "conn": "env:U", "grant": "data", "rendition": "physical" }
+          },
+          "flows": { "clonepeer": { "from": "cloud-peer", "to": "cloud-uat", "alignment": "by-name", "alignMap": { "AppCore": "AppCoreClone" } } },
+          "model": "model.json"
+        }
+        """ |> mustOk
+    match Command.resolveFlowSpec cfg (Map.find "clonepeer" cfg.Flows) previewOpts with
+    | Ok s ->
+        Assert.Equal(MovementDirection.UpPeer, s.Direction)
+        Assert.Equal(AlignmentMode.ByName, s.Alignment)
+    | Error es -> Assert.Fail(sprintf "the peer by-name flow must resolve: %A" es)
+
+[<Fact>]
 let ``flow reconcile threads onto the spec and into the transfer's LoadOpts (J2)`` () =
     match specOf "golden" commit with
     | Ok s -> Assert.Equal<string list>([ "OSUSR_RC_USER:EMAIL" ], s.Reconcile)

--- a/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
@@ -168,6 +168,67 @@ let ``align does NOT refuse drift OUTSIDE the strict scope — only the transfer
     | FsResult.Error es -> Assert.Fail(sprintf "scoped align must ignore out-of-scope drift: %A" (es |> List.map (fun e -> e.Code)))
     // The same drift IS a blocker when the whole estate is in scope.
     Assert.Contains("alignment.attribute.shapeDivergence", codesOf (NameAlignment.align map None source driftedClone))
+    // And it is a blocker when the DRIFTED entity is itself in the strict scope
+    // (this is the path that proves `Some` enforces its members, not just `None`).
+    let customerKey = (findKind source "Customer").SsKey
+    Assert.Contains("alignment.attribute.shapeDivergence",
+                    codesOf (NameAlignment.align map (Some (Set.singleton customerKey)) source driftedClone))
+
+[<Fact>]
+let ``align refuses alignment.identityCollision when two source entities share a name (non-injective)`` () =
+    // A malformed source with two "City" entities: both name-match the clone's
+    // single City → two source identities collapse onto one sink identity. The
+    // injectivity guard refuses rather than let CatalogDiff silently drop one.
+    let dupSource =
+        { source with
+            Modules = source.Modules |> List.map (fun m ->
+                let city = m.Kinds |> List.find (fun k -> Name.value k.Name = "City")
+                { m with Kinds = m.Kinds @ [ { city with SsKey = OssysOriginal (System.Guid "a9999999-0000-0000-0000-000000000000") } ] }) }
+    Assert.Contains("alignment.identityCollision", codesOf (NameAlignment.align map None dupSource clone))
+
+[<Fact>]
+let ``align remaps a catalog-level sequence by name`` () =
+    let srcSeq =
+        Sequence.create (OssysOriginal (System.Guid "a0000050-0000-0000-0000-000000000000")) (nm "SEQ_Order") "dbo" "bigint" None None None None false SequenceCacheMode.Unspecified None
+        |> Result.value
+    let snkSeq = { srcSeq with SsKey = OssysOriginal (System.Guid "b0000050-0000-0000-0000-000000000000") }
+    match NameAlignment.align map None { source with Sequences = [ srcSeq ] } { clone with Sequences = [ snkSeq ] } with
+    | FsResult.Ok aligned -> Assert.Equal(snkSeq.SsKey, (aligned.Sequences |> List.exactlyOne).SsKey)
+    | FsResult.Error es -> Assert.Fail(sprintf "%A" (es |> List.map (fun e -> e.Code)))
+
+[<Fact>]
+let ``AlignmentMode round-trips parse ∘ serialize over both cases`` () =
+    for m in [ AlignmentMode.BySsKey; AlignmentMode.ByName ] do
+        Assert.Equal<Result<AlignmentMode>>(Result.success m, AlignmentMode.parse (AlignmentMode.serialize m))
+
+/// A two-module catalog: mapped "Sales" (Customer, FK RegionId → Region) + an
+/// UN-mapped "Geo" (Region). Prefix distinguishes source ("d") from clone ("e").
+let private buildEscape (p: string) : Catalog =
+    let k (n: int) : SsKey = OssysOriginal (System.Guid (sprintf "%s%07d-0000-0000-0000-000000000000" p n))
+    let pk (n: int) (col: string) : Attribute =
+        { Attribute.create (k n) (nm col) Integer with
+            Column = ColumnRealization.create (col.ToUpperInvariant()) false |> Result.value
+            IsPrimaryKey = true; IsMandatory = true }
+    let fk (n: int) (col: string) : Attribute =
+        { Attribute.create (k n) (nm col) Integer with
+            Column = ColumnRealization.create (col.ToUpperInvariant()) true |> Result.value }
+    let region = Kind.create (k 5) (nm "Region") (tid "OSUSR_G_REGION") [ pk 50 "Id" ]
+    let custRegion = fk 61 "RegionId"
+    let customer =
+        { Kind.create (k 6) (nm "Customer") (tid "OSUSR_S_CUSTOMER") [ pk 60 "Id"; custRegion ] with
+            References = [ Reference.create (k 62) (nm "FK_Customer_Region") custRegion.SsKey region.SsKey ] }
+    mkCatalog [ mkModule (k 500) (nm "Sales") [ customer ]; mkModule (k 501) (nm "Geo") [ region ] ]
+
+[<Fact>]
+let ``align leaves an out-of-contract FK target unmapped — the escape is the T0.3 gate's, not a rewrite`` () =
+    // Only "Sales" is mapped; Customer's FK into the un-mapped "Geo" module keeps
+    // its SOURCE Region identity so the subset-FK / T0.3 gate owns the escape.
+    let escapeMap = Map.ofList [ "Sales", "Sales" ]
+    match NameAlignment.align escapeMap None (buildEscape "d") (buildEscape "e") with
+    | FsResult.Ok aligned ->
+        let fk = (findKind aligned "Customer").References |> List.exactlyOne
+        Assert.Equal((findKind (buildEscape "d") "Region").SsKey, fk.TargetKind)
+    | FsResult.Error es -> Assert.Fail(sprintf "%A" (es |> List.map (fun e -> e.Code)))
 
 [<Fact>]
 let ``align is deterministic — identical inputs yield identical output`` () =

--- a/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
@@ -145,6 +145,11 @@ let ``align refuses alignment.module.unmatched when a mapped module is absent`` 
     Assert.Contains("alignment.module.unmatched", codesOf r)
 
 [<Fact>]
+let ``align refuses alignment.mapEmpty — ByName with no map is not a silent no-op`` () =
+    let r = NameAlignment.align Map.empty source clone
+    Assert.Contains("alignment.mapEmpty", codesOf r)
+
+[<Fact>]
 let ``align is deterministic — identical inputs yield identical output`` () =
     let a = NameAlignment.align map source clone
     let b = NameAlignment.align map source clone

--- a/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
@@ -63,7 +63,7 @@ let private findKind (c: Catalog) (name: string) : Kind =
 
 [<Fact>]
 let ``align rewrites the clone pair to ONE shape — the aligned source diffs to zero against the sink`` () =
-    match NameAlignment.align map source clone with
+    match NameAlignment.align map None source clone with
     | FsResult.Error es -> Assert.Fail(sprintf "align must succeed for a true clone: %A" (es |> List.map (fun e -> e.Code)))
     | FsResult.Ok aligned ->
         // The core witness: the clone pair, once name-aligned, is structurally
@@ -75,7 +75,7 @@ let ``align rewrites the clone pair to ONE shape — the aligned source diffs to
 
 [<Fact>]
 let ``align re-points a foreign key by identity — the aligned FK targets the SINK's entity SsKey`` () =
-    match NameAlignment.align map source clone with
+    match NameAlignment.align map None source clone with
     | FsResult.Error es -> Assert.Fail(sprintf "%A" es)
     | FsResult.Ok aligned ->
         let alignedCust = findKind aligned "Customer"
@@ -102,7 +102,7 @@ let ``align refuses alignment.attribute.shapeDivergence when a name-matched attr
                                     { k with Attributes = k.Attributes |> List.map (fun a ->
                                                 if Name.value a.Name = "Name" then { a with Type = Integer } else a) }
                                 else k) }) }
-    let r = NameAlignment.align map source mutated
+    let r = NameAlignment.align map None source mutated
     Assert.Contains("alignment.attribute.shapeDivergence", codesOf r)
 
 [<Fact>]
@@ -112,7 +112,7 @@ let ``align refuses alignment.entity.unmatched when a source entity has no sink 
         { clone with
             Modules = clone.Modules |> List.map (fun m ->
                 { m with Kinds = m.Kinds |> List.filter (fun k -> Name.value k.Name <> "City") }) }
-    let r = NameAlignment.align map source cityless
+    let r = NameAlignment.align map None source cityless
     Assert.Contains("alignment.entity.unmatched", codesOf r)
 
 [<Fact>]
@@ -123,7 +123,7 @@ let ``align refuses alignment.entity.ambiguous when the mapped sink module holds
             Modules = clone.Modules |> List.map (fun m ->
                 let city = m.Kinds |> List.find (fun k -> Name.value k.Name = "City")
                 { m with Kinds = m.Kinds @ [ { city with SsKey = OssysOriginal (System.Guid "c0000001-0000-0000-0000-000000000000") } ] }) }
-    let r = NameAlignment.align map source dup
+    let r = NameAlignment.align map None source dup
     Assert.Contains("alignment.entity.ambiguous", codesOf r)
 
 [<Fact>]
@@ -136,33 +136,53 @@ let ``align refuses alignment.attribute.unmatched when a source attribute is abs
                             if Name.value k.Name = "Customer" then
                                 { k with Attributes = k.Attributes |> List.filter (fun a -> Name.value a.Name <> "Name") }
                             else k) }) }
-    let r = NameAlignment.align map source dropped
+    let r = NameAlignment.align map None source dropped
     Assert.Contains("alignment.attribute.unmatched", codesOf r)
 
 [<Fact>]
 let ``align refuses alignment.module.unmatched when a mapped module is absent`` () =
-    let r = NameAlignment.align (Map.ofList [ "Sales", "NotThere" ]) source clone
+    let r = NameAlignment.align (Map.ofList [ "Sales", "NotThere" ]) None source clone
     Assert.Contains("alignment.module.unmatched", codesOf r)
 
 [<Fact>]
 let ``align refuses alignment.mapEmpty — ByName with no map is not a silent no-op`` () =
-    let r = NameAlignment.align Map.empty source clone
+    let r = NameAlignment.align Map.empty None source clone
     Assert.Contains("alignment.mapEmpty", codesOf r)
 
 [<Fact>]
+let ``align does NOT refuse drift OUTSIDE the strict scope — only the transferred set must be a clean clone`` () =
+    // The clone's Customer has a drifted attribute (Name retyped Integer), but
+    // the transfer moves only City. Scoped to City, align succeeds (Customer is
+    // re-keyed best-effort, its drift ignored); strict-over-all (None) refuses.
+    let driftedClone =
+        { clone with
+            Modules = clone.Modules |> List.map (fun m ->
+                { m with Kinds = m.Kinds |> List.map (fun k ->
+                            if Name.value k.Name = "Customer" then
+                                { k with Attributes = k.Attributes |> List.map (fun a ->
+                                            if Name.value a.Name = "Name" then { a with Type = Integer } else a) }
+                            else k) }) }
+    let cityKey = (findKind source "City").SsKey
+    match NameAlignment.align map (Some (Set.singleton cityKey)) source driftedClone with
+    | FsResult.Ok _ -> ()
+    | FsResult.Error es -> Assert.Fail(sprintf "scoped align must ignore out-of-scope drift: %A" (es |> List.map (fun e -> e.Code)))
+    // The same drift IS a blocker when the whole estate is in scope.
+    Assert.Contains("alignment.attribute.shapeDivergence", codesOf (NameAlignment.align map None source driftedClone))
+
+[<Fact>]
 let ``align is deterministic — identical inputs yield identical output`` () =
-    let a = NameAlignment.align map source clone
-    let b = NameAlignment.align map source clone
+    let a = NameAlignment.align map None source clone
+    let b = NameAlignment.align map None source clone
     Assert.Equal<Result<Catalog>>(a, b)
 
 [<Fact>]
 let ``alignForMode BySsKey is identity — the source rides through unchanged`` () =
-    match NameAlignment.alignForMode AlignmentMode.BySsKey Map.empty source clone with
+    match NameAlignment.alignForMode AlignmentMode.BySsKey Map.empty [] source clone with
     | FsResult.Ok c -> Assert.Equal<Catalog>(source, c)
     | FsResult.Error es -> Assert.Fail(sprintf "%A" es)
 
 [<Fact>]
 let ``alignForMode ByName runs the pass — the aligned pair diffs to zero`` () =
-    match NameAlignment.alignForMode AlignmentMode.ByName map source clone with
+    match NameAlignment.alignForMode AlignmentMode.ByName map [] source clone with
     | FsResult.Ok aligned -> Assert.True(CatalogDiff.between aligned clone |> CatalogDiff.isEmpty)
     | FsResult.Error es -> Assert.Fail(sprintf "%A" (es |> List.map (fun e -> e.Code)))

--- a/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/NameAlignmentTests.fs
@@ -1,0 +1,163 @@
+module Projection.Tests.NameAlignmentTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.IRBuilders
+
+// ---------------------------------------------------------------------------
+// The cloned-module (name-aligned) peer-leg pass (`NameAlignment.align`,
+// 2026-07-09). Two CLONED modules — same-named entities with identical
+// attributes but DISTINCT native GUIDs — cannot align by SsKey. `align`
+// rewrites the SOURCE contract's SsKeys to the SINK's by NAME (within an
+// operator-declared module map), so the aligned pair diffs to zero and the
+// existing SsKey-keyed engine runs unchanged. The core witness is
+// `CatalogDiff.between (align …) clone |> isEmpty` — the clone pair, once
+// aligned, is one shape. Each dependent concern that cannot be established
+// safely refuses BY NAME (`alignment.*`).
+// ---------------------------------------------------------------------------
+
+// FSharp.Core's `Result` cases collide with `DiagnosticSeverity.Error` under
+// an open `Projection.Core`; the alias forces case resolution (the
+// `CatalogDiffTests` pattern).
+type private FsResult<'a, 'b> = Microsoft.FSharp.Core.Result<'a, 'b>
+
+let private nm (s: string) : Name = Name.create s |> Result.value
+let private tid (t: string) : TableId = TableId.create "dbo" t |> Result.value
+
+let private codesOf (r: Result<'a>) : string list =
+    match r with
+    | FsResult.Ok _ -> []
+    | FsResult.Error es -> es |> List.map (fun (e: ValidationError) -> e.Code)
+
+/// Build a two-entity catalog (City ← Customer.CityId) with GUIDs minted off
+/// `guidPrefix` and physical names off `tablePrefix`, so a SOURCE ("a"/"A")
+/// and its CLONE ("b"/"B") share every NAME but no GUID and no physical name.
+let private buildCatalog (guidPrefix: string) (tablePrefix: string) (moduleName: string) : Catalog =
+    let key (n: int) : SsKey =
+        OssysOriginal (System.Guid (sprintf "%s%07d-0000-0000-0000-000000000000" guidPrefix n))
+    let attr (n: int) (col: string) (ptype: PrimitiveType) (isPk: bool) : Attribute =
+        { Attribute.create (key n) (nm col) ptype with
+            Column       = ColumnRealization.create (col.ToUpperInvariant()) (not isPk) |> Result.value
+            IsPrimaryKey = isPk
+            IsMandatory  = isPk }
+    let cityId   = attr 10 "Id"   Integer true
+    let cityName = attr 11 "Name" Text    false
+    let city =
+        { Kind.create (key 1) (nm "City") (tid (sprintf "OSUSR_%s_CITY" tablePrefix)) [ cityId; cityName ] with
+            Indexes = [ Index.ofKeyColumns (key 30) (nm "UX_City_Name") [ cityName.SsKey ] ] }
+    let custId     = attr 20 "Id"     Integer true
+    let custName   = attr 21 "Name"   Text    false
+    let custCityId = attr 22 "CityId" Integer false
+    let customer =
+        { Kind.create (key 2) (nm "Customer") (tid (sprintf "OSUSR_%s_CUSTOMER" tablePrefix)) [ custId; custName; custCityId ] with
+            References = [ Reference.create (key 40) (nm "FK_Customer_City") custCityId.SsKey city.SsKey ] }
+    mkCatalog [ mkModule (key 100) (nm moduleName) [ city; customer ] ]
+
+let private source = buildCatalog "a" "A" "Sales"
+let private clone  = buildCatalog "b" "B" "SalesClone"
+let private map    = Map.ofList [ "Sales", "SalesClone" ]
+
+let private findKind (c: Catalog) (name: string) : Kind =
+    Catalog.allKinds c |> List.find (fun k -> Name.value k.Name = name)
+
+[<Fact>]
+let ``align rewrites the clone pair to ONE shape — the aligned source diffs to zero against the sink`` () =
+    match NameAlignment.align map source clone with
+    | FsResult.Error es -> Assert.Fail(sprintf "align must succeed for a true clone: %A" (es |> List.map (fun e -> e.Code)))
+    | FsResult.Ok aligned ->
+        // The core witness: the clone pair, once name-aligned, is structurally
+        // identical at every SsKey-keyed channel (kinds/attrs/refs/indexes).
+        Assert.True(CatalogDiff.between aligned clone |> CatalogDiff.isEmpty,
+                    "the aligned source must diff to zero against the clone")
+        // And the shape gate — the live-seam judge — agrees the pair is one shape.
+        Assert.True((PeerTransfer.shapeGate None aligned clone) |> function FsResult.Ok _ -> true | _ -> false)
+
+[<Fact>]
+let ``align re-points a foreign key by identity — the aligned FK targets the SINK's entity SsKey`` () =
+    match NameAlignment.align map source clone with
+    | FsResult.Error es -> Assert.Fail(sprintf "%A" es)
+    | FsResult.Ok aligned ->
+        let alignedCust = findKind aligned "Customer"
+        let sinkCity    = findKind clone "City"
+        let sinkCust    = findKind clone "Customer"
+        let fk = alignedCust.References |> List.exactlyOne
+        // TargetKind remapped to the sink's City; SourceAttribute to the sink's CityId.
+        Assert.Equal(sinkCity.SsKey, fk.TargetKind)
+        let sinkCityId = sinkCust.Attributes |> List.find (fun a -> Name.value a.Name = "CityId")
+        Assert.Equal(sinkCityId.SsKey, fk.SourceAttribute)
+
+[<Fact>]
+let ``align refuses alignment.attribute.shapeDivergence when a name-matched attribute differs`` () =
+    // The clone widens City.Name from Text to Integer — a facet the diff detects.
+    let divergentClone =
+        buildCatalog "b" "B" "SalesClone"
+    // Rebuild with City.Name typed Integer by rewriting the clone in place.
+    let mutated =
+        { divergentClone with
+            Modules =
+                divergentClone.Modules |> List.map (fun m ->
+                    { m with Kinds = m.Kinds |> List.map (fun k ->
+                                if Name.value k.Name = "City" then
+                                    { k with Attributes = k.Attributes |> List.map (fun a ->
+                                                if Name.value a.Name = "Name" then { a with Type = Integer } else a) }
+                                else k) }) }
+    let r = NameAlignment.align map source mutated
+    Assert.Contains("alignment.attribute.shapeDivergence", codesOf r)
+
+[<Fact>]
+let ``align refuses alignment.entity.unmatched when a source entity has no sink counterpart`` () =
+    // The clone module carries only Customer — City is absent.
+    let cityless =
+        { clone with
+            Modules = clone.Modules |> List.map (fun m ->
+                { m with Kinds = m.Kinds |> List.filter (fun k -> Name.value k.Name <> "City") }) }
+    let r = NameAlignment.align map source cityless
+    Assert.Contains("alignment.entity.unmatched", codesOf r)
+
+[<Fact>]
+let ``align refuses alignment.entity.ambiguous when the mapped sink module holds two same-named entities`` () =
+    // Duplicate City in the clone module — the correspondence is ambiguous.
+    let dup =
+        { clone with
+            Modules = clone.Modules |> List.map (fun m ->
+                let city = m.Kinds |> List.find (fun k -> Name.value k.Name = "City")
+                { m with Kinds = m.Kinds @ [ { city with SsKey = OssysOriginal (System.Guid "c0000001-0000-0000-0000-000000000000") } ] }) }
+    let r = NameAlignment.align map source dup
+    Assert.Contains("alignment.entity.ambiguous", codesOf r)
+
+[<Fact>]
+let ``align refuses alignment.attribute.unmatched when a source attribute is absent on the sink kind`` () =
+    // The clone's Customer drops the Name attribute.
+    let dropped =
+        { clone with
+            Modules = clone.Modules |> List.map (fun m ->
+                { m with Kinds = m.Kinds |> List.map (fun k ->
+                            if Name.value k.Name = "Customer" then
+                                { k with Attributes = k.Attributes |> List.filter (fun a -> Name.value a.Name <> "Name") }
+                            else k) }) }
+    let r = NameAlignment.align map source dropped
+    Assert.Contains("alignment.attribute.unmatched", codesOf r)
+
+[<Fact>]
+let ``align refuses alignment.module.unmatched when a mapped module is absent`` () =
+    let r = NameAlignment.align (Map.ofList [ "Sales", "NotThere" ]) source clone
+    Assert.Contains("alignment.module.unmatched", codesOf r)
+
+[<Fact>]
+let ``align is deterministic — identical inputs yield identical output`` () =
+    let a = NameAlignment.align map source clone
+    let b = NameAlignment.align map source clone
+    Assert.Equal<Result<Catalog>>(a, b)
+
+[<Fact>]
+let ``alignForMode BySsKey is identity — the source rides through unchanged`` () =
+    match NameAlignment.alignForMode AlignmentMode.BySsKey Map.empty source clone with
+    | FsResult.Ok c -> Assert.Equal<Catalog>(source, c)
+    | FsResult.Error es -> Assert.Fail(sprintf "%A" es)
+
+[<Fact>]
+let ``alignForMode ByName runs the pass — the aligned pair diffs to zero`` () =
+    match NameAlignment.alignForMode AlignmentMode.ByName map source clone with
+    | FsResult.Ok aligned -> Assert.True(CatalogDiff.between aligned clone |> CatalogDiff.isEmpty)
+    | FsResult.Error es -> Assert.Fail(sprintf "%A" (es |> List.map (fun e -> e.Code)))

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -172,6 +172,7 @@
     <Compile Include="ModelResolutionTests.fs" />
     <Compile Include="MovementSurfaceTests.fs" />
     <Compile Include="MovementIsomorphismTests.fs" />
+    <Compile Include="NameAlignmentTests.fs" />
     <Compile Include="ArchetypeTests.fs" />
     <Compile Include="TransferRefusalTests.fs" />
     <Compile Include="ReverseLegPropertyTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReconciliationTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReconciliationTests.fs
@@ -168,6 +168,35 @@ let ``NM-58 reconcileKind: a duplicate Sink match key keeps the OLDEST (lowest-P
     // the displaced duplicate (30) is surfaced, not silent.
     Assert.Equal<(SsKey * AssignedKey) list>([ userKey, AssignedKey.ofString "30" ], result.AmbiguousTargetKeys)
 
+// -- collation parity (2026-07-09): the Core match folds through `matchKey` so ---
+// -- it agrees with the sink's default CI_AS collation and the board's probe ----
+
+[<Fact>]
+let ``collation parity: a source key differing only by case and trailing space matches the sink row (CI_AS), never a silent miss`` () =
+    // The same business string entered as "Alice@X" in the source and "alice@x"
+    // in the sink (plus a trailing space) is ONE key under the managed-cloud
+    // default collation. The ordinal Core match would have missed it — dropping
+    // the row (exit 9) or, under a pin, re-keying it to the owner — while the
+    // board previewed the collation-match GREEN. `matchKey` closes that drift.
+    let source = [ row "280" [ "Email", "Alice@X " ] ]
+    let sink   = [ row "18" [ "Email", "alice@x" ]; row "19" [ "Email", "bob@x" ] ]
+    let result = Reconciliation.reconcileKind userKey idCol byEmail source sink
+    Assert.Equal(Some (AssignedKey.ofString "18"), SurrogateRemapContext.tryFindAssigned userKey (SourceKey.ofString "280") result.Remap)
+    Assert.Empty result.Unmatched
+
+[<Fact>]
+let ``collation parity: two sink rows differing only by case COLLIDE (CI_AS), the oldest wins, the other is displaced`` () =
+    // Under the sink's CI_AS collation "Alice@X" and "alice@x" are the SAME key,
+    // so a DISTINCT count on the sink (the board's `sinkUniqueness` probe) counts
+    // one — and the engine must agree: they collide, the oldest (PK 18) wins, and
+    // PK 30 is displaced (an NM-58 ambiguous target). Ordinal equality would have
+    // treated them as two distinct keys and matched neither to the source.
+    let source = [ row "280" [ "Email", "ALICE@X" ] ]
+    let sink   = [ row "18" [ "Email", "Alice@X" ]; row "19" [ "Email", "bob@x" ]; row "30" [ "Email", "alice@x" ] ]
+    let result = Reconciliation.reconcileKind userKey idCol byEmail source sink
+    Assert.Equal(Some (AssignedKey.ofString "18"), SurrogateRemapContext.tryFindAssigned userKey (SourceKey.ofString "280") result.Remap)
+    Assert.Equal<(SsKey * AssignedKey) list>([ userKey, AssignedKey.ofString "30" ], result.AmbiguousTargetKeys)
+
 // -- AC-I2 bridge: every UserMatchingStrategy reaches the Transfer re-key ---
 //
 // `Reconciliation.ofUserMatching` translates the User kind's

--- a/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReverseLegBoundaryTests.fs
@@ -52,7 +52,7 @@ let ``reverse-leg face: a MALFORMED reconcile spec refuses by name (arg error, e
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [ "Customer" ] [] [] [] None   // no ':' — transfer.reconcile.specShape
+            [ "Customer" ] [] [] [] [] None   // no ':' — transfer.reconcile.specShape
             false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 
@@ -64,7 +64,7 @@ let ``reverse-leg face: a reconcile spec naming an unknown table refuses by name
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [ "OSUSR_NOPE:ID" ] [] [] [] None   // table not in the contract — transfer.reconcile.tableNotFound
+            [ "OSUSR_NOPE:ID" ] [] [] [] [] None   // table not in the contract — transfer.reconcile.tableNotFound
             false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 
@@ -76,7 +76,7 @@ let ``reverse-leg face: a WELL-FORMED resolvable reconcile spec is ACCEPTED (no 
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [ "OSUSR_B_CUSTOMER:ID" ] [] [] [] None   // resolves to MatchByColumn (Id)
+            [ "OSUSR_B_CUSTOMER:ID" ] [] [] [] [] None   // resolves to MatchByColumn (Id)
             false true false EmissionMode.Incremental false false None [] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     // Past the parse/resolve gate the run reaches connection-opening, which
     // fails on the unset env vars — a connection-class exit, NEVER the arg/
@@ -202,7 +202,7 @@ let ``streaming face: an explicit --streaming with --tables refuses at the face 
             "env:L3B_SRC" "env:L3B_SINK"
             (Projection.Pipeline.CatalogRendition.logical model)
             (Projection.Pipeline.CatalogRendition.physical model)
-            [] [] [] [] None
+            [] [] [] [] [] None
             false true false EmissionMode.Incremental false true None [ "Customer" ] Projection.Pipeline.RevertPolicy.Script None SinkLoadCapability.structural
     Assert.Equal(2, exit)
 

--- a/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
@@ -293,3 +293,50 @@ let ``witness loadOrder: an alphabetical-degraded order refuses transfer.loadOrd
     | Some e -> Assert.Equal("transfer.loadOrderUnproven", e.Code)
     | None   -> Assert.Fail "an unproven (degraded) load order must refuse by name"
     Assert.True((Transfer.orderedLoadGate TopologicalOrder.empty).IsNone)
+
+// --- T0.3: the out-of-contract foreign-reference gate ---------------------
+// An in-subset FK to a NON-User kind ABSENT from the acquired contract loads the
+// raw source surrogate (a silent cross-wire). Refuse by name unless the flow
+// acknowledges it in `foreignRefs`; the platform-User path is excluded (the User
+// reflow re-points it), and an in-contract escape stays the existing gate's job.
+
+let private foreignTargetKey = mkKey ["ForeignSystemEntity"]   // never added to a catalog
+
+let private ownerRef (name: string) (isUserFk: bool) : Reference =
+    { Reference.create (mkKey ["Owner"; name]) (mkName name) (mkKey ["Owner"; "ID"]) foreignTargetKey with
+        IsUserFk = isUserFk }
+
+let private ownerCatalog (refs: Reference list) : Catalog =
+    let owner = { kindOf ["Owner"] "OSUSR_OWNER" [ pk ["Owner"] "ID" true ] with References = refs }
+    IRBuilders.mkCatalog [ IRBuilders.mkModule (mkKey ["M3"]) (mkName "M3") [ owner ] ]
+
+let private ownerLoadSet = Set.ofList [ mkKey ["Owner"] ]
+
+[<Fact>]
+let ``T0.3: an FK to a target OUTSIDE the contract is an out-of-contract escape and refuses by name`` () =
+    let cat = ownerCatalog [ ownerRef "FkToForeign" false ]
+    Assert.Equal(1, (TransferSubset.outOfContractEscapes cat ownerLoadSet Set.empty).Length)
+    match Transfer.subsetForeignRefsGate cat (Some ownerLoadSet) Set.empty Set.empty with
+    | Some e -> Assert.Equal("transfer.subsetFkEscapes.targetOutOfContract", e.Code)
+    | None   -> Assert.Fail "an unacknowledged out-of-contract FK must refuse by name"
+
+[<Fact>]
+let ``T0.3: a foreignRefs acknowledgement clears the out-of-contract refusal`` () =
+    let cat = ownerCatalog [ ownerRef "FkToForeign" false ]
+    Assert.True((Transfer.subsetForeignRefsGate cat (Some ownerLoadSet) Set.empty (Set.ofList [ "Owner.FkToForeign" ])).IsNone)
+
+[<Fact>]
+let ``T0.3: a platform-User FK (IsUserFk) is NOT an out-of-contract escape (the User reflow re-points it)`` () =
+    let cat = ownerCatalog [ ownerRef "CreatedByUser" true ]
+    Assert.Empty(TransferSubset.outOfContractEscapes cat ownerLoadSet Set.empty)
+    Assert.True((Transfer.subsetForeignRefsGate cat (Some ownerLoadSet) Set.empty Set.empty).IsNone)
+
+[<Fact>]
+let ``T0.3: an IN-contract escape (target present but out of subset) is NOT out-of-contract`` () =
+    // compositeKind references singleKey, which IS in the catalog but out of the
+    // loadSet — the existing subsetEscapeGate's business, not this gate's.
+    let compositeRefSingle =
+        { compositeKind with
+            References = [ { Reference.create (mkKey ["Composite"; "toSingle"]) (mkName "ToSingle") (mkKey ["Composite"; "ID"]) singleKey with IsUserFk = false } ] }
+    let cat = IRBuilders.mkCatalog [ IRBuilders.mkModule (mkKey ["Module"]) (mkName "M") [ compositeRefSingle; singleKind ] ]
+    Assert.Empty(TransferSubset.outOfContractEscapes cat (Set.ofList [ compositeKey ]) Set.empty)

--- a/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
@@ -188,3 +188,46 @@ let ``PE-1: with no LoadSet the wipe targets every non-reconciled loaded kind, c
     // topo [Order; Other] reversed (child-first) = [Other; Order]
     let targets = TransferResume.wipeTargets plan (topoOf [ orderKey; otherKey ]) None
     Assert.Equal<SsKey list>([ otherKey; orderKey ], targets)
+
+// --- T1.7: the revert wrong-sink guard is fail-CLOSED --------------------
+// A `revert` deletes BY KEY in whatever --against resolves to. The guard now
+// refuses a header-less script (unverifiable) AND a server- or database-
+// mismatch — only --force proceeds. Pure `guardVerdict`; the CLI face is thin.
+
+[<Fact>]
+let ``revert guard: a header-less undo is REFUSED (revert.headerMissing) unless --force`` () =
+    let p = TransferRevert.parseProvenance [ "DELETE FROM [dbo].[X] WHERE [ID] IN (1);" ]
+    Assert.False p.HasHeader
+    match TransferRevert.guardVerdict false p "srvA" "dbA" with
+    | Some e -> Assert.Equal("revert.headerMissing", e.Code)
+    | None   -> Assert.Fail "a header-less undo must refuse fail-closed"
+    Assert.Equal(None, TransferRevert.guardVerdict true p "srvA" "dbA")   // --force overrides
+
+[<Fact>]
+let ``revert guard: a database mismatch refuses (revert.sinkMismatch)`` () =
+    let p = TransferRevert.parseProvenance [ "-- projection:undo server=srvA database=dbA generated=t"; "DELETE ...;" ]
+    Assert.True p.HasHeader
+    match TransferRevert.guardVerdict false p "srvA" "dbB" with
+    | Some e -> Assert.Equal("revert.sinkMismatch", e.Code)
+    | None   -> Assert.Fail "a different database must refuse"
+
+[<Fact>]
+let ``revert guard: a SERVER mismatch refuses even when the database name matches`` () =
+    // The prior guard compared database ONLY — a same-named DB on a different
+    // server passed. The server is now checked too.
+    let p = TransferRevert.parseProvenance [ "-- projection:undo server=srvA database=dbA generated=t" ]
+    match TransferRevert.guardVerdict false p "srvB" "dbA" with
+    | Some e -> Assert.Equal("revert.sinkMismatch", e.Code)
+    | None   -> Assert.Fail "a different server must refuse even on a matching database"
+
+[<Fact>]
+let ``revert guard: a matching server+database passes; comparison is case-insensitive`` () =
+    let p = TransferRevert.parseProvenance [ "-- projection:undo server=SrvA database=DbA generated=t" ]
+    Assert.Equal(None, TransferRevert.guardVerdict false p "srva" "dba")
+
+[<Fact>]
+let ``revert guard: a legacy header without server= still verifies on database=`` () =
+    let p = TransferRevert.parseProvenance [ "-- projection:undo database=dbA generated=t" ]
+    Assert.Equal(None, p.Server)
+    Assert.Equal(None, TransferRevert.guardVerdict false p "anySrv" "dbA")   // matching db passes
+    Assert.True((TransferRevert.guardVerdict false p "anySrv" "dbB").IsSome)   // mismatching db still refuses

--- a/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
@@ -265,3 +265,31 @@ let ``revert guard: a legacy header without server= still verifies on database=`
     Assert.Equal(None, p.Server)
     Assert.Equal(None, TransferRevert.guardVerdict false p "anySrv" "dbA")   // matching db passes
     Assert.True((TransferRevert.guardVerdict false p "anySrv" "dbB").IsSome)   // mismatching db still refuses
+
+// --- Witnesses for shipped-but-unproven named refusals (audit follow-on) ---
+// staticLookup.diverged + loadOrderUnproven gated a live write yet had no
+// by-name witness. Pure decisions the go board, the engine, and the fast pool
+// now all share (the 6.A.1 pattern).
+
+[<Fact>]
+let ``witness staticLookup: a diverged static-lookup refuses transfer.staticLookup.diverged; a clean one passes`` () =
+    let dirty : StaticLookupDivergence =
+        { Kind = singleKey; ColumnDrifts = []; MissingOnTarget = [ "42" ]; ExtraOnTarget = [] }
+    Assert.False dirty.IsClean
+    match Transfer.staticLookupRefusalOf catalog [ dirty ] with
+    | Some e -> Assert.Equal("transfer.staticLookup.diverged", e.Code)
+    | None   -> Assert.Fail "a diverged static-lookup must refuse by name"
+    let clean : StaticLookupDivergence = { Kind = singleKey; ColumnDrifts = []; MissingOnTarget = []; ExtraOnTarget = [] }
+    Assert.True clean.IsClean
+    Assert.True((Transfer.staticLookupRefusalOf catalog [ clean ]).IsNone)
+
+[<Fact>]
+let ``witness loadOrder: an alphabetical-degraded order refuses transfer.loadOrderUnproven; a topological order passes`` () =
+    let degraded =
+        { TopologicalOrder.empty with
+            Mode   = Alphabetical
+            Cycles = [ { Members = [ singleKey; compositeKey ]; BreakableEdges = []; Reason = "every edge non-nullable (an all-strong cycle)" } ] }
+    match Transfer.orderedLoadGate degraded with
+    | Some e -> Assert.Equal("transfer.loadOrderUnproven", e.Code)
+    | None   -> Assert.Fail "an unproven (degraded) load order must refuse by name"
+    Assert.True((Transfer.orderedLoadGate TopologicalOrder.empty).IsNone)

--- a/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferRefusalTests.fs
@@ -101,6 +101,40 @@ let ``executeGate: a clean single-PK AssignedBySink plan passes`` () =
     let plan = planOf [ load singleKey IdentityDisposition.AssignedBySink [] ]
     Assert.True((Transfer.executeGate catalog plan).IsNone)
 
+// --- T1.5: the identity-insert gate (PreservedFromSource onto an IDENTITY PK) --
+// A load that writes explicit source PKs into an IDENTITY column was gated
+// NOWHERE. The detection is plan-derivable (so board and engine gate one fact);
+// the gate refuses transfer.writeSignoff.ungreenlit unless the flow greenlights
+// `identity-insert`. Fires on ANY Execute (WipeAndLoad OR Incremental/merge).
+
+[<Fact>]
+let ``T1.5 identityInsertTables: a PreservedFromSource load onto an IDENTITY-PK kind is identity-insert`` () =
+    let plan = planOf [ load singleKey IdentityDisposition.PreservedFromSource [] ]
+    Assert.Equal<string list>([ "Single" ], Transfer.identityInsertTables catalog plan)
+
+[<Fact>]
+let ``T1.5 identityInsertTables: an AssignedBySink load (the sink mints) is NOT identity-insert`` () =
+    let plan = planOf [ load singleKey IdentityDisposition.AssignedBySink [] ]
+    Assert.Empty(Transfer.identityInsertTables catalog plan)
+
+[<Fact>]
+let ``T1.5 identityInsertTables: a PreservedFromSource load onto a NON-identity (business) PK is NOT identity-insert`` () =
+    let bizKey = mkKey ["Biz"]
+    let bizKind = kindOf ["Biz"] "OSUSR_BIZ" [ pk ["Biz"] "CODE" false ]
+    let bizCatalog = IRBuilders.mkCatalog [ IRBuilders.mkModule (mkKey ["M2"]) (mkName "M2") [ bizKind ] ]
+    let plan = planOf [ load bizKey IdentityDisposition.PreservedFromSource [] ]
+    Assert.Empty(Transfer.identityInsertTables bizCatalog plan)
+
+[<Fact>]
+let ``T1.5 gate: identity-insert with no signoff is Missing (ungreenlit); a greenlight Confirms it`` () =
+    let tables = Transfer.identityInsertTables catalog (planOf [ load singleKey IdentityDisposition.PreservedFromSource [] ])
+    match WriteSignoff.verify "the flow" [] WriteSignoff.WriteMode.IdentityInsert tables with
+    | WriteSignoff.Missing _ -> ()
+    | other -> Assert.Fail(sprintf "expected Missing (ungreenlit), got %A" other)
+    match WriteSignoff.verify "the flow" [ WriteSignoff.greenlit WriteSignoff.WriteMode.IdentityInsert ] WriteSignoff.WriteMode.IdentityInsert tables with
+    | WriteSignoff.Confirmed _ -> ()
+    | other -> Assert.Fail(sprintf "expected Confirmed, got %A" other)
+
 // --- AC-I5: validate-user-map pre-write halt ------------------------------
 //
 // The orphan drop-set is fully resolved post-reconcile but PRE-write

--- a/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
@@ -78,6 +78,31 @@ let ``NM-58: a non-empty AmbiguousTargetMatchKeys is fail-loud (exit-9) and down
     Assert.Equal(Transfer.DroppedReferencesExit, Transfer.exitCodeForReport false displaced)
     Assert.Equal(0, Transfer.exitCodeForReport true displaced)
 
+// -- T1.6: drops/cdc acknowledged by the flag OR the durable signoff --------
+
+[<Fact>]
+let ``T1.6: drops and cdc are acknowledged by the ephemeral flag OR the durable signoff`` () =
+    let dropsSign = [ WriteSignoff.greenlit WriteSignoff.WriteMode.Drops ]
+    let cdcSign   = [ WriteSignoff.greenlit WriteSignoff.WriteMode.Cdc ]
+    // the flag alone acknowledges
+    Assert.True(Transfer.dropsAcknowledged true [])
+    Assert.False(Transfer.dropsAcknowledged false [])
+    // the durable signoff alone acknowledges (no flag needed) — and is mode-specific
+    Assert.True(Transfer.dropsAcknowledged false dropsSign)
+    Assert.False(Transfer.dropsAcknowledged false cdcSign)
+    Assert.True(Transfer.cdcAcknowledged false cdcSign)
+    Assert.False(Transfer.cdcAcknowledged false dropsSign)
+    Assert.True(Transfer.cdcAcknowledged true [])
+
+[<Fact>]
+let ``T1.6: a durable Drops signoff suppresses the exit-9 exactly as --allow-drops does`` () =
+    let dropped =
+        { reportWithReplay None with
+            AmbiguousTargetMatchKeys = [ mkKey [ "User" ], AssignedKey.ofString "30" ] }
+    Assert.Equal(Transfer.DroppedReferencesExit, Transfer.exitCodeForReport false dropped)   // no ack → exit 9
+    let acked = Transfer.dropsAcknowledged false [ WriteSignoff.greenlit WriteSignoff.WriteMode.Drops ]
+    Assert.Equal(0, Transfer.exitCodeForReport acked dropped)   // durable Drops signoff → exit 0
+
 // -- parseConnectionSpec ---------------------------------------------------
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransferSpecTests.fs
@@ -59,6 +59,25 @@ let ``NM-53: a no-op re-run of a clean prior run (no drops) stays exit-0`` () =
         Assert.Equal(0, Transfer.droppedRowCount clean)
         Assert.Equal(0, Transfer.exitCodeForReport false clean)
 
+// -- NM-58: a displaced duplicate-sink-key is fail-loud, symmetric with NM-51 --
+
+[<Fact>]
+let ``NM-58: a non-empty AmbiguousTargetMatchKeys is fail-loud (exit-9) and downgradable by --allow-drops`` () =
+    // A duplicate reconcile key on the SINK re-keyed every matching source FK onto
+    // the oldest sink row, silently displacing the rest — the same mis-attribution
+    // hazard as NM-51's duplicate SOURCE key, which is already fail-loud. This
+    // asserts the symmetry: the displaced set counts as drops (exit 9), cleared by
+    // the operator's `--allow-drops` (or a `ManualOverride` pinning the right
+    // winner). The go-board forecast reads the SAME report field — board and engine
+    // red one fact.
+    let displaced =
+        { reportWithReplay None with
+            AmbiguousTargetMatchKeys = [ mkKey [ "User" ], AssignedKey.ofString "30" ] }
+    Assert.True(Transfer.hasDrops displaced, "a displaced duplicate-sink-key must count as drops")
+    Assert.Equal(1, Transfer.droppedRowCount displaced)
+    Assert.Equal(Transfer.DroppedReferencesExit, Transfer.exitCodeForReport false displaced)
+    Assert.Equal(0, Transfer.exitCodeForReport true displaced)
+
 // -- parseConnectionSpec ---------------------------------------------------
 
 [<Fact>]


### PR DESCRIPTION
## What this is

The partial-transfer hardening program (v2 sidecar/projection), from a multi-agent audit of the transfer engine, gates, resume/revert, and test estate. Each slice is self-contained with its own tests; all validated against the Release build (FS3511-clean), the pure pool, and the transfer docker classes on the warm SQL container.

## Landed (this PR)

**Tier 0 — silent correctness landmines:**

- **T0.1 — collation-parity reconcile match** (`Reconciliation.matchKey` folds engine + board so ordinal-vs-`CI_AS` drift can't mis-key).
- **T0.2 — fail-loud duplicate sink key (NM-58)** (silent oldest-row re-key → exit-9, symmetric with NM-51).
- **T0.3 — out-of-contract FK escapes refused; durable `foreignRefs` ack** (silent raw-surrogate cross-wire → named refusal; platform-`User` excluded).
- **T0.4 — capture-journal durability + the write-ahead intent protocol**: `append` fsyncs and tolerates a torn trailing line; each chunk is journaled INTENT-before-write / COMPLETE-after, so a crash in the write→journal window leaves an in-doubt chunk the resume path probes (safe re-write, or `transfer.resume.chunkInDoubt`) instead of silently re-minting/duplicating.

**Tier 1 — destructive-write authorization:**

- **T1.5 — gate identity-insert by signoff** (was gated nowhere).
- **T1.6 — drops/cdc via the durable signoff** (flag OR durable signoff; one acknowledgement across engine + exit code).
- **T1.7 — fail-closed revert wrong-sink guard** (header-less + `server=`/`database=` mismatch refuse).
- **T1.8 — refuse merge/incremental into a populated sink** (mirrors the go board's `re-run` axis at the engine).
- **T1.9 — honest `fresh` impact text.**
- **T1.10 — signoff arm on the streaming reverse-leg** (no drift with runCore).

**Test infra & witnesses:**

- Pure named-refusal witnesses: `transfer.staticLookup.diverged`, `transfer.loadOrderUnproven`.
- **Shared two-cell peer harness** (`PeerEstateHarness.run2Cell` + `readKindRows`) — a new two-cell witness is one call.
- **Docker witnesses** (`PeerWitnessDockerTests`) for shipped-but-unproven guarantees: `transfer.supportingScope.inboundOrphan`, `transfer.incremental.populatedSink`, `transfer.staticLookup.diverged`, and `TransferImpact`'s add/delete/change/unchanged classification against a real two-DB delta.

**Cloned-module (name-aligned) peer leg:**

A secondary case: two CLONED modules — an espace cloned into a differently-named module whose entities are same-named with identical attributes but are DISTINCT OSSYS entities (different native-GUID `SsKey`s). The peer leg pairs by SsKey equality end to end, so a clone reads as all-removed/all-added — the shape gate refuses and a bypass would load nothing.

- **`NameAlignment.align`** (new pure pass) rewrites the source contract's SsKey-bearing fields (module/kind/attribute/reference/index) to the sink's corresponding SsKeys, matched BY NAME within an operator-declared source→sink module map, keeping physical coordinates/types/structure. After the pass the pair is SsKey-aligned, so the existing engine runs unchanged (the aligned clone diffs to zero). Shape is judged on the espace-safe logical shape (`Readiness.toLogicalShape`).
- **Defensive, refuse-by-name:** `alignment.module.unmatched` (short-circuit), `alignment.entity.unmatched`/`.ambiguous`, `alignment.attribute.unmatched`/`.shapeDivergence` (strict — any `AttributeFacet`), `alignment.mode.unknown`. FK targets with no sink counterpart keep their source SsKey and fall to the existing T0.3 gate.
- **Opt-in only:** a per-flow `alignment: "by-name"` + `alignMap` (closed-DU `AlignmentMode`, default `by-sskey`), threaded like `foreignRefs`; never auto-detected. The pass runs at the peer face before the SsKey-keyed gates and identically in the go board's `TransferPeer` branch (board/engine parity) — no change to `WriteOptions`/`runCore`/the runner. Peer leg only; name-derived identity is A1-bounded.
- **Proof:** `NameAlignmentTests` (10 pure — diff-to-zero + shape-gate-Ok witness, FK re-point by identity, every refusal, determinism), the A44 round-trip for `alignment`/`alignMap`, and `ClonedModuleTransferDockerTests` over `OssysSeedBuilder.asClonedModule` (re-mints every `SS_Key` GUID) — the un-aligned pair refuses `shapeDivergence`, the aligned pair lands the subset with the FK re-pointed by identity.

`PARTIAL_TRANSFER_READINESS_LOG.md` carries append-only entries throughout.

## Validation

Release FS3511-clean; pure pool green (4097 passed incl. the new `NameAlignment`/A44 tests); docker `PeerAlignedTransfer`, `PeerManagedGrant`, `GoBoardDocker`, `PeerWitnessDockerTests`, and the new `ClonedModuleTransferDockerTests` all green on the warm container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)