### PR TITLE
Profiler: fix temporal decimal overflow (variance in double)

### DIFF
--- a/sidecar/projection/src/Projection.Core/ProfileDerivation.fs
+++ b/sidecar/projection/src/Projection.Core/ProfileDerivation.fs
@@ -169,6 +169,74 @@ module ProfileDerivation =
                         HasDuplicates        = hasDuplicates
                         IsPresentButInactive = isPresentButInactive }))
 
+    /// Build a moments-enriched `NumericDistribution` from a `decimal`
+    /// sample. **The second moment is accumulated in `double`, not
+    /// `decimal`, deliberately.** Variance sums SQUARED deviations, and a
+    /// squared large-magnitude scalar overflows `decimal` (max ≈7.9e28)
+    /// long before `double` (max ≈1.8e308): a `DateTime` tick deviation of
+    /// ~1 year (≈3.2e14) squares to ≈1e29 and threw `Value was either too
+    /// large or too small for a Decimal.` in the all-decimal path once K2
+    /// widened the numeric gate to tick-encoded temporal evidence
+    /// (DECISIONS 2026-07-18, the Twin). Any large-magnitude column
+    /// (e.g. a wide `BigInt`) has the same latent overflow; ticks merely
+    /// exposed it. The VALUES — Min/Max/percentiles/Mean — stay
+    /// `decimal`-exact (every single value fits `decimal` with room to
+    /// spare; only the squared AGGREGATE needs the wider domain), and σ
+    /// (bounded by the value range) fits back into `decimal`. StdDev
+    /// already flowed through `sqrt (float …)`, so no new nondeterminism
+    /// is introduced. Shared by `deriveNumericDistributions` and
+    /// `deriveForeignKeyCardinalities` (single-axis-divergent → one
+    /// parameterized algorithm, A40); callers apply the sample-size floor
+    /// before calling.
+    let private buildNumericDistribution
+        (key: SsKey)
+        (values: decimal[])
+        : NumericDistribution option =
+        if Array.isEmpty values then None
+        else
+            let sorted = values |> Array.sort
+            let min_  = sorted.[0]
+            let max_  = sorted.[sorted.Length - 1]
+            let mean  = (values |> Array.sum) / decimal values.Length
+            // Population standard deviation: sqrt(mean of squared
+            // deviations), accumulated in `double` — see the docstring:
+            // squaring tick-scale deviations overflows `decimal`; `double`
+            // carries the aggregate and σ fits back into `decimal`.
+            let meanF = float mean
+            let variance =
+                values
+                |> Array.sumBy (fun v ->
+                    let d = float v - meanF
+                    d * d)
+                |> fun s -> s / float values.Length
+            let stdDev = decimal (sqrt variance)
+            let sampleSize = int64 values.Length
+            let probeStatus = ProbeStatus.observed sampleSize
+            let baseResult =
+                NumericDistribution.create
+                    key
+                    min_
+                    (Statistics.percentileCont sorted 0.25M)
+                    (Statistics.percentileCont sorted 0.50M)
+                    (Statistics.percentileCont sorted 0.75M)
+                    (Statistics.percentileCont sorted 0.95M)
+                    (Statistics.percentileCont sorted 0.99M)
+                    max_ sampleSize probeStatus
+            let momentsResult =
+                StatisticalMoments.create mean stdDev
+            let enriched =
+                baseResult
+                |> Result.bind (fun dist ->
+                    momentsResult
+                    |> Result.bind (fun m ->
+                        NumericDistribution.withMoments m dist))
+            match enriched with
+            | Ok d    -> Some d
+            | Error _ ->
+                match baseResult with
+                | Ok d    -> Some d
+                | Error _ -> None
+
     /// Derive `NumericDistribution` per numeric attribute. Pure
     /// F# computation over cached column values:
     ///   - Min/Max/Mean via Array.min/max/average (decimal)
@@ -222,48 +290,7 @@ module ProfileDerivation =
                         // `NumericDistribution.sampleSizeFloor` (Profile.fs), not a
                         // re-inlined `5L`.
                         if sampleSize < NumericDistribution.sampleSizeFloor then None
