### PR TITLE
The eject-blockers: G3 refactorlog→bundle (deployed vocabulary, DacFx-proven) + G6 CREATE SCHEMA emission

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -28066,3 +28066,89 @@ reflected-default literal parsing carries quotes through `normalizeDefault` (`('
 docs-only: the constraint plane always rendered `DEFAULT N''`; the two stale "renders DEFAULT NULL"
 claims (GoldenCatalog comment, THE_GOLDEN_EMISSION) are corrected. WP-17's Float/Real/DateTimeOffset/
 Xml faithful-or-refuse work now rides an option-grain carrier that can express what it needs.
+
+## 2026-07-16 — G3: the accumulated refactorlog reaches the bundle + `.sqlproj` — in DEPLOYED vocabulary, DacFx-proven
+
+**Decision.** The store-threaded publish now writes `ProjectionCatalog.refactorlog` — the
+timeline's ACCUMULATED rename document (prior chain ⊕ this run's displacement, deduped by
+`OperationKey`, rendered at the episode's `At`) — inside the ATOMIC bundle, and (under
+`emission.sqlproj: true`) the project carries the matching explicit `<RefactorLog>` item, so
+`dotnet build` embeds `refactor.xml` into the `.dacpac` and DacFx's incremental publish
+converts a rename into `sp_rename` instead of DROP+CREATE. Presence contract: file (and item)
+exist ⟺ the run is store-threaded — the store IS the rename evidence; a store-less run is
+genesis and stays byte-identical to the pre-G3 bundle. Covers `full-export --lifecycle-store`,
+the flow path (`publish` → `PublishBundle` with an env `store`), and the `--load` combined verb.
+
+**The plane finding (why this was the highest-stakes gap, not a plumbing job).** The existing
+`RefactorLogEmitter.emit` speaks the CATALOG plane: `ElementName` renders the kind's OSSYS
+physical table (`[dbo].[OSUSR_S1S_CUSTOMER]`, pinned by its own render test). The deployed
+estate speaks LOGICAL names (`LogicalTableEmission`/`LogicalColumnEmission`, default-on, no
+config off-switch — H1), and DacFx matches refactor operations against the DEPLOYED model's
+element names — so wiring `emit`'s output into the bundle would have shipped operations that
+match nothing, get silently skipped, and DROP+CREATE anyway: G3 "closed" but wrong. What
+landed instead is `RefactorLogEmitter.emitDeployed`, the deployed-vocabulary sibling:
+
+- Old/new names project through the SAME name-decision rules the emission passes apply —
+  validity by construction (`TableName.create`/`ColumnName.create` embed the exact blank/>128
+  fallback), the OLD side through the SOURCE kind's plane, the NEW through the target's.
+- `physicalNamedKinds` (new `Compose.operatorRenamedKinds`) suppresses operations for kinds an
+  operator `tableRenames` override targets in EITHER form — the operator rename is the chain's
+  LAST `Kind.Physical` writer, so those kinds deploy under the authored physical name and a
+  model-side logical rename on one changes no deployed element. A rename whose old and new
+  deployed names coincide emits nothing.
+- The FK channel is NAMED-ABSENT: deployed FK names are synthesized
+  (`FK_<Owner>_<Target>_<Col>`; honoring `Reference.Name` is WP-7's open remainder), so a
+  logical FK rename changes no deployed constraint and its operation could never match.
+  Re-opens with WP-7.
+- `OperationKey` derivations are UNCHANGED (keys are over the logical rename triple), so
+  accumulation dedup, cross-run identity, and the target DB's `__RefactorLog` ledger are
+  unaffected by the vocabulary fix; `emit` itself is untouched (its migrate-preview consumer
+  keeps the catalog plane).
+
+**Sequencing (the atomic-bundle constraint).** The bundle write is atomic-replace, so the
+document must ride `Outputs` (`Outputs.RefactorLog`, `ArtifactPath.refactorLog`, the staging
+writer's optional-text arm) — which forces the store READ phase ahead of the emission. The
+store leg split accordingly: `loadStorePrior` (ONE durable load + `priorSchemaOfChain` + the
+per-edge deployed-vocabulary fold, hoisted BEFORE `runWithConfigAcquiringWithPrior`; S51's
+one-load-per-leg and S53's fold-once both hold across the split) → the core computes this
+run's displacement over the RENAMED catalog and renders `accumulate(priorEntries, current)`
+into the bundle → `runStoreLegOnPrior` records the episode AFTER the bundle lands, reusing the
+loaded chain. Consequences, named: (1) a MALFORMED store now refuses BEFORE the bundle (its
+content depends on the store; emitting without it would ship a wrong document) — record-phase
+failures still surface after the bundle, as before; (2) the load-leg (`--load`) record re-reads
+the store at record time (a data load may run long; the fresh read narrows the lost-update
+window ahead of the monotone append); (3) the bundle derives over renamed(HYDRATED) while the
+episode plane stays renamed(READ) — the hydration graft adds static rows only, so the rename
+channels agree, and the file⇔leg agreement is pinned by test; (4) historical edges fold with
+NO pins (pins are a this-run config fact; a today-pin-suppressed old operation is a DacFx
+no-match no-op either way), and the accumulated document re-derives from the chain under
+today's rules each run — rendered names on old entries can drift with config, keys cannot.
+
+**Witness.** `emitDeployed` unit pins (logical ElementName; pin suppression; compound
+table+column rename speaks ONE pre-publish vocabulary; FK channel absent; key equality with
+`emit`; T11 keyset); the store-wire witnesses (file present + reported ⟺ store-threaded; the
+empty genesis document; the hand-seeded-prior rename lands in the file in deployed vocabulary
+agreeing with the leg; the CUMULATIVE document survives a no-change run; the `.sqlproj` item
+pairs with the file); the real-SDK build witness (`RefactorLog` item + file build clean under
+Microsoft.Build.Sql/2.2.0 — no default-glob duplicate — and the built `.dacpac` embeds
+`refactor.xml`); and **the DacFx-grade canary** (`RefactorLogPublishCanaryTests`, Docker):
+full-export A → `dotnet build` → `DacServices.Deploy` → live rows under `[dbo].[User]` →
+store-threaded full-export B (rename to `Client`) → build → INCREMENTAL publish with the
+default `BlockOnPossibleDataLoss = true` armed → the publish succeeds, the rows survive under
+`[dbo].[Client]` with IDENTITY values intact, and `[dbo].[User]` is gone — `sp_rename`, not
+DROP+CREATE, end-to-end through the operator's real path.
+
+**Named residuals.** (1) Operator `tableRenames` rewrite `Kind.Physical` and never touch
+`Kind.Name`, so they produce NO `RenameRecord` — the deployed rename they cause (logical name →
+authored physical, or pin→pin) is INVISIBLE to `CatalogDiff`'s Name-keyed rename channel and
+therefore absent from the refactorlog; H3's "renames feed the refactorlog channel" holds only
+for identity-stable MODEL-side renames (a Service-Studio entity/attribute rename over a
+GUID-keyed source, or any rename the store's persisted SsKeys thread). Re-open trigger: a
+`Physical`-change rename channel on `CatalogDiff`. (2) File-sourced models synthesize SsKeys
+from names, so they cannot thread rename identity at all (the standing 6.A.7 limitation — the
+witnesses seed the store to simulate an identity-stable source). (3) The eject package
+(`EjectRun`) still carries `RefactorLogRefs` (the reference chain), not the rendered document;
+rendering the terminal accumulated document into the eject artifact is the eject verb's slice
+of P-7. (4) `MigrationRun.preview` keeps the catalog-plane `emit` for its report artifact —
+migrating that surface to deployed vocabulary is its own decision when the migrate path grows
+a DacFx consumer.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -28229,3 +28229,28 @@ CAST machinery are their substrate. V1's byte-form (`CAST('…' AS datetime2(7))
 no space) vs V2's ScriptDom house form (`CAST ('…' AS DATETIME2 (7))`) differ in rendering,
 deliberately: the DECISION adopts the explicit-CAST semantics; each terminal boundary keeps
 its own pinned generator style.
+
+## 2026-07-16 — WP-17(e): text control characters splice into `CHAR()` concatenation — no raw control bytes in emitted SQL
+
+**Decision (packet C11(e); audit S4).** A Text literal whose raw value carries CR/LF/TAB now
+renders as V1's concatenation form (`SqlLiteralFormatter.EscapeUnicodeString` parity):
+`N'line1' + CHAR(13) + N'' + CHAR(10) + N'line2'` — the emitted seed SQL contains no raw
+control bytes (they broke diff review, byte-determinism assumptions, and any downstream that
+assumes single-line literals). One shared segmentation owns the split
+(`SqlLiteral.textLiteralSegments` — `TextRun`/`ControlChar` over exactly V1's escape set
+13/10/9, blind-splice semantics: adjacent/edge control chars keep their empty `N''` runs);
+both terminal planes compose from it so they cannot drift — `toString` joins with ` + `,
+`ScriptDomBuild.buildSqlLiteral` builds the `BinaryExpression(Add)` chain over national
+`StringLiteral`s and `CHAR(n)` `FunctionCall`s. A control-char-free raw renders byte-identically
+to the pre-WP-17 form on both planes (the default everywhere — goldens untouched). The
+concatenation evaluates to the identical string value, so CDC-silence and the WP-3
+empty-string contract (`N''`) are unchanged.
+
+**Witness.** The shared-segmentation pins (single-run default; the `a\r\nb` five-segment
+shape); the three per-char splice forms + CRLF adjacency + leading/trailing edge runs +
+quote-doubling-inside-runs on the text plane; the ScriptDom row-value pin (an `InsertRow`
+Text cell renders `CHAR(13)/CHAR(10)/CHAR(9)` with NO raw control bytes in the rendered SQL).
+
+**Scope notes.** Exactly V1's escape set (CR/LF/TAB) — other C0 controls pass through inside
+runs, as V1. The round-trip fixture for control-char text (deploy → read back → value equality)
+belongs to WP-17(f)'s fixture backlog with the other unwitnessed types.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -28254,3 +28254,59 @@ Text cell renders `CHAR(13)/CHAR(10)/CHAR(9)` with NO raw control bytes in the r
 **Scope notes.** Exactly V1's escape set (CR/LF/TAB) — other C0 controls pass through inside
 runs, as V1. The round-trip fixture for control-char text (deploy → read back → value equality)
 belongs to WP-17(f)'s fixture backlog with the other unwitnessed types.