-                        else
-                            let sorted = nonNullValues |> Array.sort
-                            let min_  = sorted.[0]
-                            let max_  = sorted.[sorted.Length - 1]
-                            let mean  =
-                                (nonNullValues |> Array.sum)
-                                    / decimal nonNullValues.Length
-                            // Population standard deviation:
-                            // sqrt(mean of squared deviations).
-                            let variance =
-                                nonNullValues
-                                |> Array.sumBy (fun v ->
-                                    let d = v - mean
-                                    d * d)
-                                |> fun s -> s / decimal nonNullValues.Length
-                            let stdDev =
-                                decimal (sqrt (float variance))
-                            let probeStatus = ProbeStatus.observed sampleSize
-                            let baseResult =
-                                NumericDistribution.create
-                                    attr.SsKey
-                                    min_
-                                    (Statistics.percentileCont sorted 0.25M)
-                                    (Statistics.percentileCont sorted 0.50M)
-                                    (Statistics.percentileCont sorted 0.75M)
-                                    (Statistics.percentileCont sorted 0.95M)
-                                    (Statistics.percentileCont sorted 0.99M)
-                                    max_ sampleSize probeStatus
-                            let momentsResult =
-                                StatisticalMoments.create mean stdDev
-                            let enriched =
-                                baseResult
-                                |> Result.bind (fun dist ->
-                                    momentsResult
-                                    |> Result.bind (fun m ->
-                                        NumericDistribution.withMoments m dist))
-                            match enriched with
-                            | Ok d    -> Some d
-                            | Error _ ->
-                                match baseResult with
-                                | Ok d -> Some d
-                                | Error _ -> None))
+                        else buildNumericDistribution attr.SsKey nonNullValues))
 
     /// Default vocabulary cap for categorical distributions
     /// derived from the cache. Slice 7 wires this through
@@ -843,48 +870,10 @@ module ProfileDerivation =
                     | None -> None
                     | Some sCol ->
                         let nonNullCount, countsPerParent = nonNullGroupCounts sCol.Values
-                        if nonNullCount < 5 then None
+                        if nonNullCount < 5 || countsPerParent.Length < 5 then None
                         else
-                            if countsPerParent.Length < 5 then None
-                            else
-                                let sorted = countsPerParent |> Array.sort
-                                let min_ = sorted.[0]
-                                let max_ = sorted.[sorted.Length - 1]
-                                let mean =
-                                    (countsPerParent |> Array.sum) / decimal countsPerParent.Length
-                                let variance =
-                                    countsPerParent
-                                    |> Array.sumBy (fun v ->
-                                        let d = v - mean
-                                        d * d)
-                                    |> fun s -> s / decimal countsPerParent.Length
-                                let stdDev = decimal (sqrt (float variance))
-                                let sampleSize = int64 countsPerParent.Length
-                                let probeStatus = ProbeStatus.observed sampleSize
-                                let baseResult =
-                                    NumericDistribution.create
-                                        reference.SsKey
-                                        min_
-                                        (Statistics.percentileCont sorted 0.25M)
-                                        (Statistics.percentileCont sorted 0.50M)
-                                        (Statistics.percentileCont sorted 0.75M)
-                                        (Statistics.percentileCont sorted 0.95M)
-                                        (Statistics.percentileCont sorted 0.99M)
-                                        max_ sampleSize probeStatus
-                                let momentsResult =
-                                    StatisticalMoments.create mean stdDev
-                                let enriched =
-                                    baseResult
-                                    |> Result.bind (fun dist ->
-                                        momentsResult
-                                        |> Result.bind (fun m ->
-                                            NumericDistribution.withMoments m dist))
-                                match enriched with
-                                | Ok dist -> Some (ForeignKeyCardinality.create reference.SsKey dist)
-                                | Error _ ->
-                                    match baseResult with
-                                    | Ok dist -> Some (ForeignKeyCardinality.create reference.SsKey dist)
-                                    | Error _ -> None))
+                            buildNumericDistribution reference.SsKey countsPerParent
+                            |> Option.map (ForeignKeyCardinality.create reference.SsKey)))
 
     [<Literal>]
     let private defaultFkSelectivityVocabularyLimit = 50

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -523,6 +523,43 @@ let ``K2: the derivation gate captures DateTime columns as tick decimals`` () =
     Assert.Equal(decimal K2Fixture.lo.Ticks, d.Min)
     Assert.Equal(decimal (K2Fixture.lo.AddDays(9.0).Ticks), d.Max)
 