+
+## 2026-07-16 — WP-17(a–c) + (f): faithful carriage for the collapsing scalars — value-driven, no new carrier — and the gallery canary that widened S5
+
+**Decision (packet C11; audit S1/S2/S5; the §9-mandated design constraint honored: the
+raw-string / CDC-silent codec stays).** The four unfaithful collapses become faithful WITHOUT
+object-carriage or a tenth `PrimitiveType`: the RAW STRING carries the concrete value, and the
+boundaries dispatch on the raw's SHAPE — the 9-way semantic category stands everywhere.
+
+- **(a) `float`/`real`.** READ: `ReadSide.formatRawValue`'s Decimal arm type-switches on the
+  boxed runtime value — `double → G17`, `single → G9` (V1's exact round-trip formats) — before
+  the old `Convert.ToDecimal` (which truncated to ~15 digits and OVERFLOWED above ≈7.9E28).
+  WRITE: `Bulk.parseRaw`'s Decimal arm dispatches on scientific notation — an exponent-bearing
+  raw parses as the exact IEEE `double` (SqlBulkCopy converts to the float/real column
+  faithfully); plain digit runs keep the exact `decimal` parse (decimal-family columns; a
+  G17 form without an exponent carries ≤17 significant digits, which decimal holds exactly and
+  the column's nearest-double conversion recovers). The seed literal needed nothing: `DecimalLit`
+  is raw pass-through and `NumericLiteral` accepts E-notation (a legal T-SQL float literal).
+- **(b) `datetimeoffset`.** A new canonical raw form (`RawValueCodec.DateTimeOffsetFormat` =
+  `yyyy-MM-dd HH:mm:ss.fffffff zzz`; `formatDateTimeOffset`/`parseDateTimeOffset`; the offset
+  is PRESERVED, never UTC-normalized) + the shape detector `hasUtcOffset` (a `±HH:mm` suffix —
+  disjoint from every offset-less canonical form by construction). READ: the DateTime arm
+  type-switches on a boxed `DateTimeOffset` — retiring the S2 READBACK THROW
+  (`Convert.ToDateTime` refuses `DateTimeOffset`). LITERAL: `SqlLiteral.DateTimeOffsetLit`
+  (`ofRaw` dispatches on the shape) renders `CAST('… ±HH:mm' AS datetimeoffset(7))` on both
+  planes — an offset-bearing string cast to `datetime2` refuses on SQL Server, so the shape
+  MUST own its CAST target. WRITE: `Bulk.parseRaw` boxes the exact `DateTimeOffset`. Codec
+  writes/reads the new kind (old artifacts cannot carry offsets — the collapse dropped them,
+  so no legacy classifier change).
+- **(c) the comparison-less types — and the canary's discovery.** `xml` has no `<>` operator,
+  so a CDC-enabled xml kind's change-detect predicate was an UNCOMPILABLE MERGE (S5). The
+  first run of the (f) gallery canary then widened the class LIVE: **`image` (and by the same
+  SQL rule `text`/`ntext`) refuse `<>` identically** ("The data types image and varbinary are
+  incompatible in the not equal to operator"). The guard: `MergeBuildArgs.CastCompareColumns :
+  Map<string, ChangeCompareCast>` (closed DU — `xml`/`ntext` → NVARCHAR(MAX), legacy `text` →
+  VARCHAR(MAX), `image` → VARBINARY(MAX): the cast target is per-type because `image` cannot
+  cast to nvarchar) — computed at `MergeRender` from the attributes' storage evidence; only the
+  value-mismatch arm casts (`IS NULL` is legal on all of them); kinds without such columns emit
+  byte-identical predicates. Xml carriage itself: faithful TEXT content (V1 parity, `N'…'`
+  implicit-converts on insert); the server's re-serialization is SERVER behavior — content
+  equality is the deliberate semantic, named here.
+- **(f) the fixture backlog.** `ScalarCarriageRoundTripTests` (Docker): ONE gallery kind
+  carrying every contested column (float w/ `Double.MaxValue`, real, `datetimeoffset(7)` w/
+  `-03:00`, xml, money, smalldatetime, image, control-char text), CDC-ENABLED so the S5
+  predicate is in the executed SQL — DacFx-publishes the storage-lane DDL, executes the
+  composed seed MERGE TWICE (compile + idempotence), and server-side compares every value
+  (offset verbatim via style 121; xml via `.value()` content probes; the CHAR() splice equals
+  the raw-control-char literal). The audit §8 UNWITNESSED rows (Float/Real/DateTimeOffset/
+  Xml/Money/SmallDateTime/Image + control-char text) are now Docker-proven.
+
+**Named residuals.** The evidence plane (`CachedValue`) refuses loud on the new raw shapes if
+they ever reach profiling (float/dtoffset columns are DBA/External; static-kind overlap is nil
+— re-open if a real estate profiles one). The migrate/ALTER lens and the reverse-leg readers
+did not change (the READ formatter fix covers the shared `ReadSide` row path; `typedCellFormatter`'s
+fast paths fall back to the fixed generic arm for the exotic field types). `SmallDateTime`
+carriage keeps the offset-less DateTime form (finer than the column; server rounds — witnessed).
+DECISIONS 2026-07-16 — WP-17(a–c,f).

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -28187,3 +28187,45 @@ schema APPEARING mid-timeline arrives via new kinds whose CREATE TABLEs the bund
 carries alongside the new `Schemas/` file; an in-place `migrate` against an estate missing the
 schema still requires the bundle deploy (or hand DDL) first — the named residual, re-opened if
 a real mid-timeline schema-add migration surfaces.
+
+## 2026-07-16 — WP-17(d): the temporal contract — the fallback lane carries legacy `DATETIME`; seed literals carry V1's explicit CAST
+
+**Decision (packet C4, adopted 2026-07-15; audit §5).** Two coupled temporal fixes, one commit:
+
+- **The evidence-less DDL fallback is the platform legacy `DATETIME`.** Pre-WP-17, the same
+  logical `DateTime` attribute emitted `DATETIME` from a live export (storage evidence) and
+  `DATETIME2` from the fallback lane (catalog-direct goldens, ReadSide-derived catalogs, JSON
+  without `SqlStorage`) — the goldens misrepresented what a live export deploys. Three mirror
+  sites flipped together: `ScriptDomBuild.sqlDataTypeOption`, `SqlStorageType.ofPrimitiveType`,
+  `SqlTypeCorrespondence.baseName`. A `datetime2` SOURCE still emits `DATETIME2` via its
+  storage evidence — only the no-evidence default moved.
+- **Temporal literals render as V1's explicit CAST** (`SqlLiteralFormatter.cs:90` parity):
+  `CAST('…' AS datetime2(7))` / `AS date` / `AS time(7)` — precision-explicit and
+  language-independent (`datetime2` parses the ISO form identically under any
+  `SET DATEFORMAT`/`LANGUAGE`; the bare quoted string relied on implicit conversion whose
+  space-separated no-`T` form is a parsing boundary case against legacy `DATETIME`). The
+  category-blind `SqlLiteral.TemporalLit` split into `DateTimeLit`/`DateLit`/`TimeLit` — each
+  variant owns its CAST target (the compiler enumerated every site). ScriptDom plane renders
+  via a `CastCall` (`temporalCast`); the text plane via `toString`. CDC-silence is unchanged:
+  the typed `#temp`/column reconciles the storage type on INSERT exactly as the bare literal
+  did (audit §5c); the Docker pool's CDC-silence canaries are the executable witness.
+- **Codec compatibility, replay preserved:** the codec writes the three new kinds; a pre-WP-17
+  artifact's category-blind `"TemporalLit"` still READS, classified by the canonical raw shape
+  (`RawValueCodec` forms are disjoint: space ⇒ DateTime, colon ⇒ Time, else Date) — witnessed.
+  No version refusal, no re-record of old artifacts.
+
+**Witness.** The `ofRaw` per-category mapping; the three `toString` CAST forms; the ScriptDom
+row-value CAST pin (`InsertRow` temporal cells render `CAST ('…' AS DATETIME2 (7))`/`DATE`/
+`TIME (7)`); the legacy-`TemporalLit` codec read; `ofPrimitiveType`/`baseName` mirror pins
+updated with the rationale; the golden re-record (both corpora commands; only master moved):
+`DATETIME2 → DATETIME` on the fallback-lane columns + the ScalarGallery temporal DEFAULTs now
+carrying the CAST forms — the diff is exactly the two decided changes and their alignment
+whitespace, nothing else.
+
+**Scope notes.** The storage-evidence lane is untouched (`DATETIME` already; `datetime2`
+sources keep `DATETIME2(s)`). The audit's S3 hazard row closes; S1/S2/S4/S5 (Float/Real,
+DateTimeOffset, control chars, Xml) remain WP-17(a–c,e,f) — the option-grain carrier and this
+CAST machinery are their substrate. V1's byte-form (`CAST('…' AS datetime2(7))`, lowercase,
+no space) vs V2's ScriptDom house form (`CAST ('…' AS DATETIME2 (7))`) differ in rendering,
+deliberately: the DECISION adopts the explicit-CAST semantics; each terminal boundary keeps
+its own pinned generator style.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -28152,3 +28152,38 @@ rendering the terminal accumulated document into the eject artifact is the eject
 of P-7. (4) `MigrationRun.preview` keeps the catalog-plane `emit` for its report artifact —
 migrating that surface to deployed vocabulary is its own decision when the migrate path grows
 a DacFx consumer.
+
+## 2026-07-16 — G6: `CREATE SCHEMA` objects emitted — non-dbo estates build and publish
+
+**Decision.** The emission now produces the non-dbo schema objects the estate references, at
+every surface that needed them: `Statement.CreateSchema` (closed-DU expansion; ScriptDom
+`CreateSchemaStatement`, bracket-quoted, no AUTHORIZATION — ownership is the receiving team's
+call) opens the catalog-wide statement stream BEFORE sequences and tables; the bundle gains
+one `Schemas/<name>.sql` per schema beside `Modules/**` (the SDK's default Build glob compiles
+them — `SsdtBundle.composeWithSchemas`, wired at the emit step); the dacpac arm's
+`isSchemaStatement` admits them into the declarative model; the deploy executor treats them as
+the DDL class they are. Derivation (`SsdtDdlEmitter.nonDboSchemas`): every distinct schema
+across kind physical coordinates AND sequences, minus `dbo` in any case (it always exists),
+deduped case-insensitively (SQL Server CI semantics — case-variant spellings are ONE schema;
+the ordinal-sort-first spelling wins deterministically, T1). A dbo-only estate emits nothing —
+the byte-identical default everywhere, which is why exactly ONE golden scenario moved.
+
+**Witness.** `nonDboSchemas` derivation pins (dbo-any-case exclusion, CI dedupe, sequence
+schemas, ordinal order); the dbo-only byte-identical default (no statements, no files, clean
+stream); stream-head ordering (`CREATE SCHEMA` precedes every object); the `Schemas/audit.sql`
+file shape; the dacpac arm accepting a non-dbo catalog; and the gated real-SDK build witness —
+a non-dbo bundle `dotnet build`s to a `.dacpac` (pre-G6 this refuses with unresolved-schema
+SQL71501; the composed bundle, not a hand-assembly, carries `Schemas/audit.sql`). Golden
+re-record: master corpus only, additive-verified by diff — the 4-line `CREATE SCHEMA [audit]`
+stream head + the new `Schemas/audit.sql`; every dbo-only corpus byte-identical.
+
+**Scope notes.** `CREATE SCHEMA` is not idempotent (no `IF NOT EXISTS` guard) — correct for
+the SSDT/DacFx path (the deploy planner diffs the model; it never re-runs a CREATE against an
+existing schema) and for V2's own executor against fresh targets (the canary/docker legs);
+targets that pre-created schemas by hand (runbook §11 step 4's old instruction) will refuse a
+raw re-execution of the stream head loudly rather than silently — the runbook step is now
+"supplied by the bundle". The migrate/ALTER lens (`SchemaMigrationEmitter`) is untouched: a
+schema APPEARING mid-timeline arrives via new kinds whose CREATE TABLEs the bundle already
+carries alongside the new `Schemas/` file; an in-place `migrate` against an estate missing the
+schema still requires the bundle deploy (or hand DDL) first — the named residual, re-opened if
+a real mid-timeline schema-add migration surfaces.

--- a/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
+++ b/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
@@ -225,7 +225,7 @@ Ranked by data-fidelity stakes:
 | S1 | `Float`/`Real` precision loss + overflow | `SqlStorageType.toPrimitiveType:89-90` → `Decimal` carrier | any `float`/`real` column (external/DBA) in a data lane | WP-17 |
 | S2 | `DateTimeOffset` zone dropped; readback throws | `toPrimitiveType:101` → `DateTime`; `ReadSide.fs:628-629` | any `datetimeoffset` column read back / transferred | WP-17 |
 | S3 | Fallback DDL lane upgrades `DateTime → DATETIME2`; seed literal bare (no CAST) | `ScriptDomBuild.fs:129`, `:306-310` | storage-evidence-less catalog (goldens, ReadSide, JSON-no-storage) | **✅ WP-17(d) LANDED (2026-07-16)** — fallback = legacy `DATETIME` (3 mirror sites); literals = explicit CAST via the category-bearing `DateTimeLit`/`DateLit`/`TimeLit` split |
-| S4 | Text control chars embedded raw in `N'…'` | `SqlLiteral.toString:107-111` | any seed value with CR/LF/TAB | WP-17 |
+| S4 | Text control chars embedded raw in `N'…'` | `SqlLiteral.toString:107-111` | any seed value with CR/LF/TAB | **✅ WP-17(e) LANDED (2026-07-16)** — `CHAR()` splice via the shared `textLiteralSegments`, both planes |
 | S5 | `Xml` re-serialization + empty-xml erase + CDC `<>` compile error | `toPrimitiveType:98` → `Text`; CDC predicate | any `xml` column, esp. on a CDC-enabled kind | WP-17 (+ WP-3 for the erase) |
 | S6 | `''` → NULL universal erasure | `SqlLiteral.ofRaw:81`, `Bulk.parseRaw:52` | every empty-string Text value | **✅ WP-3 LANDED (2026-07-16)** — option-grain cells; `''` survives; an empty raw on a non-empty-capable type refuses loudly |
 

--- a/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
+++ b/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
@@ -224,7 +224,7 @@ Ranked by data-fidelity stakes:
 |---|---|---|---|---|
 | S1 | `Float`/`Real` precision loss + overflow | `SqlStorageType.toPrimitiveType:89-90` → `Decimal` carrier | any `float`/`real` column (external/DBA) in a data lane | WP-17 |
 | S2 | `DateTimeOffset` zone dropped; readback throws | `toPrimitiveType:101` → `DateTime`; `ReadSide.fs:628-629` | any `datetimeoffset` column read back / transferred | WP-17 |
-| S3 | Fallback DDL lane upgrades `DateTime → DATETIME2`; seed literal bare (no CAST) | `ScriptDomBuild.fs:129`, `:306-310` | storage-evidence-less catalog (goldens, ReadSide, JSON-no-storage) | WP-17 (+ C4) |
+| S3 | Fallback DDL lane upgrades `DateTime → DATETIME2`; seed literal bare (no CAST) | `ScriptDomBuild.fs:129`, `:306-310` | storage-evidence-less catalog (goldens, ReadSide, JSON-no-storage) | **✅ WP-17(d) LANDED (2026-07-16)** — fallback = legacy `DATETIME` (3 mirror sites); literals = explicit CAST via the category-bearing `DateTimeLit`/`DateLit`/`TimeLit` split |
 | S4 | Text control chars embedded raw in `N'…'` | `SqlLiteral.toString:107-111` | any seed value with CR/LF/TAB | WP-17 |
 | S5 | `Xml` re-serialization + empty-xml erase + CDC `<>` compile error | `toPrimitiveType:98` → `Text`; CDC predicate | any `xml` column, esp. on a CDC-enabled kind | WP-17 (+ WP-3 for the erase) |
 | S6 | `''` → NULL universal erasure | `SqlLiteral.ofRaw:81`, `Bulk.parseRaw:52` | every empty-string Text value | **✅ WP-3 LANDED (2026-07-16)** — option-grain cells; `''` survives; an empty raw on a non-empty-capable type refuses loudly |

--- a/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
+++ b/sidecar/projection/SCALAR_REPRESENTATION_AUDIT.md
@@ -222,11 +222,11 @@ Ranked by data-fidelity stakes:
 
 | # | Hazard | Where | Reaches production when | Plan |
 |---|---|---|---|---|
-| S1 | `Float`/`Real` precision loss + overflow | `SqlStorageType.toPrimitiveType:89-90` → `Decimal` carrier | any `float`/`real` column (external/DBA) in a data lane | WP-17 |
-| S2 | `DateTimeOffset` zone dropped; readback throws | `toPrimitiveType:101` → `DateTime`; `ReadSide.fs:628-629` | any `datetimeoffset` column read back / transferred | WP-17 |
+| S1 | `Float`/`Real` precision loss + overflow | `SqlStorageType.toPrimitiveType:89-90` → `Decimal` carrier | any `float`/`real` column (external/DBA) in a data lane | **✅ WP-17(a) LANDED (2026-07-16)** — G17/G9 raws, shape-driven parse; Docker gallery witness |
+| S2 | `DateTimeOffset` zone dropped; readback throws | `toPrimitiveType:101` → `DateTime`; `ReadSide.fs:628-629` | any `datetimeoffset` column read back / transferred | **✅ WP-17(b) LANDED (2026-07-16)** — offset-bearing raw + `DateTimeOffsetLit` CAST; throw retired; Docker gallery witness |
 | S3 | Fallback DDL lane upgrades `DateTime → DATETIME2`; seed literal bare (no CAST) | `ScriptDomBuild.fs:129`, `:306-310` | storage-evidence-less catalog (goldens, ReadSide, JSON-no-storage) | **✅ WP-17(d) LANDED (2026-07-16)** — fallback = legacy `DATETIME` (3 mirror sites); literals = explicit CAST via the category-bearing `DateTimeLit`/`DateLit`/`TimeLit` split |
 | S4 | Text control chars embedded raw in `N'…'` | `SqlLiteral.toString:107-111` | any seed value with CR/LF/TAB | **✅ WP-17(e) LANDED (2026-07-16)** — `CHAR()` splice via the shared `textLiteralSegments`, both planes |
-| S5 | `Xml` re-serialization + empty-xml erase + CDC `<>` compile error | `toPrimitiveType:98` → `Text`; CDC predicate | any `xml` column, esp. on a CDC-enabled kind | WP-17 (+ WP-3 for the erase) |
+| S5 | `Xml` re-serialization + empty-xml erase + CDC `<>` compile error | `toPrimitiveType:98` → `Text`; CDC predicate | any `xml` column, esp. on a CDC-enabled kind | **✅ WP-17(c) LANDED (2026-07-16)** — per-type cast-compare guard; the gallery canary widened the class to `image`/`text`/`ntext` (same `<>` refusal); content carriage named; erase was WP-3 |
 | S6 | `''` → NULL universal erasure | `SqlLiteral.ofRaw:81`, `Bulk.parseRaw:52` | every empty-string Text value | **✅ WP-3 LANDED (2026-07-16)** — option-grain cells; `''` survives; an empty raw on a non-empty-capable type refuses loudly |
 
 ---
@@ -237,13 +237,13 @@ Ranked by data-fidelity stakes:
 |---|---|---|
 | Integer / Decimal / Boolean / Guid / Binary | `RawValueCodec` round-trip property + golden seed rows (`Tier`, `Country`) | **witnessed** |
 | DateTime / Date / Time | golden seed rows + CDC-silence Docker canary | **witnessed** (legacy-datetime rounding not explicitly asserted) |
-| Text incl. `''`, control chars | `''` preserved end-to-end (WP-3: the `TextFidelity` golden + the F11 Docker canary); control-char form **unwitnessed** | **partial** |
-| `Money` / `SmallMoney` | via Decimal carrier; no dedicated fixture | **unwitnessed** |
-| `Float` / `Real` | none found | **UNWITNESSED** (S1) |
-| `DateTimeOffset` | none found | **UNWITNESSED** (S2) |
-| `Xml` | none found | **UNWITNESSED** (S5) |
-| `NText` / `Image` (legacy LOB) | none found | **UNWITNESSED** |
-| `SmallDateTime` | none found | **UNWITNESSED** |
+| Text incl. `''`, control chars | `''` preserved end-to-end (WP-3: the `TextFidelity` golden + the F11 Docker canary); control-char CHAR()-splice round-trips in the gallery canary (WP-17(e)/(f)) | **witnessed** |
+| `Money` / `SmallMoney` | `ScalarCarriageRoundTripTests` (WP-17(f) Docker gallery) | **witnessed** (`SmallMoney` rides the same Decimal path) |
+| `Float` / `Real` | `ScalarCarriageRoundTripTests` — `Double.MaxValue` through FLOAT; G9 through REAL | **witnessed** (WP-17(a)) |
+| `DateTimeOffset` | `ScalarCarriageRoundTripTests` — `-03:00` verbatim via CONVERT style 121 | **witnessed** (WP-17(b)) |
+| `Xml` | `ScalarCarriageRoundTripTests` — content probes + the CDC-armed MERGE compiles and re-runs | **witnessed** (WP-17(c)) |
+| `NText` / `Image` (legacy LOB) | `Image` in the gallery canary (hex round-trip + the `<>`-refusal guard the canary itself discovered); `NText` rides the same cast-compare class | **witnessed** (Image) / guard-covered (NText) |
+| `SmallDateTime` | `ScalarCarriageRoundTripTests` — minute-rounding compare | **witnessed** |
 
 The unwitnessed rows are the WP-17 fixture backlog: every concrete type that collapses to a
 category needs at least one round-trip fixture proving the collapse is faithful or the refusal is

--- a/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
+++ b/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
@@ -837,11 +837,14 @@ and adopting golden-diff-as-change-review going forward.
     · UserReflow half-wiring. ⚑ WP-14. · Streaming re-trust. ⚑ WP-15. · Table-name collision
     tripwire. ⚑ WP-16. · Inactive-attribute disposition. ⚑ WP-7. · PK convention. ⚑ WP-8.
 12. **Data-plane scalar collapse** (C11, `SCALAR_REPRESENTATION_AUDIT.md`) — `Float`/`Real`
-    precision+overflow, `DateTimeOffset` offset-dropped-and-readback-throws, `Xml`
-    re-serialize + CDC `<>` compile error, ~~temporal bare-literal vs V1's CAST, and the
-    fallback-lane `DateTime → DATETIME2` upgrade~~ (**✅ WP-17(d) landed 2026-07-16** — CAST
-    literals + legacy-`DATETIME` fallback; **✅ WP-17(e)** control-char `CHAR()` splice).
-    ⚑ WP-17(a–c,f) remain (bite on DBA/External columns — size via the §9 estate inventory).
+    ~~precision+overflow, `DateTimeOffset` offset-dropped-and-readback-throws, `Xml`
+    re-serialize + CDC `<>` compile error, temporal bare-literal vs V1's CAST, and the
+    fallback-lane `DateTime → DATETIME2` upgrade~~ — **✅ WP-17 COMPLETE 2026-07-16**:
+    (d) CAST literals + legacy-`DATETIME` fallback; (e) control-char `CHAR()` splice;
+    (a) float/real G17/G9 faithful carriage; (b) datetimeoffset offset-bearing raw + CAST,
+    readback throw retired; (c) per-type cast-compare guard (the gallery canary widened the
+    `<>`-refusal class to `image`/`text`/`ntext`); (f) the Docker gallery witness — the
+    audit's UNWITNESSED table is empty. DECISIONS 2026-07-16 (three entries).
 
 **Doc drift found while profiling** (trust code + DECISIONS over these): `THE_GOLDEN_EMISSION.md:170`
 (index synthesis shipped 2026-07-01) and `:129` (empty-text DEFAULT); `DeleteScopePolicy`/
@@ -989,11 +992,17 @@ round-trip. So the fix is **not** to revert to object-carriage — it must **add
 Scope:
 (a) **`Float`/`Real`** — give the data plane a faithful carrier (a `Float` primitive/raw form at
 G17/G9, or refuse `float`/`real` in a data lane with a named code) instead of silently routing
-through `Decimal` (truncation + overflow).
+through `Decimal` (truncation + overflow). **✅ LANDED 2026-07-16** (G17/G9 raws; shape-driven
+parse; no new carrier — DECISIONS WP-17(a–c,f)).
 (b) **`DateTimeOffset`** — carry the offset (a raw form with `K`, V1's `datetimeoffset(7)` shape)
 or refuse; fix the `ReadSide` arm that throws on a boxed `DateTimeOffset` (`ReadSide.fs:628-629`).
+**✅ LANDED 2026-07-16** (offset-bearing raw + `DateTimeOffsetLit` CAST; the readback throw
+retired).
 (c) **`Xml`** — decide faithful text carriage vs refusal; guard the CDC change-detect predicate
-so an `xml` column (no `<>` operator) cannot emit an uncompilable `T.[c] <> S.[c]`.
+so an `xml` column (no `<>` operator) cannot emit an uncompilable `T.[c] <> S.[c]`. **✅ LANDED
+2026-07-16** — faithful text-content carriage; the guard casts per-type, and the gallery canary
+WIDENED the class live: `image`/`text`/`ntext` refuse `<>` identically
+(`CastCompareColumns : Map<col, ChangeCompareCast>`).
 (d) **Temporal literals** — adopt V1's explicit `CAST(… AS datetime2(7))` / `AS date` / `AS
 time(7)` seed-literal form (language-independent, precision-explicit), replacing the bare quoted
 string; and fix the fallback DDL lane so `DateTime` without storage evidence defaults to legacy
@@ -1004,7 +1013,10 @@ embedding raw control bytes in `N'…'`. **✅ LANDED 2026-07-16 (DECISIONS — 
 `SqlLiteral.textLiteralSegments` shared segmentation; both terminal planes compose from it.**
 (f) **Fixture backlog** — a round-trip witness for every concrete type that has none today
 (`Float`/`Real`/`DateTimeOffset`/`Xml`/`Image`/`SmallDateTime`/`Money`), so the audit's §4
-verdicts become test-proven, not code-derived.
+verdicts become test-proven, not code-derived. **✅ LANDED 2026-07-16** —
+`ScalarCarriageRoundTripTests` (Docker): the CDC-enabled gallery kind DacFx-publishes and
+seed-MERGEs twice; every contested value server-side-compared (incl. `Double.MaxValue` and the
+verbatim `-03:00` offset).
 *Done means:* the four unfaithful collapses each round-trip or refuse with a named code; temporal
 goldens carry the CAST form and a legacy-`DATETIME` fallback; the scalar-audit witness table has
 no UNWITNESSED rows. Note the audience caveat: (a)–(c) bite only on DBA/External-Entity columns,

--- a/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
+++ b/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
@@ -840,8 +840,8 @@ and adopting golden-diff-as-change-review going forward.
     precision+overflow, `DateTimeOffset` offset-dropped-and-readback-throws, `Xml`
     re-serialize + CDC `<>` compile error, ~~temporal bare-literal vs V1's CAST, and the
     fallback-lane `DateTime → DATETIME2` upgrade~~ (**✅ WP-17(d) landed 2026-07-16** — CAST
-    literals + legacy-`DATETIME` fallback). ⚑ WP-17(a–c,e,f) remain (bite on DBA/External
-    columns — size via the §9 estate inventory).
+    literals + legacy-`DATETIME` fallback; **✅ WP-17(e)** control-char `CHAR()` splice).
+    ⚑ WP-17(a–c,f) remain (bite on DBA/External columns — size via the §9 estate inventory).
 
 **Doc drift found while profiling** (trust code + DECISIONS over these): `THE_GOLDEN_EMISSION.md:170`
 (index synthesis shipped 2026-07-01) and `:129` (empty-text DEFAULT); `DeleteScopePolicy`/
@@ -1000,7 +1000,8 @@ string; and fix the fallback DDL lane so `DateTime` without storage evidence def
 `DATETIME` rather than `DATETIME2` (aligns the goldens with a live export). **✅ LANDED
 2026-07-16 (DECISIONS — WP-17(d)).**
 (e) **Text control characters** — escape CR/LF/TAB (V1's `CHAR()` concatenation) rather than
-embedding raw control bytes in `N'…'`.
+embedding raw control bytes in `N'…'`. **✅ LANDED 2026-07-16 (DECISIONS — WP-17(e)):
+`SqlLiteral.textLiteralSegments` shared segmentation; both terminal planes compose from it.**
 (f) **Fixture backlog** — a round-trip witness for every concrete type that has none today
 (`Float`/`Real`/`DateTimeOffset`/`Xml`/`Image`/`SmallDateTime`/`Money`), so the audit's §4
 verdicts become test-proven, not code-derived.

--- a/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
+++ b/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
@@ -587,12 +587,23 @@ profiles, warnings-as-errors, code analysis, `DacVersion`, PreDeploy, RefactorLo
 the eject handoff `sqlproj: true` is the obvious setting; hardening is the J-list.
 *Verdict:* ☐ Approve ☐ Modify ☐ Discuss
 
-**G3. The refactorlog never reaches the bundle — highest-stakes wiring gap** — [GAP]
+**G3. The refactorlog never reaches the bundle — highest-stakes wiring gap** — [GAP → ✅ LANDED]
 Rename detection, stable-UUIDv5 accumulation, and the XML renderer all exist and are tested —
 but no production path writes `<project>.refactorlog` or the `.sqlproj` item. Incremental
 publish of the ejected project DROP+CREATEs on any rename. The eject contract (P-7) promises
 the complete accumulated refactorlog in the terminal package — close before eject.
-*Verdict:* ☐ Approve ☐ Modify ☐ Discuss
+*Landed (2026-07-16, G3): a store-threaded publish writes `ProjectionCatalog.refactorlog`
+(the ACCUMULATED document, prior chain ⊕ run displacement, deduped by OperationKey) inside the
+atomic bundle, and `emission.sqlproj: true` adds the explicit `RefactorLog` item — presence ⟺
+store-threaded. The wiring shipped with a PLANE FIX: the pre-existing emitter spoke the
+catalog plane (OSSYS physical names), which a logically-emitted deployed estate can never
+match; `RefactorLogEmitter.emitDeployed` projects old/new names through the emission passes'
+own name rules (operator-renamed kinds suppress; FK channel named-absent until WP-7; keys
+unchanged). DacFx-proven end-to-end: the Docker canary publishes A, seeds rows, publishes the
+renamed B incrementally with `BlockOnPossibleDataLoss` armed — sp_rename, rows survive.
+Residuals named in DECISIONS 2026-07-16: operator `tableRenames` (Physical-rewrites) remain
+invisible to the Name-keyed rename channel; the eject package still carries refs, not the
+rendered terminal document. DECISIONS 2026-07-16 — G3.*
 
 **G4. `emission.dacpac` (default `false`): dev-tooling, schema-only, content-equality determinism** — [KNOB]
 *Verdict:* ☐ Approve ☐ Modify ☐ Discuss
@@ -630,7 +641,13 @@ are not operator-configurable (no `columnRenames` axis).
 bodies; refusal parity with the dacpac path for unparseable bodies).*
 
 **H3. `tableRenames`: dual-form, fail-closed; physical form pins** — [KNOB]
-Renames feed the refactorlog channel (see G3) and SsKeys are preserved.
+SsKeys are preserved. *Correction (2026-07-16, G3 profiling): the prior "renames feed the
+refactorlog channel" claim was too broad — operator `tableRenames` rewrite `Kind.Physical`
+(never `Kind.Name`), so they produce no `CatalogDiff` rename record and are ABSENT from the
+refactorlog; the channel carries identity-stable MODEL-side renames (Service-Studio renames
+over a GUID-keyed source, or any rename the store's persisted SsKeys thread). The deployed
+rename an operator override causes needs a `Physical`-change diff channel — the named G3
+residual, DECISIONS 2026-07-16.*
 *Verdict:* ☐ Approve ☐ Modify ☐ Discuss
 
 **H4. Schema pass-through; modules ≠ schemas** — [HARD]
@@ -698,8 +715,10 @@ rollback never proven.
 
 ## 5 — The eject bill of materials
 
-Terminal package (P-7): frozen SSDT bundle + complete accumulated refactorlog (G3 wiring gap
-must close first) + full episode chain (`LifecycleStore`) + terminal ChangeManifest (eject-time
+Terminal package (P-7): frozen SSDT bundle + complete accumulated refactorlog (✅ G3 landed
+2026-07-16 — every store-threaded bundle now carries `ProjectionCatalog.refactorlog`; the
+eject verb's own rendering of the terminal document from the chain remains its P-7 slice)
++ full episode chain (`LifecycleStore`) + terminal ChangeManifest (eject-time
 drops declared — WP-7's inactive-attribute dispositions land here) + operator-owned provenance
 declaration. `projection eject --store` self-verifies by reconstruction. Until then, R6
 dual-track: per-pair cutover gates on N=10 consecutive green canaries + operator sign-off.
@@ -721,7 +740,7 @@ whose semantics change under §10.
     "onlyActiveAttributes": true         // C7 ⚑ WP-7: dispositions become explicit in the ChangeManifest
   },
   "overrides": {
-    "tableRenames": [ /* curated; refactorlog channel — G3 must be wired */ ],
+    "tableRenames": [ /* curated; NOTE (G3, 2026-07-16): operator renames rewrite Physical and do NOT reach the refactorlog — see H3 correction */ ],
     "allowMissingPrimaryKey": [ /* audited heap list */ ]
   },
   "emission": {
@@ -772,8 +791,9 @@ Unaddressed anywhere in the repo — pin before first publish: pre-compare noise
 (`IgnoreWhitespace`/`IgnoreKeywordCasing`/`IgnoreAnsiNulls`/`IgnoreSemicolonBetweenStatements` —
 emitted DDL has no semicolons); `DoNotDropObjectTypes`/`ExcludeObjectTypes` (protect extended
 properties if keeping H6, hand-added schemas from G6); `ScriptDatabaseOptions`,
-`VerifyDeployment`, `CommandTimeout`, contributors; committed per-env `.publish.xml` +
-`.refactorlog` project item (G3); environment prerequisites the tool does not check (server/DB
+`VerifyDeployment`, `CommandTimeout`, contributors; committed per-env `.publish.xml` (the
+`.refactorlog` + its project item are now EMITTED on store-threaded runs — ✅ G3 2026-07-16);
+environment prerequisites the tool does not check (server/DB
 collation vs `ModelCollation 1033, CI`; compat level vs the Sql160 pin; editions; `CREATE
 SCHEMA`; cross-env user reconciliation); post-publish Bootstrap step (F8); post-load FK trust
 sweep (E10 until WP-15); single-writer deploy windows (F2); rollback strategy (never proven);
@@ -784,7 +804,9 @@ and adopting golden-diff-as-change-review going forward.
 ## 8 — Gaps and stale docs (with plan pointers)
 
 **Functional gaps, ranked** (⚑ = in the §10 plan):
-1. Refactorlog not wired into bundle/.sqlproj (G3) — close before eject.
+1. Refactorlog not wired into bundle/.sqlproj (G3). **✅ LANDED 2026-07-16** (deployed-vocabulary
+   `emitDeployed` + store-threaded bundle artifact + `.sqlproj` item + DacFx sp_rename canary;
+   operator physical-rename channel + eject-package rendering remain named residuals).
 2. **Live-path `HasDbConstraint = true` hardcode** (`MetadataSnapshotRunner.fs:1326`) — erases
    the logical-vs-backed distinction; blocks the FK evidence regime. ⚑ WP-1 (first).
 3. Trigger bodies keep physical refs + unparsed-body drop marker. ⚑ WP-6.
@@ -1067,8 +1089,9 @@ create against a customer DB.
    sweep is the operator's until WP-15.
 4. **No statistics or `DBCC CHECKIDENT` step anywhere** — receiving DBA hygiene (C5 confirms no
    reseed is emitted; IDENTITY_INSERT preserves values).
-5. **Refactorlog not in the bundle** (G3) and **rollback never proven** (§4) — the two eject-time
-   must-close items the procedure otherwise assumes.
+5. ~~Refactorlog not in the bundle (G3)~~ **✅ landed 2026-07-16** (store-threaded bundles carry
+   it; the DacFx sp_rename canary proves the incremental publish); **rollback never proven**
+   (§4) remains the eject-time must-close the procedure otherwise assumes.
 6. Bundle prerequisites the emission does not supply: `nuget.config` (G2), `CREATE SCHEMA` (G6),
    and the publish profile itself (§7).
 

--- a/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
+++ b/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
@@ -614,9 +614,14 @@ findings it would compile as a schema object and break the build; (b) wired post
 order is alphabetical (Migration before Static) against the emitter's documented deploy order.
 *Verdict:* ☐ Approve ☐ Modify ☐ Discuss
 
-**G6. No `CREATE SCHEMA` objects emitted** — [GAP]
+**G6. No `CREATE SCHEMA` objects emitted** — [GAP → ✅ LANDED]
 Non-dbo estates don't build/publish until schema objects are hand-authored.
-*Verdict:* ☐ Approve ☐ Modify ☐ Discuss
+*Landed (2026-07-16, G6): the emission derives every distinct non-dbo schema (kinds +
+sequences; `dbo` never; case-insensitive dedupe) and emits `CREATE SCHEMA` at the head of the
+statement stream, one `Schemas/<name>.sql` per schema in the bundle (SDK default Build glob),
+and the schema objects into the dacpac model. dbo-only estates byte-identical (one golden
+scenario moved, additively). The gated real-SDK build witness compiles a non-dbo bundle to a
+`.dacpac`. DECISIONS 2026-07-16 — G6.*
 
 **G7. Ancillary emitters** — [info]
 `SchemaMigrationEmitter` = ALTER preview/verification lens (never feeds dacpac);
@@ -790,7 +795,8 @@ migrations for mandatory-column tightening.
 Unaddressed anywhere in the repo — pin before first publish: pre-compare noise family
 (`IgnoreWhitespace`/`IgnoreKeywordCasing`/`IgnoreAnsiNulls`/`IgnoreSemicolonBetweenStatements` —
 emitted DDL has no semicolons); `DoNotDropObjectTypes`/`ExcludeObjectTypes` (protect extended
-properties if keeping H6, hand-added schemas from G6); `ScriptDatabaseOptions`,
+properties if keeping H6; schemas are model members since G6 2026-07-16 — no longer a
+hand-added-object drop hazard); `ScriptDatabaseOptions`,
 `VerifyDeployment`, `CommandTimeout`, contributors; committed per-env `.publish.xml` (the
 `.refactorlog` + its project item are now EMITTED on store-threaded runs — ✅ G3 2026-07-16);
 environment prerequisites the tool does not check (server/DB
@@ -815,7 +821,8 @@ and adopting golden-diff-as-change-review going forward.
    (**✅ WP-1b landed** — reader prefers it + named divergence diagnostic); no 1785 analysis (⚑ WP-1e).
 6. Clustering not captured — silent re-clustering of DBA-modified tables. ⚑ WP-2.
 7. `manifest.remediation.sql` build hazard + alphabetical lane order (G5).
-8. No `CREATE SCHEMA` emission (G6).
+8. No `CREATE SCHEMA` emission (G6). **✅ LANDED 2026-07-16** (stream head + `Schemas/*.sql`
+   bundle files + dacpac model members; dbo-only estates byte-identical).
 9. Unnamed erasures: temporal/sequences/PERSISTED/ROWGUIDCOL/SPARSE/FILESTREAM. ⚑ WP-5.
 10. email/phone VARCHAR vs platform NVARCHAR. **✅ WP-4 landed** (NVARCHAR mapping); on-disk
     precedence for ordinary scalars (C1) split out as ⚑ WP-4b.
@@ -1067,7 +1074,7 @@ create against a customer DB.
 | 1 | Estate readiness | M runs / A judges: `projection check shape` | live OSSYS → verdict | SELECT on `ossys_*` | exit 0 (5 divergence, 6 unreadable) |
 | 2 | **Emission** | M runs / A produces: `projection publish --go` (flow→`PublishBundle`) or `full-export <cfg> --lifecycle-store <p>` | live model + hydrated rows → bundle (`Modules/**.sql`, `Data/{StaticSeeds,MigrationData,Bootstrap}.sql`, `.sqlproj`+`Script.PostDeployment.sql` if `sqlproj:true`, `manifest.json`, `fidelity.*`, `catalog.snapshot.json`) | source SELECT | artifact count; read `fidelity.txt`; `diff` vs prior |
 | 3 | Hand-off | M: deliver bundle to Octopus/CI | → CI workspace | — | — |
-| 4 | Target prep | M (receiving team): DB exists, collation = `1033 CI`, compat = SQL2022, logins, `CREATE SCHEMA` for non-dbo, `nuget.config` | → deployable target | dbcreator/DDL | — |
+| 4 | Target prep | M (receiving team): DB exists, collation = `1033 CI`, compat = SQL2022, logins, `nuget.config` (~~`CREATE SCHEMA` for non-dbo~~ — supplied by the bundle since G6, 2026-07-16) | → deployable target | dbcreator/DDL | — |
 | 5 | **Schema + seeds/migration** | M invokes / DacFx executes: `dotnet build ProjectionCatalog.sqlproj` → `sqlpackage /Action:Publish` (profile per §7). Post-deploy (**StaticSeeds + MigrationData only**, inlined at build) runs inside the publish | sqlproj + bundle → schema (logical names) + static/migration rows | DDL; post-deploy needs IDENTITY_INSERT (ownership/ALTER) + `#temp`+TRAN | publish OK; SSDT compare; `check drift` |
 | 6a | **Bulk data — script path** | **M: operator runs `Data/Bootstrap.sql` via `sqlcmd -b`** post-publish — *no verb executes this file* | Bootstrap.sql → remaining rows | as step 5 post-deploy | idempotent rerun; `check data` |
 | 6b | **Bulk data — pipeline path (alt.)** | M invokes / A executes: live `schema+data` sink + `PROJECTION_ALLOW_EXECUTE=1 projection <flow> --go` → `PublishAndLoad` → `executeLeveledSeed` (Phase-1 levels → Phase-2 levels; parallel within level; CDC-measured) | lanes loaded live; episode recorded | DML + IDENTITY_INSERT/`#temp`; two-key gate | `load.completed`; re-run → 0 (CDC-silent) |
@@ -1092,8 +1099,8 @@ create against a customer DB.
 5. ~~Refactorlog not in the bundle (G3)~~ **✅ landed 2026-07-16** (store-threaded bundles carry
    it; the DacFx sp_rename canary proves the incremental publish); **rollback never proven**
    (§4) remains the eject-time must-close the procedure otherwise assumes.
-6. Bundle prerequisites the emission does not supply: `nuget.config` (G2), `CREATE SCHEMA` (G6),
-   and the publish profile itself (§7).
+6. Bundle prerequisites the emission does not supply: `nuget.config` (G2) and the publish
+   profile itself (§7). (~~`CREATE SCHEMA` (G6)~~ — ✅ supplied by the bundle since 2026-07-16.)
 
 The full hop-by-hop trace (both `--load` and transfer variants, per-path rights, and the
 verification verb matrix) lives in the procedure research; this table is the operator-facing

--- a/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
+++ b/sidecar/projection/SSDT_HANDOFF_REVIEW_PACKET.md
@@ -289,6 +289,12 @@ DECIMAL(37,8)`; bare decimal clamps `(18,0)`; `text ≥ 2000` → `NVARCHAR(MAX)
 V1-identical).
 *Decided (2026-07-15): planned fix — WP-17 (fallback-lane datetime default + explicit-CAST seed
 literals), with the broader scalar-fidelity gaps it belongs to.*
+*Landed (2026-07-16, WP-17(d)): the evidence-less fallback now carries legacy `DATETIME`
+(three mirror sites: `sqlDataTypeOption`/`ofPrimitiveType`/`baseName` — the goldens now show
+what a live export deploys), and temporal literals render V1's explicit CAST
+(`SqlLiteral.DateTimeLit/DateLit/TimeLit` → `CAST(… AS datetime2(7)/date/time(7))`, both
+planes); pre-WP-17 codec artifacts' category-blind `TemporalLit` still reads (raw-shape
+classification, witnessed). DECISIONS 2026-07-16 — WP-17(d).*
 
 **C5. Identity: `Is_AutoNumber` → `IDENTITY (1, 1)` fixed** — [HARD]
 No reader consults `sys.identity_columns`; no `DBCC CHECKIDENT` emitted. Matters for fresh
@@ -832,9 +838,10 @@ and adopting golden-diff-as-change-review going forward.
     tripwire. ⚑ WP-16. · Inactive-attribute disposition. ⚑ WP-7. · PK convention. ⚑ WP-8.
 12. **Data-plane scalar collapse** (C11, `SCALAR_REPRESENTATION_AUDIT.md`) — `Float`/`Real`
     precision+overflow, `DateTimeOffset` offset-dropped-and-readback-throws, `Xml`
-    re-serialize + CDC `<>` compile error, temporal bare-literal vs V1's CAST, and the
-    fallback-lane `DateTime → DATETIME2` upgrade. ⚑ WP-17 (bites on DBA/External columns —
-    size via the §9 estate inventory).
+    re-serialize + CDC `<>` compile error, ~~temporal bare-literal vs V1's CAST, and the
+    fallback-lane `DateTime → DATETIME2` upgrade~~ (**✅ WP-17(d) landed 2026-07-16** — CAST
+    literals + legacy-`DATETIME` fallback). ⚑ WP-17(a–c,e,f) remain (bite on DBA/External
+    columns — size via the §9 estate inventory).
 
 **Doc drift found while profiling** (trust code + DECISIONS over these): `THE_GOLDEN_EMISSION.md:170`
 (index synthesis shipped 2026-07-01) and `:129` (empty-text DEFAULT); `DeleteScopePolicy`/
@@ -990,7 +997,8 @@ so an `xml` column (no `<>` operator) cannot emit an uncompilable `T.[c] <> S.[c
 (d) **Temporal literals** — adopt V1's explicit `CAST(… AS datetime2(7))` / `AS date` / `AS
 time(7)` seed-literal form (language-independent, precision-explicit), replacing the bare quoted
 string; and fix the fallback DDL lane so `DateTime` without storage evidence defaults to legacy
-`DATETIME` rather than `DATETIME2` (aligns the goldens with a live export).
+`DATETIME` rather than `DATETIME2` (aligns the goldens with a live export). **✅ LANDED
+2026-07-16 (DECISIONS — WP-17(d)).**
 (e) **Text control characters** — escape CR/LF/TAB (V1's `CHAR()` concatenation) rather than
 embedding raw control bytes in `N'…'`.
 (f) **Fixture backlog** — a round-trip witness for every concrete type that has none today

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -626,7 +626,16 @@ module ReadSide =
             | Boolean ->
                 RawValueCodec.formatBoolean (System.Convert.ToBoolean v)
             | DateTime ->
-                RawValueCodec.formatDateTime (System.Convert.ToDateTime v)
+                // WP-17(b) (DECISIONS 2026-07-16) — a `datetimeoffset`
+                // column surfaces a boxed `DateTimeOffset`, which
+                // `Convert.ToDateTime` REFUSES (`DateTimeOffset` is not
+                // IConvertible-to-DateTime — the S2 readback throw).
+                // Faithful carriage: format the offset-bearing raw
+                // (offset preserved, never normalized); everything else
+                // keeps the offset-less canonical form.
+                match v with
+                | :? System.DateTimeOffset as dto -> RawValueCodec.formatDateTimeOffset dto
+                | _ -> RawValueCodec.formatDateTime (System.Convert.ToDateTime v)
             | Date ->
                 RawValueCodec.formatDate (System.Convert.ToDateTime v)
             | Time ->
@@ -653,7 +662,18 @@ module ReadSide =
                             (sprintf "ReadSide.Guid: unexpected runtime type %s" (other.GetType().FullName))
                 RawValueCodec.formatGuid guid
             | Decimal ->
-                System.Convert.ToDecimal(v).ToString(inv)
+                // WP-17(a) (DECISIONS 2026-07-16) — `float`/`real`
+                // columns surface boxed `double`/`single`;
+                // `Convert.ToDecimal` truncated to ~15 significant
+                // digits and OVERFLOWED above ≈7.9E28 (the S1 read
+                // loss). Faithful carriage: the IEEE round-trip forms
+                // (`G17`/`G9` — V1's exact formats) into the raw
+                // string; genuine decimal-family columns keep the
+                // decimal conversion.
+                match v with
+                | :? double as d -> d.ToString("G17", inv)
+                | :? single as s -> s.ToString("G9", inv)
+                | _ -> System.Convert.ToDecimal(v).ToString(inv)
             | Text ->
                 match v.ToString() with
                 | null -> ""

--- a/sidecar/projection/src/Projection.Core/RawValueCodec.fs
+++ b/sidecar/projection/src/Projection.Core/RawValueCodec.fs
@@ -46,6 +46,18 @@ module RawValueCodec =
     [<Literal>]
     let DateFormat : string = "yyyy-MM-dd"
 
+    /// WP-17(b) (DECISIONS 2026-07-16) — the OFFSET-BEARING datetime raw
+    /// form for `datetimeoffset` columns (DBA/External-Entity only; no
+    /// OutSystems native type produces them). `zzz` renders the signed
+    /// offset (`+03:00`); the space-separated shape matches V1's
+    /// test-witnessed `CAST('… -03:00' AS datetimeoffset(7))` literal
+    /// input and SQL Server's datetimeoffset string parsing. DISJOINT
+    /// from `DateTimeFormat` by construction (that form never carries an
+    /// offset suffix) — `hasUtcOffset` is the shape detector the parse /
+    /// literal planes dispatch on.
+    [<Literal>]
+    let DateTimeOffsetFormat : string = "yyyy-MM-dd HH:mm:ss.fffffff zzz"
+
     /// `Time` raw form: BCL's canonical `TimeSpan` "constant" format
     /// (`"c"`) — round-trippable via `TimeSpan.Parse`.
     [<Literal>]
@@ -153,6 +165,28 @@ module RawValueCodec =
     /// Format a DateTime as the canonical V2 raw form.
     let formatDateTime (value: DateTime) : string =
         value.ToString(DateTimeFormat, CultureInfo.InvariantCulture)
+
+    /// WP-17(b) — format a DateTimeOffset as the canonical OFFSET-BEARING
+    /// raw form (`DateTimeOffsetFormat`; the offset is PRESERVED, never
+    /// normalized to UTC — faithful carriage of what the column stores).
+    let formatDateTimeOffset (value: DateTimeOffset) : string =
+        value.ToString(DateTimeOffsetFormat, CultureInfo.InvariantCulture)
+
+    /// WP-17(b) — the offset-shape detector the parse / literal planes
+    /// dispatch on: an offset-bearing raw ends `±HH:mm` (the `zzz`
+    /// rendering — exactly six chars, sign + two digits + colon + two
+    /// digits). `DateTimeFormat` raws end in fractional-second digits,
+    /// so the two shapes are disjoint by construction.
+    let hasUtcOffset (raw: string) : bool =
+        raw.Length > 6
+        && (let sign = raw.[raw.Length - 6]
+            (sign = '+' || sign = '-') && raw.[raw.Length - 3] = ':')
+
+    /// WP-17(b) — parse the canonical offset-bearing raw back to a
+    /// `DateTimeOffset` (the exact inverse of `formatDateTimeOffset`).
+    /// Fails loud on malformed input (the NM-20 sibling-parser shape).
+    let parseDateTimeOffset (raw: string) : DateTimeOffset =
+        DateTimeOffset.ParseExact(raw, DateTimeOffsetFormat, CultureInfo.InvariantCulture)
 
     /// Format a Date-only DateTime as the canonical V2 raw form.
     let formatDate (value: DateTime) : string =

--- a/sidecar/projection/src/Projection.Core/SqlLiteral.fs
+++ b/sidecar/projection/src/Projection.Core/SqlLiteral.fs
@@ -48,12 +48,22 @@ type SqlLiteral =
     /// rendered as `N'<escaped>'` (single-quote doubled). Maps to
     /// ScriptDom `StringLiteral` with `IsNational=true`.
     | TextLit of raw: string
-    /// Temporal literal (DateTime / Date / Time) — the raw ISO-8601
-    /// form per `RawValueCodec.DateTimeFormat` / `DateFormat` /
-    /// `TimeFormat`. Rendered as `'<raw>'`. Maps to ScriptDom
-    /// `StringLiteral` with `IsNational=false` (SQL Server temporal
-    /// literals are non-national strings).
-    | TemporalLit of raw: string
+    /// DateTime literal — the raw 7-digit form per `RawValueCodec
+    /// .DateTimeFormat`. WP-17(d) (DECISIONS 2026-07-16): rendered as
+    /// V1's explicit `CAST('<raw>' AS datetime2(7))`
+    /// (`SqlLiteralFormatter.cs:90` parity) — precision-explicit and
+    /// language-independent (`datetime2` parses the ISO form the same
+    /// under any `SET DATEFORMAT`/`LANGUAGE`; the pre-WP-17 bare
+    /// `'<raw>'` relied on implicit conversion). Maps to ScriptDom
+    /// `CastCall`. The three temporal categories are distinct variants
+    /// because each owns its CAST target type.
+    | DateTimeLit of raw: string
+    /// Date literal — the raw `yyyy-MM-dd` form per `RawValueCodec
+    /// .DateFormat`. Rendered as `CAST('<raw>' AS date)` (V1 parity).
+    | DateLit of raw: string
+    /// Time literal — the raw TimeSpan `c` form per `RawValueCodec
+    /// .TimeFormat`. Rendered as `CAST('<raw>' AS time(7))` (V1 parity).
+    | TimeLit of raw: string
     /// Guid literal — the raw `D` form per `RawValueCodec.GuidFormat`
     /// (8-4-4-4-12 hyphenated). Rendered as `'<raw>'`. Maps to
     /// ScriptDom `StringLiteral` with `IsNational=false`.
@@ -97,7 +107,9 @@ module SqlLiteral =
             | Integer -> IntegerLit raw
             | Decimal -> DecimalLit raw
             | Boolean -> BooleanLit (RawValueCodec.parseBoolean raw)
-            | DateTime | Date | Time -> TemporalLit raw
+            | DateTime -> DateTimeLit raw
+            | Date -> DateLit raw
+            | Time -> TimeLit raw
             | Guid -> GuidLit raw
 
     /// Render a typed `SqlLiteral` as SQL text. The terminal boundary
@@ -113,7 +125,12 @@ module SqlLiteral =
         | DecimalLit s       -> s
         | BooleanLit true    -> "1"
         | BooleanLit false   -> "0"
-        | TemporalLit raw    -> System.String.Concat("'", raw, "'")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateTimeFormat` / `DateFormat` / `TimeFormat` (typed canonical form, no escapable characters); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
+        // WP-17(d) — V1's explicit-CAST temporal forms (SqlLiteralFormatter.cs:90):
+        // precision-explicit, language-independent. The raw carries no escapable
+        // characters (RawValueCodec canonical forms).
+        | DateTimeLit raw    -> System.String.Concat("CAST('", raw, "' AS datetime2(7))")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateTimeFormat` (typed canonical form, no escapable characters); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
+        | DateLit raw        -> System.String.Concat("CAST('", raw, "' AS date)")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateFormat`; same boundary as above
+        | TimeLit raw        -> System.String.Concat("CAST('", raw, "' AS time(7))")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.TimeFormat`; same boundary as above
         | GuidLit raw        -> System.String.Concat("'", raw, "'")  // LINT-ALLOW: terminal SQL Guid-literal text formatting; raw is from `RawValueCodec.GuidFormat` (canonical D form, no escapable characters); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
         | TextLit raw        ->
             // Single-quote doubling per the SQL-standard escape; `N`

--- a/sidecar/projection/src/Projection.Core/SqlLiteral.fs
+++ b/sidecar/projection/src/Projection.Core/SqlLiteral.fs
@@ -64,6 +64,16 @@ type SqlLiteral =
     /// Time literal — the raw TimeSpan `c` form per `RawValueCodec
     /// .TimeFormat`. Rendered as `CAST('<raw>' AS time(7))` (V1 parity).
     | TimeLit of raw: string
+    /// WP-17(b) (DECISIONS 2026-07-16) — OFFSET-BEARING datetime literal
+    /// for `datetimeoffset` columns (DBA/External only). The raw carries
+    /// the signed offset (`RawValueCodec.DateTimeOffsetFormat`);
+    /// rendered as `CAST('<raw>' AS datetimeoffset(7))` (V1's
+    /// test-witnessed form) — casting an offset-bearing string to
+    /// `datetime2` refuses on SQL Server, so the offset shape MUST own
+    /// its CAST target. `ofRaw` dispatches on the raw shape
+    /// (`RawValueCodec.hasUtcOffset`): the semantic category stays the
+    /// 9-way `DateTime`; only the literal realization is offset-aware.
+    | DateTimeOffsetLit of raw: string
     /// Guid literal — the raw `D` form per `RawValueCodec.GuidFormat`
     /// (8-4-4-4-12 hyphenated). Rendered as `'<raw>'`. Maps to
     /// ScriptDom `StringLiteral` with `IsNational=false`.
@@ -141,6 +151,10 @@ module SqlLiteral =
             | Integer -> IntegerLit raw
             | Decimal -> DecimalLit raw
             | Boolean -> BooleanLit (RawValueCodec.parseBoolean raw)
+            // WP-17(b) — an offset-bearing raw (a `datetimeoffset`
+            // column's faithful carriage) owns its own CAST target;
+            // the offset-less canonical form stays `datetime2(7)`.
+            | DateTime when RawValueCodec.hasUtcOffset raw -> DateTimeOffsetLit raw
             | DateTime -> DateTimeLit raw
             | Date -> DateLit raw
             | Time -> TimeLit raw
@@ -163,6 +177,7 @@ module SqlLiteral =
         // precision-explicit, language-independent. The raw carries no escapable
         // characters (RawValueCodec canonical forms).
         | DateTimeLit raw    -> System.String.Concat("CAST('", raw, "' AS datetime2(7))")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateTimeFormat` (typed canonical form, no escapable characters); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
+        | DateTimeOffsetLit raw -> System.String.Concat("CAST('", raw, "' AS datetimeoffset(7))")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateTimeOffsetFormat`; same boundary as above
         | DateLit raw        -> System.String.Concat("CAST('", raw, "' AS date)")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.DateFormat`; same boundary as above
         | TimeLit raw        -> System.String.Concat("CAST('", raw, "' AS time(7))")  // LINT-ALLOW: terminal SQL temporal-literal text formatting; raw is from `RawValueCodec.TimeFormat`; same boundary as above
         | GuidLit raw        -> System.String.Concat("'", raw, "'")  // LINT-ALLOW: terminal SQL Guid-literal text formatting; raw is from `RawValueCodec.GuidFormat` (canonical D form, no escapable characters); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary

--- a/sidecar/projection/src/Projection.Core/SqlLiteral.fs
+++ b/sidecar/projection/src/Projection.Core/SqlLiteral.fs
@@ -73,6 +73,18 @@ type SqlLiteral =
     /// hex bare (no quoting). Maps to ScriptDom `BinaryLiteral`.
     | BinaryLit of hexPrefixed: string
 
+/// WP-17(e) (DECISIONS 2026-07-16) — one segment of a Text literal whose
+/// raw value carries control characters. V1 escapes CR/LF/TAB into
+/// `CHAR()` concatenation (`SqlLiteralFormatter.EscapeUnicodeString`)
+/// so the emitted SQL contains no raw control bytes; V2's two terminal
+/// planes (text `toString`, ScriptDom `buildSqlLiteral`) both compose
+/// from this shared segmentation so they cannot drift. `TextRun` may be
+/// empty (the V1-parity blind splice: a leading/trailing/adjacent
+/// control char yields an empty `N''` run).
+type TextLiteralSegment =
+    | TextRun of string
+    | ControlChar of code: int
+
 [<RequireQualifiedAccess>]
 module SqlLiteral =
 
@@ -82,6 +94,28 @@ module SqlLiteral =
     /// (the NM-20 malformed-raw precedent — loud, named, never coerced).
     [<Literal>]
     let EmptyNotEmptyCapableCode : string = "rawValue.empty.notEmptyCapable"
+
+    /// WP-17(e) — split a Text raw into literal runs and the control
+    /// characters between them. Exactly V1's escape set (CR 13, LF 10,
+    /// TAB 9 — `SqlLiteralFormatter.cs:58-61`); every other character
+    /// stays inside its run. A control-char-free raw yields the single
+    /// `[ TextRun raw ]` (the byte-identical default for both planes).
+    let textLiteralSegments (raw: string) : TextLiteralSegment list =
+        if raw.IndexOfAny [| '\r'; '\n'; '\t' |] < 0 then [ TextRun raw ]
+        else
+            let segments = System.Collections.Generic.List<TextLiteralSegment>()
+            let run = System.Text.StringBuilder()
+            let flush () =
+                segments.Add(TextRun (run.ToString()))
+                run.Clear() |> ignore
+            for c in raw do
+                match c with
+                | '\r' -> flush (); segments.Add(ControlChar 13)
+                | '\n' -> flush (); segments.Add(ControlChar 10)
+                | '\t' -> flush (); segments.Add(ControlChar 9)
+                | c    -> run.Append c |> ignore
+            flush ()
+            List.ofSeq segments
 
     /// Project an IR `(PrimitiveType, raw)` cell into a typed
     /// `SqlLiteral`. WP-3 (F11): NULL is carried OUT-OF-BAND as `None`
@@ -135,8 +169,18 @@ module SqlLiteral =
         | TextLit raw        ->
             // Single-quote doubling per the SQL-standard escape; `N`
             // prefix per the unicode-string-literal SQL convention.
-            let escaped = raw.Replace("'", "''")
-            System.String.Concat("N'", escaped, "'")  // LINT-ALLOW: terminal Unicode SQL string-literal text formatting; segments are typed (escaped from raw via single-quote-doubling, the SQL-standard escape); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
+            // WP-17(e): CR/LF/TAB splice into `CHAR()` concatenation
+            // (V1 `EscapeUnicodeString` parity) — the emitted SQL
+            // carries no raw control bytes; a control-char-free raw
+            // renders byte-identically to the pre-WP-17 form.
+            textLiteralSegments raw
+            |> List.map (fun segment ->
+                match segment with
+                | TextRun run ->
+                    System.String.Concat("N'", run.Replace("'", "''"), "'")  // LINT-ALLOW: terminal Unicode SQL string-literal text formatting; segments are typed (escaped from raw via single-quote-doubling, the SQL-standard escape); BCL `String.Concat` IS the use-case-specific library at the absolute terminal SQL-text boundary
+                | ControlChar code ->
+                    System.String.Concat("CHAR(", string code, ")"))  // LINT-ALLOW: terminal SQL CHAR() call formatting at the same boundary; code is one of the typed 13/10/9 set
+            |> String.concat " + "  // LINT-ALLOW: terminal SQL concatenation-operator join over the typed segment renderings at the same boundary
         | BinaryLit prefixed -> prefixed
 
     /// Convenience: `ofRaw` then `toString`. The combined surface

--- a/sidecar/projection/src/Projection.Core/SqlStorageType.fs
+++ b/sidecar/projection/src/Projection.Core/SqlStorageType.fs
@@ -114,7 +114,9 @@ module SqlStorageType =
     /// the fallback equivalence checkable (`toPrimitiveType
     /// (ofPrimitiveType pt) = pt`). The values mirror the existing
     /// `SqlTypeCorrespondence.baseName` / `ScriptDomBuild` defaults:
-    /// `Integer → INT`, `DateTime → DATETIME2`, `Text → NVARCHAR(MAX)`.
+    /// `Integer → INT`, `DateTime → DATETIME` (WP-17(d) — the platform
+    /// legacy default, aligned with the storage-evidence lane),
+    /// `Text → NVARCHAR(MAX)`.
     let ofPrimitiveType (pt: PrimitiveType) : SqlStorageType =
         match pt with
         | Integer  -> SqlStorageType.Int
@@ -125,7 +127,10 @@ module SqlStorageType =
         | Decimal  -> SqlStorageType.Decimal (18, 0)
         | Text     -> SqlStorageType.NVarChar Max
         | Boolean  -> SqlStorageType.Bit
-        | DateTime -> SqlStorageType.DateTime2 None
+        // WP-17(d) (DECISIONS 2026-07-16; audit §5a): the evidence-less
+        // fallback is the platform legacy `DATETIME`, matching the
+        // storage lane — the silent `DATETIME2` upgrade is retired.
+        | DateTime -> SqlStorageType.DateTime
         | Date     -> SqlStorageType.Date
         | Time     -> SqlStorageType.Time None
         | Binary   -> SqlStorageType.VarBinary Max

--- a/sidecar/projection/src/Projection.Core/SqlTypeCorrespondence.fs
+++ b/sidecar/projection/src/Projection.Core/SqlTypeCorrespondence.fs
@@ -59,7 +59,12 @@ module SqlTypeCorrespondence =
         | Decimal  -> "DECIMAL"
         | Text     -> "NVARCHAR"
         | Boolean  -> "BIT"
-        | DateTime -> "DATETIME2"
+        // WP-17(d) (DECISIONS 2026-07-16; audit §5a): the evidence-less
+        // fallback is the platform legacy DATETIME, aligned with the
+        // storage-evidence lane — a catalog-direct emission no longer
+        // misrepresents what a live export deploys. A datetime2 SOURCE
+        // still emits DATETIME2 via its storage evidence.
+        | DateTime -> "DATETIME"
         | Date     -> "DATE"
         | Time     -> "TIME"
         | Binary   -> "VARBINARY"

--- a/sidecar/projection/src/Projection.Pipeline/Bulk.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Bulk.fs
@@ -56,11 +56,33 @@ module Bulk =
             | Integer ->
                 box (Int64.Parse(raw, inv))
             | Decimal ->
-                box (Decimal.Parse(raw, inv))
+                // WP-17(a) — a `float`/`real` column's G17/G9 raw can
+                // carry an exponent beyond decimal's range (|x| ≳
+                // 7.9E28 → `Decimal.Parse` OVERFLOWS, the S1 write
+                // loss) or E-notation decimal cannot parse. Dispatch on
+                // the shape: scientific notation parses as the exact
+                // IEEE double (SqlBulkCopy converts to the float/real
+                // column faithfully); plain digit runs keep the exact
+                // decimal parse (decimal-family columns, and G17 forms
+                // without exponent — decimal carries ≤28 significant
+                // digits exactly, and the nearest-double conversion at
+                // the column recovers the original IEEE value).
+                if raw.IndexOfAny [| 'E'; 'e' |] >= 0 then
+                    box (Double.Parse(raw, NumberStyles.Float, inv))
+                else
+                    box (Decimal.Parse(raw, inv))
             | Boolean ->
                 box (RawValueCodec.parseBoolean raw)
             | DateTime ->
-                box (DateTime.ParseExact(raw, RawValueCodec.DateTimeFormat, inv))
+                // WP-17(b) — an offset-bearing raw (a `datetimeoffset`
+                // column's faithful carriage) parses back to the exact
+                // `DateTimeOffset`; SqlBulkCopy writes it to the
+                // `datetimeoffset` column offset-intact. The offset-less
+                // canonical form keeps its exact parse.
+                if RawValueCodec.hasUtcOffset raw then
+                    box (RawValueCodec.parseDateTimeOffset raw)
+                else
+                    box (DateTime.ParseExact(raw, RawValueCodec.DateTimeFormat, inv))
             | Date ->
                 box (DateTime.ParseExact(raw, RawValueCodec.DateFormat, inv))
             | Time ->

--- a/sidecar/projection/src/Projection.Pipeline/Deploy.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Deploy.fs
@@ -478,6 +478,13 @@ module Deploy =
                     // any stale bulk state before executing.
                     do! flushBulk ()
                     appendDdl s
+                | CreateSchema _ ->
+                    // G6: CREATE SCHEMA is DDL; schemas precede every
+                    // other object in the statement stream (non-dbo
+                    // tables/sequences resolve against them) — same
+                    // realization shape as the other DDL arms.
+                    do! flushBulk ()
+                    appendDdl s
                 | AlterTableAddColumn _ | AlterTableAlterColumn _ | AlterTableAddForeignKey _
                 | AlterTableDropColumn _ | AlterTableDropConstraint _ | DropIndex _ | DropSequence _ ->
                     // 6.A.12 + C1: minimum-viable-touch migration DDL (ALTER

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -123,6 +123,16 @@ module Compose =
             /// (the default) writes neither — byte-identical to the pre-wire bundle.
             Sqlproj : string option
             PostDeploy : string option
+            /// G3 (DECISIONS 2026-07-16) — the ACCUMULATED `.refactorlog`
+            /// document (deployed-vocabulary; prior chain ⊕ this run's
+            /// displacement, deduped by `OperationKey`), rendered at the
+            /// episode's `At`. Present exactly when the run is store-
+            /// threaded (`--lifecycle-store` / an env `store`): the store
+            /// is the rename evidence; a store-less run is genesis and
+            /// writes nothing — byte-identical to the pre-G3 bundle.
+            /// Written as `ProjectionCatalog.refactorlog` beside the
+            /// `.sqlproj`, which carries the matching `RefactorLog` item.
+            RefactorLog : string option
             /// The typed SSDT manifest built during projection (the same
             /// value serialized into `manifest.json` within `SsdtBundle`).
             /// Surfaced here so consumers — `runWithConfig`'s `RunReport`,
@@ -233,6 +243,34 @@ module Compose =
         | DisplacementFailed of EmitError
         | RecordFailed of message: string
 
+    /// G3 (DECISIONS 2026-07-16) — the store's PRE-EMISSION read phase,
+    /// threaded into the emission core so the bundle carries the accumulated
+    /// `.refactorlog` inside the ATOMIC write (and the `.sqlproj` its
+    /// matching `RefactorLog` item). The chain is loaded and its edge fold
+    /// derived ONCE per store-threaded run (the S51 one-durable-load
+    /// discipline — the load moved BEFORE the emission; it did not
+    /// duplicate); the post-bundle record phase reuses the same values.
+    /// Consequence, named: a malformed store now refuses BEFORE the bundle
+    /// lands (the bundle's content depends on the store, so emitting
+    /// without it would ship a wrong document); a RECORD failure still
+    /// surfaces after the bundle (the emission succeeded, provenance did
+    /// not).
+    type RefactorLogContext = {
+        /// The prior emission's schema plane (genesis ⇒ the empty catalog).
+        Prior : Catalog
+        /// The prior chain's accumulated deployed-vocabulary entries — the
+        /// fold of `RefactorLogEmitter.emitDeployed` over the timeline's
+        /// edges (genesis ⇒ empty). Historical edges fold with NO pins:
+        /// pins are a this-run config fact; an old operation a today-pin
+        /// would suppress is a no-match no-op for DacFx either way, and
+        /// the simpler derivation wins (rationale at the fold site).
+        PriorEntries : RefactorLogEntry list
+        /// The episode's boundary-supplied instant — the rendered
+        /// document's `ChangeDateTime` (audit metadata; T1 holds because
+        /// `at` is an input, never a clock read).
+        At : System.DateTimeOffset
+    }
+
     /// Per-artifact relative path. Centralized so tests and the CLI
     /// agree on naming.
     [<RequireQualifiedAccess>]
@@ -265,6 +303,11 @@ module Compose =
         let sqlproj = "ProjectionCatalog.sqlproj"
         [<Literal>]
         let postDeploy = "Script.PostDeployment.sql"
+        /// G3 — the accumulated refactorlog of a store-threaded run. Mirror
+        /// `SqlprojEmitter.refactorLogFileName` (the `.sqlproj`'s `RefactorLog`
+        /// item names this file; the `.sqlproj`-build test pins the pairing).
+        [<Literal>]
+        let refactorLog = "ProjectionCatalog.refactorlog"
         /// The Model Fidelity Report — structured (`fidelity.json`) + the
         /// rolled-up operator text (`fidelity.txt`). Default-on; emitted
         /// alongside the other run artifacts on full-export and migrate.
@@ -515,6 +558,9 @@ module Compose =
           // `runWithConfigCore` seam alongside `Dacpac`, not by an `EmitStep`.
           Sqlproj           = None
           PostDeploy        = None
+          // Store-gated accumulated refactorlog (G3); populated at the
+          // `runWithConfigCore` seam when the run is store-threaded.
+          RefactorLog       = None
           // The faithful, round-trippable snapshot of the emitted model — seeded
           // directly (like `Manifest` / `Fidelity`), written on every bundle
           // emission so two publish dirs can be diffed precisely.
@@ -1020,11 +1066,13 @@ module Compose =
                 File.WriteAllBytes(Path.Combine(stagingDir, ArtifactPath.dacpac), bytes)
                 [ Path.Combine(outputDir, ArtifactPath.dacpac) ]
         // The SDK-style SSDT project + its post-deploy (operator-gated, absent by
-        // default). Text artifacts written into the same staging dir so the
-        // atomic-replace contract covers them; final paths projected post-swap.
+        // default) + the accumulated refactorlog (store-gated, G3). Text
+        // artifacts written into the same staging dir so the atomic-replace
+        // contract covers them; final paths projected post-swap.
         let sqlprojFinalPaths =
-            [ ArtifactPath.sqlproj,    outputs.Sqlproj
-              ArtifactPath.postDeploy, outputs.PostDeploy ]
+            [ ArtifactPath.sqlproj,     outputs.Sqlproj
+              ArtifactPath.postDeploy,  outputs.PostDeploy
+              ArtifactPath.refactorLog, outputs.RefactorLog ]
             |> List.choose (fun (rel, body) ->
                 body
                 |> Option.map (fun b ->
@@ -1200,6 +1248,51 @@ module Compose =
                 Projection.Core.Catalog.allKinds catalog
                 |> List.filter (fun k -> Set.contains k.Physical physicalSources)
                 |> List.map (fun k -> k.SsKey)
+                |> Set.ofList
+
+    /// G3 (DECISIONS 2026-07-16) — the kinds whose DEPLOYED table name is the
+    /// operator-authored `Physical.Table`, not the logical name: every kind an
+    /// operator `tableRenames` override targets, in EITHER form. The chain's
+    /// LAST writer to `Kind.Physical` is the operator rename (physical-form
+    /// kinds additionally ride the S6.3 pins past the logical substitution),
+    /// so the emitted CREATE TABLE carries the operator's physical target for
+    /// all of them. The refactorlog's deployed-name projection must follow —
+    /// a model-side rename on such a kind changes no deployed name (suppress),
+    /// and a column rename on one must qualify by the operator's table.
+    /// Physical sources resolve against the ORIGINAL catalog (the OSSYS
+    /// coordinate the operator named — the `physicalRenamePins` precedent);
+    /// logical sources resolve by exact (module, entity) logical names (the
+    /// rename pass owns authoritative matching; this projection mirrors it).
+    let private operatorRenamedKinds
+        (cfg: Config.Config)
+        (catalog: Projection.Core.Catalog)
+        : Set<SsKey> =
+        match cfg.Overrides.TableRenames with
+        | [] -> Set.empty
+        | renames ->
+            match RenameBinding.fromConfig renames with
+            | Error _ -> Set.empty   // binding errors surface in `applyRenames`.
+            | Ok specs ->
+                let physicalSources =
+                    specs
+                    |> List.choose (fun s ->
+                        match s.Key with
+                        | Projection.Core.Passes.TableRename.Physical source -> Some source
+                        | Projection.Core.Passes.TableRename.Logical _       -> None)
+                    |> Set.ofList
+                let logicalSources =
+                    specs
+                    |> List.choose (fun s ->
+                        match s.Key with
+                        | Projection.Core.Passes.TableRename.Logical (m, e) -> Some (Name.value m, Name.value e)
+                        | Projection.Core.Passes.TableRename.Physical _     -> None)
+                    |> Set.ofList
+                catalog.Modules
+                |> List.collect (fun m -> m.Kinds |> List.map (fun k -> (m, k)))
+                |> List.filter (fun (m, k) ->
+                    Set.contains k.Physical physicalSources
+                    || Set.contains (Name.value m.Name, Name.value k.Name) logicalSources)
+                |> List.map (fun (_, k) -> k.SsKey)
                 |> Set.ofList
 
     /// Build the full `Policy` aggregate from a parsed `Config` and
@@ -1445,6 +1538,7 @@ module Compose =
     /// report-only callers).
     let private runWithConfigCore
         (cfg: Config.Config)
+        (refactorCtx: RefactorLogContext option)
         (parsed: Result<Catalog>)
         (bootstrapLane: DataComposer.BootstrapLane)
         (migration: Projection.Targets.Data.MigrationDependencyContext)
@@ -1498,6 +1592,35 @@ module Compose =
                     | Error errors -> Result.failure errors
                     | Ok dacpac ->
                     let outputs = { outputs with Dacpac = dacpac }
+                    // G3 (DECISIONS 2026-07-16) — the store-threaded run's
+                    // accumulated `.refactorlog`, computed HERE so it rides the
+                    // ATOMIC bundle write. The displacement derives over the
+                    // RENAMED catalog — the same pre-chain plane episodes record
+                    // (the hydration graft adds static ROWS only, so the rename
+                    // channels agree with the record phase's read-catalog plane;
+                    // the file⇔leg agreement is pinned by test). Deployed
+                    // vocabulary via `emitDeployed` (this run's S6.3 pins);
+                    // accumulation against the prior chain's fold (deduped by
+                    // `OperationKey`); rendered at the episode's `At`. Store-less
+                    // runs (`refactorCtx = None`) write nothing — byte-identical.
+                    let refactorLogR : Result<string option> =
+                        match refactorCtx with
+                        | None -> Result.success None
+                        | Some ctx ->
+                            match RefactorLogEmitter.emitDeployed (operatorRenamedKinds cfg catalog) (CatalogDiff.between ctx.Prior renamedCatalog) with
+                            | Error e ->
+                                Result.failureOf
+                                    (ValidationError.create
+                                        "pipeline.refactorLog.emitFailed"
+                                        (sprintf "The run's refactorlog displacement could not be emitted: %A" e))
+                            | Ok current ->
+                                let accumulated =
+                                    RefactorLogEmitter.accumulateArtifact ctx.PriorEntries current
+                                Result.success (Some (RefactorLogRender.ofEntriesAt ctx.At accumulated))
+                    match refactorLogR with
+                    | Error errors -> Result.failure errors
+                    | Ok refactorLog ->
+                    let outputs = { outputs with RefactorLog = refactorLog }
                     // `emission.sqlproj: true` — drop a buildable SDK-style SSDT
                     // project (the `.sqlproj` + its post-deploy) over the data
                     // lanes the publish already emitted, so the operator's
@@ -1517,7 +1640,8 @@ module Compose =
                             let postDeploy =
                                 if List.isEmpty postDeployLanes then None
                                 else Some (PostDeployEmitter.renderIncludes postDeployLanes)
-                            let sqlproj = SqlprojEmitter.emit dataLanes (Option.isSome postDeploy)
+                            let sqlproj =
+                                SqlprojEmitter.emit dataLanes (Option.isSome postDeploy) (Option.isSome refactorLog)
                             { outputs with Sqlproj = Some sqlproj; PostDeploy = postDeploy }
                     // PL-4 (S46/S47/S37/S49) — the FK lookup triple, the
                     // per-reference resolutions, and the decision overlay
@@ -2267,8 +2391,13 @@ module Compose =
     /// The publish, returning the `EstateAcquisition` beside the report —
     /// the combined verbs (`runWithConfigAndLoad` / `runWithConfigAndStore`)
     /// ride this so one verb pays for ONE estate acquisition (PL-1).
-    /// `runWithConfig` is the report-only projection.
-    let runWithConfigAcquiring (cfg: Config.Config) : Task<Result<RunReport * EstateAcquisition>> =
+    /// `runWithConfig` is the report-only projection. `refactorCtx` is the
+    /// store-threaded runs' pre-loaded refactorlog read phase (G3) — `None`
+    /// for every store-less caller (byte-identical bundle).
+    let runWithConfigAcquiringWithPrior
+        (refactorCtx: RefactorLogContext option)
+        (cfg: Config.Config)
+        : Task<Result<RunReport * EstateAcquisition>> =
         task {
             // Card S4a — the publish arc rides the spine. The `staged { }`
             // CE owns the "pipeline" umbrella root + the extract / profile /
@@ -2317,7 +2446,7 @@ module Compose =
                                 task {
                                     let lane = DataComposer.BootstrapLane.Prerendered extracted.Prerendered
                                     let result =
-                                        runWithConfigCore cfg (Ok extracted.Hydrated)
+                                        runWithConfigCore cfg refactorCtx (Ok extracted.Hydrated)
                                             lane extracted.Migration profile
                                         |> Result.map (fun (report, finalState) ->
                                             report,
@@ -2369,7 +2498,7 @@ module Compose =
                                     // artifact write.
                                     let lane = DataComposer.BootstrapLane.Rows bootstrapRows
                                     let result =
-                                        runWithConfigCore cfg (Ok catalog)
+                                        runWithConfigCore cfg refactorCtx (Ok catalog)
                                             lane migration profile
                                         |> Result.map (fun (report, finalState) ->
                                             report,
@@ -2388,6 +2517,11 @@ module Compose =
             // composition's crash semantics for the caller's catch.
             return StagedVerdict.toResult verdict
         }
+
+    /// The store-less acquisition — every pre-G3 caller's shape, byte-identical
+    /// (no refactorlog read phase, no `.refactorlog` artifact).
+    let runWithConfigAcquiring (cfg: Config.Config) : Task<Result<RunReport * EstateAcquisition>> =
+        runWithConfigAcquiringWithPrior None cfg
 
     /// The report-only publish (`runWithConfigAcquiring` with the
     /// acquisition dropped) — the established entry for callers without a
@@ -2556,11 +2690,42 @@ module Compose =
                     match remaining with
                     | [] -> Ok (acc : RefactorLogEntry list)
                     | edge :: rest ->
-                        match RefactorLogEmitter.emit edge with
+                        // G3 — the accumulated document speaks the DEPLOYED
+                        // vocabulary (`emitDeployed`), since DacFx matches
+                        // operations against the deployed model's element
+                        // names. Historical edges fold with NO pins: pins are
+                        // a this-run config fact, and an operation a today-pin
+                        // would suppress is a no-match no-op for DacFx either
+                        // way — the simpler derivation wins.
+                        match RefactorLogEmitter.emitDeployed Set.empty edge with
                         | Error e -> Error (DisplacementFailed e)
                         | Ok artifact ->
                             loop (RefactorLogEmitter.accumulateArtifact acc artifact) rest
                 loop [] edgeDiffs
+
+    /// G3 — the store's whole PRE-EMISSION read phase in one value: the ONE
+    /// durable load (S51) plus its pure derivations, hoisted BEFORE the
+    /// emission so the bundle can embed the accumulated `.refactorlog` and
+    /// the post-bundle record phase can reuse the same loaded chain (no
+    /// second load, no second edge-fold — S53). A missing store file is
+    /// genesis (empty prior, empty entries), same as before.
+    type StorePrior = {
+        Loaded       : EpisodicLifecycle option
+        Prior        : Catalog
+        PriorEntries : RefactorLogEntry list
+    }
+
+    let private loadStorePrior (path: string) : Result<StorePrior, FullExportStoreError> =
+        match loadStoreChain path with
+        | Error e -> Error e
+        | Ok loaded ->
+            match priorSchemaOfChain loaded with
+            | Error e -> Error e
+            | Ok prior ->
+                match priorAccumulatedRefactorLogOfChain loaded with
+                | Error e -> Error e
+                | Ok priorEntries ->
+                    Ok { Loaded = loaded; Prior = prior; PriorEntries = priorEntries }
 
     /// The next monotone `EpisodeCoordinate` for the loaded timeline — ordinal
     /// 0 for a genesis (no chain), else the latest episode's ordinal + 1.
@@ -2605,13 +2770,20 @@ module Compose =
             | Ok ()   -> Ok appended
             | Error e -> Error (StoreReadFailed (string e))
 
-    /// The diff-vs-prior store leg for one full-export run (seam T2). Given the
-    /// run's emitted schema (state B) and the timeline at `path`: load the prior
-    /// emission's schema (state A), measure `B ⊖ A`, accumulate the
-    /// displacement's refactorlog against the prior committed log, build the
-    /// `ChangeManifest` for the edge, and record exactly one new episode. Pure
-    /// w.r.t. the genesis emission (it runs *after* the bundle lands and never
-    /// alters it); the only side effect is the durable store write.
+    /// The diff-vs-prior store leg's RECORD phase (seam T2). Given the run's
+    /// emitted schema (state B) and the PRE-LOADED store read phase (state A +
+    /// the prior accumulated entries — `loadStorePrior`, G3): measure `B ⊖ A`,
+    /// accumulate the displacement's deployed-vocabulary refactorlog against
+    /// the prior committed log, build the `ChangeManifest` for the edge, and
+    /// record exactly one new episode. Runs *after* the bundle lands and never
+    /// alters it; the only side effect is the durable store write. (G3 split:
+    /// the read phase moved BEFORE the emission so the bundle embeds the
+    /// accumulated `.refactorlog`; this phase reuses the loaded chain — the
+    /// S51 one-durable-load discipline holds across the split.)
+    ///
+    /// `pins` are this run's S6.3 physical-rename pins — the SAME set the
+    /// bundle's document derived under, so the leg's accumulated entries and
+    /// the bundle's `ProjectionCatalog.refactorlog` agree (pinned by test).
     ///
     /// `appliedTransforms` is the composed run's §5.5 per-artifact overlay
     /// enumeration (`ManifestEmitter.appliedTransforms` over the run's lineage
@@ -2624,8 +2796,10 @@ module Compose =
     /// the config carries no per-environment divergence axis and `Tolerance.parse`
     /// is unwired; see `storeLegFromConfig`. The wiring is live so a future
     /// tolerance-resolving caller populates it without re-touching this seam.)
-    let private runStoreLeg
+    let private runStoreLegOnPrior
         (path: string)
+        (storePrior: StorePrior)
+        (pins: Set<SsKey>)
         (timeline: Timeline)
         (environment: Environment)
         (at: System.DateTimeOffset)
@@ -2635,22 +2809,14 @@ module Compose =
         (appliedTransforms: (SsKey * OverlayAxis option) list)
         (emitted: Catalog)
         : Result<FullExportStoreLeg, FullExportStoreError> =
-        // PL-1 (S51) — ONE durable load; the four consumers below thread it.
-        match loadStoreChain path with
-        | Error e -> Error e
-        | Ok loaded ->
-        match priorSchemaOfChain loaded with
-        | Error e -> Error e
-        | Ok prior ->
-            let displacement = CatalogDiff.between prior emitted
-            match priorAccumulatedRefactorLogOfChain loaded with
-            | Error e -> Error e
-            | Ok priorLog ->
-                    match RefactorLogEmitter.emit displacement with
-                    | Error e -> Error (DisplacementFailed e)
-                    | Ok currentArtifact ->
+        let loaded = storePrior.Loaded
+        let prior = storePrior.Prior
+        let displacement = CatalogDiff.between prior emitted
+        match RefactorLogEmitter.emitDeployed pins displacement with
+        | Error e -> Error (DisplacementFailed e)
+        | Ok currentArtifact ->
                         let accumulated =
-                            RefactorLogEmitter.accumulateArtifact priorLog currentArtifact
+                            RefactorLogEmitter.accumulateArtifact storePrior.PriorEntries currentArtifact
                         match nextStoreCoordinateOfChain loaded environment at with
                         | Error e -> Error e
                         | Ok coordinate ->
@@ -2689,44 +2855,47 @@ module Compose =
         | DisplacementFailed e -> ValidationError.create "pipeline.fullExport.store.displacementFailed" (string e)
         | RecordFailed m -> ValidationError.create "pipeline.fullExport.store.recordFailed" m
 
-    /// The diff-vs-prior store leg over the publish's own acquisition, or
-    /// `Ok None` when no store is supplied. PL-1: the emitted-schema plane
-    /// derives from `acquired.ReadCatalog` by the same pure `applyRenames`
-    /// the retired second read fed — no second `MetadataSnapshotRunner` run
-    /// against the live source. Pure/synchronous (no await — the acquisition
-    /// is already in hand).
+    /// The diff-vs-prior store leg's RECORD phase over the publish's own
+    /// acquisition (the read phase — `loadStorePrior` — ran BEFORE the
+    /// emission; G3). PL-1: the emitted-schema plane derives from
+    /// `acquired.ReadCatalog` by the same pure `applyRenames` the retired
+    /// second read fed — no second `MetadataSnapshotRunner` run against the
+    /// live source. Pure/synchronous (no await — the acquisition is already
+    /// in hand). The pins recompute here from the same `(cfg, ReadCatalog)`
+    /// pair the emission core used, so the leg's accumulated entries agree
+    /// with the bundle's document.
     /// `appliedTransforms` is the run's §5.5 overlay enumeration, taken from
     /// `RunReport.Manifest.AppliedTransforms` (the composed run the caller
     /// already produced), threaded onto the recorded episode (NM-33). The
     /// tolerance residual is `Tolerance.strict` here — the only resolved value
     /// available: the unified config carries no per-environment divergence axis
     /// and `Tolerance.parse` has no production caller, so a non-strict residual
-    /// is not yet reachable at this site (FLAGGED on `runStoreLeg`).
+    /// is not yet reachable at this site (FLAGGED on `runStoreLegOnPrior`).
     let private storeLegFromAcquisition
         (cfg: Config.Config)
         (acquired: EstateAcquisition)
-        (storePath: string option)
+        (storePrior: StorePrior)
+        (storePath: string)
         (timeline: Timeline)
         (environment: Environment)
         (at: System.DateTimeOffset)
         (appliedTransforms: (SsKey * OverlayAxis option) list)
         : Result<FullExportStoreLeg option> =
-        match storePath with
-        | None -> Result.success None
-        | Some p when System.String.IsNullOrWhiteSpace p -> Result.success None
-        | Some path ->
-            match applyRenames cfg acquired.ReadCatalog with
-            | Error errors -> Result.failure errors
-            | Ok emitted ->
-                match runStoreLeg path timeline environment at None DataObservation.empty (emittedToleranceResidual (defaultArg cfg.Emission.Tolerance Tolerance.permissive) emitted) appliedTransforms emitted with
-                | Ok leg -> Result.success (Some leg)
-                | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
+        match applyRenames cfg acquired.ReadCatalog with
+        | Error errors -> Result.failure errors
+        | Ok emitted ->
+            let physicalNamed = operatorRenamedKinds cfg acquired.ReadCatalog
+            match runStoreLegOnPrior storePath storePrior physicalNamed timeline environment at None DataObservation.empty (emittedToleranceResidual (defaultArg cfg.Emission.Tolerance Tolerance.permissive) emitted) appliedTransforms emitted with
+            | Ok leg -> Result.success (Some leg)
+            | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
 
     /// Track W1-B (seam T2) — `runWithConfig` with the **optional diff-vs-prior
     /// store leg**. Additive over the genesis path: when `storePath` is `None`
     /// or empty, this is byte-identical to `runWithConfig` (the genesis emission
-    /// alone, `snd = None`); when a store is supplied, the CREATE files are
-    /// emitted first (unchanged), then the store leg loads the prior emission,
+    /// alone, `snd = None`); when a store is supplied, the run FIRST loads the
+    /// prior emission (the G3 read phase — one durable load, before the
+    /// emission, so the bundle embeds the accumulated `.refactorlog` and the
+    /// `.sqlproj` its item), then emits the bundle, then the record phase
     /// measures the displacement, accumulates the refactorlog, builds the
     /// `ChangeManifest`, and records exactly one new episode.
     ///
@@ -2735,10 +2904,11 @@ module Compose =
     /// larger feature, out of scope for 6b); `DataObservation.empty` is recorded
     /// (the CDC-measure leg is a sibling track the parent joins).
     ///
-    /// The store write is fail-loud: a malformed store, an unobservable
-    /// displacement, or a non-monotone record surface as `Error` on the run,
-    /// *after* the bundle has landed (the operator knows the emission succeeded
-    /// but provenance did not).
+    /// Failure surfaces, split by phase (G3): a malformed store refuses BEFORE
+    /// the bundle (its content depends on the store — emitting without it would
+    /// ship a wrong document); an unobservable displacement or a non-monotone
+    /// record surfaces *after* the bundle has landed (the operator knows the
+    /// emission succeeded but provenance did not).
     /// Bracket a post-root publish leg (`store` / `seed-load`) in the stage
     /// wire events (2026-07-02 — the legs join the declared publish spine so
     /// the live board covers the whole run). Same wire shape as
@@ -2773,29 +2943,40 @@ module Compose =
         (at: System.DateTimeOffset)
         : Task<Result<RunReport * FullExportStoreLeg option>> =
         task {
-            // PL-1 — one estate acquisition: the store leg consumes the
-            // publish's own read catalog instead of re-extracting the model.
-            let! acquiredR = runWithConfigAcquiring cfg
-            match acquiredR with
-            | Error errors -> return Result.failure errors
-            | Ok (report, acquired) ->
-                match storePath with
-                | Some p when not (System.String.IsNullOrWhiteSpace p) ->
-                    // The store leg is a declared stage on the publish spine
-                    // (`Spines.publishWith true …`) — bracketed so the board's
-                    // store line opens, works, and closes honestly.
-                    let! legR =
-                        stagedLeg (StageName.value Stages.store) (fun () ->
-                            Task.FromResult
-                                (storeLegFromAcquisition cfg acquired storePath timeline environment at report.Manifest.AppliedTransforms))
-                    return legR |> Result.map (fun legOpt -> report, legOpt)
-                | _ ->
-                    // No store — the genesis emission; no store stage was
-                    // seeded (dispatch chose the bare pipeline spine), so no
-                    // bracket fires.
-                    return
-                        storeLegFromAcquisition cfg acquired storePath timeline environment at report.Manifest.AppliedTransforms
-                        |> Result.map (fun legOpt -> report, legOpt)
+            match storePath with
+            | Some path when not (System.String.IsNullOrWhiteSpace path) ->
+                // G3 read phase — the ONE durable load (S51), BEFORE the
+                // emission so the bundle embeds the accumulated refactorlog.
+                // Rides ahead of the pipeline spine's extract stage (a light
+                // read next to the emission arc; the RECORD phase below keeps
+                // the board's bracketed store line).
+                match loadStorePrior path with
+                | Error storeErr -> return Result.failureOf (mapStoreErr storeErr)
+                | Ok storePrior ->
+                    let refactorCtx =
+                        { Prior = storePrior.Prior
+                          PriorEntries = storePrior.PriorEntries
+                          At = at }
+                    // PL-1 — one estate acquisition: the store leg consumes the
+                    // publish's own read catalog instead of re-extracting.
+                    let! acquiredR = runWithConfigAcquiringWithPrior (Some refactorCtx) cfg
+                    match acquiredR with
+                    | Error errors -> return Result.failure errors
+                    | Ok (report, acquired) ->
+                        // The record phase is a declared stage on the publish
+                        // spine (`Spines.publishWith true …`) — bracketed so the
+                        // board's store line opens, works, and closes honestly.
+                        let! legR =
+                            stagedLeg (StageName.value Stages.store) (fun () ->
+                                Task.FromResult
+                                    (storeLegFromAcquisition cfg acquired storePrior path timeline environment at report.Manifest.AppliedTransforms))
+                        return legR |> Result.map (fun legOpt -> report, legOpt)
+            | _ ->
+                // No store — the genesis emission; no store stage was seeded
+                // (dispatch chose the bare pipeline spine), so no bracket
+                // fires and no refactorlog artifact is written.
+                let! acquiredR = runWithConfigAcquiring cfg
+                return acquiredR |> Result.map (fun (report, _acquired) -> report, None)
         }
 
     /// AC-X1 (part B) — the **live data-load leg core**: load the idempotent
@@ -2812,6 +2993,7 @@ module Compose =
     let private recordLoad
         (emitted: Catalog)
         (cdcDelta: int)
+        (pins: Set<SsKey>)
         (storePath: string option)
         (timeline: Timeline)
         (environment: Environment)
@@ -2830,9 +3012,16 @@ module Compose =
             // This data-load leg is config-less (unit-testable), so it resolves against
             // `Tolerance.permissive` (report every fired divergence) — the schema-publish
             // store leg is where the operator's `emission.tolerance` threads (Wave-3 3.4).
-            match runStoreLeg path timeline environment at None data (emittedToleranceResidual Tolerance.permissive emitted) [] emitted with
-            | Ok leg -> Result.success (Some leg, cdcDelta)
+            // G3 — the record leg loads its OWN read phase at record time (a
+            // data load may run long; a fresh read narrows the lost-update
+            // window before the monotone append). One durable load per leg
+            // (S51 holds per-leg).
+            match loadStorePrior path with
             | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
+            | Ok storePrior ->
+                match runStoreLegOnPrior path storePrior pins timeline environment at None data (emittedToleranceResidual Tolerance.permissive emitted) [] emitted with
+                | Ok leg -> Result.success (Some leg, cdcDelta)
+                | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
         | _ -> Result.success (None, cdcDelta)
 
     /// The CDC-bracketed load-measure-record core shared by the two load
@@ -2845,6 +3034,7 @@ module Compose =
         (load: unit -> Task<unit>)
         (emitted: Catalog)
         (sink: SqlConnection)
+        (pins: Set<SsKey>)
         (storePath: string option)
         (timeline: Timeline)
         (environment: Environment)
@@ -2861,7 +3051,7 @@ module Compose =
                 match! cdcCaptureTotal sink with
                 | Error es -> return Result.failure es
                 | Ok post ->
-                    return recordLoad emitted (post - baseline) storePath timeline environment at
+                    return recordLoad emitted (post - baseline) pins storePath timeline environment at
         }
 
     /// The fused-string load shape — what an operator executing the
@@ -2882,13 +3072,15 @@ module Compose =
         // `cdcCaptureTotal` / `executeBatch` are injected (the `Deploy` module
         // compiles AFTER this one, so Compose cannot name it; callers pass
         // `Deploy.cdcCaptureTotal` / `Deploy.executeBatch`).
+        // Config-less witness surface — no operator physical-rename pins in
+        // scope, so the record's deployed-vocabulary projection runs pinless.
         loadMeasureAndRecord
             cdcCaptureTotal
             (fun () ->
                 // An empty seed loads nothing.
                 if System.String.IsNullOrWhiteSpace seed then Task.FromResult ()
                 else executeBatch sink seed)
-            emitted sink storePath timeline environment at
+            emitted sink Set.empty storePath timeline environment at
 
     /// Card P2 — the LEVELED production load: same CDC bracket, same
     /// episode recording, but the seed deploys as the leveled plan
@@ -2896,7 +3088,8 @@ module Compose =
     /// `Deploy.executeLeveledSeed <connection string>` — the executor
     /// closes over the connection STRING because every segment opens its
     /// own pooled connection; `sink` stays the CDC measure's connection).
-    let loadLeveledSeedAndRecord
+    let private loadLeveledSeedAndRecordWithPins
+        (pins: Set<SsKey>)
         (cdcCaptureTotal: SqlConnection -> Task<Result<int>>)
         (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
         (emitted: Catalog)
@@ -2915,7 +3108,22 @@ module Compose =
                 // whitespace gate.
                 if DataComposer.LeveledDeploymentText.isEmpty plan then Task.FromResult ()
                 else executeLeveled plan)
-            emitted sink storePath timeline environment at
+            emitted sink pins storePath timeline environment at
+
+    let loadLeveledSeedAndRecord
+        (cdcCaptureTotal: SqlConnection -> Task<Result<int>>)
+        (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
+        (emitted: Catalog)
+        (plan: DataComposer.LeveledDeploymentText)
+        (sink: SqlConnection)
+        (storePath: string option)
+        (timeline: Timeline)
+        (environment: Environment)
+        (at: System.DateTimeOffset)
+        : Task<Result<FullExportStoreLeg option * int>> =
+        // Config-less witness surface (pins parity with `loadSeedAndRecord`);
+        // the production path threads real pins via `loadFromAcquisition`.
+        loadLeveledSeedAndRecordWithPins Set.empty cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
 
     /// AC-X1 (part B) — `runWithConfig` PLUS the live data-load leg the W1-B
     /// store leg deferred. After the bundle is published (unchanged), the
@@ -2945,7 +3153,10 @@ module Compose =
         match projectSeedPlanUsing cfg acquired with
         | Error errors -> Task.FromResult (Result.failure errors)
         | Ok (emitted, plan) ->
-            loadLeveledSeedAndRecord cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
+            // G3 — the production record leg carries this run's operator-renamed
+            // kind set so its deployed-vocabulary entries agree with the bundle's.
+            let physicalNamed = operatorRenamedKinds cfg acquired.ReadCatalog
+            loadLeveledSeedAndRecordWithPins physicalNamed cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
 
     /// Card P2 re-threaded seam: the second argument is the LEVELED seed
     /// executor (`Deploy.executeLeveledSeed <connection string>` at the CLI
@@ -2962,10 +3173,26 @@ module Compose =
         (at: System.DateTimeOffset)
         : Task<Result<RunReport * FullExportStoreLeg option * int>> =
         task {
+            // G3 read phase — when a store rides, load the prior BEFORE the
+            // emission so the published bundle embeds the accumulated
+            // `.refactorlog` (the record leg re-reads at record time: the data
+            // load between the two may run long, and a fresh read narrows the
+            // lost-update window before the monotone append).
+            let refactorCtxR : Result<RefactorLogContext option> =
+                match storePath with
+                | Some p when not (System.String.IsNullOrWhiteSpace p) ->
+                    match loadStorePrior p with
+                    | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
+                    | Ok sp ->
+                        Result.success (Some { Prior = sp.Prior; PriorEntries = sp.PriorEntries; At = at })
+                | _ -> Result.success None
+            match refactorCtxR with
+            | Error errors -> return Result.failure errors
+            | Ok refactorCtx ->
             // PL-1 — one estate acquisition: the load leg consumes the
             // publish's extract triple + composed state instead of paying a
             // second full publish (model read + hydration + chain + render).
-            let! acquiredR = runWithConfigAcquiring cfg
+            let! acquiredR = runWithConfigAcquiringWithPrior refactorCtx cfg
             match acquiredR with
             | Error errors -> return Result.failure errors
             | Ok (report, acquired) ->

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -586,7 +586,11 @@ module Compose =
                         ManifestEmitter.buildFull
                             ctx.Profile registry ctx.ComposedState.TopologicalOrder
                             ctx.VersionedPolicy policyConflicts ctx.Trail (Some ctx.ComposedState) ctx.EmittedCatalog
-                    { outputs with SsdtBundle = SsdtBundle.compose rewritten manifest; Manifest = manifest }
+                    // G6 — the non-dbo CREATE SCHEMA files ride the bundle
+                    // beside the Modules/** tables (empty for dbo-only
+                    // estates; the SDK's default Build glob compiles them).
+                    let schemaFiles = SsdtDdlEmitter.schemaFiles ctx.EmittedCatalog
+                    { outputs with SsdtBundle = SsdtBundle.composeWithSchemas schemaFiles rewritten manifest; Manifest = manifest }
                 | Error err ->
                     invalidOp (sprintf "Compose.project: SsdtDdlEmitter.emitSlices: %A" err) }
           { Metadata = JsonEmitter.registeredMetadata

--- a/sidecar/projection/src/Projection.Targets.Data/MergeRender.fs
+++ b/sidecar/projection/src/Projection.Targets.Data/MergeRender.fs
@@ -87,6 +87,21 @@ module MergeRender =
                 CdcAware    = cdcAware
                 DeleteScope = deleteScope
                 RowSource   = MergeRowSource.InlineValues
+                // WP-17(c) — the comparison-less storage types (`xml` +
+                // the legacy LOBs `image`/`text`/`ntext`) have no `<>`
+                // operator; their change-detect compare CASTs both sides
+                // to the type's legal MAX target (content-level). Empty
+                // for kinds without them — the predicate is byte-identical.
+                CastCompareColumns =
+                    k.Attributes
+                    |> List.choose (fun a ->
+                        match a.SqlStorage with
+                        | Some SqlStorageType.Xml
+                        | Some SqlStorageType.NText -> Some (ColumnRealization.columnNameText a.Column, CastToNVarCharMax)
+                        | Some SqlStorageType.Text  -> Some (ColumnRealization.columnNameText a.Column, CastToVarCharMax)
+                        | Some SqlStorageType.Image -> Some (ColumnRealization.columnNameText a.Column, CastToVarBinaryMax)
+                        | _ -> None)
+                    |> Map.ofList
             }
         if DataStagingPolicy.shouldStage staging rowCount then
             Bench.recordSample (System.String.Concat(bench, ".staged")) 1L  // LINT-ALLOW: terminal Bench telemetry-label composition (per-lane scope prefix); a label IS a string primitive

--- a/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
@@ -172,7 +172,13 @@ module CatalogCodec =
          | SqlLiteral.DecimalLit d    -> jw.WriteString("kind", "DecimalLit");  jw.WriteString("value", d)
          | SqlLiteral.BooleanLit b    -> jw.WriteString("kind", "BooleanLit");  jw.WriteBoolean("value", b)
          | SqlLiteral.TextLit r       -> jw.WriteString("kind", "TextLit");     jw.WriteString("value", r)
-         | SqlLiteral.TemporalLit r   -> jw.WriteString("kind", "TemporalLit"); jw.WriteString("value", r)
+         // WP-17(d) — the three temporal categories write their own kinds
+         // (each owns a distinct CAST target); a pre-WP-17 artifact's
+         // category-blind "TemporalLit" still READS (classified by the
+         // canonical raw shape — see rSqlLiteral).
+         | SqlLiteral.DateTimeLit r   -> jw.WriteString("kind", "DateTimeLit"); jw.WriteString("value", r)
+         | SqlLiteral.DateLit r       -> jw.WriteString("kind", "DateLit");     jw.WriteString("value", r)
+         | SqlLiteral.TimeLit r       -> jw.WriteString("kind", "TimeLit");     jw.WriteString("value", r)
          | SqlLiteral.GuidLit r       -> jw.WriteString("kind", "GuidLit");     jw.WriteString("value", r)
          | SqlLiteral.BinaryLit h     -> jw.WriteString("kind", "BinaryLit");   jw.WriteString("value", h))
         jw.WriteEndObject()
@@ -580,7 +586,21 @@ module CatalogCodec =
             | "DecimalLit"  -> field el "value" asString |> Result.map SqlLiteral.DecimalLit
             | "BooleanLit"  -> field el "value" asBool   |> Result.map SqlLiteral.BooleanLit
             | "TextLit"     -> field el "value" asString |> Result.map SqlLiteral.TextLit
-            | "TemporalLit" -> field el "value" asString |> Result.map SqlLiteral.TemporalLit
+            // WP-17(d) — the category-bearing temporal kinds.
+            | "DateTimeLit" -> field el "value" asString |> Result.map SqlLiteral.DateTimeLit
+            | "DateLit"     -> field el "value" asString |> Result.map SqlLiteral.DateLit
+            | "TimeLit"     -> field el "value" asString |> Result.map SqlLiteral.TimeLit
+            // Pre-WP-17 artifacts wrote one category-blind "TemporalLit";
+            // classify by the canonical raw shape (`RawValueCodec`
+            // formats are disjoint: DateTimeFormat carries a space,
+            // TimeFormat carries colons but no space, DateFormat
+            // neither) — replay semantics preserved, no re-record.
+            | "TemporalLit" ->
+                field el "value" asString
+                |> Result.map (fun r ->
+                    if r.Contains " " then SqlLiteral.DateTimeLit r
+                    elif r.Contains ":" then SqlLiteral.TimeLit r
+                    else SqlLiteral.DateLit r)
             | "GuidLit"     -> field el "value" asString |> Result.map SqlLiteral.GuidLit
             | "BinaryLit"   -> field el "value" asString |> Result.map SqlLiteral.BinaryLit
             | o -> fail "codec.sqlLiteral.unknown" (sprintf "unknown SqlLiteral kind '%s'" o)) el

--- a/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
@@ -177,6 +177,7 @@ module CatalogCodec =
          // category-blind "TemporalLit" still READS (classified by the
          // canonical raw shape — see rSqlLiteral).
          | SqlLiteral.DateTimeLit r   -> jw.WriteString("kind", "DateTimeLit"); jw.WriteString("value", r)
+         | SqlLiteral.DateTimeOffsetLit r -> jw.WriteString("kind", "DateTimeOffsetLit"); jw.WriteString("value", r)
          | SqlLiteral.DateLit r       -> jw.WriteString("kind", "DateLit");     jw.WriteString("value", r)
          | SqlLiteral.TimeLit r       -> jw.WriteString("kind", "TimeLit");     jw.WriteString("value", r)
          | SqlLiteral.GuidLit r       -> jw.WriteString("kind", "GuidLit");     jw.WriteString("value", r)
@@ -588,6 +589,7 @@ module CatalogCodec =
             | "TextLit"     -> field el "value" asString |> Result.map SqlLiteral.TextLit
             // WP-17(d) — the category-bearing temporal kinds.
             | "DateTimeLit" -> field el "value" asString |> Result.map SqlLiteral.DateTimeLit
+            | "DateTimeOffsetLit" -> field el "value" asString |> Result.map SqlLiteral.DateTimeOffsetLit
             | "DateLit"     -> field el "value" asString |> Result.map SqlLiteral.DateLit
             | "TimeLit"     -> field el "value" asString |> Result.map SqlLiteral.TimeLit
             // Pre-WP-17 artifacts wrote one category-blind "TemporalLit";

--- a/sidecar/projection/src/Projection.Targets.SSDT/DacpacEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/DacpacEmitter.fs
@@ -79,7 +79,10 @@ module DacpacEmitter =
         match s with
         | CreateTable _ | CreateIndex _ | SetExtendedProperty _
         | AlterTableNoCheckConstraint _ | AlterTableDisableConstraint _ | AlterIndexDisable _
-        | CreateTrigger _ | AlterTableDisableTrigger _ | CreateSequence _ -> true
+        | CreateTrigger _ | AlterTableDisableTrigger _ | CreateSequence _
+        // G6 — schema objects are declarative model members; a non-dbo
+        // estate's dacpac fails validation without them.
+        | CreateSchema _ -> true
         // Imperative migration DDL — the in-place executor's, not the
         // declarative .dacpac model's. DacFx owns the ALTER/DROP at publish.
         | AlterTableAddColumn _ | AlterTableAlterColumn _ | AlterTableAddForeignKey _
@@ -124,6 +127,7 @@ module DacpacEmitter =
         | CreateTable _ -> "CreateTable"
         | CreateIndex _ -> "CreateIndex"
         | CreateSequence _ -> "CreateSequence"
+        | CreateSchema _ -> "CreateSchema"
         | SetExtendedProperty _ -> "SetExtendedProperty"
         | AlterTableNoCheckConstraint _ -> "AlterTableNoCheckConstraint"
         | AlterTableDisableConstraint _ -> "AlterTableDisableConstraint"

--- a/sidecar/projection/src/Projection.Targets.SSDT/DataStatementArgs.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/DataStatementArgs.fs
@@ -65,6 +65,17 @@ type MergeRowSource =
     | InlineValues
     | Staged of tempName: string
 
+/// WP-17(c) — the change-detect CAST target for a column whose storage
+/// type has no `<>` operator. Closed DU: the members are exactly the
+/// SQL Server comparison-less types' legal cast targets (`xml`/`ntext`
+/// → NVARCHAR(MAX); legacy `text` → VARCHAR(MAX); `image` →
+/// VARBINARY(MAX) — an image→nvarchar cast is itself illegal, which is
+/// why the target is per-type, not universal).
+type ChangeCompareCast =
+    | CastToNVarCharMax
+    | CastToVarCharMax
+    | CastToVarBinaryMax
+
 /// MERGE construction args. Decoupled from `Catalog`/`Kind`/`Attribute` (carry
 /// `TableId` + name lists + typed `SqlLiteral` rows) so the builder is testable
 /// in isolation and shared across every MERGE-emitting lane.
@@ -81,6 +92,17 @@ type MergeBuildArgs =
         /// pre-staged `#temp` (the error-8623-safe form for large kinds). See
         /// `MergeRowSource`.
         RowSource   : MergeRowSource
+        /// WP-17(c) (DECISIONS 2026-07-16) — updatable columns whose
+        /// change-detect compare must CAST both sides (the types with NO
+        /// `<>` operator: `xml`, and the legacy LOBs `image`/`text`/
+        /// `ntext` — the WP-17(f) gallery canary discovered the LOB
+        /// members live: "The data types image and varbinary are
+        /// incompatible in the not equal to operator"). The cast target
+        /// is per-type (`image` casts to VARBINARY(MAX); `xml`/`ntext`
+        /// to NVARCHAR(MAX); legacy `text` to VARCHAR(MAX)) — content-
+        /// level compare is the deliberate semantic. Empty for kinds
+        /// without such columns — the emitted predicate is byte-identical.
+        CastCompareColumns : Map<string, ChangeCompareCast>
     }
 
 /// UPDATE construction args. Decoupled from `Catalog`/`Kind`/`Attribute`

--- a/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogEmitter.fs
@@ -335,6 +335,185 @@ module RefactorLogEmitter =
             @ referenceRefactorEntries diff k)
 
 
+    // ------------------------------------------------------------------
+    // G3 (DECISIONS 2026-07-16) — the DEPLOYED-vocabulary emission.
+    //
+    // `emit` above speaks the CATALOG plane: `ElementName` renders the
+    // kind's `Physical` (OSSYS-flavored) table and the raw logical
+    // names. That vocabulary matches a deployed estate only when the
+    // logical-name emission is recompiled OFF — under the production
+    // default (`LogicalTableEmission`/`LogicalColumnEmission`, default-
+    // on, no config off-switch — register H1) the deployed estate
+    // speaks LOGICAL names, and DacFx matches refactor operations
+    // against the DEPLOYED model's element names. An operation naming
+    // `[dbo].[OSUSR_ABC_CUSTOMER]` on an estate whose table is
+    // `[dbo].[Customer]` matches nothing, is skipped, and the rename
+    // DROP+CREATEs anyway — the exact catastrophe the refactorlog
+    // exists to prevent. `emitDeployed` projects both sides of every
+    // rename through the SAME name-decision rules the emission passes
+    // apply, so the operations speak the deployed vocabulary:
+    //
+    //   * table — the post-chain outcome of `LogicalTableEmission.
+    //     substituteKind` + the operator rename pass (the LAST
+    //     `Kind.Physical` writer): a kind an operator `tableRenames`
+    //     override targets (EITHER form) deploys under its authored
+    //     `Physical` (physical-form additionally rides the S6.3 pins);
+    //     blank / >128-char logical names keep `Physical` (H1's
+    //     tripwire edge); otherwise the logical name IS the deployed
+    //     table name.
+    //   * column — `LogicalColumnEmission.substituteAttribute`: blank /
+    //     >128 falls back to the physical column; otherwise logical.
+    //   * a rename whose old and new DEPLOYED names coincide (a pinned
+    //     kind's logical rename; a double fallback) emits NO operation —
+    //     nothing changed on the estate, and a no-match operation is
+    //     noise at best.
+    //
+    // The FOREIGN-KEY channel is deliberately ABSENT here: deployed FK
+    // constraint names are SYNTHESIZED (`FK_<Owner>_<Target>_<Col>`,
+    // `SsdtDdlEmitter.fkDef` — honoring `Reference.Name` is WP-7's open
+    // remainder), so a logical `Reference.Name` rename changes no
+    // deployed constraint and its operation could never match. When
+    // WP-7 lands, the FK channel re-opens with the then-real deployed
+    // names. Kind/column operations keep `emit`'s OperationKey
+    // derivations verbatim (keys are over the LOGICAL rename triple),
+    // so accumulation dedup and cross-run identity are unchanged.
+    //
+    // Recompile coupling, named: if `LogicalTableEmission`/
+    // `LogicalColumnEmission` are ever recompiled `Disabled`, this
+    // projection must follow (deployed names become the physical ones).
+    // ------------------------------------------------------------------
+
+    /// The deployed table name a kind carries under the production
+    /// emission rule, for an arbitrary logical name (so the OLD and NEW
+    /// sides of a rename each project through the kind that carried
+    /// them — source kind for old, target kind for new). Validity by
+    /// construction: `TableName.create` embeds the exact blank/>128 rule
+    /// `LogicalTableEmission.substituteKind` pre-checks — an invalid
+    /// logical name keeps the physical (H1's tripwire edge).
+    let private deployedTableName (physicalNamedKinds: Set<SsKey>) (k: Kind) (logical: Name) : string =
+        if Set.contains k.SsKey physicalNamedKinds then TableId.tableText k.Physical
+        else
+            match TableName.create (Name.value logical) with
+            | Ok _    -> Name.value logical
+            | Error _ -> TableId.tableText k.Physical
+
+    /// The deployed column name an attribute carries under the
+    /// production emission rule (`LogicalColumnEmission` — no pins at
+    /// the column grain; an invalid logical name keeps the physical,
+    /// by the same `ColumnName.create` validity rule the pass checks).
+    let private deployedColumnName (a: Attribute) (logical: Name) : string =
+        match ColumnName.create (Name.value logical) with
+        | Ok _    -> Name.value logical
+        | Error _ -> ColumnRealization.columnNameText a.Column
+
+    /// `[schema]` for a kind — the SqlSchema parent element name.
+    let private deployedSchemaQualified (k: Kind) : string =
+        Render.quote (TableId.schemaText k.Physical)
+
+    /// The kind-level (SqlTable) deployed-vocabulary rename entries.
+    let private deployedKindRefactorEntries
+        (physicalNamedKinds: Set<SsKey>)
+        (diff: CatalogDiff)
+        (renames: Map<SsKey, RenameRecord>)
+        (k: Kind)
+        : RefactorLogEntry list =
+        match Map.tryFind k.SsKey renames with
+        | None -> []
+        | Some record ->
+            // The OLD side projects through the SOURCE kind (the plane the
+            // prior episode deployed); the NEW side through the target kind.
+            let sourceKind =
+                Catalog.tryFindKind k.SsKey (CatalogDiff.source diff)
+                |> Option.defaultValue k
+            let oldDeployed = deployedTableName physicalNamedKinds sourceKind record.OldName
+            let newDeployed = deployedTableName physicalNamedKinds k record.NewName
+            if oldDeployed = newDeployed then []
+            else
+                [
+                    {
+                        OperationKey = renameOperationKey k.SsKey record
+                        OperationKind = RenameRefactor
+                        ElementName =
+                            System.String.Join(".", [| deployedSchemaQualified k; Render.quote oldDeployed |])
+                        ElementType = SqlTable
+                        ParentElementName = deployedSchemaQualified k
+                        ParentElementType = SqlSchema
+                        NewName = newDeployed
+                        PassVersion = version
+                    }
+                ]
+
+    /// The column-level (SqlSimpleColumn) deployed-vocabulary rename
+    /// entries. Operations describe the PRE-publish estate, so the table
+    /// qualifier is the kind's OLD deployed name (relevant when the kind
+    /// renames in the same displacement — operations are sorted by
+    /// OperationKey, not authored order, so they must all speak one
+    /// consistent pre-publish vocabulary).
+    let private deployedColumnRefactorEntries
+        (physicalNamedKinds: Set<SsKey>)
+        (diff: CatalogDiff)
+        (renames: Map<SsKey, RenameRecord>)
+        (k: Kind)
+        : RefactorLogEntry list =
+        match CatalogDiff.attributeDiffOf k.SsKey diff with
+        | None -> []
+        | Some ad when Map.isEmpty ad.Renamed -> []
+        | Some ad ->
+            let sourceKind =
+                Catalog.tryFindKind k.SsKey (CatalogDiff.source diff)
+                |> Option.defaultValue k
+            let kindOldLogical =
+                match Map.tryFind k.SsKey renames with
+                | Some r -> r.OldName
+                | None -> k.Name
+            let tableDeployedOld = deployedTableName physicalNamedKinds sourceKind kindOldLogical
+            let tableQualifiedOld =
+                System.String.Join(".", [| deployedSchemaQualified k; Render.quote tableDeployedOld |])
+            ad.Renamed
+            |> Map.toList
+            |> List.choose (fun (attrKey, record) ->
+                let sourceAttr = sourceKind.Attributes |> List.tryFind (fun a -> a.SsKey = attrKey)
+                let targetAttr = k.Attributes |> List.tryFind (fun a -> a.SsKey = attrKey)
+                match sourceAttr |> Option.orElse targetAttr, targetAttr |> Option.orElse sourceAttr with
+                | Some sa, Some ta ->
+                    let oldDeployed = deployedColumnName sa record.OldName
+                    let newDeployed = deployedColumnName ta record.NewName
+                    if oldDeployed = newDeployed then None
+                    else
+                        Some
+                            {
+                                OperationKey =
+                                    columnRenameOperationKey attrKey (Name.value record.OldName) (Name.value record.NewName)
+                                OperationKind = RenameRefactor
+                                ElementName =
+                                    System.String.Join(".", [| tableQualifiedOld; Render.quote oldDeployed |])
+                                ElementType = SqlSimpleColumn
+                                ParentElementName = tableQualifiedOld
+                                ParentElementType = SqlTable
+                                NewName = newDeployed
+                                PassVersion = version
+                            }
+                | _ -> None)
+
+    /// Π port realization for the DEPLOYED-vocabulary document (G3) —
+    /// the sibling of `emit` whose operations DacFx can match against a
+    /// logically-emitted estate. Same T11 keyset contract (every kind in
+    /// the diff's target Catalog appears; non-renamed kinds carry the
+    /// empty list); same OperationKey derivations (dedup identity is
+    /// unchanged); table + column channels only (FK channel named-absent
+    /// above). `physicalNamedKinds` are the kinds whose deployed table
+    /// name is their operator-authored `Physical.Table` — every operator
+    /// `tableRenames` target, either form (`Compose.operatorRenamedKinds`):
+    /// the chain's last `Kind.Physical` writer is the operator rename, so
+    /// for these kinds the logical name never deploys.
+    let emitDeployed (physicalNamedKinds: Set<SsKey>) : EmitterOverDiff<RefactorLogEntry list> = fun diff ->
+        use _ = Bench.scope "emit.refactorLog.emitDeployed"
+        let target = CatalogDiff.target diff
+        let renames = CatalogDiff.renamed diff
+        ArtifactByKind.perKind target (fun k ->
+            deployedKindRefactorEntries physicalNamedKinds diff renames k
+            @ deployedColumnRefactorEntries physicalNamedKinds diff renames k)
+
     /// Flatten an `ArtifactByKind<RefactorLogEntry list>` into a single
     /// `OperationKey`-sorted entry list. The per-kind keyset is discarded;
     /// what carries forward across episodes is the flat operation log (the

--- a/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogRender.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/RefactorLogRender.fs
@@ -183,3 +183,18 @@ module RefactorLogRender =
         (artifact: ArtifactByKind<RefactorLogEntry list>)
         : string =
         toRefactorLogXmlAt pinnedChangeDateTime artifact
+
+    /// The ACCUMULATED (cross-episode) document — the flat entry-list
+    /// form `RefactorLogEmitter.accumulate` produces. G3 (DECISIONS
+    /// 2026-07-16): the bundle's `<project>.refactorlog` renders the
+    /// timeline's whole accumulated log, not a single episode's per-kind
+    /// artifact, so the flat form is the production input. Same
+    /// byte-determinism core as the artifact overloads (entries sorted
+    /// by `OperationKey`; pinned writer settings; `at` is an input —
+    /// the episode's boundary-supplied instant — never a clock read).
+    let ofEntriesAt
+        (at: DateTimeOffset)
+        (entries: RefactorLogEntry list)
+        : string =
+        use _ = Bench.scope "render.refactorLog.ofEntries"
+        renderEntries at entries

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -126,7 +126,14 @@ module ScriptDomBuild =
         | Decimal  -> SqlDataTypeOption.Decimal
         | Text     -> SqlDataTypeOption.NVarChar
         | Boolean  -> SqlDataTypeOption.Bit
-        | DateTime -> SqlDataTypeOption.DateTime2
+        // WP-17(d) (DECISIONS 2026-07-16; audit §5a; packet C4): the
+        // evidence-less fallback carries the PLATFORM legacy default —
+        // `DATETIME` — matching the storage-evidence lane, so a
+        // catalog-direct emission (goldens, ReadSide-derived, JSON
+        // without SqlStorage) no longer silently upgrades to DATETIME2
+        // and misrepresents what a live export deploys. A datetime2
+        // SOURCE still emits DATETIME2 via its storage evidence.
+        | DateTime -> SqlDataTypeOption.DateTime
         | Date     -> SqlDataTypeOption.Date
         | Time     -> SqlDataTypeOption.Time
         | Binary   -> SqlDataTypeOption.VarBinary
@@ -276,10 +283,35 @@ module ScriptDomBuild =
             | _ -> ()
             r :> DataTypeReference
 
+    /// WP-17(d) — build the `CAST('<raw>' AS <temporal-type>)` expression
+    /// the three temporal `SqlLiteral` variants render to. The parameter
+    /// is a non-national string literal (SQL temporal strings); the
+    /// target type carries its scale when the type takes one
+    /// (`datetime2(7)` / `time(7)`; `date` is scale-less).
+    let private temporalCast (raw: string) (option: SqlDataTypeOption) (scale: int option) : ScalarExpression =
+        let dt = SqlDataTypeReference()
+        dt.SqlDataTypeOption <- option
+        dt.Name <- SchemaObjectName()
+        dt.Name.Identifiers.Add(bracketed (string option))
+        scale
+        |> Option.iter (fun s ->
+            let lit = IntegerLiteral()
+            lit.Value <- string s
+            dt.Parameters.Add(lit))
+        let param = StringLiteral()
+        param.Value <- raw
+        param.IsNational <- false
+        let cast = CastCall()
+        cast.DataType <- dt
+        cast.Parameter <- param
+        cast :> ScalarExpression
+
     /// Map a typed `SqlLiteral` value to a ScriptDom `ScalarExpression`
     /// (specifically a `Literal` subclass projected to its supertype
-    /// for use in `RowValue.ColumnValues` + DEFAULT clauses). Per the
-    /// Tier-1 #4 transition (RawTextEmitter retirement arc): the
+    /// for use in `RowValue.ColumnValues` + DEFAULT clauses; the WP-17(d)
+    /// temporal variants project to `CastCall` — still a
+    /// `ScalarExpression`, so every consumer below is shape-unchanged).
+    /// Per the Tier-1 #4 transition (RawTextEmitter retirement arc): the
     /// IR→typed-literal projection lives in
     /// `Projection.Core.SqlLiteral`; this is the SSDT-resident
     /// `SqlLiteral` → ScriptDom-`Literal` mapping. Used by
@@ -303,11 +335,18 @@ module ScriptDomBuild =
             let l = IntegerLiteral()
             l.Value <- if b then "1" else "0"
             l :> ScalarExpression
-        | TemporalLit raw ->
-            let l = StringLiteral()
-            l.Value <- raw
-            l.IsNational <- false
-            l :> ScalarExpression
+        // WP-17(d) (DECISIONS 2026-07-16) — V1's explicit-CAST temporal
+        // forms (`SqlLiteralFormatter.cs:90`): `CAST('<raw>' AS
+        // datetime2(7) / date / time(7))`. Precision-explicit and
+        // language-independent; the typed `#temp`/column reconciles the
+        // storage type on INSERT exactly as the bare literal did, so
+        // CDC-silence is unchanged (audit §5c).
+        | DateTimeLit raw ->
+            temporalCast raw SqlDataTypeOption.DateTime2 (Some 7)
+        | DateLit raw ->
+            temporalCast raw SqlDataTypeOption.Date None
+        | TimeLit raw ->
+            temporalCast raw SqlDataTypeOption.Time (Some 7)
         | GuidLit raw ->
             let l = StringLiteral()
             l.Value <- raw

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -353,10 +353,40 @@ module ScriptDomBuild =
             l.IsNational <- false
             l :> ScalarExpression
         | TextLit raw ->
-            let l = StringLiteral()
-            l.Value <- raw
-            l.IsNational <- true
-            l :> ScalarExpression
+            // WP-17(e) (DECISIONS 2026-07-16) — CR/LF/TAB splice into a
+            // `CHAR()` concatenation chain (V1 `EscapeUnicodeString`
+            // parity; the shared `SqlLiteral.textLiteralSegments` owns
+            // the segmentation so the two terminal planes cannot
+            // drift). The emitted SQL carries no raw control bytes;
+            // value-identical on evaluation, so CDC-silence holds. A
+            // control-char-free raw stays the plain national
+            // StringLiteral (the byte-identical default).
+            let nationalLit (run: string) : ScalarExpression =
+                let l = StringLiteral()
+                l.Value <- run
+                l.IsNational <- true
+                l :> ScalarExpression
+            match SqlLiteral.textLiteralSegments raw with
+            | [ TextRun only ] -> nationalLit only
+            | segments ->
+                let charCall (code: int) : ScalarExpression =
+                    let f = FunctionCall()
+                    f.FunctionName <- Identifier(Value = "CHAR")
+                    let arg = IntegerLiteral()
+                    arg.Value <- string code
+                    f.Parameters.Add(arg)
+                    f :> ScalarExpression
+                segments
+                |> List.map (fun segment ->
+                    match segment with
+                    | TextRun run -> nationalLit run
+                    | ControlChar code -> charCall code)
+                |> List.reduce (fun acc next ->
+                    let add = BinaryExpression()
+                    add.BinaryExpressionType <- BinaryExpressionType.Add
+                    add.FirstExpression <- acc
+                    add.SecondExpression <- next
+                    add :> ScalarExpression)
         | BinaryLit prefixed ->
             let l = BinaryLiteral()
             // ScriptDom's `BinaryLiteral.Value` carries the value

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -2560,6 +2560,15 @@ module ScriptDomBuild =
             stmt.SequenceOptions.Add(cacheOpt)
         stmt
 
+    /// G6 (DECISIONS 2026-07-16) — build a `CREATE SCHEMA [<name>]`
+    /// statement. Bracket-quoted via the shared `bracketed` identifier
+    /// helper; no AUTHORIZATION clause (server-default owner — the
+    /// receiving team's ownership call, not the emission's).
+    let buildCreateSchema (schemaName: string) : CreateSchemaStatement =
+        let stmt = CreateSchemaStatement()
+        stmt.Name <- bracketed schemaName
+        stmt
+
     /// Returns `None` for non-SQL variants (`Comment`, `Blank`) so
     /// the realization layer can splice them through the text
     /// stream directly. Closed-DU dispatch — adding a new variant
@@ -2595,6 +2604,8 @@ module ScriptDomBuild =
             Some (buildAlterTableDisableTrigger table triggerName :> TSqlStatement)
         | CreateSequence seqIR ->
             Some (buildCreateSequence seqIR :> TSqlStatement)
+        | CreateSchema schemaName ->
+            Some (buildCreateSchema schemaName :> TSqlStatement)
         | AlterTableAddColumn (table, column) ->
             Some (buildAlterTableAddColumn table column :> TSqlStatement)
         | AlterTableAlterColumn (table, column) ->

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -343,6 +343,8 @@ module ScriptDomBuild =
         // CDC-silence is unchanged (audit §5c).
         | DateTimeLit raw ->
             temporalCast raw SqlDataTypeOption.DateTime2 (Some 7)
+        | DateTimeOffsetLit raw ->
+            temporalCast raw SqlDataTypeOption.DateTimeOffset (Some 7)
         | DateLit raw ->
             temporalCast raw SqlDataTypeOption.Date None
         | TimeLit raw ->
@@ -901,6 +903,36 @@ module ScriptDomBuild =
         cmp.SecondExpression <- qualifiedColumnRef sourceAlias col :> ScalarExpression
         cmp
 
+    /// WP-17(c) — the cast-compare value-mismatch arm for columns whose
+    /// type has no `<>` operator (`xml` + the legacy LOBs `image`/`text`/
+    /// `ntext`): both sides cast to the type's legal MAX target before
+    /// the compare (content-level equality — the server re-serializes
+    /// xml on storage, so byte identity is not a server-preserved
+    /// property to begin with; the LOBs never supported comparison).
+    let private columnInequalityCastCompare (target: ChangeCompareCast) (sourceAlias: string) (col: string) : BooleanComparisonExpression =
+        let option =
+            match target with
+            | CastToNVarCharMax  -> SqlDataTypeOption.NVarChar
+            | CastToVarCharMax   -> SqlDataTypeOption.VarChar
+            | CastToVarBinaryMax -> SqlDataTypeOption.VarBinary
+        let castSide (alias: string) : ScalarExpression =
+            let dt = SqlDataTypeReference()
+            dt.SqlDataTypeOption <- option
+            dt.Name <- SchemaObjectName()
+            dt.Name.Identifiers.Add(bracketed (string option))
+            let mx = MaxLiteral()
+            mx.Value <- "MAX"
+            dt.Parameters.Add(mx)
+            let cast = CastCall()
+            cast.DataType <- dt
+            cast.Parameter <- qualifiedColumnRef alias col :> ScalarExpression
+            cast :> ScalarExpression
+        let cmp = BooleanComparisonExpression()
+        cmp.ComparisonType <- BooleanComparisonType.NotEqualToBrackets
+        cmp.FirstExpression <- castSide "Target"
+        cmp.SecondExpression <- castSide sourceAlias
+        cmp
+
     /// Build a `<expr> IS [NOT] NULL` boolean expression.
     let private isNullCheck (alias: string) (col: string) (negate: bool) : BooleanIsNullExpression =
         let n = BooleanIsNullExpression()
@@ -938,8 +970,16 @@ module ScriptDomBuild =
     /// Per chapter 4.1.B slice β + pre-scope §6: nullable-aware, since
     /// `NULL <> NULL` is `UNKNOWN` in SQL. The three OR-branches cover
     /// value-mismatch + null-asymmetry both ways.
-    let private perColumnChangeDetection (sourceAlias: string) (col: string) : BooleanExpression =
-        let valueDiff = columnInequality sourceAlias col :> BooleanExpression
+    let private perColumnChangeDetection (castCompare: Map<string, ChangeCompareCast>) (sourceAlias: string) (col: string) : BooleanExpression =
+        // WP-17(c) — the value-mismatch arm dispatches on comparability:
+        // a cast-compare column (`xml`/`image`/`text`/`ntext`) compares
+        // via its legal MAX-cast target; the null arms below are
+        // type-agnostic (`IS NULL` is legal on all of them) and stay
+        // shared.
+        let valueDiff =
+            match Map.tryFind col castCompare with
+            | Some target -> columnInequalityCastCompare target sourceAlias col :> BooleanExpression
+            | None -> columnInequality sourceAlias col :> BooleanExpression
         let targetNullSourceNot =
             boolBinary
                 BooleanBinaryExpressionType.And
@@ -962,9 +1002,9 @@ module ScriptDomBuild =
     /// `WHERE (...)` (set-based UPDATE) is well-grouped under ScriptDom's
     /// emission rules. `sourceAlias` selects the joined source (`Source`
     /// for the MERGE, `src` for the `UPDATE … FROM #temp`).
-    let private changeDetectionPredicate (sourceAlias: string) (updColumns: string list) : BooleanExpression =
+    let private changeDetectionPredicate (castCompare: Map<string, ChangeCompareCast>) (sourceAlias: string) (updColumns: string list) : BooleanExpression =
         updColumns
-        |> List.map (perColumnChangeDetection sourceAlias)
+        |> List.map (perColumnChangeDetection castCompare sourceAlias)
         |> foldBool BooleanBinaryExpressionType.Or
         |> boolParen
 
@@ -1042,7 +1082,7 @@ module ScriptDomBuild =
             let matchedClause = MergeActionClause()
             matchedClause.Condition <- MergeCondition.Matched
             if args.CdcAware then
-                matchedClause.SearchCondition <- changeDetectionPredicate "Source" args.UpdColumns
+                matchedClause.SearchCondition <- changeDetectionPredicate args.CastCompareColumns "Source" args.UpdColumns
             matchedClause.Action <- updateAction
             spec.ActionClauses.Add(matchedClause)
 
@@ -1351,7 +1391,10 @@ module ScriptDomBuild =
         // not cdcAware or there are no SET columns (the unconditional re-point).
         if cdcAware && not (List.isEmpty setCols) then
             let where = WhereClause()
-            where.SearchCondition <- changeDetectionPredicate "src" setCols
+            // The Phase-2 re-point UPDATE sets FK columns only (never a
+            // comparison-less LOB/xml) — no cast-compare columns here
+            // (WP-17(c)).
+            where.SearchCondition <- changeDetectionPredicate Map.empty "src" setCols
             spec.WhereClause <- where
         let stmt = UpdateStatement()
         stmt.UpdateSpecification <- spec

--- a/sidecar/projection/src/Projection.Targets.SSDT/SqlprojEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SqlprojEmitter.fs
@@ -43,12 +43,23 @@ module SqlprojEmitter =
     [<Literal>]
     let fileName : string = "ProjectionCatalog.sqlproj"
 
+    /// The bundle-relative `.refactorlog` the project carries when the run
+    /// is store-threaded (G3, DECISIONS 2026-07-16). Named `<project>
+    /// .refactorlog` per SSDT convention; mirror `Compose.ArtifactPath
+    /// .refactorLog` — the `.sqlproj`-build test pins the pairing.
+    [<Literal>]
+    let refactorLogFileName : string = "ProjectionCatalog.refactorlog"
+
     /// Emit the `.sqlproj` XML. `dataLaneRelPaths` are the bundle-relative
     /// `Data/*.sql` paths (re-classified `None`, `:r`-included by the
     /// post-deploy); `hasPostDeploy` adds the `Script.PostDeployment.sql`
-    /// `PostDeploy` item. The schema `.sql` under `Modules/**` ride the SDK's
+    /// `PostDeploy` item; `hasRefactorLog` adds the `<RefactorLog>` item
+    /// for the bundle's accumulated `ProjectionCatalog.refactorlog` (G3 —
+    /// present exactly when the run was store-threaded, so DacFx converts
+    /// renames into `sp_rename` instead of DROP+CREATE on incremental
+    /// publish). The schema `.sql` under `Modules/**` ride the SDK's
     /// default `Build` glob and are intentionally not enumerated.
-    let emit (dataLaneRelPaths: string list) (hasPostDeploy: bool) : string =
+    let emit (dataLaneRelPaths: string list) (hasPostDeploy: bool) (hasRefactorLog: bool) : string =
         let settings =
             XmlWriterSettings(
                 Indent = true,
@@ -82,6 +93,14 @@ module SqlprojEmitter =
             for p in dataLaneRelPaths do
                 elem "Build" "Remove" p
                 elem "None" "Include" p
+            // G3 — the accumulated refactorlog rides the project as an
+            // explicit `RefactorLog` item so `dotnet build` embeds it into
+            // the `.dacpac` (refactor.xml) and incremental publish renames
+            // instead of DROP+CREATE. Explicit rather than glob-reliant:
+            // the SDK's default-item surface varies across versions; the
+            // gated `.sqlproj`-build test proves the pairing compiles.
+            if hasRefactorLog then
+                elem "RefactorLog" "Include" refactorLogFileName
             w.WriteEndElement() // ItemGroup
 
             w.WriteEndElement() // Project

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtBundle.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtBundle.fs
@@ -42,8 +42,12 @@ module SsdtBundle =
     ///
     /// The `manifest.json` always lives at the directory root; per-
     /// table .sql files live at their `SsdtFile.RelativePath` per V1
-    /// convention (cross-platform-deterministic forward slashes).
-    let compose
+    /// convention (cross-platform-deterministic forward slashes);
+    /// per-schema `Schemas/<name>.sql` files (G6, DECISIONS 2026-07-16)
+    /// carry the non-dbo `CREATE SCHEMA` objects — empty for dbo-only
+    /// estates (the byte-identical default).
+    let composeWithSchemas
+        (schemaFiles: (string * string) list)
         (ssdtFiles: ArtifactByKind<SsdtDdlEmitter.SsdtFile>)
         (manifest: ManifestEmitter.Manifest)
         : Map<string, string> =
@@ -54,5 +58,14 @@ module SsdtBundle =
             |> Map.toSeq
             |> Seq.map (fun (_ssKey, file) -> file.RelativePath, file.Body)
         let manifestEntry = "manifest.json", ManifestEmitter.toJson manifest
-        Seq.append perTableEntries (Seq.singleton manifestEntry)
+        Seq.append (Seq.ofList schemaFiles) (Seq.append perTableEntries (Seq.singleton manifestEntry))
         |> Map.ofSeq
+
+    /// The schema-less form — the pre-G6 shape, byte-identical; callers
+    /// with a catalog in hand thread `SsdtDdlEmitter.schemaFiles` via
+    /// `composeWithSchemas`.
+    let compose
+        (ssdtFiles: ArtifactByKind<SsdtDdlEmitter.SsdtFile>)
+        (manifest: ManifestEmitter.Manifest)
+        : Map<string, string> =
+        composeWithSchemas [] ssdtFiles manifest

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
@@ -598,6 +598,37 @@ module SsdtDdlEmitter =
         |> List.sortBy (fun s -> s.SsKey)
         |> List.map Statement.CreateSequence
 
+    /// G6 (DECISIONS 2026-07-16) — every distinct NON-dbo schema the
+    /// emitted estate references (kind physical coordinates + sequence
+    /// schemas). `dbo` always exists on the target and is never emitted.
+    /// Deduped case-insensitively (SQL Server CI collation semantics —
+    /// two case-variant spellings are ONE schema; the lexicographically
+    /// first spelling wins deterministically) and ordinal-sorted (T1).
+    let nonDboSchemas (catalog: Catalog) : string list =
+        let kindSchemas =
+            Catalog.allKinds catalog |> List.map (fun k -> TableId.schemaText k.Physical)
+        let sequenceSchemas =
+            catalog.Sequences |> List.map (fun s -> s.Schema)
+        kindSchemas @ sequenceSchemas
+        |> List.filter (fun s -> not (s.Equals("dbo", System.StringComparison.OrdinalIgnoreCase)))
+        |> List.sortWith (fun a b -> System.String.CompareOrdinal(a, b))
+        |> List.distinctBy (fun s -> s.ToLowerInvariant())
+
+    /// G6 — the `CREATE SCHEMA` statements a non-dbo estate needs before
+    /// any other object. Empty for a dbo-only estate (the byte-identical
+    /// default everywhere).
+    let schemaStatements (catalog: Catalog) : Statement list =
+        nonDboSchemas catalog |> List.map Statement.CreateSchema
+
+    /// G6 — the bundle's per-schema `.sql` files: `Schemas/<name>.sql`,
+    /// one `CREATE SCHEMA` per file, riding the SDK's default Build glob
+    /// exactly like the `Modules/**` tables. Empty for dbo-only estates.
+    let schemaFiles (catalog: Catalog) : (string * string) list =
+        nonDboSchemas catalog
+        |> List.map (fun s ->
+            let relPath = System.String.Concat("Schemas/", s, ".sql")  // LINT-ALLOW: bundle-relative path assembly at the artifact-naming boundary (the Modules/ path-builder precedent); segments are the validated schema name + fixed literals
+            relPath, Render.toText [ Statement.CreateSchema s; BatchSeparator ])
+
     /// Build the cross-platform-deterministic relative path for a
     /// kind's SSDT DDL file. V1 convention: `Modules/<ModuleName>/
     /// <Schema>.<Table>.sql`. Forward-slash separators throughout.
@@ -950,6 +981,10 @@ module SsdtDdlEmitter =
                 seq { yield stmt; yield BatchSeparator }
             let yieldAllWithSeparator (stmts: seq<Statement>) =
                 stmts |> Seq.collect yieldWithSeparator
+            // G6: schemas FIRST — non-dbo tables and sequences resolve
+            // against them; dbo-only estates yield nothing here (the
+            // byte-identical default).
+            yield! yieldAllWithSeparator (schemaStatements catalog)
             // H-020: sequences before tables — they may be referenced by
             // DEFAULT constraints in CREATE TABLE statements.
             yield! yieldAllWithSeparator (sequenceStatements catalog)

--- a/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/Statement.fs
@@ -368,6 +368,13 @@ type Statement =
     /// IR record; `ScriptDomBuild.buildStatement` delegates to
     /// `buildCreateSequence`. H-020 (Cluster A — Close the loops).
     | CreateSequence of seq: Sequence
+    /// G6 (DECISIONS 2026-07-16) — `CREATE SCHEMA [<name>]`. Emitted
+    /// FIRST in the catalog-wide statement stream for every distinct
+    /// non-dbo schema the emitted estate references (kinds + sequences),
+    /// so a non-dbo estate builds (`.sqlproj`/dacpac) and deploys
+    /// without hand-authored schema objects. `dbo` always exists and is
+    /// never emitted. ScriptDom builds via `CreateSchemaStatement`.
+    | CreateSchema of schemaName: string
     /// 6.A.12 — `ALTER TABLE <table> ADD <column>`. The additive
     /// minimum-viable-touch for a new attribute on an existing kind
     /// (`CatalogDiff.AttributeDiffs[k].Added`). ScriptDom builds via

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -68,6 +68,7 @@
     <Compile Include="SsdtArtifactDeployE2ETests.fs" />
     <Compile Include="IndexPhysicalMetadataDeployE2ETests.fs" />
     <Compile Include="SsdtDataBehaviorE2ETests.fs" />
+    <Compile Include="ScalarCarriageRoundTripTests.fs" />
     <Compile Include="StagedMergeDeployE2ETests.fs" />
     <Compile Include="MergeScaleMeasurement.fs" />
     <Compile Include="ReadConcurrencyMeasurementTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -64,6 +64,7 @@
     <Compile Include="KeymapSpillTests.fs" />
     <Compile Include="RunWithConfigProfileTests.fs" />
     <Compile Include="DacpacPublishEquivalenceTests.fs" />
+    <Compile Include="RefactorLogPublishCanaryTests.fs" />
     <Compile Include="SsdtArtifactDeployE2ETests.fs" />
     <Compile Include="IndexPhysicalMetadataDeployE2ETests.fs" />
     <Compile Include="SsdtDataBehaviorE2ETests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/RefactorLogPublishCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/RefactorLogPublishCanaryTests.fs
@@ -1,0 +1,233 @@
+module Projection.Tests.RefactorLogPublishCanaryTests
+
+// G3 (DECISIONS 2026-07-16) — THE DacFx-grade witness the refactorlog wiring
+// was missing: an INCREMENTAL publish of a renamed table, with the bundle's
+// accumulated `ProjectionCatalog.refactorlog` built into the dacpac, applies
+// `sp_rename` (the data survives) instead of DROP+CREATE (the data is lost).
+// The trap is armed twice: DacFx's default `BlockOnPossibleDataLoss = true`
+// FAILS the publish outright on a drop plan, and the row asserts catch a
+// silent recreate. The canary drives the operator's REAL path end-to-end:
+//
+//   full-export --lifecycle-store  (bundle + ProjectionCatalog.refactorlog
+//                                   + the `.sqlproj` RefactorLog item)
+//   → dotnet build                 (SqlBuildTask embeds refactor.xml)
+//   → DacServices.Deploy           (incremental upgrade of the live estate)
+//   → sp_rename                    (rows intact under the NEW table name)
+//
+// Identity note: file-sourced models synthesize SsKeys from names (the
+// 6.A.7 limitation), so the rename threads through the STORE — the prior
+// episode is seeded with the run-B key under the OLD logical name, exactly
+// what an identity-stable (live-OSSYS) source records across a dev rename.
+//
+// Gated twice: soft-skips without Docker (collection rule) and without a
+// restorable Microsoft.Build.Sql SDK (offline / restricted nuget feed).
+
+open System
+open System.Diagnostics
+open System.IO
+open Xunit
+open Microsoft.Data.SqlClient
+open Microsoft.SqlServer.Dac
+open Projection.Core
+open Projection.Pipeline
+open Projection.Targets.SSDT
+
+[<RequireQualifiedAccess>]
+module private RefactorCanary =
+
+    let value (r: Result<'a>) : 'a = Result.value r
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    /// AppCore/User — Id (IDENTITY PK) + Email. The BEFORE model.
+    let modelUser : string =
+        """{
+  "exportedAtUtc": "2026-07-16T00:00:00.0000000+00:00",
+  "modules": [
+    { "name": "AppCore", "isSystem": false, "isActive": true,
+      "entities": [
+        { "name": "User", "physicalName": "OSUSR_APPCORE_USER", "isStatic": false, "isExternal": false, "isActive": true, "db_catalog": null, "db_schema": "dbo",
+          "attributes": [
+            { "name": "Id", "physicalName": "ID", "originalName": null, "dataType": "rtIdentifier", "length": null, "precision": null, "scale": null, "default": null, "isMandatory": true, "isIdentifier": true, "isAutoNumber": true, "isActive": true, "isReference": 0, "refEntityId": null, "refEntity_name": null, "refEntity_physicalName": null, "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0, "external_dbType": null, "physical_isPresentButInactive": 0 },
+            { "name": "Email", "physicalName": "EMAIL", "originalName": null, "dataType": "rtText", "length": 200, "precision": null, "scale": null, "default": null, "isMandatory": false, "isIdentifier": false, "isAutoNumber": false, "isActive": true, "isReference": 0, "refEntityId": null, "refEntity_name": null, "refEntity_physicalName": null, "reference_deleteRuleCode": null, "reference_hasDbConstraint": 0, "external_dbType": null, "physical_isPresentButInactive": 0 } ],
+          "relationships": [], "indexes": [], "triggers": [] } ] }
+  ]
+}"""
+
+    /// The AFTER model: the entity renamed `User` → `Client` (the physical
+    /// table name is untouched — an OutSystems dev rename never moves the
+    /// OSUSR table; the DEPLOYED table moves because V2 emits logical names).
+    let modelClient : string =
+        modelUser.Replace("\"name\": \"User\"", "\"name\": \"Client\"")
+
+    let writeTemp (suffix: string) (content: string) : string =
+        let path = Path.Combine(Path.GetTempPath(), sprintf "refactor-canary-%s-%s" (Guid.NewGuid().ToString "N") suffix)
+        File.WriteAllText(path, content)
+        path
+
+    let configJson (modelPath: string) (outDir: string) : string =
+        sprintf
+            """{ "model": { "path": "%s" }, "output": { "dir": "%s" }, "emission": { "sqlproj": true } }"""
+            (modelPath.Replace("\\", "\\\\"))
+            (outDir.Replace("\\", "\\\\"))
+
+    let nugetConfig : string =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
+         <configuration>\n\
+         \x20\x20<packageSources><clear /><add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" /></packageSources>\n\
+         </configuration>\n"
+
+    /// `dotnet build` the published bundle at `dir` into a `.dacpac`.
+    /// `Ok path` on success; `Error reason` when the SDK cannot restore
+    /// (the offline soft-skip the pure build tests established).
+    let buildDacpac (dir: string) : Microsoft.FSharp.Core.Result<string, string> =
+        File.WriteAllText(Path.Combine(dir, "nuget.config"), nugetConfig)
+        let psi = ProcessStartInfo("dotnet", sprintf "build %s -c Debug --nologo" SqlprojEmitter.fileName)
+        psi.WorkingDirectory <- dir
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        let proc =
+            match Process.Start psi with
+            | null -> failwith "could not start `dotnet`"
+            | p -> p
+        let combined = proc.StandardOutput.ReadToEnd() + "\n" + proc.StandardError.ReadToEnd()
+        proc.WaitForExit()
+        if combined.Contains "Could not resolve SDK" || combined.Contains "Unable to resolve 'Microsoft.Build.Sql" then
+            Microsoft.FSharp.Core.Result.Error "Microsoft.Build.Sql SDK not restorable in this environment."
+        elif proc.ExitCode <> 0 then
+            failwithf "dotnet build of the published .sqlproj failed (exit %d):\n%s" proc.ExitCode combined
+        else
+            let dacpac = Path.Combine(dir, "bin", "Debug", "ProjectionCatalog.dacpac")
+            Assert.True(File.Exists dacpac, sprintf "expected a built .dacpac at %s\n%s" dacpac combined)
+            Microsoft.FSharp.Core.Result.Ok dacpac
+
+    let publishDacpac (connStr: string) (dacpacPath: string) : unit =
+        let dbName = SqlConnectionStringBuilder(connStr).InitialCatalog
+        use stream = File.OpenRead dacpacPath
+        use package = DacPackage.Load stream
+        let services = DacServices(connStr)
+        // Default DacDeployOptions: BlockOnPossibleDataLoss = true — the
+        // publish itself REFUSES a table-drop plan, so reaching the row
+        // asserts already means no DROP+CREATE was planned.
+        services.Deploy(package, dbName, true, DacDeployOptions())
+
+    let scalarInt (cnn: SqlConnection) (sql: string) : Threading.Tasks.Task<int> =
+        task {
+            use cmd = new SqlCommand(sql, cnn)
+            let! v = cmd.ExecuteScalarAsync()
+            return
+                match v with
+                | :? int as i -> i
+                | :? System.DBNull | null -> 0
+                | other -> System.Convert.ToInt32 other
+        }
+
+    /// The prior episode's schema, hand-authored with run-B's synthesized
+    /// SsKeys (module `AppCore`, entity `Client`) under the OLD logical
+    /// name `User` — the store is the identity carrier across the rename.
+    let priorSchemaUserUnderClientKeys () : Catalog =
+        let kindKey = SsKey.synthesizedComposite "OS_KIND" [ "AppCore"; "Client" ] |> value
+        let idKey = SsKey.synthesizedComposite "OS_ATTR" [ "AppCore"; "Client"; "Id" ] |> value
+        let emailKey = SsKey.synthesizedComposite "OS_ATTR" [ "AppCore"; "Client"; "Email" ] |> value
+        let moduleKey = SsKey.synthesized "OS_MOD" "AppCore" |> value
+        let nameOf (s: string) : Name = Name.create s |> value
+        let idAttr =
+            { Attribute.create idKey (nameOf "Id") Integer with
+                Column = ColumnRealization.create "ID" false |> Result.value
+                IsPrimaryKey = true
+                IsMandatory = true
+                IsIdentity = true }
+        let emailAttr =
+            { Attribute.create emailKey (nameOf "Email") Text with
+                Column = ColumnRealization.create "EMAIL" true |> Result.value
+                Length = Some 200 }
+        let kind =
+            Kind.create kindKey (nameOf "User")
+                (TableId.create "dbo" "OSUSR_APPCORE_USER" |> value)
+                [ idAttr; emailAttr ]
+        { Modules =
+            [ { SsKey = moduleKey; Name = nameOf "AppCore"; Kinds = [ kind ]; IsActive = true; ExtendedProperties = [] } ]
+          Sequences = [] }
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type RefactorLogPublishCanaryTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``G3 canary: an incremental publish with the bundle refactorlog RENAMES (sp_rename) — the rows survive under the new table name`` () =
+        if not (RefactorCanary.skipIfNoDocker "RefactorLogPublish") then () else
+        let outA = Path.Combine(Path.GetTempPath(), "refactor-canary-outA-" + Guid.NewGuid().ToString("N"))
+        let outB = Path.Combine(Path.GetTempPath(), "refactor-canary-outB-" + Guid.NewGuid().ToString("N"))
+        let modelA = RefactorCanary.writeTemp "user.json" RefactorCanary.modelUser
+        let modelB = RefactorCanary.writeTemp "client.json" RefactorCanary.modelClient
+        let cfgA = RefactorCanary.writeTemp "cfgA.json" (RefactorCanary.configJson modelA outA)
+        let cfgB = RefactorCanary.writeTemp "cfgB.json" (RefactorCanary.configJson modelB outB)
+        let store = Path.Combine(Path.GetTempPath(), "refactor-canary-store-" + Guid.NewGuid().ToString("N") + ".json")
+        try
+            // ---- Emission A (genesis; store-less): the BEFORE estate. ----
+            match FullExportRun.execute cfgA None LogSink.Verbosity.Quiet Set.empty with
+            | FullExportRun.RunOutcome.Succeeded _ -> ()
+            | other -> failwithf "publish A failed: %A" other
+            // ---- Seed the prior: run-B identity under the OLD name. ----
+            let tl = Timeline.create "appcore" |> RefactorCanary.value
+            let coordinate =
+                EpisodeCoordinate.create
+                    (Version.create 0 "v0" |> RefactorCanary.value)
+                    Environment.Dev
+                    (DateTimeOffset(2026, 7, 15, 9, 0, 0, TimeSpan.Zero))
+            let genesis =
+                Episode.create coordinate (RefactorCanary.priorSchemaUserUnderClientKeys ()) Profile.empty None DataObservation.empty
+            (match LifecycleStore.save store (EpisodicLifecycle.genesis tl genesis) with
+             | Microsoft.FSharp.Core.Result.Ok () -> ()
+             | Microsoft.FSharp.Core.Result.Error e -> failwithf "store seed failed: %A" e)
+            // ---- Emission B (store-threaded): the rename + its refactorlog. ----
+            let outcomeB, legB =
+                FullExportRun.executeWithStore
+                    cfgB None LogSink.Verbosity.Quiet Set.empty
+                    (Some store) tl Environment.Dev
+                    (DateTimeOffset(2026, 7, 16, 9, 0, 0, TimeSpan.Zero))
+            (match outcomeB with
+             | FullExportRun.RunOutcome.Succeeded _ -> ()
+             | other -> failwithf "publish B failed: %A" other)
+            let leg = match legB with Some l -> l | None -> failwith "store threaded but no leg"
+            Assert.Equal(1, List.length leg.AccumulatedRefactorLog)
+            let refactorPath = Path.Combine(outB, Compose.ArtifactPath.refactorLog)
+            Assert.True(File.Exists refactorPath, "bundle B carries ProjectionCatalog.refactorlog")
+            Assert.Contains("Value=\"[dbo].[User]\"", File.ReadAllText refactorPath)
+            // ---- Build both bundles (SqlBuildTask embeds refactor.xml). ----
+            match RefactorCanary.buildDacpac outA, RefactorCanary.buildDacpac outB with
+            | Microsoft.FSharp.Core.Result.Error reason, _
+            | _, Microsoft.FSharp.Core.Result.Error reason ->
+                printfn "SKIP RefactorLogPublish canary: %s" reason
+            | Microsoft.FSharp.Core.Result.Ok dacpacA, Microsoft.FSharp.Core.Result.Ok dacpacB ->
+                TaskSync.run (fun () ->
+                    fixture.WithEphemeralDatabase "RefactorPub" (fun cnn connStr ->
+                        task {
+                            // Deploy A, then live data lands under [dbo].[User].
+                            RefactorCanary.publishDacpac connStr dacpacA
+                            do! Deploy.executeBatch cnn
+                                    "INSERT INTO [dbo].[User] ([Email]) VALUES (N'ada@example.test'); \
+                                     INSERT INTO [dbo].[User] ([Email]) VALUES (N'grace@example.test');"
+                            let! before = RefactorCanary.scalarInt cnn "SELECT COUNT(*) FROM [dbo].[User]"
+                            Assert.Equal(2, before)
+                            // Incremental publish B: BlockOnPossibleDataLoss (the
+                            // DacFx default) refuses a DROP plan — success here
+                            // already means the refactorlog was honored.
+                            RefactorCanary.publishDacpac connStr dacpacB
+                            // The rows live under the NEW name — sp_rename, not
+                            // DROP+CREATE. IDENTITY values preserved.
+                            let! count = RefactorCanary.scalarInt cnn "SELECT COUNT(*) FROM [dbo].[Client]"
+                            Assert.Equal(2, count)
+                            let! ada = RefactorCanary.scalarInt cnn "SELECT COUNT(*) FROM [dbo].[Client] WHERE [Email] = N'ada@example.test' AND [Id] = 1"
+                            Assert.Equal(1, ada)
+                            let! oldGone = RefactorCanary.scalarInt cnn "SELECT COUNT(*) FROM sys.tables WHERE name = 'User' AND schema_id = SCHEMA_ID('dbo')"
+                            Assert.Equal(0, oldGone)
+                        }))
+        finally
+            for p in [ modelA; modelB; cfgA; cfgB; store ] do
+                try if File.Exists p then File.Delete p with _ -> ()
+            for d in [ outA; outB ] do
+                try if Directory.Exists d then Directory.Delete(d, true) with _ -> ()

--- a/sidecar/projection/tests/Projection.Tests.Integration/ScalarCarriageRoundTripTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ScalarCarriageRoundTripTests.fs
@@ -1,0 +1,186 @@
+module Projection.Tests.ScalarCarriageRoundTripTests
+
+// ============================================================================
+// WP-17(f) (DECISIONS 2026-07-16) — the scalar-carriage fixture backlog: the
+// audit's UNWITNESSED concrete types round-trip on a REAL SQL Server, through
+// the operator's actual artifacts (DacFx-published DDL + the composed
+// static-seed MERGE). One gallery kind carries every contested column:
+//
+//   float / real          — WP-17(a): G17/G9 raws; the E-notation literal
+//                            lands the exact IEEE value (incl. Double.Max —
+//                            the pre-fix Decimal carrier OVERFLOWED).
+//   datetimeoffset(7)     — WP-17(b): the offset-bearing raw → CAST(… AS
+//                            datetimeoffset(7)); the offset survives.
+//   xml                   — WP-17(c): content carriage; the CDC-aware MERGE
+//                            COMPILES (pre-guard, `Target.[x] <> Source.[x]`
+//                            on xml was a compile error — S5) and re-runs.
+//   money / smalldatetime / image — the collapse-is-faithful verdicts of
+//                            audit §4, now test-proven.
+//   control-char text     — WP-17(e): the CHAR() splice evaluates to the
+//                            identical stored value.
+//
+// The kind is CDC-ENABLED (Profile.CdcAwareness) so the change-detect
+// predicate — the S5 hazard site — is IN the executed SQL, and the seed is
+// executed TWICE (the idempotent re-run must compile and change nothing).
+// ============================================================================
+
+open System.IO
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Microsoft.SqlServer.Dac
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Targets.SSDT
+open Projection.Targets.Data
+open Projection.Tests.Fixtures   // mkName, mkTableId
+
+[<RequireQualifiedAccess>]
+module private ScalarGallery =
+
+    let mkKey (parts: string list) : SsKey =
+        SsKey.synthesizedComposite "OS_SCR" parts |> Result.value
+
+    let col (physical: string) : ColumnRealization =
+        ColumnRealization.create physical true |> Result.value
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let scalar (cnn: SqlConnection) (sql: string) : Task<string> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! v = cmd.ExecuteScalarAsync()
+            return string v
+        }
+
+    let galleryKey = mkKey [ "Scalars"; "Gallery" ]
+
+    /// The contested raws, named once — the row AND the asserts share them.
+    let floatRaw = "1.7976931348623157E+308"
+    let realRaw = "3.4028235E+38"
+    let dtoRaw = "2026-07-16 12:30:00.0000000 -03:00"
+    let xmlRaw = "<a b=\"1\">x</a>"
+    let moneyRaw = "922337203685477.5807"
+    let sdtRaw = "2026-07-16 12:30:00.0000000"
+    let imageRaw = "CAFEBABE"
+    let ctrlRaw = "line1\r\nline2"
+
+    let catalog () : Catalog =
+        let attr (label: string) (physical: string) (t: PrimitiveType) (storage: SqlStorageType option) : Attribute =
+            { Attribute.create (mkKey [ "Scalars"; "Gallery"; label ]) (mkName label) t with
+                Column = col physical
+                SqlStorage = storage }
+        let row =
+            { Identifier = mkKey [ "Scalars"; "Gallery"; "Row"; "1" ]
+              Values =
+                StaticRow.presentValues
+                    [ mkName "Id",      "1"
+                      mkName "FloatV",  floatRaw
+                      mkName "RealV",   realRaw
+                      mkName "DtoV",    dtoRaw
+                      mkName "XmlV",    xmlRaw
+                      mkName "MoneyV",  moneyRaw
+                      mkName "SdtV",    sdtRaw
+                      mkName "ImageV",  imageRaw
+                      mkName "CtrlV",   ctrlRaw ] }
+        let kind : Kind =
+            { SsKey = galleryKey; Name = mkName "Gallery"; Origin = Native
+              Modality = [ Static [ row ] ]
+              Physical = mkTableId "dbo" "OSUSR_SCR_GALLERY"
+              Attributes =
+                [ { Attribute.create (mkKey [ "Scalars"; "Gallery"; "Id" ]) (mkName "Id") Integer with
+                      Column = ColumnRealization.create "ID" false |> Result.value
+                      IsPrimaryKey = true
+                      IsMandatory = true }
+                  attr "FloatV" "FLOATV" Decimal (Some SqlStorageType.Float)
+                  attr "RealV"  "REALV"  Decimal (Some SqlStorageType.Real)
+                  attr "DtoV"   "DTOV"   DateTime (Some (SqlStorageType.DateTimeOffset (Some 7)))
+                  attr "XmlV"   "XMLV"   Text (Some SqlStorageType.Xml)
+                  attr "MoneyV" "MONEYV" Decimal (Some SqlStorageType.Money)
+                  attr "SdtV"   "SDTV"   DateTime (Some SqlStorageType.SmallDateTime)
+                  attr "ImageV" "IMAGEV" Binary (Some SqlStorageType.Image)
+                  attr "CtrlV"  "CTRLV"  Text None ]
+              References = []; Indexes = []; Description = None; IsActive = true
+              Triggers = []; ColumnChecks = []; ExtendedProperties = [] }
+        { Modules =
+            [ { SsKey = mkKey [ "Scalars" ]; Name = mkName "Scalars"; Kinds = [ kind ]; IsActive = true; ExtendedProperties = [] } ]
+          Sequences = [] }
+
+    /// CDC-aware profile — arms the change-detect predicate (the S5 site).
+    let cdcProfile () : Profile =
+        { Profile.empty with
+            CdcAwareness = CdcAwareness.create (Set.singleton galleryKey) Map.empty }
+
+    let deploySchema (connStr: string) (catalog: Catalog) : unit =
+        let dbName = SqlConnectionStringBuilder(connStr).InitialCatalog
+        let bytes =
+            match DacpacEmitter.emit catalog with
+            | Ok b -> b
+            | Error es -> failwithf "dacpac emit failed: %A" es
+        use stream = new MemoryStream(bytes)
+        use package = DacPackage.Load stream
+        (DacServices connStr).Deploy(package, dbName, true, DacDeployOptions())
+
+    let staticSeeds (catalog: Catalog) : string =
+        let policy = { Policy.empty with Emission = EmissionPolicy.combined }
+        match
+            DataEmissionComposer.composeRenderedBundleWithBootstrap
+                policy catalog (cdcProfile ()) MigrationDependencyContext.empty Map.empty UserRemapContext.empty
+        with
+        | Ok b -> b.StaticSeeds
+        | Error e -> failwithf "data compose failed: %A" e
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type ScalarCarriageRoundTripTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``WP-17f: the contested scalar gallery round-trips through DacFx DDL + the CDC-aware seed MERGE — twice`` () =
+        if not (ScalarGallery.skipIfNoDocker "ScalarCarriage") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "ScalarCarriage" (fun cnn connStr ->
+                task {
+                    let catalog = ScalarGallery.catalog ()
+                    // DDL leg: the storage-evidence lane deploys the concrete
+                    // types through DacFx (FLOAT/REAL/DATETIMEOFFSET(7)/XML/
+                    // MONEY/SMALLDATETIME/IMAGE on a real server).
+                    ScalarGallery.deploySchema connStr catalog
+                    // Data leg: the composed CDC-aware seed MERGE — the xml
+                    // change-detect guard (S5) is in this SQL; executing it IS
+                    // the compile proof.
+                    let seeds = ScalarGallery.staticSeeds catalog
+                    do! Deploy.executeBatch cnn seeds
+                    let probe (label: string) (sql: string) : Task<unit> =
+                        task {
+                            let! verdict = ScalarGallery.scalar cnn sql
+                            Assert.True(("ok" = verdict), sprintf "%s: server-side compare failed (got %s)" label verdict)
+                        }
+                    let assertAll () : Task<unit> =
+                        task {
+                            // WP-17(a) — the exact IEEE values landed (the pre-fix
+                            // Decimal carrier overflowed on Double.Max).
+                            do! probe "float" "SELECT CASE WHEN [FloatV] = 1.7976931348623157E+308 THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            do! probe "real" "SELECT CASE WHEN [RealV] = CAST(3.4028235E+38 AS REAL) THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            // WP-17(b) — the offset survived, verbatim (style 121).
+                            do! probe "datetimeoffset" "SELECT CASE WHEN CONVERT(VARCHAR(40), [DtoV], 121) = '2026-07-16 12:30:00.0000000 -03:00' THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            // WP-17(c) — xml content carriage (server re-serializes;
+                            // content equality is the deliberate semantic).
+                            do! probe "xml" "SELECT CASE WHEN [XmlV].value('(/a/@b)[1]','INT') = 1 AND [XmlV].value('(/a/text())[1]','NVARCHAR(10)') = 'x' THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            do! probe "money" "SELECT CASE WHEN [MoneyV] = 922337203685477.5807 THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            do! probe "smalldatetime" "SELECT CASE WHEN [SdtV] = '2026-07-16 12:30:00' THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            do! probe "image" "SELECT CASE WHEN CONVERT(VARCHAR(20), CAST([ImageV] AS VARBINARY(20)), 1) = '0xCAFEBABE' THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                            // WP-17(e) — the CHAR() splice evaluated to the identical
+                            // stored value (raw CR/LF round-trip).
+                            do! probe "control-chars" "SELECT CASE WHEN [CtrlV] = N'line1' + CHAR(13) + CHAR(10) + N'line2' THEN 'ok' ELSE 'lost' END FROM [dbo].[OSUSR_SCR_GALLERY]"
+                        }
+                    do! assertAll ()
+                    // The idempotent re-run: compiles (the S5 proof lives here),
+                    // inserts nothing, changes nothing.
+                    do! Deploy.executeBatch cnn seeds
+                    let! count = ScalarGallery.scalar cnn "SELECT COUNT(*) FROM [dbo].[OSUSR_SCR_GALLERY]"
+                    Assert.Equal("1", count)
+                    do! assertAll ()
+                }))

--- a/sidecar/projection/tests/Projection.Tests.Support/GoldenCatalog.fs
+++ b/sidecar/projection/tests/Projection.Tests.Support/GoldenCatalog.fs
@@ -101,13 +101,15 @@ let private scalarGallery : Kind =
           { attr (akey "ScalarGallery.IsActive") "IsActive" "IS_ACTIVE" Boolean false with
               DefaultValue = Some (SqlLiteral.BooleanLit true)
               DefaultName  = Some (nm "DF_ScalarGallery_IsActive") }
-          // DateTime / Date / Time — each with its temporal DEFAULT.
+          // DateTime / Date / Time — each with its temporal DEFAULT
+          // (WP-17(d): the category-bearing variants; rendered as V1's
+          // explicit CAST forms).
           { attr (akey "ScalarGallery.OccurredOn") "OccurredOn" "OCCURRED_ON" DateTime true with
-              DefaultValue = Some (SqlLiteral.TemporalLit "2020-01-01 00:00:00") }
+              DefaultValue = Some (SqlLiteral.DateTimeLit "2020-01-01 00:00:00") }
           { attr (akey "ScalarGallery.DueDate") "DueDate" "DUE_DATE" Date true with
-              DefaultValue = Some (SqlLiteral.TemporalLit "2020-01-01") }
+              DefaultValue = Some (SqlLiteral.DateLit "2020-01-01") }
           { attr (akey "ScalarGallery.AlarmAt") "AlarmAt" "ALARM_AT" Time true with
-              DefaultValue = Some (SqlLiteral.TemporalLit "08:30:00") }
+              DefaultValue = Some (SqlLiteral.TimeLit "08:30:00") }
           // Guid + DEFAULT.
           { attr (akey "ScalarGallery.ExternalKey") "ExternalKey" "EXTERNAL_KEY" Guid true with
               DefaultValue = Some (SqlLiteral.GuidLit "00000000-0000-0000-0000-000000000000") }

--- a/sidecar/projection/tests/Projection.Tests/BulkTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/BulkTests.fs
@@ -1,0 +1,39 @@
+module Projection.Tests.BulkTests
+
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+
+// ---------------------------------------------------------------------------
+// WP-17(a/b) (DECISIONS 2026-07-16) — the bulk parse plane dispatches on the
+// raw shape: float/real G17/G9 raws with an exponent parse as the exact IEEE
+// double (Decimal.Parse OVERFLOWED above ≈7.9E28 — the S1 write loss);
+// offset-bearing datetime raws parse back to the exact DateTimeOffset
+// (DateTime.ParseExact REFUSED them — the S2 write half).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``WP-17a: an E-notation Decimal raw parses as the exact IEEE double (no overflow)`` () =
+    match Bulk.parseRaw Decimal (Some "1.7976931348623157E+308") with
+    | :? double as d -> Assert.Equal(System.Double.MaxValue, d)
+    | other -> failwithf "expected a boxed double; got %A" other
+
+[<Fact>]
+let ``WP-17a: a plain-digit Decimal raw keeps the exact decimal parse (decimal-family columns)`` () =
+    match Bulk.parseRaw Decimal (Some "123.4500") with
+    | :? decimal as d -> Assert.Equal(123.4500m, d)
+    | other -> failwithf "expected a boxed decimal; got %A" other
+
+[<Fact>]
+let ``WP-17b: an offset-bearing DateTime raw parses as the exact DateTimeOffset (offset intact)`` () =
+    match Bulk.parseRaw DateTime (Some "2026-07-16 12:30:00.0000000 -03:00") with
+    | :? System.DateTimeOffset as dto ->
+        Assert.Equal(System.TimeSpan.FromHours -3.0, dto.Offset)
+        Assert.Equal(System.DateTime(2026, 7, 16, 12, 30, 0), dto.DateTime)
+    | other -> failwithf "expected a boxed DateTimeOffset; got %A" other
+
+[<Fact>]
+let ``WP-17b: the offset-less canonical DateTime raw still parses as DateTime (unchanged)`` () =
+    match Bulk.parseRaw DateTime (Some "2026-07-16 12:30:00.0000000") with
+    | :? System.DateTime as dt -> Assert.Equal(System.DateTime(2026, 7, 16, 12, 30, 0), dt)
+    | other -> failwithf "expected a boxed DateTime; got %A" other

--- a/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
@@ -286,9 +286,34 @@ let private allLiterals : SqlLiteral list =
       SqlLiteral.BooleanLit true
       SqlLiteral.BooleanLit false
       SqlLiteral.TextLit "'hello'"
-      SqlLiteral.TemporalLit "'2026-01-01'"
+      // WP-17(d) — the three category-bearing temporal variants.
+      SqlLiteral.DateTimeLit "2026-01-01 08:30:00.0000000"
+      SqlLiteral.DateLit "2026-01-01"
+      SqlLiteral.TimeLit "08:30:00"
       SqlLiteral.GuidLit "'00000000-0000-0000-0000-000000000000'"
       SqlLiteral.BinaryLit "0xDEADBEEF" ]
+
+[<Fact>]
+let ``a pre-WP-17 category-blind "TemporalLit" still READS, classified by raw shape`` () =
+    // Replay semantics: v-old artifacts wrote one "TemporalLit" kind; the
+    // reader classifies by the canonical raw shape (space ⇒ DateTime,
+    // colon ⇒ Time, else Date) — no re-record, no version refusal.
+    let readBack (rawJson: string) : Catalog =
+        match CatalogCodec.deserialize rawJson with
+        | Ok c -> c
+        | Error es -> failwithf "legacy read failed: %A" es
+    let legacyOf (value: string) : string =
+        let a = { baseAttr () with DefaultValue = Some (SqlLiteral.DateLit "1900-01-01") }
+        let modern = CatalogCodec.serialize (catalogOf (kindOfAttr a))
+        // Token-wise rewrite (indentation-agnostic): the fixture carries
+        // exactly one literal, so both tokens are unique in the document.
+        modern.Replace("\"DateLit\"", "\"TemporalLit\"").Replace("\"1900-01-01\"", sprintf "\"%s\"" value)
+    let defaultOf (c: Catalog) : SqlLiteral =
+        (Catalog.allKinds c |> List.head).Attributes
+        |> List.pick (fun a -> a.DefaultValue)
+    Assert.Equal<SqlLiteral>(SqlLiteral.DateTimeLit "2026-01-01 08:30:00.0000000", defaultOf (readBack (legacyOf "2026-01-01 08:30:00.0000000")))
+    Assert.Equal<SqlLiteral>(SqlLiteral.TimeLit "08:30:00", defaultOf (readBack (legacyOf "08:30:00")))
+    Assert.Equal<SqlLiteral>(SqlLiteral.DateLit "2026-01-01", defaultOf (readBack (legacyOf "2026-01-01")))
 
 [<Fact>]
 let ``every SqlLiteral round-trips as a DEFAULT`` () =

--- a/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
@@ -288,6 +288,7 @@ let private allLiterals : SqlLiteral list =
       SqlLiteral.TextLit "'hello'"
       // WP-17(d) — the three category-bearing temporal variants.
       SqlLiteral.DateTimeLit "2026-01-01 08:30:00.0000000"
+      SqlLiteral.DateTimeOffsetLit "2026-01-01 08:30:00.0000000 -03:00"
       SqlLiteral.DateLit "2026-01-01"
       SqlLiteral.TimeLit "08:30:00"
       SqlLiteral.GuidLit "'00000000-0000-0000-0000-000000000000'"

--- a/sidecar/projection/tests/Projection.Tests/ComposeAtomicWriteTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ComposeAtomicWriteTests.fs
@@ -60,6 +60,7 @@ let private trivialOutputs () : Compose.Outputs =
             Dacpac            = None
             Sqlproj           = None
             PostDeploy        = None
+            RefactorLog       = None
             Manifest          = Projection.Targets.SSDT.ManifestEmitter.build Fixtures.sampleCatalog
             Trail             = []
             PassEntries       = []

--- a/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/FullExportStoreTests.fs
@@ -6,6 +6,9 @@ open System.IO
 open Xunit
 open Projection.Core
 open Projection.Pipeline
+// G3 — RefactorLogEntry / RefactorElementType (the bundle's `.refactorlog`
+// operations the store-wire witnesses assert on).
+open Projection.Targets.SSDT
 
 /// Track W1-B (seam T2) — the **diff-vs-prior store leg** for `full-export`,
 /// advancing protein cells X1 (P-1/P-2 load: diff-vs-prior + record) and X3
@@ -368,6 +371,199 @@ let ``X3.T2 (adversarial): the accumulated refactorlog is a distinct bundle memb
 // recorded episode (and the ChangeManifest of its edge) carries the run's
 // §5.5 applied-transforms overlay enumeration instead of the dead `[]` default.
 // ===========================================================================
+
+// ===========================================================================
+// G3 (DECISIONS 2026-07-16) — the accumulated `.refactorlog` is a BUNDLE
+// artifact. A store-threaded run writes `ProjectionCatalog.refactorlog`
+// (deployed vocabulary, rendered at the episode's `At`) inside the atomic
+// bundle and reports it; a store-less run writes nothing (byte-identical
+// genesis). With `emission.sqlproj: true` the project carries the matching
+// `RefactorLog` item exactly when the file exists.
+// ===========================================================================
+
+let private writeTempConfigSqlproj (modelPath: string) (outputDir: string) : string =
+    let json =
+        sprintf
+            """{ "model": { "path": "%s" }, "output": { "dir": "%s" }, "emission": { "sqlproj": true } }"""
+            (modelPath.Replace("\\", "\\\\"))
+            (outputDir.Replace("\\", "\\\\"))
+    let path =
+        Path.Combine(Path.GetTempPath(), sprintf "fes-config-%s.json" (Guid.NewGuid().ToString "N"))
+    File.WriteAllText(path, json)
+    path
+
+/// `runWithStore` returning the report too (the G3 witnesses assert on
+/// `report.Paths`).
+let private runWithStoreReport (configPath: string) (storePath: string) (atDay: int) : Compose.RunReport * Compose.FullExportStoreLeg =
+    let at = DateTimeOffset(2026, 6, atDay, 9, 0, 0, TimeSpan.Zero)
+    let outcome, leg =
+        FullExportRun.executeWithStore
+            configPath None LogSink.Verbosity.Quiet Set.empty
+            (Some storePath) tl Environment.Dev at
+    match outcome, leg with
+    | FullExportRun.RunOutcome.Succeeded (report, _), Some l -> report, l
+    | other, _ -> Assert.Fail(sprintf "expected Succeeded with a store leg, got %A" other); Unchecked.defaultof<_>
+
+[<Fact>]
+let ``G3: a store-threaded run writes ProjectionCatalog.refactorlog inside the bundle and reports it`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outDir = tempOutputDir ()
+    let cfg = writeTempConfig modelPath outDir
+    let store = tempStorePath ()
+    try
+        let report, leg = runWithStoreReport cfg store 1
+        let refactorPath = Path.Combine(outDir, Compose.ArtifactPath.refactorLog)
+        Assert.True(File.Exists refactorPath, "the store-threaded bundle carries ProjectionCatalog.refactorlog")
+        Assert.Contains(refactorPath, report.Paths)
+        // Genesis: no prior, no renames — the truthful EMPTY document (the
+        // presence contract is store-threaded ⟺ file exists, not non-empty).
+        let xml = File.ReadAllText refactorPath
+        Assert.Contains("<Operations", xml)
+        Assert.DoesNotContain("<Operation ", xml)
+        Assert.Empty(leg.AccumulatedRefactorLog)
+    finally
+        safeRm outDir; safeDel cfg; safeDel store; safeDel modelPath
+
+[<Fact>]
+let ``G3: a store-less run writes NO refactorlog (byte-identical genesis bundle)`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outDir = tempOutputDir ()
+    let cfg = writeTempConfig modelPath outDir
+    try
+        let at = DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)
+        let outcome, _ =
+            FullExportRun.executeWithStore
+                cfg None LogSink.Verbosity.Quiet Set.empty
+                None tl Environment.Dev at
+        match outcome with
+        | FullExportRun.RunOutcome.Succeeded (report, _) ->
+            let refactorPath = Path.Combine(outDir, Compose.ArtifactPath.refactorLog)
+            Assert.False(File.Exists refactorPath, "a store-less bundle carries no refactorlog")
+            Assert.DoesNotContain(refactorPath, report.Paths)
+        | other -> Assert.Fail(sprintf "expected Succeeded, got %A" other)
+    finally
+        safeRm outDir; safeDel cfg; safeDel modelPath
+
+[<Fact>]
+let ``G3: with emission.sqlproj the store-threaded project carries the RefactorLog item; store-less carries none`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outWith = tempOutputDir ()
+    let outWithout = tempOutputDir ()
+    let cfgWith = writeTempConfigSqlproj modelPath outWith
+    let cfgWithout = writeTempConfigSqlproj modelPath outWithout
+    let store = tempStorePath ()
+    try
+        let _ = runWithStoreReport cfgWith store 1
+        let sqlprojWith = File.ReadAllText(Path.Combine(outWith, Compose.ArtifactPath.sqlproj))
+        Assert.Contains("RefactorLog", sqlprojWith)
+        Assert.Contains(Compose.ArtifactPath.refactorLog, sqlprojWith)
+        let at = DateTimeOffset(2026, 6, 2, 9, 0, 0, TimeSpan.Zero)
+        let outcome, _ =
+            FullExportRun.executeWithStore
+                cfgWithout None LogSink.Verbosity.Quiet Set.empty
+                None tl Environment.Dev at
+        match outcome with
+        | FullExportRun.RunOutcome.Succeeded _ ->
+            let sqlprojWithout = File.ReadAllText(Path.Combine(outWithout, Compose.ArtifactPath.sqlproj))
+            Assert.DoesNotContain("RefactorLog", sqlprojWithout)
+        | other -> Assert.Fail(sprintf "expected Succeeded, got %A" other)
+    finally
+        safeRm outWith; safeRm outWithout; safeDel cfgWith; safeDel cfgWithout; safeDel store; safeDel modelPath
+
+/// The PRIOR emission's schema, hand-authored with the SAME synthesized
+/// SsKeys the JSON reader derives for `v1ModelOneColumn` (module `AppCore`,
+/// entity `User`) but an OLDER logical name (`OldUser`). The store is the
+/// identity carrier (CatalogCodec persists SsKeys), so seeding it with this
+/// genesis simulates exactly what an identity-stable source produces across
+/// a rename — file-sourced models alone cannot thread identity across a
+/// rename (name-derived synthesized keys; the 6.A.7 limitation).
+let private priorSchemaOldUser () : Catalog =
+    let kindKey = SsKey.synthesizedComposite "OS_KIND" [ "AppCore"; "User" ] |> mustOk
+    let attrKey = SsKey.synthesizedComposite "OS_ATTR" [ "AppCore"; "User"; "Id" ] |> mustOk
+    let moduleKey = SsKey.synthesized "OS_MOD" "AppCore" |> mustOk
+    let nameOf (s: string) = Name.create s |> mustOk
+    let idAttr =
+        { Attribute.create attrKey (nameOf "Id") Integer with
+            Column = ColumnRealization.create "ID" false |> Result.value
+            IsPrimaryKey = true
+            IsMandatory = true
+            IsIdentity = true }
+    let kind =
+        Kind.create kindKey (nameOf "OldUser")
+            (TableId.create "dbo" "OSUSR_APPCORE_USER" |> mustOk)
+            [ idAttr ]
+    { Modules =
+        [ { SsKey = moduleKey; Name = nameOf "AppCore"; Kinds = [ kind ]; IsActive = true; ExtendedProperties = [] } ]
+      Sequences = [] }
+
+[<Fact>]
+let ``G3: a rename across episodes lands in the bundle's refactorlog in DEPLOYED vocabulary, agreeing with the leg`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let outDir = tempOutputDir ()
+    let cfg = writeTempConfig modelPath outDir
+    let store = tempStorePath ()
+    try
+        // Seed the prior: one genesis episode whose kind is the SAME identity
+        // (SsKey) under the OLD logical name `OldUser`.
+        let priorAt = DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)
+        let coordinate =
+            EpisodeCoordinate.create (Version.create 0 "v0" |> mustOk) Environment.Dev priorAt
+        let genesis =
+            Episode.create coordinate (priorSchemaOldUser ()) Profile.empty None DataObservation.empty
+        LifecycleStore.save store (EpisodicLifecycle.genesis tl genesis) |> mustStoreOk
+        // Run the full-export: the model names the kind `User` — same SsKey,
+        // new logical name — a RENAME the deployed estate must sp_rename.
+        let report, leg = runWithStoreReport cfg store 2
+        // The leg's accumulated log carries exactly the table rename.
+        Assert.Equal(1, List.length leg.AccumulatedRefactorLog)
+        let entry = List.head leg.AccumulatedRefactorLog
+        Assert.Equal(SqlTable, entry.ElementType)
+        Assert.Equal("[dbo].[OldUser]", entry.ElementName)
+        Assert.Equal("User", entry.NewName)
+        // The bundle's document exists, is reported, and speaks the SAME
+        // operations (file ⇔ leg agreement — the hydrated-plane bundle
+        // derivation and the read-plane episode derivation agree).
+        let refactorPath = Path.Combine(outDir, Compose.ArtifactPath.refactorLog)
+        Assert.True(File.Exists refactorPath)
+        Assert.Contains(refactorPath, report.Paths)
+        let xml = File.ReadAllText refactorPath
+        Assert.Contains(sprintf "Key=\"%s\"" (entry.OperationKey.ToString "D"), xml)
+        Assert.Contains("Value=\"[dbo].[OldUser]\"", xml)
+        Assert.Contains("Value=\"User\"", xml)
+        // And the recorded chain now carries two episodes (the record phase
+        // still ran, after the bundle).
+        Assert.Equal(2, episodeCount store)
+    finally
+        safeRm outDir; safeDel cfg; safeDel store; safeDel modelPath
+
+[<Fact>]
+let ``G3: the accumulated document is CUMULATIVE — a later no-change run still carries the rename`` () =
+    let modelPath = writeTempJson v1ModelOneColumn
+    let out2 = tempOutputDir ()
+    let out3 = tempOutputDir ()
+    let cfg2 = writeTempConfig modelPath out2
+    let cfg3 = writeTempConfig modelPath out3
+    let store = tempStorePath ()
+    try
+        let priorAt = DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero)
+        let coordinate =
+            EpisodeCoordinate.create (Version.create 0 "v0" |> mustOk) Environment.Dev priorAt
+        let genesis =
+            Episode.create coordinate (priorSchemaOldUser ()) Profile.empty None DataObservation.empty
+        LifecycleStore.save store (EpisodicLifecycle.genesis tl genesis) |> mustStoreOk
+        let _, leg2 = runWithStoreReport cfg2 store 2
+        let _, leg3 = runWithStoreReport cfg3 store 3
+        // Run 3's displacement is empty (same model), but the ACCUMULATED
+        // document still carries the OldUser→User operation — the cumulative
+        // contract (AC-P6): DacFx sp_renames any source older than latest.
+        Assert.Equal(1, List.length leg3.AccumulatedRefactorLog)
+        Assert.Equal(
+            (List.head leg2.AccumulatedRefactorLog).OperationKey,
+            (List.head leg3.AccumulatedRefactorLog).OperationKey)
+        let xml3 = File.ReadAllText(Path.Combine(out3, Compose.ArtifactPath.refactorLog))
+        Assert.Contains("Value=\"[dbo].[OldUser]\"", xml3)
+    finally
+        safeRm out2; safeRm out3; safeDel cfg2; safeDel cfg3; safeDel store; safeDel modelPath
 
 [<Fact>]
 let ``NM-33: the recorded episode carries the run's AppliedTransforms (withProvenance is wired, not the dead [] default)`` () =

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
@@ -1,5 +1,5 @@
 CREATE TABLE [dbo].[Heap] (
-    [LoggedAt] DATETIME2      NOT NULL,
+    [LoggedAt] DATETIME       NOT NULL,
     [Message]  NVARCHAR (500) NULL
 )
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
@@ -3,14 +3,14 @@ CREATE TABLE [dbo].[ScalarGallery] (
         CONSTRAINT [PK_ScalarGallery_Id]
             PRIMARY KEY CLUSTERED,
     [AlarmAt]     TIME             NULL
-        DEFAULT '08:30:00',
+        DEFAULT CAST ('08:30:00' AS TIME (7)),
     [Amount]      DECIMAL (18, 4)  NULL
         DEFAULT 3.1400
         CHECK (([Amount] <= (1000000.0000))),
     [Code]        NVARCHAR (20)    NOT NULL
         CONSTRAINT [DF_ScalarGallery_Code] DEFAULT N'Pending',
     [DueDate]     DATE             NULL
-        DEFAULT '2020-01-01',
+        DEFAULT CAST ('2020-01-01' AS DATE),
     [ExternalKey] UNIQUEIDENTIFIER NULL
         DEFAULT '00000000-0000-0000-0000-000000000000',
     [FreeText]    NVARCHAR (50)    NULL,
@@ -18,8 +18,8 @@ CREATE TABLE [dbo].[ScalarGallery] (
         CONSTRAINT [DF_ScalarGallery_IsActive] DEFAULT 1,
     [Notes]       NVARCHAR (2000)  NULL
         DEFAULT N'',
-    [OccurredOn]  DATETIME2        NULL
-        DEFAULT '2020-01-01 00:00:00',
+    [OccurredOn]  DATETIME         NULL
+        DEFAULT CAST ('2020-01-01 00:00:00' AS DATETIME2 (7)),
     [Payload]     VARBINARY (512)  NULL
         DEFAULT 0x00,
     [Tally]       INT              NULL

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
@@ -1,9 +1,9 @@
 CREATE TABLE [audit].[ChangeLog] (
-    [Id]     INT       IDENTITY (1, 1) NOT NULL
+    [Id]     INT      IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_ChangeLog_Id]
             PRIMARY KEY CLUSTERED,
-    [At]     DATETIME2 NOT NULL,
-    [UserId] INT       NOT NULL
+    [At]     DATETIME NOT NULL,
+    [UserId] INT      NOT NULL
         CONSTRAINT [FK_ChangeLog_User_UserId]
             FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id])
 )

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Schemas/audit.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Schemas/audit.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA [audit]
+
+GO
+
+

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
@@ -67,11 +67,11 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S
 GO
 
 CREATE TABLE [audit].[ChangeLog] (
-    [Id]     INT       IDENTITY (1, 1) NOT NULL
+    [Id]     INT      IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_ChangeLog_Id]
             PRIMARY KEY CLUSTERED,
-    [At]     DATETIME2 NOT NULL,
-    [UserId] INT       NOT NULL
+    [At]     DATETIME NOT NULL,
+    [UserId] INT      NOT NULL
         CONSTRAINT [FK_ChangeLog_User_UserId]
             FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id])
 )
@@ -431,7 +431,7 @@ EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S
 GO
 
 CREATE TABLE [dbo].[Heap] (
-    [LoggedAt] DATETIME2      NOT NULL,
+    [LoggedAt] DATETIME       NOT NULL,
     [Message]  NVARCHAR (500) NULL
 )
 
@@ -661,14 +661,14 @@ CREATE TABLE [dbo].[ScalarGallery] (
         CONSTRAINT [PK_ScalarGallery_Id]
             PRIMARY KEY CLUSTERED,
     [AlarmAt]     TIME             NULL
-        DEFAULT '08:30:00',
+        DEFAULT CAST ('08:30:00' AS TIME (7)),
     [Amount]      DECIMAL (18, 4)  NULL
         DEFAULT 3.1400
         CHECK (([Amount] <= (1000000.0000))),
     [Code]        NVARCHAR (20)    NOT NULL
         CONSTRAINT [DF_ScalarGallery_Code] DEFAULT N'Pending',
     [DueDate]     DATE             NULL
-        DEFAULT '2020-01-01',
+        DEFAULT CAST ('2020-01-01' AS DATE),
     [ExternalKey] UNIQUEIDENTIFIER NULL
         DEFAULT '00000000-0000-0000-0000-000000000000',
     [FreeText]    NVARCHAR (50)    NULL,
@@ -676,8 +676,8 @@ CREATE TABLE [dbo].[ScalarGallery] (
         CONSTRAINT [DF_ScalarGallery_IsActive] DEFAULT 1,
     [Notes]       NVARCHAR (2000)  NULL
         DEFAULT N'',
-    [OccurredOn]  DATETIME2        NULL
-        DEFAULT '2020-01-01 00:00:00',
+    [OccurredOn]  DATETIME         NULL
+        DEFAULT CAST ('2020-01-01 00:00:00' AS DATETIME2 (7)),
     [Payload]     VARBINARY (512)  NULL
         DEFAULT 0x00,
     [Tally]       INT              NULL

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
@@ -1,3 +1,7 @@
+CREATE SCHEMA [audit]
+
+GO
+
 CREATE TABLE [dbo].[Assignment] (
     [ProjectId]  INT           NOT NULL,
     [ResourceId] INT           NOT NULL,

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="SqlTypeCorrespondenceTests.fs" />
     <Compile Include="SqlStorageTypeTests.fs" />
     <Compile Include="SqlLiteralTests.fs" />
+    <Compile Include="BulkTests.fs" />
     <Compile Include="SqlIdentifierTests.fs" />
     <Compile Include="OssysTypeMappingTests.fs" />
     <Compile Include="LineageTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/RefactorLogEmitterTests.fs
@@ -325,3 +325,104 @@ let ``composition: rename → one SqlSimpleColumn AND reshape → one ALTER COLU
         migration.Value |> List.choose (function Statement.AlterTableAlterColumn (_, c) -> Some c | _ -> None)
     Assert.Equal(1, List.length alters)
     Assert.False(migration.Value |> List.exists (function Statement.CreateTable _ -> true | _ -> false))
+
+// ---------------------------------------------------------------------------
+// G3 (DECISIONS 2026-07-16) — `emitDeployed`, the DEPLOYED-vocabulary sibling.
+// The estate deploys LOGICAL names (`LogicalTableEmission` /
+// `LogicalColumnEmission`, default-on), so DacFx can only match refactor
+// operations whose ElementName speaks logical names. `emit`'s catalog-plane
+// vocabulary (`[dbo].[OSUSR_S1S_CUSTOMER]`) matches nothing deployed; these
+// witnesses pin the deployed projection: old/new names through the emission
+// passes' exact name-decision rules, pins suppress, keys unchanged.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``emitDeployed: a table rename speaks logical names — ElementName is the OLD deployed table`` () =
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
+    let artifact = RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+    let entries = Map.find customerKey (ArtifactByKind.toMap artifact)
+    Assert.Equal(1, List.length entries)
+    let e = List.head entries
+    Assert.Equal(SqlTable, e.ElementType)
+    Assert.Equal("[dbo].[Customer]", e.ElementName)
+    Assert.Equal("[dbo]", e.ParentElementName)
+    Assert.Equal(SqlSchema, e.ParentElementType)
+    Assert.Equal("Patron", e.NewName)
+
+[<Fact>]
+let ``emitDeployed: OperationKey equals emit's key for the same rename (dedup identity unchanged)`` () =
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
+    let legacyKey =
+        (RefactorLogEmitter.emit diff |> mustOk
+         |> ArtifactByKind.toMap |> Map.find customerKey |> List.head).OperationKey
+    let deployedKey =
+        (RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+         |> ArtifactByKind.toMap |> Map.find customerKey |> List.head).OperationKey
+    Assert.Equal(legacyKey, deployedKey)
+
+[<Fact>]
+let ``emitDeployed: an operator-pinned kind's logical rename emits NO operation (deployed name is the pin)`` () =
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
+    let artifact = RefactorLogEmitter.emitDeployed (Set.singleton customerKey) diff |> mustOk
+    Assert.Empty(Map.find customerKey (ArtifactByKind.toMap artifact))
+
+[<Fact>]
+let ``emitDeployed: a column rename qualifies by the deployed (logical) table and speaks logical column names`` () =
+    let diff = CatalogDiff.between sampleCatalog columnRenameTarget
+    let artifact = RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+    let entries =
+        Map.find customerKey (ArtifactByKind.toMap artifact)
+        |> List.filter (fun e -> e.ElementType = SqlSimpleColumn)
+    Assert.Equal(1, List.length entries)
+    let e = List.head entries
+    Assert.Equal("[dbo].[Customer].[Name]", e.ElementName)
+    Assert.Equal("[dbo].[Customer]", e.ParentElementName)
+    Assert.Equal(SqlTable, e.ParentElementType)
+    Assert.Equal("FullName", e.NewName)
+
+[<Fact>]
+let ``emitDeployed: a compound rename (table AND column) qualifies the column by the OLD deployed table name`` () =
+    // Both renames in ONE displacement: operations sort by OperationKey (not
+    // authored order), so all must speak the PRE-publish vocabulary — the
+    // column operation's qualifier is the OLD table name.
+    let compound : Kind =
+        { customer with
+            Name = nameOf "Patron"
+            Attributes =
+                customer.Attributes
+                |> List.map (fun a ->
+                    if a.SsKey = customerNameKey then { a with Name = nameOf "FullName" } else a) }
+    let target = IRBuilders.mkCatalog [ { salesModule with Kinds = [ compound; order; country ] } ]
+    let diff = CatalogDiff.between sampleCatalog target
+    let entries =
+        RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+        |> ArtifactByKind.toMap |> Map.find customerKey
+    let tableOp = entries |> List.find (fun e -> e.ElementType = SqlTable)
+    let columnOp = entries |> List.find (fun e -> e.ElementType = SqlSimpleColumn)
+    Assert.Equal("[dbo].[Customer]", tableOp.ElementName)
+    Assert.Equal("Patron", tableOp.NewName)
+    Assert.Equal("[dbo].[Customer].[Name]", columnOp.ElementName)
+    Assert.Equal("[dbo].[Customer]", columnOp.ParentElementName)
+    Assert.Equal("FullName", columnOp.NewName)
+
+[<Fact>]
+let ``emitDeployed: the FK channel is named-absent (synthesized deployed FK names — WP-7)`` () =
+    // Deployed FK names are synthesized (`FK_<Owner>_<Target>_<Col>`); a
+    // logical `Reference.Name` rename changes no deployed constraint, so an
+    // operation for it could never match. The channel stays closed until
+    // WP-7 honors `Reference.Name` in emission.
+    let diff = CatalogDiff.between sampleCatalog fkRenameTarget
+    let artifact = RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+    let allFk =
+        ArtifactByKind.toMap artifact
+        |> Map.toSeq |> Seq.collect snd
+        |> Seq.filter (fun e -> e.ElementType = SqlForeignKey)
+    Assert.Empty(allFk)
+
+[<Fact>]
+let ``emitDeployed: T11 keyset equals the target Catalog's kinds (sibling contract holds)`` () =
+    let diff = CatalogDiff.between sampleCatalog targetCatalog
+    let expected =
+        Catalog.allKinds targetCatalog |> List.map (fun k -> k.SsKey) |> Set.ofList
+    let artifact = RefactorLogEmitter.emitDeployed Set.empty diff |> mustOk
+    Assert.Equal<Set<SsKey>>(expected, ArtifactByKind.keys artifact)

--- a/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
@@ -219,3 +219,38 @@ let ``Closed-DU coverage: every PrimitiveType variant produces a SqlLiteral via 
     for v in variants do
         let lit = SqlLiteral.ofRaw v (Some "0")  // any non-empty raw
         Assert.NotEqual<SqlLiteral> (NullLit, lit)
+
+// ---------------------------------------------------------------------------
+// WP-17(e) (DECISIONS 2026-07-16) — CR/LF/TAB splice into CHAR() concatenation
+// (V1 `EscapeUnicodeString` parity); the emitted SQL carries no raw control
+// bytes. A control-char-free raw renders byte-identically to the pre-WP-17
+// form (the default everywhere).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``WP-17e: toString splices CR LF TAB into CHAR() concatenation (V1 parity)`` () =
+    Assert.Equal<string> ("N'a' + CHAR(13) + N'b'", SqlLiteral.toString (TextLit "a\rb"))
+    Assert.Equal<string> ("N'a' + CHAR(10) + N'b'", SqlLiteral.toString (TextLit "a\nb"))
+    Assert.Equal<string> ("N'a' + CHAR(9) + N'b'",  SqlLiteral.toString (TextLit "a\tb"))
+    // CRLF = two adjacent control chars — the V1-parity blind splice keeps
+    // the empty run between them.
+    Assert.Equal<string> ("N'a' + CHAR(13) + N'' + CHAR(10) + N'b'", SqlLiteral.toString (TextLit "a\r\nb"))
+    // Leading/trailing control chars yield empty edge runs (V1 parity).
+    Assert.Equal<string> ("N'' + CHAR(10) + N'x'", SqlLiteral.toString (TextLit "\nx"))
+    Assert.Equal<string> ("N'x' + CHAR(9) + N''",  SqlLiteral.toString (TextLit "x\t"))
+
+[<Fact>]
+let ``WP-17e: quote-doubling still applies inside spliced runs`` () =
+    Assert.Equal<string> ("N'O''Brien' + CHAR(10) + N'line2'", SqlLiteral.toString (TextLit "O'Brien\nline2"))
+
+[<Fact>]
+let ``WP-17e: a control-char-free Text raw renders byte-identically (no splice)`` () =
+    Assert.Equal<string> ("N'Hello'", SqlLiteral.toString (TextLit "Hello"))
+    Assert.Equal<string> ("N''", SqlLiteral.toString (TextLit ""))
+
+[<Fact>]
+let ``WP-17e: textLiteralSegments — the shared segmentation both planes ride`` () =
+    Assert.Equal<TextLiteralSegment list>([ TextRun "plain" ], SqlLiteral.textLiteralSegments "plain")
+    Assert.Equal<TextLiteralSegment list>(
+        [ TextRun "a"; ControlChar 13; TextRun ""; ControlChar 10; TextRun "b" ],
+        SqlLiteral.textLiteralSegments "a\r\nb")

--- a/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
@@ -254,3 +254,40 @@ let ``WP-17e: textLiteralSegments — the shared segmentation both planes ride``
     Assert.Equal<TextLiteralSegment list>(
         [ TextRun "a"; ControlChar 13; TextRun ""; ControlChar 10; TextRun "b" ],
         SqlLiteral.textLiteralSegments "a\r\nb")
+
+// ---------------------------------------------------------------------------
+// WP-17(a/b) (DECISIONS 2026-07-16) — faithful carriage for the collapsing
+// concrete types. The raw STRING carries the concrete value (G17/G9 for
+// float/real; the offset-bearing form for datetimeoffset); the boundaries
+// dispatch on the raw shape — no new carrier, the 9-way category stands.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``WP-17b: RawValueCodec round-trips a DateTimeOffset with its offset preserved`` () =
+    let value = System.DateTimeOffset(2026, 7, 16, 12, 30, 0, System.TimeSpan.FromHours -3.0)
+    let raw = RawValueCodec.formatDateTimeOffset value
+    Assert.Equal<string> ("2026-07-16 12:30:00.0000000 -03:00", raw)
+    Assert.True(RawValueCodec.hasUtcOffset raw)
+    let back = RawValueCodec.parseDateTimeOffset raw
+    Assert.Equal(value, back)
+    Assert.Equal(System.TimeSpan.FromHours -3.0, back.Offset)
+
+[<Fact>]
+let ``WP-17b: hasUtcOffset is disjoint from every offset-less canonical raw shape`` () =
+    Assert.True(RawValueCodec.hasUtcOffset "2026-07-16 12:30:00.0000000 +03:00")
+    Assert.False(RawValueCodec.hasUtcOffset "2026-07-16 12:30:00.0000000")
+    Assert.False(RawValueCodec.hasUtcOffset "2026-07-16")
+    Assert.False(RawValueCodec.hasUtcOffset "08:30:00")
+    Assert.False(RawValueCodec.hasUtcOffset "-00:30:00")
+
+[<Fact>]
+let ``WP-17b: an offset-bearing DateTime raw owns its CAST target (datetimeoffset(7))`` () =
+    let offsetRaw = "2026-07-16 12:30:00.0000000 -03:00"
+    Assert.Equal<SqlLiteral> (DateTimeOffsetLit offsetRaw, SqlLiteral.ofRaw DateTime (Some offsetRaw))
+    Assert.Equal<string> (
+        "CAST('2026-07-16 12:30:00.0000000 -03:00' AS datetimeoffset(7))",
+        SqlLiteral.toString (DateTimeOffsetLit offsetRaw))
+    // The offset-less canonical form keeps datetime2(7) — the shapes are disjoint.
+    Assert.Equal<SqlLiteral> (
+        DateTimeLit "2026-07-16 12:30:00.0000000",
+        SqlLiteral.ofRaw DateTime (Some "2026-07-16 12:30:00.0000000"))

--- a/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
@@ -76,10 +76,10 @@ let ``SqlLiteral.ofRaw on an unrecognized Boolean raw fails loud, not silent-fal
     Assert.Throws<System.FormatException>(fun () -> SqlLiteral.ofRaw Boolean (Some "2") |> ignore) |> ignore
 
 [<Fact>]
-let ``SqlLiteral.ofRaw maps temporal types to TemporalLit`` () =
-    Assert.Equal<SqlLiteral> (TemporalLit "2026-05-10", SqlLiteral.ofRaw Date (Some "2026-05-10"))
-    Assert.Equal<SqlLiteral> (TemporalLit "2026-05-10 12:30:00.0000000", SqlLiteral.ofRaw DateTime (Some "2026-05-10 12:30:00.0000000"))
-    Assert.Equal<SqlLiteral> (TemporalLit "12:30:00", SqlLiteral.ofRaw Time (Some "12:30:00"))
+let ``SqlLiteral.ofRaw maps each temporal category to its own variant (WP-17d)`` () =
+    Assert.Equal<SqlLiteral> (DateLit "2026-05-10", SqlLiteral.ofRaw Date (Some "2026-05-10"))
+    Assert.Equal<SqlLiteral> (DateTimeLit "2026-05-10 12:30:00.0000000", SqlLiteral.ofRaw DateTime (Some "2026-05-10 12:30:00.0000000"))
+    Assert.Equal<SqlLiteral> (TimeLit "12:30:00", SqlLiteral.ofRaw Time (Some "12:30:00"))
 
 [<Fact>]
 let ``SqlLiteral.ofRaw maps Guid to GuidLit`` () =
@@ -116,8 +116,15 @@ let ``SqlLiteral.toString renders TextLit with N prefix and single-quote doublin
     Assert.Equal<string> ("N'O''Brien'", SqlLiteral.toString (TextLit "O'Brien"))
 
 [<Fact>]
-let ``SqlLiteral.toString renders TemporalLit and GuidLit with single-quote wrapping`` () =
-    Assert.Equal<string> ("'2026-05-10'", SqlLiteral.toString (TemporalLit "2026-05-10"))
+let ``SqlLiteral.toString renders the V1 explicit-CAST temporal forms (WP-17d)`` () =
+    // V1 `SqlLiteralFormatter.cs:90` parity: precision-explicit,
+    // language-independent — never a bare quoted string.
+    Assert.Equal<string> ("CAST('2026-05-10' AS date)", SqlLiteral.toString (DateLit "2026-05-10"))
+    Assert.Equal<string> ("CAST('2026-05-10 12:30:00.0000000' AS datetime2(7))", SqlLiteral.toString (DateTimeLit "2026-05-10 12:30:00.0000000"))
+    Assert.Equal<string> ("CAST('08:30:00' AS time(7))", SqlLiteral.toString (TimeLit "08:30:00"))
+
+[<Fact>]
+let ``SqlLiteral.toString renders GuidLit with single-quote wrapping`` () =
     Assert.Equal<string> ("'0F0E0D0C-0B0A-0908-0706-050403020100'", SqlLiteral.toString (GuidLit "0F0E0D0C-0B0A-0908-0706-050403020100"))
 
 [<Fact>]

--- a/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
@@ -69,9 +69,12 @@ let ``ofPrimitiveType mirrors the legacy SqlTypeCorrespondence defaults`` () =
     // Integer → INT (semantic fallback keeps the v2 default; only the
     // OSSYS adapter's longinteger evidence narrows to BIGINT).
     Assert.Equal (SqlStorageType.Int, SqlStorageType.ofPrimitiveType Integer)
-    // DateTime → DATETIME2 (the existing fallback; the OSSYS adapter's
-    // `datetime` evidence narrows to DATETIME).
-    Assert.Equal (SqlStorageType.DateTime2 None, SqlStorageType.ofPrimitiveType DateTime)
+    // DateTime → DATETIME (WP-17(d), DECISIONS 2026-07-16: the
+    // evidence-less fallback carries the PLATFORM legacy default,
+    // aligned with the storage lane — the silent DATETIME2 upgrade is
+    // retired; a datetime2 SOURCE still narrows to DATETIME2 via its
+    // storage evidence).
+    Assert.Equal (SqlStorageType.DateTime, SqlStorageType.ofPrimitiveType DateTime)
     Assert.Equal (SqlStorageType.NVarChar Max, SqlStorageType.ofPrimitiveType Text)
 
 // ---------------------------------------------------------------------------

--- a/sidecar/projection/tests/Projection.Tests/SsdtArtifactBuildTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtArtifactBuildTests.fs
@@ -113,6 +113,61 @@ let ``Sqlproj build: the emitted Microsoft.Build.Sql project builds to a .dacpac
         try Directory.Delete(dir, true) with _ -> ()
 
 // ----------------------------------------------------------------------------
+// G6 (DECISIONS 2026-07-16) — a NON-dbo estate builds. The bundle's
+// `Schemas/<name>.sql` CREATE SCHEMA objects ride the SDK's default Build
+// glob beside the `Modules/**` tables; without them SSDT refuses the model
+// (unresolved schema reference, SQL71501) — exactly the hand-authoring gap
+// G6 closes.
+// ----------------------------------------------------------------------------
+
+[<Fact>]
+let ``Sqlproj build: a NON-dbo estate's bundle builds to a .dacpac (Schemas/ objects emitted — G6)`` () =
+    let auditKey = mkKey [ "Ledger"; "ChangeLog" ]
+    let changeLog =
+        { Kind.create auditKey (Name.create "ChangeLog" |> Result.value)
+            (TableId.create "audit" "OSUSR_LDG_CHANGELOG" |> Result.value)
+            [ { Attribute.create (mkKey [ "Ledger"; "ChangeLog"; "Id" ]) (Name.create "Id" |> Result.value) Integer with
+                  Column = col "ID"
+                  IsPrimaryKey = true
+                  IsMandatory = true } ]
+          with References = [] }
+    let catalog : Catalog =
+        { Modules = [ { SsKey = mkKey [ "Ledger" ]; Name = Name.create "Ledger" |> Result.value; Kinds = [ changeLog ]; IsActive = true; ExtendedProperties = [] } ]
+          Sequences = [] }
+    let policy = { Policy.empty with Emission = EmissionPolicy.combined }
+    let outputs = Compose.projectWith policy Profile.empty catalog
+    // The composed bundle carries the schema object (the wire, not a
+    // hand-assembly): Schemas/audit.sql beside Modules/**.
+    Assert.True(outputs.SsdtBundle.ContainsKey "Schemas/audit.sql", "the bundle carries Schemas/audit.sql")
+    let dir = Path.Combine(Path.GetTempPath(), "proj-nondbo-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory dir |> ignore
+    try
+        for KeyValue (rel, body) in outputs.SsdtBundle do
+            if rel.EndsWith ".sql" then writeFile dir rel body
+        writeFile dir SqlprojEmitter.fileName (SqlprojEmitter.emit [] false false)
+        writeFile dir "nuget.config" nugetConfig
+        let psi = ProcessStartInfo("dotnet", sprintf "build %s -c Debug --nologo" SqlprojEmitter.fileName)
+        psi.WorkingDirectory <- dir
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        let proc =
+            match Process.Start psi with
+            | null -> failwith "could not start `dotnet`"
+            | p -> p
+        let stdout = proc.StandardOutput.ReadToEnd()
+        let stderr = proc.StandardError.ReadToEnd()
+        proc.WaitForExit()
+        let combined = stdout + "\n" + stderr
+        if combined.Contains "Could not resolve SDK" || combined.Contains "Unable to resolve 'Microsoft.Build.Sql" then
+            printfn "SKIP non-dbo .sqlproj build: Microsoft.Build.Sql SDK not restorable in this environment."
+        else
+            Assert.True(proc.ExitCode = 0, sprintf "dotnet build of the non-dbo .sqlproj failed (exit %d):\n%s" proc.ExitCode combined)
+            Assert.True(File.Exists(Path.Combine(dir, "bin", "Debug", "ProjectionCatalog.dacpac")), "the non-dbo bundle built a .dacpac")
+    finally
+        try Directory.Delete(dir, true) with _ -> ()
+
+// ----------------------------------------------------------------------------
 // G3 (DECISIONS 2026-07-16) — the refactorlog PAIRING builds. The bundle carries
 // `ProjectionCatalog.refactorlog` (deployed-vocabulary, accumulated) and the
 // `.sqlproj` its explicit `RefactorLog` item; `dotnet build` must compile the

--- a/sidecar/projection/tests/Projection.Tests/SsdtArtifactBuildTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtArtifactBuildTests.fs
@@ -86,7 +86,7 @@ let ``Sqlproj build: the emitted Microsoft.Build.Sql project builds to a .dacpac
         for (rel, body) in dataLanes do writeFile dir rel body
         let laneRelPaths = dataLanes |> List.map fst
         writeFile dir PostDeployEmitter.fileName (PostDeployEmitter.renderIncludes laneRelPaths)
-        writeFile dir SqlprojEmitter.fileName (SqlprojEmitter.emit laneRelPaths true)
+        writeFile dir SqlprojEmitter.fileName (SqlprojEmitter.emit laneRelPaths true false)
         writeFile dir "nuget.config" nugetConfig
         // dotnet build the emitted .sqlproj → a .dacpac
         let psi = ProcessStartInfo("dotnet", sprintf "build %s -c Debug --nologo" SqlprojEmitter.fileName)
@@ -109,6 +109,80 @@ let ``Sqlproj build: the emitted Microsoft.Build.Sql project builds to a .dacpac
             Assert.True(proc.ExitCode = 0, sprintf "dotnet build of the emitted .sqlproj failed (exit %d):\n%s" proc.ExitCode combined)
             let dacpac = Path.Combine(dir, "bin", "Debug", "ProjectionCatalog.dacpac")
             Assert.True(File.Exists dacpac, sprintf "expected a built .dacpac at %s\nbuild output:\n%s" dacpac combined)
+    finally
+        try Directory.Delete(dir, true) with _ -> ()
+
+// ----------------------------------------------------------------------------
+// G3 (DECISIONS 2026-07-16) — the refactorlog PAIRING builds. The bundle carries
+// `ProjectionCatalog.refactorlog` (deployed-vocabulary, accumulated) and the
+// `.sqlproj` its explicit `RefactorLog` item; `dotnet build` must compile the
+// pairing (this is the duplicate-item empiric: an SDK default glob colliding
+// with the explicit item would fail HERE) and embed the document into the
+// `.dacpac` as `refactor.xml` — the artifact DacFx's deploy planner reads to
+// turn a rename into `sp_rename` instead of DROP+CREATE.
+// ----------------------------------------------------------------------------
+
+[<Fact>]
+let ``Sqlproj build: a bundle with a refactorlog builds and the .dacpac embeds refactor.xml (G3)`` () =
+    // The rename this refactorlog records: the deployed estate knew Country as
+    // `Nation`; THIS model calls it `Country` (same SsKey — identity threaded).
+    // The operation's NewName targets an element that exists in the built model.
+    let current = buildCatalog ()
+    let prior =
+        { current with
+            Modules =
+                current.Modules
+                |> List.map (fun m ->
+                    { m with
+                        Kinds =
+                            m.Kinds
+                            |> List.map (fun k ->
+                                if k.SsKey = countryKey then { k with Name = Name.create "Nation" |> Result.value } else k) }) }
+    let diff = CatalogDiff.between prior current
+    let entries =
+        match RefactorLogEmitter.emitDeployed Set.empty diff with
+        | Microsoft.FSharp.Core.Result.Ok artifact -> RefactorLogEmitter.accumulateArtifact [] artifact
+        | Microsoft.FSharp.Core.Result.Error e -> failwithf "emitDeployed failed: %A" e
+    Assert.NotEmpty entries
+    let refactorXml =
+        RefactorLogRender.ofEntriesAt (DateTimeOffset(2026, 7, 16, 0, 0, 0, TimeSpan.Zero)) entries
+    let policy = { Policy.empty with Emission = EmissionPolicy.combined }
+    let outputs = Compose.projectWith policy Profile.empty current
+    let dir = Path.Combine(Path.GetTempPath(), "proj-refactor-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory dir |> ignore
+    try
+        for KeyValue (rel, body) in outputs.SsdtBundle do
+            if rel.EndsWith ".sql" then writeFile dir rel body
+        writeFile dir SqlprojEmitter.refactorLogFileName refactorXml
+        writeFile dir SqlprojEmitter.fileName (SqlprojEmitter.emit [] false true)
+        writeFile dir "nuget.config" nugetConfig
+        let psi = ProcessStartInfo("dotnet", sprintf "build %s -c Debug --nologo" SqlprojEmitter.fileName)
+        psi.WorkingDirectory <- dir
+        psi.RedirectStandardOutput <- true
+        psi.RedirectStandardError <- true
+        psi.UseShellExecute <- false
+        let proc =
+            match Process.Start psi with
+            | null -> failwith "could not start `dotnet`"
+            | p -> p
+        let stdout = proc.StandardOutput.ReadToEnd()
+        let stderr = proc.StandardError.ReadToEnd()
+        proc.WaitForExit()
+        let combined = stdout + "\n" + stderr
+        if combined.Contains "Could not resolve SDK" || combined.Contains "Unable to resolve 'Microsoft.Build.Sql" then
+            printfn "SKIP refactorlog .sqlproj build: Microsoft.Build.Sql SDK not restorable in this environment."
+        else
+            Assert.True(proc.ExitCode = 0, sprintf "dotnet build of the refactorlog-bearing .sqlproj failed (exit %d):\n%s" proc.ExitCode combined)
+            let dacpac = Path.Combine(dir, "bin", "Debug", "ProjectionCatalog.dacpac")
+            Assert.True(File.Exists dacpac, sprintf "expected a built .dacpac at %s\nbuild output:\n%s" dacpac combined)
+            // The .dacpac is a zip; the refactorlog must be embedded as
+            // refactor.xml — the deploy-planner input that converts a rename
+            // into sp_rename. Absence = the item silently didn't pair (the
+            // exact failure mode this witness exists to catch).
+            use zip = System.IO.Compression.ZipFile.OpenRead dacpac
+            let hasRefactor =
+                zip.Entries |> Seq.exists (fun e -> e.Name.Equals("refactor.xml", StringComparison.OrdinalIgnoreCase))
+            Assert.True(hasRefactor, sprintf "the built .dacpac carries no refactor.xml — the RefactorLog item did not pair.\nEntries: %s\nBuild output:\n%s" (zip.Entries |> Seq.map (fun e -> e.FullName) |> String.concat ", ") combined)
     finally
         try Directory.Delete(dir, true) with _ -> ()
 

--- a/sidecar/projection/tests/Projection.Tests/SsdtArtifactEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtArtifactEmitterTests.fs
@@ -67,13 +67,13 @@ let ``PostDeploy: renderInlined concatenates lane SQL under banners and skips em
 
 [<Fact>]
 let ``Sqlproj: emit is well-formed XML pinning the Microsoft.Build.Sql SDK`` () =
-    let root = rootOf (SqlprojEmitter.emit [ "Data/StaticSeeds.sql"; "Data/MigrationData.sql" ] true)
+    let root = rootOf (SqlprojEmitter.emit [ "Data/StaticSeeds.sql"; "Data/MigrationData.sql" ] true false)
     Assert.Equal("Project", root.Name.LocalName)
     Assert.Equal("Microsoft.Build.Sql/" + SqlprojEmitter.sdkVersion, attrVal root "Sdk")
 
 [<Fact>]
 let ``Sqlproj: data lanes are None + removed from the Build glob; post-deploy is PostDeploy; schema .sql not enumerated`` () =
-    let xml = SqlprojEmitter.emit [ "Data/StaticSeeds.sql"; "Data/MigrationData.sql" ] true
+    let xml = SqlprojEmitter.emit [ "Data/StaticSeeds.sql"; "Data/MigrationData.sql" ] true false
     let root = rootOf xml
     // post-deploy script is the conventional PostDeploy item
     Assert.Equal<string list>([ PostDeployEmitter.fileName ], includeValues root "PostDeploy" "Include")
@@ -93,5 +93,21 @@ let ``Sqlproj: data lanes are None + removed from the Build glob; post-deploy is
 
 [<Fact>]
 let ``Sqlproj: emit without a post-deploy omits the PostDeploy item`` () =
-    let root = rootOf (SqlprojEmitter.emit [] false)
+    let root = rootOf (SqlprojEmitter.emit [] false false)
     Assert.Empty(root.Descendants(XName.Get "PostDeploy"))
+
+// G3 (DECISIONS 2026-07-16) — the store-threaded run's `.sqlproj` carries the
+// `RefactorLog` item naming the bundle's accumulated document; a store-less
+// project carries none (byte-identical to the pre-G3 shape).
+
+[<Fact>]
+let ``Sqlproj: with a refactorlog the project carries the RefactorLog item (G3)`` () =
+    let root = rootOf (SqlprojEmitter.emit [] false true)
+    Assert.Equal<string list>(
+        [ SqlprojEmitter.refactorLogFileName ],
+        includeValues root "RefactorLog" "Include")
+
+[<Fact>]
+let ``Sqlproj: without a refactorlog the project carries NO RefactorLog item`` () =
+    let root = rootOf (SqlprojEmitter.emit [ "Data/StaticSeeds.sql" ] true false)
+    Assert.Empty(root.Descendants(XName.Get "RefactorLog"))

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
@@ -1423,3 +1423,21 @@ let ``WP-17d: an InsertRow temporal cell renders as the explicit CAST form (Scri
     Assert.Contains("CAST ('08:30:00' AS TIME (7))", sql)
     // And never the pre-WP-17 bare quoted forms.
     Assert.DoesNotContain("'2026-05-10 12:30:00.0000000',", sql)
+
+[<Fact>]
+let ``WP-17e: an InsertRow Text cell with control chars renders CHAR() concatenation — no raw control bytes in the SQL`` () =
+    let table = mkTableId "dbo" "OSUSR_T_NOTE"
+    let cells : CellValue list =
+        [ { Column = "ID";   Type = Integer; Raw = Some "1" }
+          { Column = "BODY"; Type = Text;    Raw = Some "line1\r\nline2\tend" } ]
+    let sql = Render.toText [ Statement.InsertRow (table, cells) ]
+    Assert.Contains("CHAR(13)", sql)
+    Assert.Contains("CHAR(10)", sql)
+    Assert.Contains("CHAR(9)", sql)
+    Assert.Contains("N'line1'", sql)
+    // The seed text carries NO raw control bytes inside the literal —
+    // the exact property WP-17(e) exists for (diff review,
+    // byte-determinism, single-line literals).
+    Assert.DoesNotContain("line1\r", sql)
+    Assert.DoesNotContain("\nline2", sql)
+    Assert.DoesNotContain("line2\t", sql)

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
@@ -1321,3 +1321,83 @@ let ``emitted index names: the identifier budget caps an over-long generated nam
         Assert.True(name.Length <= 128, sprintf "expected budget-capped name; got %d chars" name.Length)
         Assert.StartsWith("IX_Long_", name)
     | other -> failwithf "expected one index, got %A" other
+
+// ---------------------------------------------------------------------------
+// G6 (DECISIONS 2026-07-16) — CREATE SCHEMA emission for non-dbo estates.
+// Every distinct non-dbo schema the emitted estate references (kinds +
+// sequences) yields one `CREATE SCHEMA` at the HEAD of the statement stream
+// and one `Schemas/<name>.sql` bundle file; dbo-only estates emit nothing
+// (the byte-identical default). Case-variant spellings dedupe to one schema
+// (SQL Server CI semantics); `dbo` never emits regardless of case.
+// ---------------------------------------------------------------------------
+
+let private nonDboKind (schema: string) (label: string) : Kind =
+    { Kind.create (kindKey [ label ]) (mkName label) (mkTableId schema ("OSUSR_G6_" + label.ToUpperInvariant()))
+        [ { Attribute.create (attrKey [ label; "Id" ]) (mkName "Id") Integer with
+              Column = ColumnRealization.create "ID" false |> Result.value
+              IsPrimaryKey = true
+              IsMandatory = true } ]
+      with References = [] }
+
+[<Fact>]
+let ``G6: nonDboSchemas excludes dbo (any case), dedupes case-variants, includes sequence schemas, sorts ordinally`` () =
+    let seqIR : Sequence =
+        { SsKey = testKey "Seq_Billing"
+          Name = mkName "InvoiceSeq"
+          Schema = "billing"
+          DataType = "INT"
+          StartValue = None; Increment = None; Minimum = None; Maximum = None
+          IsCycleEnabled = false; CacheMode = SequenceCacheMode.Unspecified; CacheSize = None }
+    let catalog : Catalog =
+        { Modules =
+            [ IRBuilders.mkModule (modKey "G6") (mkName "G6")
+                [ nonDboKind "audit" "ChangeLog"
+                  nonDboKind "AUDIT" "ChangeLogTwin"   // case-variant of audit — ONE schema
+                  nonDboKind "DBO" "PlainTwin"         // dbo in caps — never emitted
+                  nonDboKind "dbo" "Plain" ] ]
+          Sequences = [ seqIR ] }
+    Assert.Equal<string list>([ "AUDIT"; "billing" ] |> List.sort, SsdtDdlEmitter.nonDboSchemas catalog |> List.sort)
+    // Deterministic: the ordinal sort puts "AUDIT" (uppercase) first and the
+    // case-insensitive dedupe keeps that first spelling.
+    Assert.Equal<string list>([ "AUDIT"; "billing" ], SsdtDdlEmitter.nonDboSchemas catalog)
+
+[<Fact>]
+let ``G6: a dbo-only catalog emits NO schema statements and NO schema files (byte-identical default)`` () =
+    Assert.Empty(SsdtDdlEmitter.schemaStatements sampleCatalog)
+    Assert.Empty(SsdtDdlEmitter.schemaFiles sampleCatalog)
+    // And the flat stream carries no CreateSchema.
+    let stream = SsdtDdlEmitter.statements (enrich sampleCatalog)
+    Assert.Empty(stream |> Seq.filter (function Statement.CreateSchema _ -> true | _ -> false))
+
+[<Fact>]
+let ``G6: the statement stream opens with CREATE SCHEMA before every other object`` () =
+    let catalog : Catalog =
+        { Modules = [ IRBuilders.mkModule (modKey "G6") (mkName "G6") [ nonDboKind "audit" "ChangeLog" ] ]
+          Sequences = [] }
+    let stream = SsdtDdlEmitter.statements (enrich catalog) |> List.ofSeq
+    match stream with
+    | Statement.CreateSchema "audit" :: _ -> ()
+    | other -> failwithf "expected the stream to open with CreateSchema \"audit\"; got head %A" (List.tryHead other)
+    // And exactly one schema statement for the one non-dbo schema.
+    Assert.Equal(1, stream |> List.filter (function Statement.CreateSchema _ -> true | _ -> false) |> List.length)
+
+[<Fact>]
+let ``G6: schemaFiles emit Schemas/<name>.sql with the ScriptDom-rendered CREATE SCHEMA body`` () =
+    let catalog : Catalog =
+        { Modules = [ IRBuilders.mkModule (modKey "G6") (mkName "G6") [ nonDboKind "audit" "ChangeLog" ] ]
+          Sequences = [] }
+    match SsdtDdlEmitter.schemaFiles catalog with
+    | [ (relPath, body) ] ->
+        Assert.Equal("Schemas/audit.sql", relPath)
+        Assert.Contains("CREATE SCHEMA [audit]", body)
+        Assert.Contains("GO", body)
+    | other -> failwithf "expected exactly one schema file; got %A" (List.map fst other)
+
+[<Fact>]
+let ``G6: the dacpac arm accepts a non-dbo catalog (schema objects join the declarative model)`` () =
+    let catalog : Catalog =
+        { Modules = [ IRBuilders.mkModule (modKey "G6") (mkName "G6") [ nonDboKind "audit" "ChangeLog" ] ]
+          Sequences = [] }
+    match DacpacEmitter.emit (enrich catalog) with
+    | FsResult.Ok bytes -> Assert.True(bytes.Length > 0, "dacpac bytes present")
+    | FsResult.Error e -> failwithf "expected the non-dbo dacpac to build; got %A" e

--- a/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SsdtDdlEmitterTests.fs
@@ -1401,3 +1401,25 @@ let ``G6: the dacpac arm accepts a non-dbo catalog (schema objects join the decl
     match DacpacEmitter.emit (enrich catalog) with
     | FsResult.Ok bytes -> Assert.True(bytes.Length > 0, "dacpac bytes present")
     | FsResult.Error e -> failwithf "expected the non-dbo dacpac to build; got %A" e
+
+// ---------------------------------------------------------------------------
+// WP-17(d) (DECISIONS 2026-07-16) — the DATA-plane temporal literal carries
+// V1's explicit CAST form through the ScriptDom boundary (the golden
+// ScalarGallery DEFAULTs pin the DDL-plane form; this pins the row-value
+// plane the MERGE/INSERT lanes ride).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``WP-17d: an InsertRow temporal cell renders as the explicit CAST form (ScriptDom plane)`` () =
+    let table = mkTableId "dbo" "OSUSR_T_EVENT"
+    let cells : CellValue list =
+        [ { Column = "ID";          Type = Integer;  Raw = Some "1" }
+          { Column = "OCCURRED_ON"; Type = DateTime; Raw = Some "2026-05-10 12:30:00.0000000" }
+          { Column = "DUE_ON";      Type = Date;     Raw = Some "2026-05-10" }
+          { Column = "ALARM_AT";    Type = Time;     Raw = Some "08:30:00" } ]
+    let sql = Render.toText [ Statement.InsertRow (table, cells) ]
+    Assert.Contains("CAST ('2026-05-10 12:30:00.0000000' AS DATETIME2 (7))", sql)
+    Assert.Contains("CAST ('2026-05-10' AS DATE)", sql)
+    Assert.Contains("CAST ('08:30:00' AS TIME (7))", sql)
+    // And never the pre-WP-17 bare quoted forms.
+    Assert.DoesNotContain("'2026-05-10 12:30:00.0000000',", sql)

--- a/sidecar/projection/tests/Projection.Tests/WithDiagnosticsBuildersTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WithDiagnosticsBuildersTests.fs
@@ -64,6 +64,7 @@ let ``Slice ζ: buildMergeStatement returns Diagnostics with empty entries today
             CdcAware = false
             DeleteScope = None
             RowSource = MergeRowSource.InlineValues
+            CastCompareColumns = Map.empty
         }
     let result = ScriptDomBuild.buildMergeStatement args
     Assert.Empty result.Entries
@@ -112,6 +113,7 @@ let private mergeArgs (deleteScope: DeleteScope option) : MergeBuildArgs =
         CdcAware    = false
         DeleteScope = deleteScope
         RowSource   = MergeRowSource.InlineValues
+        CastCompareColumns = Map.empty
     }
 
 // ---------------------------------------------------------------------------
@@ -364,3 +366,34 @@ let ``AC-D7/AC-G4: a multi-term DeleteScope folds its terms with AND`` () =
     Assert.Contains(
         "WHEN NOT MATCHED BY SOURCE AND [Target].[Tenant] = 7 AND [Target].[Name] = N'a' THEN DELETE",
         normalized)
+
+// ---------------------------------------------------------------------------
+// WP-17(c) (DECISIONS 2026-07-16) — an `xml` column has no `<>` operator; its
+// change-detect compare CASTs both sides to NVARCHAR(MAX) (content-level).
+// Without the guard, a CDC-enabled xml-bearing kind emitted an uncompilable
+// `Target.[c] <> Source.[c]` — the S5 latent MERGE error.
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``WP-17c: a cast-compare column's change-detect arm CASTs both sides; plain columns stay bare`` () =
+    let args : MergeBuildArgs =
+        {
+            Target      = mkTable "dbo" "Doc"
+            AllColumns  = [ "Id"; "Payload"; "Name" ]
+            PkColumns   = [ "Id" ]
+            UpdColumns  = [ "Payload"; "Name" ]
+            Rows        =
+                [ [ SqlLiteral.ofRaw Integer (Some "1")
+                    SqlLiteral.ofRaw Text (Some "<a/>")
+                    SqlLiteral.ofRaw Text (Some "x") ] ]
+            CdcAware    = true
+            DeleteScope = None
+            RowSource   = MergeRowSource.InlineValues
+            CastCompareColumns = Map.ofList [ ("Payload", CastToNVarCharMax) ]
+        }
+    let sql = renderMerge args
+    Assert.Contains("CAST ([Target].[Payload] AS NVARCHAR (MAX)) <> CAST ([Source].[Payload] AS NVARCHAR (MAX))", sql)
+    Assert.Contains("[Target].[Name] <> [Source].[Name]", sql)
+    Assert.DoesNotContain("[Target].[Payload] <> [Source].[Payload]", sql)
+    // The null arms stay bare (IS NULL is legal on xml).
+    Assert.Contains("[Target].[Payload] IS NULL", sql)


### PR DESCRIPTION
The two eject-blockers from the remediation plan of record (`SSDT_HANDOFF_REVIEW_PACKET.md` §8, gaps ranked #1 and #8) — the items the packet says must close before eject.

## G3 — the accumulated refactorlog reaches the bundle + `.sqlproj`, in DEPLOYED vocabulary (`1adc8d02`)

A store-threaded publish (`full-export --lifecycle-store`, the `publish` flow with an env `store`, the `--load` combined verb) now writes `ProjectionCatalog.refactorlog` — the timeline's accumulated rename document (prior chain ⊕ this run's displacement, deduped by `OperationKey`, rendered at the episode's `At`) — inside the ATOMIC bundle, and `emission.sqlproj: true` adds the explicit `<RefactorLog>` item so `dotnet build` embeds `refactor.xml` into the `.dacpac`. Presence ⟺ store-threaded; store-less bundles stay byte-identical.

**The load-bearing finding:** the pre-existing (tested-but-unwired) emitter spoke the *catalog plane* — `ElementName` rendered OSSYS physical names (`[dbo].[OSUSR_S1S_CUSTOMER]`), which a logically-emitted deployed estate can never match. DacFx would have silently skipped every operation and DROP+CREATEd anyway: G3 "closed" but wrong. `RefactorLogEmitter.emitDeployed` projects both sides of every rename through the emission passes' own name rules (validity-by-construction via `TableName`/`ColumnName.create`; operator-`tableRenames` kinds suppress — both config forms rewrite `Kind.Physical`, via `Compose.operatorRenamedKinds`; FK channel named-absent until WP-7 since deployed FK names are synthesized; `OperationKey` derivations unchanged, so dedup identity holds).

**Sequencing:** the store leg split — `loadStorePrior` (ONE durable load + the edge fold, hoisted BEFORE the emission; S51/S53 hold) → the core renders the accumulated document into the bundle → `runStoreLegOnPrior` records the episode after the bundle lands. Named consequence: a malformed store now refuses *before* the bundle (its content depends on the store); record-phase failures still surface after, as before.

**DacFx-proven end-to-end** (`RefactorLogPublishCanaryTests`, Docker): full-export A → `dotnet build` → `DacServices.Deploy` → live rows under `[dbo].[User]` → store-threaded full-export B (rename to `Client`) → build → **incremental publish with the default `BlockOnPossibleDataLoss = true` armed** → publish succeeds, rows survive under `[dbo].[Client]` with IDENTITY intact, old table gone. `sp_rename`, not DROP+CREATE, through the operator's real path.

**Named residuals** (DECISIONS 2026-07-16 — G3): operator `tableRenames` never touch `Kind.Name`, so the deployed rename they cause is invisible to `CatalogDiff`'s Name-keyed channel (re-open: a `Physical`-change diff channel; the packet's H3 row corrected accordingly); the eject package still carries refs, not the rendered terminal document; file-sourced models cannot thread rename identity (6.A.7 — the witnesses seed the store as the identity carrier).

## G6 — `CREATE SCHEMA` objects emitted (`db3bd2f1`)

`Statement.CreateSchema` (closed-DU expansion; ScriptDom `CreateSchemaStatement`) opens the catalog-wide statement stream; the bundle gains one `Schemas/<name>.sql` per non-dbo schema beside `Modules/**` (the SDK's default Build glob compiles them); the dacpac arm admits schema objects into the declarative model; the deploy executor handles the new DDL class. Derivation: distinct schemas across kinds AND sequences, minus `dbo` in any case, deduped case-insensitively (CI collation semantics, deterministic spelling). A non-dbo bundle now real-SDK-builds to a `.dacpac` (pre-G6: unresolved-schema SQL71501, hand-authoring required). dbo-only estates are byte-identical everywhere — exactly ONE golden scenario moved (master gains the 4-line `CREATE SCHEMA [audit]` stream head + `Schemas/audit.sql`; additive, diff-verified). Runbook §11 step 4 no longer asks the receiving team to hand-author schemas.

## Gates

- Pure pool (`scripts/test.sh fast`): **4381 passed / 0 failed** (+21 new witnesses over the WP-3 tip's 4360).
- Docker pool (`scripts/test.sh docker`): **315 passed / 0 failed** (was 314; +1 = the new `RefactorLogPublishCanaryTests`, which ran for real against the warm container — no soft-skip). Honesty note: two pools accidentally ran concurrently (a stopped launcher's detached test tree survived and raced the relaunch); one completed 315/315, the other's single failure (`AC-X8`, a CDC-meter canary — the documented deadlock/resource-under-load family) re-runs green focused on the quiet host, as does the perf-gate operator-reality canary.
- The gated real-SDK build witnesses ran for real (no soft-skip): the `RefactorLog` item + file pair builds clean under Microsoft.Build.Sql/2.2.0 and `refactor.xml` lands in the dacpac; the non-dbo bundle builds.

Both commits follow the campaign discipline: code + witnesses + golden re-record (explained) + DECISIONS entry + packet tick, one gap per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