+[<Fact>]
+let ``K2: a multi-decade DateTime column derives σ in double instead of overflowing decimal`` () =
+    // Regression (profiler temporal-decimal overflow): the K2 gate encodes
+    // DateTime as tick decimals, and the variance step squares deviations.
+    // A tick deviation of ~1 year (≈3.2e14) squares to ≈1e29 — past
+    // decimal's ≈7.9e28 ceiling — so any estate whose dates span more than
+    // ~a year threw "Value was either too large or too small for a Decimal."
+    // during profiling, before any artifact was emitted. The second moment
+    // now accumulates in double; the VALUES stay decimal-exact.
+    let dto (d: System.DateTime) = System.DateTimeOffset(d, System.TimeSpan.Zero)
+    let minDt = System.DateTime(1985, 6, 15)
+    let maxDt = System.DateTime(2024, 6, 15)
+    let idValues = System.Collections.Generic.List<CachedValue>()
+    let onValues = System.Collections.Generic.List<CachedValue>()
+    // 40 rows, one per year 1985..2024: deviations of ~2 decades in ticks,
+    // whose squares (and their sum) far exceed decimal's range but sit
+    // comfortably inside double's.
+    for i in 0 .. 39 do
+        idValues.Add(CachedValue.IntValue (int64 i))
+        onValues.Add(CachedValue.DateValue (dto (System.DateTime(1985 + i, 6, 15))))
+    let cached =
+        EvidenceCache.cachedKindOfColumns Map.empty K2Fixture.kind 40L [| idValues; onValues |]
+        |> Option.defaultWith (fun () -> failwith "cachedKindOfColumns returned None for an attribute-bearing kind")
+    let cache : EvidenceCache = { Kinds = Map.ofList [ K2Fixture.eventKey, cached ] }
+    // The all-decimal variance path raised OverflowException here.
+    let dists = ProfileDerivation.deriveNumericDistributions cache K2Fixture.catalog
+    let d = dists |> List.find (fun d -> d.AttributeKey = K2Fixture.eventOn)
+    Assert.Equal(decimal minDt.Ticks, d.Min)
+    Assert.Equal(decimal maxDt.Ticks, d.Max)
+    match d.Moments with
+    | Some m ->
+        // σ populated, positive, and fits back into decimal (bounded by the
+        // value range — nowhere near decimal's ceiling).
+        Assert.True(m.StdDev > 0M, "a multi-decade span has positive standard deviation")
+        Assert.True(m.StdDev < decimal System.DateTime.MaxValue.Ticks, "σ fits within decimal")
+    | None -> Assert.Fail "Expected Moments populated for a 40-row DateTime column"
+
 // ---------------------------------------------------------------------------
 // K1b (DECISIONS 2026-07-18, the Twin) — pool augmentation: pinned keys ride
 // after the minted pool, referenceable by child FK draws, generation


### PR DESCRIPTION
## Problem

A dev publish failed during the **profile stage** with `Value was either too large or too small for a Decimal.`, before any artifact was emitted.

Root cause: **K2** (DECISIONS 2026-07-18, the Twin) widened the numeric-evidence gate to `DateTime`/`Date` columns, encoded as tick decimals. The variance step squares deviations from the mean — a tick deviation of ~1 year (~3.2e14) squares to ~1e29, past `System.Decimal`'s ~7.9e28 ceiling. Any estate whose dates span more than ~a year overflows.

## Diagnosis

The defect is **arithmetic-domain, not type-modeling**. `decimal` is the wrong domain for a sum of squared deviations of *any* large-magnitude scalar (a wide `BigInt` column overflows the same step; ticks merely exposed it). Temporal-as-tick-decimal is a wanted design — the σ sampler depends on it — and the VALUES (Min/Max/percentiles/Mean) all fit `decimal` exactly. Only the squared second moment overflows, and it's enrichment metadata the temporal sampler never even reads.

## Fix

- Extracted `buildNumericDistribution`, which accumulates variance/StdDev in **`double`** (max ~1.8e308) and keeps values `decimal`-exact. σ, bounded by the value range, fits back into `decimal`. StdDev already flowed through `sqrt(float …)`, so no new nondeterminism.
- Routed **both** variance sites through it — `deriveNumericDistributions` (the failing path) and `deriveForeignKeyCardinalities` (the identical latent pattern) — per the A40 "single-axis-divergent → one parameterized algorithm" discipline.

## Tests

- New regression: a 40-row multi-decade `DateTime` column that raised `OverflowException` on the all-decimal path now derives a finite positive σ.
- Pure pool green: `SyntheticDataTests` 36/36; `AttributeDistribution` + `EvidenceCacheDerivation` 62/62. `Mean` stays decimal-exact (FK-cardinality `Mean = 2M` assertion unaffected).

## Follow-up (not in this PR)

A short `DECISIONS.md` amendment naming the `decimal`→`double` second-moment domain split would be the house move for this kernel seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)