### PR TITLE
fidelity.json recommendation layer: evidence → interpretation → action → lever

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -29608,3 +29608,77 @@ safely requires first confirming where the estate captures operational evidence 
 wiring `GrantAwareness` into that same path — a focused evidence-plumbing slice that deserves
 its own session rather than the tail of a long one. The design above is the whole of it; only
 the capture wiring is open.
+
+## 2026-07-18 — The fidelity recommendation layer: violations carry the decision they open; two metadata-interpretation corrections land with it
+
+**Status:** ADOPTED (operator assignment 2026-07-18 — "turn those facts into operator
+decisions … evidence → interpretation → suggested action → config knob or cleanup path";
+online references adjudicate the model-vs-deployed authority question).
+
+**Context.** A dev-estate publish read `fidelity.json` and found it stating facts without
+moves: 131 duplicate findings across 60 entities, 13 required-column NULL violations, 2 FK
+orphan findings, and length-overflow findings of the shape "observed 5, declared 0". The
+model-read notices separately named nullability / text-width / Unicode / decimal-precision
+divergences between the logical model and the deployed schema, each ending at "the engine
+emits the X value" with no reading of what the operator should do about it.
+
+**The platform ground (researched, cited in code comments).** Four OutSystems 11 references
+resolve what is drift and what is the platform's own contract: (1) *Is Mandatory is a
+run-time validation only* — database constraints are created for primary keys and reference
+attributes, so mandatory-over-nullable is the deployment shape of every estate, not drift;
+(2) *an Ignore delete rule creates no foreign-key constraint* — orphans under an Ignore
+reference accumulate by design; (3) *Decimal storage takes precision and scale from the
+Length and Decimals properties* (Service-Studio defaults 37 and 8) — the digit budget lives
+in OSSYS `Length`; (4) *Text ≤ 2000 deploys bounded, above it `nvarchar(max)`*. A fifth,
+Microsoft-side: a narrowing publish is blocked at deploy while data exceeds the declared
+shape (the DacFx data-loss gate) — the reason deployed-authoritative is the standing default
+before cutover, and model-authority is a tightening RULING taken with profile evidence.
+
+**Decision.**
+1. **Every `fidelity.json` data violation carries a typed `Recommendation`** —
+   interpretation (stative, grounded), action (bare imperative), lever (a closed DU:
+   `ReviewRemediation` → the `manifest.remediation.sql` block; `EditConfig` → a
+   `SuggestedConfig` carrying the overlay vocabulary verbatim
+   (`$.policy.tightening.interventions[+]`, `keepNullable` / `keepUntracked` entries the
+   tightening binder accepts — A44 both ways); `ReviewModel`; `ReviewConstraint`). Per-kind
+   dispositions: NOT-NULL → backfill at or below the repair band, `keepNullable` above it;
+   uniqueness → constraint review, never automatic cleanup; orphans → cleanup at or below
+   the band with the interpretation split by `ConstraintState` (`NoDbConstraint` = the
+   Ignore shape), `keepUntracked` above it; overflow → the width ruling (widen or truncate —
+   the D4 discipline). The render states each non-clean category's interpretation and ends
+   on its move; the codec round-trips the nodes; a legacy document parses with
+   `Recommendation = None` and the render falls back to the generic both-arm imperative.
+2. **The repair band's source of truth moves to `ModelFidelity.repairBandDefault`**
+   (Estate aliases it), so the fidelity report's fix-vs-relax arms and the estate board's
+   lanes split on ONE threshold. `composeWithBand` is the full form; `compose` keeps the
+   standing signature under the default.
+3. **Interpretation correction (overflow):** a non-positive declared `Length` declares NO
+   width — the storage lane already read it so (`OssysTypeMapping` treats only positive
+   lengths as `Bounded`); the fidelity overflow gate now agrees. "Observed 5, declared 0"
+   findings were rooted in the reader, not the data.
+4. **Interpretation correction (decimal):** `OssysTypeMapping.tryParse "decimal"` reads
+   precision ← explicit `Precision`, else positive `Length`, else 37; scale defaults to 8 —
+   the platform's own storage contract. The prior invented `(18, 0)` fallback made every
+   standard Decimal diverge from its deployed `decimal(37,8)`, which is exactly the
+   "decimal(18,\*) vs decimal(37,\*)" drift the estate reported. Those storage-divergence
+   notices now fire only on GENUINE divergence.
+5. **Detector-altitude correction (uniqueness):** only single-column unique indexes and a
+   SOLE primary-key attribute are singly unique-backed. Per-column duplicate evidence
+   cannot witness a composite-key violation (each member column may duplicate while the
+   tuple stays distinct) — the column-by-column reading of composite business keys was the
+   131-finding flood. Tuple-grain evidence for DECLARED-unique composite indexes is a named
+   follow-on (`deriveCompositeUniqueCandidates` probes non-unique candidates only today).
+6. **The model-read notices state the authority choice explicitly.** The storage-divergence
+   notice appends the per-posture recommendation (deployed-wins: why, and the tightening
+   path that would change it; forced-BIGINT and cross-category arms name their own moves) in
+   message + metadata; the nullability aggregate grounds itself in the run-time-only
+   contract and points at the fidelity report's per-column recommendations. Emission
+   behavior is UNCHANGED — deployed-authoritative for same-category refinements stands
+   (decision 2 / WP-4b); what changed is that the posture is now stated with its reason.
+
+**Named residuals.** `SqlStorageType.ofPrimitiveType Decimal` still falls back to
+`Decimal (18, 0)` on the storage-evidence-less DDL lane — aligning it to the platform
+default `(37, 8)` re-blesses goldens and is deferred with this trigger: the first
+storage-evidence-less catalog whose emitted decimal width is observed wrong in review.
+Tuple-grain declared-unique composite evidence (point 5) fires when an estate's composite
+duplicates must block a cutover rather than inform a review.

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/MetadataSnapshotRunner.fs
@@ -1261,10 +1261,23 @@ module MetadataSnapshotRunner =
                 let sampleMeta =
                     sample
                     |> List.mapi (fun i col -> sprintf "sample.%d" i, col)
+                // The recommendation layer (2026-07-18): the divergence is
+                // grounded in the platform's own contract — a mandatory
+                // attribute is validated at run time only; database
+                // constraints are created for primary keys and reference
+                // attributes (OutSystems 11, entity-attribute properties /
+                // database constraints) — so mandatory-over-nullable is the
+                // platform's deployment shape on every estate, not drift.
+                // The emitted NOT NULL is therefore a TIGHTENING, and its
+                // data evidence + per-column recommendation live in
+                // fidelity.json (backfill at or below the repair band,
+                // keepNullable above it).
+                let recommendation =
+                    "Publish the tightenings with their fidelity evidence: backfill at or below the repair band, keep the column nullable (keepNullable) above it."
                 [ { DiagnosticEntry.create
                       "adapter:OSSYS" DiagnosticSeverity.Info
                       "adapter.ossys.columnReality.nullabilityDivergence"
-                      (sprintf "%d column(s) diverge on nullability between the logical OSSYS model and the deployed schema (%d logical-mandatory over deployed-nullable, %d logical-nullable over deployed NOT NULL; e.g. %s). A deployed NOT NULL is preserved in the emitted schema (decision 2); a logical-mandatory declaration over a deployed-nullable column emits NOT NULL from the model, and rows that violate it are itemized separately in the data-fidelity diagnostics."
+                      (sprintf "%d column(s) diverge on nullability between the logical OSSYS model and the deployed schema (%d logical-mandatory over deployed-nullable, %d logical-nullable over deployed NOT NULL; e.g. %s). A mandatory attribute is validated by the platform at run time only (database constraints are created for primary keys and references), so logical-mandatory over deployed-nullable is the platform's own deployment shape. A deployed NOT NULL is preserved in the emitted schema (decision 2); a logical-mandatory declaration over a deployed-nullable column emits NOT NULL from the model — a tightening — and the rows that contradict it are itemized in fidelity.json with per-column recommendations (the backfill block, or a keepNullable entry past the repair band)."
                           (List.length diverged)
                           (List.length mandatoryButNullable)
                           (List.length nullableButNotNull)
@@ -1273,7 +1286,8 @@ module MetadataSnapshotRunner =
                           Map.ofList
                               ([ "count", string (List.length diverged)
                                  "logicalMandatoryDeployedNullable", string (List.length mandatoryButNullable)
-                                 "logicalNullableDeployedNotNull", string (List.length nullableButNotNull) ]
+                                 "logicalNullableDeployedNotNull", string (List.length nullableButNotNull)
+                                 "recommendation", recommendation ]
                                @ sampleMeta) } ]
         identityDivergences @ nullabilitySummary
 
@@ -1313,13 +1327,32 @@ module MetadataSnapshotRunner =
                             | _ -> false
                         let sameCategory = SqlStorageType.toPrimitiveType deployed = logicalPt
                         let emitsDeployed = (not isForced) && sameCategory
+                        // The recommendation layer (2026-07-18): the posture
+                        // is stated WITH its reason and the move that would
+                        // change it, so the model-vs-deployed authority
+                        // choice is explicit, never implicit in a bare
+                        // "emits X". Deployed-authoritative is the standing
+                        // default before cutover: live data already occupies
+                        // the deployed shape, and a narrowing publish is
+                        // blocked at deploy while data exceeds the declared
+                        // shape (the data-loss gate) — so model-authority is
+                        // a tightening RULING taken with profile evidence,
+                        // not a drift repair.
+                        let recommendation =
+                            if emitsDeployed then
+                                "Live data already occupies the deployed shape, and a narrowing publish is blocked while the data exceeds the declared shape. Treat the model as authoritative only as a tightening ruling — schedule it with profile evidence — or leave the deployed shape standing."
+                            elif isForced then
+                                "The BIGINT identifier family is a deliberate estate decision; align the deployed column with it, or amend the decision before publishing."
+                            else
+                                "A deployed type outside the declared category is never adopted silently; correct the declared type in the model, or align the deployed column — the divergence stands until one side moves."
                         Some
                             { DiagnosticEntry.create
                                 "adapter:OSSYS" DiagnosticSeverity.Warning
                                 "adapter.ossys.columnReality.storageDivergence"
-                                (sprintf "Column %s (attr %d): the logical OSSYS model maps type '%s' to %A but the deployed schema has %A. The engine emits the %s value."
+                                (sprintf "Column %s (attr %d): the logical OSSYS model maps type '%s' to %A but the deployed schema has %A. The engine emits the %s value. %s"
                                     a.PhysicalCol a.AttrId rawType logicalStorage deployed
-                                    (if emitsDeployed then "DEPLOYED (on-disk precedence)" else "LOGICAL"))
+                                    (if emitsDeployed then "DEPLOYED (on-disk precedence)" else "LOGICAL")
+                                    recommendation)
                               with Metadata =
                                     Map.ofList
                                         [ "attrId", string a.AttrId
@@ -1327,7 +1360,8 @@ module MetadataSnapshotRunner =
                                           "logicalType", rawType
                                           "logicalStorage", sprintf "%A" logicalStorage
                                           "deployedStorage", sprintf "%A" deployed
-                                          "emits", (if emitsDeployed then "deployed" else "logical") ] }
+                                          "emits", (if emitsDeployed then "deployed" else "logical")
+                                          "recommendation", recommendation ] }
                     | _ -> None
                 | _ -> None
             | _ -> None)

--- a/sidecar/projection/src/Projection.Core/OssysTypeMapping.fs
+++ b/sidecar/projection/src/Projection.Core/OssysTypeMapping.fs
@@ -71,11 +71,28 @@ module OssysTypeMapping =
         // arrives intact via the deployed-reflection lane.
         | "date"           -> Some (DateTime, SqlStorageType.DateTime)
         | "time"           -> Some (DateTime, SqlStorageType.DateTime)
+        // Decimal — the platform's own storage contract (Database Data Types,
+        // OutSystems 11): "precision and scale match the Length and Decimals
+        // properties", with Service-Studio defaults Length = 37, Decimals = 8.
+        // OSSYS estates carry the digit budget in `Length` (there is no
+        // `Precision` column on a standard `ossys_Entity_Attr`; the rowset
+        // reader surfaces `Decimals` through the `scale` slot) — so a positive
+        // declared Length IS the precision, and the absent-metadata fallback is
+        // the platform default (37, 8), not an invented (18, 0). Before this
+        // read (2026-07-18), a standard Decimal attribute resolved to
+        // decimal(18, 8) against a deployed decimal(37, 8) — a per-column
+        // storage-divergence notice on every Decimal of the estate, rooted in
+        // the reader, not the estate. An explicit `Precision` (estates that
+        // carry the column, external overrides) still wins verbatim.
         | "decimal"        ->
+            let digits =
+                match precision, length with
+                | Some p, _              -> p
+                | None, Some n when n > 0 -> n
+                | _                      -> 37
             Some
                 (Decimal,
-                 SqlStorageType.Decimal
-                    (Option.defaultValue 18 precision, Option.defaultValue 0 scale))
+                 SqlStorageType.Decimal (digits, Option.defaultValue 8 scale))
         | "currency"       -> Some (Decimal, SqlStorageType.Decimal (37, 8))
         | "double" | "float" -> Some (Decimal, SqlStorageType.Float)
         | "real"           -> Some (Decimal, SqlStorageType.Real)

--- a/sidecar/projection/src/Projection.Pipeline/Estate.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Estate.fs
@@ -275,8 +275,12 @@ module Estate =
     /// 113,000-orphan UPDATE/DELETE is not an operator's afternoon; the
     /// posture (untrack / keep nullable) with its reopen probe is the
     /// honest interim. The default; `readiness.estate.repairBand` overrides
-    /// it (consumed in this wave — A44, never an inert key).
-    let repairBandDefault : int64 = 100_000L
+    /// it (consumed in this wave — A44, never an inert key). Source of truth
+    /// moved to `ModelFidelity.repairBandDefault` (2026-07-18, the
+    /// fidelity-recommendation program): the fidelity report's per-violation
+    /// recommendations split on the SAME band this board's lanes split on,
+    /// so the two surfaces cannot disagree about fix-vs-relax.
+    let repairBandDefault : int64 = ModelFidelity.repairBandDefault
 
     /// The operator-controlled inputs `computeWith` reads beside the
     /// resolved operands (wave A6): the repair band, and the loaded

--- a/sidecar/projection/src/Projection.Pipeline/ModelFidelity.fs
+++ b/sidecar/projection/src/Projection.Pipeline/ModelFidelity.fs
@@ -49,6 +49,58 @@ module ModelFidelity =
     let entityColumnText (ec: EntityColumn) : string =
         System.String.Concat(ec.Entity, ".", ec.Column)
 
+    // -- The recommendation layer (evidence → interpretation → move) --------
+    //
+    // 2026-07-18 (the fidelity-recommendation program): a violation is a
+    // FACT; the operator needs the DECISION it opens. Each violation carries
+    // a typed recommendation — the interpretation its evidence supports, the
+    // next move as a bare imperative, and the lever the move ends on (the
+    // prepared remediation block, a config edit in the overlay vocabulary, a
+    // model correction, or a constraint review). The copy holds THE_VOICE's
+    // twelve rules: stative interpretation, imperative move, no pronouns,
+    // hedged only where genuinely interpretive (rule 4). The platform facts
+    // the interpretations rest on are the OutSystems 11 references: a
+    // mandatory attribute is validated at run time only (database
+    // constraints exist for primary keys and references); an Ignore delete
+    // rule creates no foreign-key constraint; Decimal storage takes its
+    // precision and scale from the Length and Decimals properties.
+
+    /// The lever a recommendation's move ends on. `EditConfig` reuses the
+    /// Core `SuggestedConfig` triple (path + serialized value + note) — the
+    /// same §12 shape the overlay and `suggest-config.json` speak, so the
+    /// config-edit vocabulary stays one vocabulary across artifacts.
+    type RecommendationLever =
+        /// Review the prepared per-finding block in `manifest.remediation.sql`.
+        | ReviewRemediation
+        /// Merge a config edit (the overlay vocabulary: the intervention
+        /// entry the tightening binder accepts, at the interventions path).
+        | EditConfig of SuggestedConfig
+        /// Correct the declaration in the model (the metadata side).
+        | ReviewModel
+        /// Review the declared key itself before touching any data.
+        | ReviewConstraint
+
+    /// One violation's recommendation: what the evidence most plausibly
+    /// means, the next move, and the lever it ends on.
+    type Recommendation =
+        {
+            /// The interpretation the evidence supports — stative, grounded.
+            Interpretation : string
+            /// The next move — a bare imperative (THE_VOICE rule 2).
+            Action         : string
+            /// The lever the move ends on.
+            Lever          : RecommendationLever
+        }
+
+    /// The fix-vs-relax threshold for a data violation: at or below the band
+    /// the prepared repair leads (backfill / cleanup, then the declaration
+    /// deploys); above it the interim relaxation leads (`keepNullable` /
+    /// `keepUntracked`) until the data clears. ONE source of truth for both
+    /// consumers — the per-violation recommendation here and the estate
+    /// board's lane split (`Estate.dataFindingOf`, which aliases this);
+    /// `readiness.estate.repairBand` overrides at the estate surface.
+    let repairBandDefault : int64 = 100_000L
+
     // -- Data violations (the headline section) ----------------------------
 
     /// The four declared-constraint axes the source data can contradict. A
@@ -71,6 +123,11 @@ module ModelFidelity =
         {
             Reference  : EntityColumn
             Kind       : ViolationKind
+            /// The decision this violation opens (the recommendation layer,
+            /// 2026-07-18). Minted at `compose` from the violation's own
+            /// evidence + catalog context; `None` only on a legacy
+            /// `fidelity.json` parsed without recommendation nodes.
+            Recommendation : Recommendation option
         }
 
     /// The four-way rollup category a violation rolls up into (the renderer's
@@ -173,22 +230,31 @@ module ModelFidelity =
     // Aggregation — from a declared Catalog × the profiled evidence.
     // ----------------------------------------------------------------------
 
-    /// Every attribute that backs a UNIQUE index or the PK of its kind — the
-    /// set whose `HasDuplicates` evidence is a real violation (a duplicate in a
-    /// non-unique column is expected, not a contradiction).
+    /// Every attribute whose per-column duplicate evidence WITNESSES a
+    /// uniqueness violation: the sole column of a single-column UNIQUE index /
+    /// PK, or the sole PK attribute of its kind. **Single-column only, by
+    /// altitude** (2026-07-18): a composite unique declaration constrains the
+    /// TUPLE — each member column can carry duplicates while the tuple stays
+    /// distinct — so per-column `HasDuplicates` can never witness a composite
+    /// violation, and reading it as one flooded real estates with findings
+    /// rooted in the detector, not the data (the column-by-column reading of
+    /// a composite business key). Tuple-grain evidence for DECLARED-unique
+    /// composite indexes is a named follow-on (`deriveCompositeUniqueCandidates`
+    /// probes non-unique candidates only today).
     let private uniqueBackedAttributeKeys (kind: Kind) : Set<SsKey> =
         let fromIndexes =
             kind.Indexes
             |> List.filter (fun ix ->
-                IndexUniqueness.isUnique ix.Uniqueness || IndexUniqueness.isPrimaryKey ix.Uniqueness)
+                (IndexUniqueness.isUnique ix.Uniqueness || IndexUniqueness.isPrimaryKey ix.Uniqueness)
+                && List.length ix.Columns = 1)
             |> List.collect (fun ix -> ix.Columns |> List.map (fun ic -> ic.Attribute))
             |> Set.ofList
-        // PK attributes are always unique-backed even absent an explicit index row.
+        // A SOLE PK attribute is unique-backed even absent an explicit index
+        // row; the attributes of a composite PK are not singly backed.
         let fromPk =
-            kind.Attributes
-            |> List.filter (fun a -> a.IsPrimaryKey)
-            |> List.map (fun a -> a.SsKey)
-            |> Set.ofList
+            match kind.Attributes |> List.filter (fun a -> a.IsPrimaryKey) with
+            | [ sole ] -> Set.singleton sole.SsKey
+            | _        -> Set.empty
         Set.union fromIndexes fromPk
 
     let private entityColumnOf (kind: Kind) (attr: Attribute) : EntityColumn =
@@ -198,6 +264,138 @@ module ModelFidelity =
     let private realityFor (attrKey: SsKey) (profile: Profile) : AttributeReality option =
         profile.AttributeRealities |> List.tryFind (fun r -> r.AttributeKey = attrKey)
 
+    // -- Recommendation minting (per-category, evidence-driven) -------------
+
+    let private humaneBand (band: int64) : string =
+        band.ToString("N0", System.Globalization.CultureInfo.InvariantCulture)
+
+    /// The 3-part `Module.Entity.Attribute` reference the tightening binder
+    /// resolves (`TighteningBinding.resolveAttributeRef`) — the overlay
+    /// vocabulary's addressing form.
+    let private attributeRef3 (moduleName: string) (ec: EntityColumn) : string =
+        System.String.Concat(moduleName, ".", ec.Entity, ".", ec.Column) // LINT-ALLOW: the tightening binder's 3-part dotted addressing form, minted once at the recommendation boundary from validated name segments
+
+    /// The `keepNullable` intervention entry as the overlay vocabulary's
+    /// suggested edit — the EXACT shape `TighteningBinding` binds (A44:
+    /// every emitted key binds and reaches emission), at the interventions
+    /// path. Mirrors `EstateOverlayEmitter.entryOf`'s nullability arm.
+    let private keepNullableEdit (moduleName: string) (ec: EntityColumn) (nullCount: int64) : SuggestedConfig =
+        let value = JsonObject()
+        value.["id"] <- JsonValue.Create (System.String.Concat("fidelity.notNull:", entityColumnText ec)) // LINT-ALLOW: stable intervention id token — the fidelity category discriminator + the operator-facing reference, joined once at the config-edit boundary
+        value.["kind"] <- JsonValue.Create "nullability"
+        let overrides = JsonArray()
+        let o = JsonObject()
+        o.["attributeRef"] <- JsonValue.Create (attributeRef3 moduleName ec)
+        o.["action"] <- JsonValue.Create "keepNullable"
+        overrides.Add o
+        value.["overrides"] <- overrides
+        { Path  = "$.policy.tightening.interventions[+]"
+          Value = value.ToJsonString()
+          Note  =
+            Some (
+                sprintf "Interim relaxation; the NULL count that forced it: %s. Retire the entry once the backfill lands."
+                    (humaneBand nullCount)) }
+
+    /// The `keepUntracked` intervention entry — the overlay vocabulary's
+    /// foreign-key arm, same contract as `keepNullableEdit`.
+    let private keepUntrackedEdit (moduleName: string) (ec: EntityColumn) (orphanCount: int64) : SuggestedConfig =
+        let value = JsonObject()
+        value.["id"] <- JsonValue.Create (System.String.Concat("fidelity.orphans:", entityColumnText ec)) // LINT-ALLOW: stable intervention id token — the fidelity category discriminator + the operator-facing reference, joined once at the config-edit boundary
+        value.["kind"] <- JsonValue.Create "foreignKey"
+        let overrides = JsonArray()
+        let o = JsonObject()
+        o.["referenceRef"] <- JsonValue.Create (attributeRef3 moduleName ec)
+        o.["action"] <- JsonValue.Create "keepUntracked"
+        overrides.Add o
+        value.["referenceOverrides"] <- overrides
+        { Path  = "$.policy.tightening.interventions[+]"
+          Value = value.ToJsonString()
+          Note  =
+            Some (
+                sprintf "Interim relaxation; the orphan count that forced it: %s. Retire the entry once the references clear."
+                    (humaneBand orphanCount)) }
+
+    /// The NOT-NULL recommendation: the platform validates a mandatory
+    /// attribute at run time only (no database constraint), so NULL rows
+    /// under a mandatory declaration are a tightening decision, not
+    /// corruption. At or below the band the backfill leads; above it the
+    /// interim `keepNullable` relaxation leads.
+    let private recommendNotNull
+        (band: int64)
+        (moduleName: string)
+        (ec: EntityColumn)
+        (nullCount: int64)
+        : Recommendation =
+        let interpretation =
+            "A mandatory attribute is validated by the platform at run time only; the deployed column allows NULL, and the NOT NULL declaration cannot deploy while the rows remain."
+        if nullCount > band then
+            { Interpretation = interpretation
+              Action =
+                sprintf "Keep the column nullable until the backfill — %s NULL row(s) exceed the repair band (%s). Merge the keepNullable entry for %s."
+                    (humaneBand nullCount) (humaneBand band) (attributeRef3 moduleName ec)
+              Lever = EditConfig (keepNullableEdit moduleName ec nullCount) }
+        else
+            { Interpretation = interpretation
+              Action =
+                "Review the backfill block in manifest.remediation.sql, or keep the column nullable (keepNullable) until the backfill."
+              Lever = ReviewRemediation }
+
+    /// The uniqueness recommendation: a constraint review, never an
+    /// automatic cleanup — duplicates under a single-column unique
+    /// declaration frequently mean the declared key is narrower than the
+    /// real business key, or the declaration is stale (rule 4: a genuine
+    /// interpretation, hedged).
+    let private recommendUnique : Recommendation =
+        { Interpretation =
+            "Duplicates under a single-column unique declaration frequently mean the declared key is narrower than the real business key, or the declaration is stale — a data cleanup cannot settle which."
+          Action =
+            "Review the declared key before any cleanup: confirm the business key, then correct the declaration or schedule the deduplication."
+          Lever = ReviewConstraint }
+
+    /// The FK-orphan recommendation, split by the reference's constraint
+    /// state: an Ignore delete rule creates no database constraint (orphans
+    /// accumulate by the platform's own design); WITH NOCHECK never
+    /// validated the existing rows; a trusted constraint with observed
+    /// orphans is a disagreement worth naming. At or below the band the
+    /// prepared cleanup leads; above it `keepUntracked` leads.
+    let private recommendOrphans
+        (band: int64)
+        (moduleName: string)
+        (ec: EntityColumn)
+        (state: ConstraintState)
+        (orphanCount: int64)
+        : Recommendation =
+        let interpretation =
+            match state with
+            | ConstraintState.NoDbConstraint ->
+                "The relationship carries no database constraint (an Ignore delete rule creates none), so rows referencing absent targets accumulate by the platform's own design."
+            | ConstraintState.UntrustedConstraint ->
+                "The relationship's constraint is enforced WITH NOCHECK (untrusted), so the existing rows were never validated against it."
+            | ConstraintState.TrustedConstraint ->
+                "The relationship's constraint is trusted, yet the profile observed orphan rows — the two readings disagree, and the evidence basis merits review."
+        if orphanCount > band then
+            { Interpretation = interpretation
+              Action =
+                sprintf "Keep the relationship untracked until the references clear — %s orphan row(s) exceed the repair band (%s). Merge the keepUntracked entry for %s."
+                    (humaneBand orphanCount) (humaneBand band) (attributeRef3 moduleName ec)
+              Lever = EditConfig (keepUntrackedEdit moduleName ec orphanCount) }
+        else
+            { Interpretation = interpretation
+              Action =
+                "Review the block in manifest.remediation.sql: point the row(s) at existing targets, clear the reference, or delete them."
+              Lever = ReviewRemediation }
+
+    /// The overflow recommendation: a width RULING (the estate board's D4
+    /// discipline) — widen the declaration or truncate the rows; the ruling
+    /// precedes any repair, because a prepared truncation would read as a
+    /// default path and there is none.
+    let private recommendOverflow : Recommendation =
+        { Interpretation =
+            "Values past the declared width are already present, so the declared width cannot deploy without loss and the load cannot carry the rows."
+          Action =
+            "Rule the width: declare the wider envelope in the model, or truncate the rows to the declaration — the ruling precedes any repair."
+          Lever = ReviewModel }
+
     /// NOT-NULL declared but NULLs present — generalizes
     /// `Preflight.dataViolatesTightening` beyond the `EnforceNotNull` overlay:
     /// EVERY attribute the model declares non-nullable (a PK, or a column with
@@ -205,7 +403,12 @@ module ModelFidelity =
     /// Exact `NullCount` carried from `Profile.Columns` when present; otherwise
     /// the boolean `HasNulls` reality witnesses the violation with an unknown
     /// count (carried as 0, which the renderer reads as "present").
-    let private notNullViolations (catalog: Catalog) (profile: Profile) : DataViolation list =
+    let private notNullViolations
+        (moduleOf: Kind -> string)
+        (band: int64)
+        (catalog: Catalog)
+        (profile: Profile)
+        : DataViolation list =
         catalog
         |> Catalog.allKinds
         |> List.collect (fun kind ->
@@ -221,16 +424,20 @@ module ModelFidelity =
                         realityFor attr.SsKey profile
                         |> Option.map (fun r -> r.HasNulls)
                         |> Option.defaultValue false
+                    let violation (n: int64) : DataViolation =
+                        let reference = entityColumnOf kind attr
+                        { Reference = reference
+                          Kind = NotNullButNullsPresent n
+                          Recommendation = Some (recommendNotNull band (moduleOf kind) reference n) }
                     match exactCount with
-                    | Some n when n > 0L ->
-                        Some { Reference = entityColumnOf kind attr; Kind = NotNullButNullsPresent n }
+                    | Some n when n > 0L -> Some (violation n)
                     | Some _ -> None
-                    | None when realityHasNulls ->
-                        Some { Reference = entityColumnOf kind attr; Kind = NotNullButNullsPresent 0L }
+                    | None when realityHasNulls -> Some (violation 0L)
                     | None -> None))
 
-    /// UNIQUE / PK declared but duplicates present — every unique-backed
-    /// attribute whose `AttributeReality.HasDuplicates = true`.
+    /// UNIQUE / PK declared but duplicates present — every SINGLY
+    /// unique-backed attribute whose `AttributeReality.HasDuplicates = true`
+    /// (the single-column altitude; see `uniqueBackedAttributeKeys`).
     let private uniqueViolations (catalog: Catalog) (profile: Profile) : DataViolation list =
         catalog
         |> Catalog.allKinds
@@ -245,14 +452,22 @@ module ModelFidelity =
                         |> Option.map (fun r -> r.HasDuplicates)
                         |> Option.defaultValue false
                     if hasDuplicates then
-                        Some { Reference = entityColumnOf kind attr; Kind = UniqueButDuplicatesPresent }
+                        Some
+                            { Reference = entityColumnOf kind attr
+                              Kind = UniqueButDuplicatesPresent
+                              Recommendation = Some recommendUnique }
                     else None))
 
     /// FK orphans — reuse the profiler's per-Reference orphan evidence
     /// (`ForeignKeyReality.HasOrphan` + `OrphanCount`). The orphan is reported
     /// against the FK's SOURCE attribute (the column whose values fail to
     /// resolve), so the operator sees `Entity.ForeignKeyColumn`.
-    let private orphanViolations (catalog: Catalog) (profile: Profile) : DataViolation list =
+    let private orphanViolations
+        (moduleOf: Kind -> string)
+        (band: int64)
+        (catalog: Catalog)
+        (profile: Profile)
+        : DataViolation list =
         catalog
         |> Catalog.allKinds
         |> List.collect (fun kind ->
@@ -264,20 +479,30 @@ module ModelFidelity =
                         Kind.tryFindAttribute reference.SourceAttribute kind
                         |> Option.map (fun a -> Name.value a.Name)
                         |> Option.defaultValue (Name.value reference.Name)
+                    let ec = { Entity = Name.value kind.Name; Column = column }
                     Some
-                        { Reference = { Entity = Name.value kind.Name; Column = column }
-                          Kind = ForeignKeyOrphans fk.OrphanCount }
+                        { Reference = ec
+                          Kind = ForeignKeyOrphans fk.OrphanCount
+                          Recommendation =
+                            Some (recommendOrphans band (moduleOf kind) ec reference.ConstraintState fk.OrphanCount) }
                 | _ -> None))
 
     /// Length / type overflow — declared `Attribute.Length` vs the profiled
     /// `ColumnProfile.MaxObservedLength`. A violation fires when the source
     /// carries a value LONGER than the declared cap: the declared model
     /// asserts a width the data exceeds, so the declaration cannot hold the
-    /// reality. Scoped to attributes that declare a finite `Length` (a `None`
-    /// declared length is MAX / open-ended — no cap to overflow) and that
-    /// carry a probed `MaxObservedLength` (a non-text/binary column, or an
-    /// unprobed one, surfaces no length axis → no violation). The `observed`
-    /// / `declared` tokens render the proof beside the finding.
+    /// reality. Scoped to attributes that declare a POSITIVE `Length` — an
+    /// absent length is MAX / open-ended, and a `0` (or negative) carried
+    /// from OSSYS metadata declares NO width, not a width of zero: the
+    /// storage lane already reads it so (`OssysTypeMapping.textLength` /
+    /// `boundedOr` treat only a positive length as `Bounded`), and the
+    /// platform's own mapping has no zero-width bounded type. Before this
+    /// gate aligned (2026-07-18), a metadata `Length = 0` under any observed
+    /// value fired "observed 5, declared 0" findings rooted in the reader,
+    /// not the data. Also scoped to attributes carrying a probed
+    /// `MaxObservedLength` (a non-text/binary column, or an unprobed one,
+    /// surfaces no length axis → no violation). The `observed` / `declared`
+    /// tokens render the proof beside the finding.
     let private overflowViolations (catalog: Catalog) (profile: Profile) : DataViolation list =
         catalog
         |> Catalog.allKinds
@@ -285,8 +510,7 @@ module ModelFidelity =
             kind.Attributes
             |> List.choose (fun attr ->
                 match attr.Length with
-                | None -> None  // MAX / not-length-applicable — no cap to overflow.
-                | Some declared ->
+                | Some declared when declared > 0 ->
                     Profile.tryFindColumn attr.SsKey profile
                     |> Option.bind (fun c -> c.MaxObservedLength)
                     |> Option.bind (fun observed ->
@@ -296,16 +520,30 @@ module ModelFidelity =
                                   Kind =
                                     LengthOrTypeOverflow (
                                         observed = string observed,
-                                        declared = string declared) }
-                        else None)))
+                                        declared = string declared)
+                                  Recommendation = Some recommendOverflow }
+                        else None)
+                | _ -> None))  // Absent or non-positive — no declared cap to overflow.
 
     /// Aggregate the data-violation section from a declared catalog × profiled
     /// evidence. Deterministic — sorted by category then operator-facing
-    /// reference (T1), so the rollup is byte-stable across runs.
-    let private aggregateDataViolations (catalog: Catalog) (profile: Profile) : DataViolation list =
-        [ notNullViolations catalog profile
+    /// reference (T1), so the rollup is byte-stable across runs. The
+    /// kind→module index resolves each violation's 3-part config reference
+    /// (`Module.Entity.Attribute`) once, for the recommendation layer.
+    let private aggregateDataViolations (band: int64) (catalog: Catalog) (profile: Profile) : DataViolation list =
+        let moduleByKind : Map<SsKey, string> =
+            catalog.Modules
+            |> List.collect (fun m ->
+                m.Kinds |> List.map (fun k -> k.SsKey, Name.value m.Name))
+            |> Map.ofList
+        let moduleOf (kind: Kind) : string =
+            // Total by construction — every catalog kind belongs to a module;
+            // the defensive arm keeps the resolver total over a hand-built
+            // catalog fragment.
+            Map.tryFind kind.SsKey moduleByKind |> Option.defaultValue "Model"
+        [ notNullViolations moduleOf band catalog profile
           uniqueViolations catalog profile
-          orphanViolations catalog profile
+          orphanViolations moduleOf band catalog profile
           overflowViolations catalog profile ]
         |> List.concat
         |> List.sortBy (fun v -> categoryOrdinal (categoryOf v), entityColumnText v.Reference)
@@ -348,8 +586,11 @@ module ModelFidelity =
 
     /// Compose the full report from a declared catalog, the profiled evidence,
     /// the categorical-uniqueness decision set, and the run's accepted-tolerance
-    /// residual. The estate masthead counts modules + entities from the catalog.
-    let compose
+    /// residual, under an explicit fix-vs-relax band (the recommendation
+    /// layer's threshold). The estate masthead counts modules + entities from
+    /// the catalog.
+    let composeWithBand
+        (band: int64)
         (estate: string)
         (catalog: Catalog)
         (profile: Profile)
@@ -359,9 +600,20 @@ module ModelFidelity =
         { Estate               = estate
           ModuleCount          = List.length catalog.Modules
           EntityCount          = catalog |> Catalog.allKinds |> List.length
-          DataViolations       = aggregateDataViolations catalog profile
+          DataViolations       = aggregateDataViolations band catalog profile
           AcceptedDivergences  = acceptedDivergences |> List.map (fun d -> { Divergence = d })
           UniquenessCandidates = aggregateUniquenessCandidates catalog categoricalDecisions }
+
+    /// `composeWithBand` under the default repair band — the standing
+    /// signature every existing caller keeps.
+    let compose
+        (estate: string)
+        (catalog: Catalog)
+        (profile: Profile)
+        (categoricalDecisions: CategoricalUniquenessDecisionSet)
+        (acceptedDivergences: ToleratedDivergence list)
+        : ModelFidelityReport =
+        composeWithBand repairBandDefault estate catalog profile categoricalDecisions acceptedDivergences
 
     // ----------------------------------------------------------------------
     // Rollups — count-first totals the renderer + codec both read.
@@ -507,6 +759,64 @@ module ModelFidelity =
         | OrphanCategory   -> "FK orphans"
         | OverflowCategory -> "Length / type overflow"
 
+    /// The category-level interpretation the render states beneath each
+    /// non-clean category line — total over the category vocabulary, so a
+    /// new axis cannot land without its reading. The per-violation
+    /// interpretations in `fidelity.json` refine these (the orphan split by
+    /// constraint state); the category line carries the shared mechanism.
+    let private categoryInterpretation (c: ViolationCategory) : string =
+        match c with
+        | NotNullCategory ->
+            "A mandatory attribute is validated by the platform at run time only; the deployed columns allow NULL, and the NOT NULL declarations cannot deploy while the rows remain."
+        | UniqueCategory ->
+            "Duplicates under a single-column unique declaration frequently mean the declared key is narrower than the real business key, or the declaration is stale — a data cleanup cannot settle which."
+        | OrphanCategory ->
+            "A relationship without a database constraint (an Ignore delete rule creates none), or one enforced WITH NOCHECK, accumulates rows that reference absent targets."
+        | OverflowCategory ->
+            "Values past a declared width are already present, so the declared width cannot deploy without loss and the load cannot carry the rows."
+
+    /// Join the per-arm fragments into one imperative sentence — sentence
+    /// case on the lead, "; " between arms, terminal period. The fallback
+    /// carries the category's generic both-arm imperative when no violation
+    /// carries a lever (a legacy `fidelity.json` parsed without
+    /// recommendation nodes).
+    let private joinArms (fallback: string) (parts: string list) : string =
+        match parts with
+        | [] -> fallback
+        | _ ->
+            let sentence = String.concat "; " parts
+            let lead =
+                System.String.Concat(
+                    string (System.Char.ToUpperInvariant sentence.[0]),
+                    sentence.Substring 1)
+            System.String.Concat(lead, ".")
+
+    /// The category-level next-move line, aggregated from the per-violation
+    /// arms: the count on the prepared-repair arm (the remediation block)
+    /// beside the count on the relax arm (past-band `keepNullable` /
+    /// `keepUntracked` config entries).
+    let private categoryActionLine (c: ViolationCategory) (violations: DataViolation list) : string =
+        let levers = violations |> List.choose (fun v -> v.Recommendation |> Option.map (fun r -> r.Lever))
+        let repairs = levers |> List.filter (function ReviewRemediation -> true | _ -> false) |> List.length
+        let relaxes = levers |> List.filter (function EditConfig _ -> true | _ -> false) |> List.length
+        match c with
+        | NotNullCategory ->
+            [ if repairs > 0 then
+                yield sprintf "review the backfill block(s) in manifest.remediation.sql (%s column(s))" (humane repairs)
+              if relaxes > 0 then
+                yield sprintf "keep %s column(s) nullable via keepNullable entries (past the repair band)" (humane relaxes) ]
+            |> joinArms "Review the backfill blocks in manifest.remediation.sql, or keep past-band columns nullable via keepNullable entries."
+        | UniqueCategory ->
+            "Review each declared key before any cleanup: confirm the business key, then correct the declaration or schedule the deduplication."
+        | OrphanCategory ->
+            [ if repairs > 0 then
+                yield sprintf "review the orphan block(s) in manifest.remediation.sql (%s relationship(s))" (humane repairs)
+              if relaxes > 0 then
+                yield sprintf "keep %s relationship(s) untracked via keepUntracked entries (past the repair band)" (humane relaxes) ]
+            |> joinArms "Review the orphan blocks in manifest.remediation.sql, or keep past-band relationships untracked via keepUntracked entries."
+        | OverflowCategory ->
+            "Rule each width: declare the wider envelope in the model, or truncate the rows to the declaration — the ruling precedes any repair."
+
     /// Render the full report as the operator-facing rolled-up text — totals at
     /// the top, per-entity breakdown beneath (the operator's "eminently useful
     /// at first glance" requirement). THE_VOICE: stative, agentless, neutral
@@ -532,6 +842,13 @@ module ModelFidelity =
                       yield
                           sprintf "      %-36s %s   %s   %s"
                               (categoryLabel cat.Category) (humane cat.Count) entities offenders
+                      // The recommendation layer (2026-07-18): the finding on
+                      // top, the interpretation beneath it, the next move
+                      // last — every category ends on its move (THE_VOICE:
+                      // end on the move; the statement on top, the proof and
+                      // the reading one level beneath).
+                      yield sprintf "          %s" (categoryInterpretation cat.Category)
+                      yield sprintf "          Next: %s" (categoryActionLine cat.Category cat.Violations)
 
           // Section 2 — accepted divergences (the per-run tolerance residual).
           match report.AcceptedDivergences with
@@ -581,12 +898,38 @@ module ModelFidelity =
             o.["declared"] <- JsonValue.Create declared
         o
 
+    /// The lever's stable machine token (the `fidelity.json` discriminator).
+    let private leverToken (lever: RecommendationLever) : string =
+        match lever with
+        | ReviewRemediation -> "reviewRemediation"
+        | EditConfig _      -> "editConfig"
+        | ReviewModel       -> "reviewModel"
+        | ReviewConstraint  -> "reviewConstraint"
+
+    let private recommendationNode (r: Recommendation) : JsonObject =
+        let o = JsonObject()
+        o.["interpretation"] <- JsonValue.Create r.Interpretation
+        o.["action"] <- JsonValue.Create r.Action
+        o.["lever"] <- JsonValue.Create (leverToken r.Lever)
+        (match r.Lever with
+         | EditConfig sc ->
+             o.["configPath"] <- JsonValue.Create sc.Path
+             o.["configValue"] <- JsonValue.Create sc.Value
+             match sc.Note with
+             | Some note -> o.["configNote"] <- JsonValue.Create note
+             | None -> ()
+         | _ -> ())
+        o
+
     let private violationNode (v: DataViolation) : JsonObject =
         let o = JsonObject()
         o.["entity"] <- JsonValue.Create v.Reference.Entity
         o.["column"] <- JsonValue.Create v.Reference.Column
         o.["reference"] <- JsonValue.Create (entityColumnText v.Reference)
         o.["kind"] <- violationKindNode v.Kind
+        match v.Recommendation with
+        | Some r -> o.["recommendation"] <- recommendationNode r
+        | None -> ()
         o
 
     /// Serialize the report to its `fidelity.json` document — the structured,
@@ -609,6 +952,15 @@ module ModelFidelity =
             c.["category"] <- JsonValue.Create (categoryLabel cat.Category)
             c.["count"] <- JsonValue.Create cat.Count
             c.["entities"] <- JsonValue.Create cat.Entities
+            // The category-grain recommendation (2026-07-18) — pre-computed
+            // like the rollups, so a downstream reader gets the
+            // interpretation + next move without re-aggregating; the
+            // per-violation nodes beneath carry the refined per-finding arms.
+            if cat.Count > 0 then
+                let recNode = JsonObject()
+                recNode.["interpretation"] <- JsonValue.Create (categoryInterpretation cat.Category)
+                recNode.["action"] <- JsonValue.Create (categoryActionLine cat.Category cat.Violations)
+                c.["recommendation"] <- recNode
             let items = JsonArray()
             for v in cat.Violations do items.Add(violationNode v)
             c.["violations"] <- items
@@ -686,6 +1038,29 @@ module ModelFidelity =
             Some (LengthOrTypeOverflow (tryStr o "observed" |> Option.defaultValue "", tryStr o "declared" |> Option.defaultValue ""))
         | _ -> None
 
+    /// Parse a violation's recommendation node back — verbatim carry (the
+    /// recommendation was minted at compose time; a reader re-derives
+    /// nothing). `None` on an absent node (a legacy document) or an unknown
+    /// lever token (fail-closed to no recommendation, never a crash).
+    let private recommendationFromNode (o: JsonObject) : Recommendation option =
+        match tryStr o "interpretation", tryStr o "action", tryStr o "lever" with
+        | Some interpretation, Some action, Some lever ->
+            let leverValue =
+                match lever with
+                | "reviewRemediation" -> Some ReviewRemediation
+                | "reviewModel"       -> Some ReviewModel
+                | "reviewConstraint"  -> Some ReviewConstraint
+                | "editConfig" ->
+                    match tryStr o "configPath", tryStr o "configValue" with
+                    | Some path, Some value ->
+                        Some (EditConfig { Path = path; Value = value; Note = tryStr o "configNote" })
+                    | _ -> None
+                | _ -> None
+            leverValue
+            |> Option.map (fun l ->
+                { Interpretation = interpretation; Action = action; Lever = l })
+        | _ -> None
+
     /// Parse a `fidelity.json` document back into a `ModelFidelityReport`.
     /// `None` on a malformed document (fail-closed). Reconstructs the
     /// data-violation list from the per-category arrays + the candidate /
@@ -720,7 +1095,14 @@ module ModelFidelity =
                                                   | Some entity, Some column, Some k ->
                                                       match kindFromNode k with
                                                       | Some kind ->
-                                                          yield { Reference = { Entity = entity; Column = column }; Kind = kind }
+                                                          let recommendation =
+                                                              tryNode v "recommendation"
+                                                              |> Option.bind asObject
+                                                              |> Option.bind recommendationFromNode
+                                                          yield
+                                                              { Reference = { Entity = entity; Column = column }
+                                                                Kind = kind
+                                                                Recommendation = recommendation }
                                                       | None -> ()
                                                   | _ -> () ]
                 let accepted =

--- a/sidecar/projection/tests/Projection.Tests/ModelFidelityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ModelFidelityTests.fs
@@ -370,3 +370,253 @@ let ``ModelFidelity: a clean report yields NO rollup payload (no envelope to emi
     let report = ModelFidelity.compose "ACME" fixtureCatalog Profile.empty { Decisions = [] } []
     Assert.Empty(report.DataViolations)
     Assert.True((ModelFidelity.dataViolationsPayload "r" "f" report).IsNone)
+
+// ---------------------------------------------------------------------------
+// The recommendation layer (2026-07-18): evidence → interpretation → move →
+// lever. Each violation carries the decision it opens; the copy holds
+// THE_VOICE's register; the band splits fix-vs-relax on the SAME threshold
+// the estate board's lanes split on.
+// ---------------------------------------------------------------------------
+
+let private violationsOf (report: ModelFidelity.ModelFidelityReport) = report.DataViolations
+
+let private recommendationOf (v: ModelFidelity.DataViolation) : ModelFidelity.Recommendation =
+    match v.Recommendation with
+    | Some r -> r
+    | None -> failwithf "expected a recommendation on %s" (ModelFidelity.entityColumnText v.Reference)
+
+// Null-safe JsonNode navigation (F#9 nullness: the BCL indexers surface
+// `JsonNode | null`; the fixture fails loud on an absent node).
+let private parsedJson (text: string) : System.Text.Json.Nodes.JsonNode =
+    match Option.ofObj (System.Text.Json.Nodes.JsonNode.Parse text) with
+    | Some n -> n
+    | None -> failwith "fixture: JSON parsed to null"
+
+let private childOf (name: string) (node: System.Text.Json.Nodes.JsonNode) : System.Text.Json.Nodes.JsonNode =
+    match Option.ofObj node.[name] with
+    | Some n -> n
+    | None -> failwithf "fixture: missing JSON node '%s'" name
+
+let private itemOf (i: int) (node: System.Text.Json.Nodes.JsonNode) : System.Text.Json.Nodes.JsonNode =
+    match Option.ofObj node.[i] with
+    | Some n -> n
+    | None -> failwithf "fixture: missing JSON item %d" i
+
+[<Fact>]
+let ``Recommendation: a NOT-NULL violation at or below the band ends on the remediation block`` () =
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let v =
+        violationsOf report
+        |> List.find (fun v -> match v.Kind with ModelFidelity.NotNullButNullsPresent _ -> true | _ -> false)
+    let r = recommendationOf v
+    Assert.Equal(ModelFidelity.ReviewRemediation, r.Lever)
+    Assert.Contains("manifest.remediation.sql", r.Action)
+    Assert.Contains("run time only", r.Interpretation)
+
+[<Fact>]
+let ``Recommendation: a NOT-NULL violation past the band ends on a keepNullable config edit with the 3-part reference`` () =
+    // Band of 3: the 4 NULL rows exceed it — the interim relaxation leads.
+    let report = ModelFidelity.composeWithBand 3L "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let v =
+        violationsOf report
+        |> List.find (fun v -> match v.Kind with ModelFidelity.NotNullButNullsPresent _ -> true | _ -> false)
+    match (recommendationOf v).Lever with
+    | ModelFidelity.EditConfig sc ->
+        Assert.Equal("$.policy.tightening.interventions[+]", sc.Path)
+        // The entry is the overlay vocabulary the tightening binder accepts.
+        let value = parsedJson sc.Value
+        Assert.Equal("nullability", (childOf "kind" value).GetValue<string>())
+        let entry = value |> childOf "overrides" |> itemOf 0
+        Assert.Equal("Sales.Customer.Email", (childOf "attributeRef" entry).GetValue<string>())
+        Assert.Equal("keepNullable", (childOf "action" entry).GetValue<string>())
+        Assert.True(sc.Note.IsSome, "the edit carries its evidence note")
+    | other -> Assert.Fail(sprintf "expected EditConfig keepNullable, got %A" other)
+
+[<Fact>]
+let ``Recommendation: a uniqueness violation ends on a constraint review, never a cleanup`` () =
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let v = violationsOf report |> List.find (fun v -> v.Kind = ModelFidelity.UniqueButDuplicatesPresent)
+    let r = recommendationOf v
+    Assert.Equal(ModelFidelity.ReviewConstraint, r.Lever)
+    Assert.Contains("Review the declared key before any cleanup", r.Action)
+    Assert.Contains("business key", r.Interpretation)
+
+[<Fact>]
+let ``Recommendation: an orphan violation on a constraint-less reference names the platform's Ignore design`` () =
+    // The fixture reference is `Reference.create`'s default — NoDbConstraint,
+    // the shape an Ignore delete rule deploys (no FK constraint is created).
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let v =
+        violationsOf report
+        |> List.find (fun v -> match v.Kind with ModelFidelity.ForeignKeyOrphans _ -> true | _ -> false)
+    let r = recommendationOf v
+    Assert.Equal(ModelFidelity.ReviewRemediation, r.Lever)
+    Assert.Contains("no database constraint", r.Interpretation)
+    Assert.Contains("Ignore", r.Interpretation)
+    Assert.Contains("manifest.remediation.sql", r.Action)
+
+[<Fact>]
+let ``Recommendation: an orphan violation past the band ends on a keepUntracked config edit`` () =
+    // Band of 5: the 7 orphans exceed it.
+    let report = ModelFidelity.composeWithBand 5L "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let v =
+        violationsOf report
+        |> List.find (fun v -> match v.Kind with ModelFidelity.ForeignKeyOrphans _ -> true | _ -> false)
+    match (recommendationOf v).Lever with
+    | ModelFidelity.EditConfig sc ->
+        let value = parsedJson sc.Value
+        Assert.Equal("foreignKey", (childOf "kind" value).GetValue<string>())
+        let entry = value |> childOf "referenceOverrides" |> itemOf 0
+        Assert.Equal("Sales.Order.CustomerId", (childOf "referenceRef" entry).GetValue<string>())
+        Assert.Equal("keepUntracked", (childOf "action" entry).GetValue<string>())
+    | other -> Assert.Fail(sprintf "expected EditConfig keepUntracked, got %A" other)
+
+[<Fact>]
+let ``Recommendation: an overflow violation ends on the width ruling (model review)`` () =
+    let catalog = cappedCatalog 50
+    let profile = { Profile.empty with Columns = [ columnWithMaxLength custEmailKey 100L 80 ] }
+    let report = ModelFidelity.compose "ACME" catalog profile { Decisions = [] } []
+    let v =
+        violationsOf report
+        |> List.find (fun v -> match v.Kind with ModelFidelity.LengthOrTypeOverflow _ -> true | _ -> false)
+    let r = recommendationOf v
+    Assert.Equal(ModelFidelity.ReviewModel, r.Lever)
+    Assert.Contains("Rule the width", r.Action)
+
+[<Fact>]
+let ``Recommendation: the register holds — no pronouns, complete sentences ending on a period`` () =
+    let report = ModelFidelity.composeWithBand 3L "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    for v in violationsOf report do
+        let r = recommendationOf v
+        for text in [ r.Interpretation; r.Action ] do
+            let lowered = text.ToLowerInvariant()
+            // THE_VOICE rule 1 — no first or second person on the surface.
+            for banned in [ " you "; " your "; " we "; " i " ] do
+                Assert.DoesNotContain(banned, lowered)
+            Assert.EndsWith(".", text)
+
+// -- The metadata-interpretation corrections (2026-07-18) --------------------
+
+[<Fact>]
+let ``Overflow: a declared length of 0 carries no cap — no violation regardless of observed length`` () =
+    // OSSYS metadata carries `Length = 0` where no width is declared; the
+    // storage lane reads only a POSITIVE length as bounded
+    // (`OssysTypeMapping`), and the platform mapping has no zero-width type.
+    // The prior gate read 0 as a cap and fired "observed 5, declared 0" —
+    // a finding rooted in the reader, not the data.
+    let catalog = cappedCatalog 0
+    let profile = { Profile.empty with Columns = [ columnWithMaxLength custEmailKey 100L 5 ] }
+    let report = ModelFidelity.compose "ACME" catalog profile { Decisions = [] } []
+    let overflows =
+        violationsOf report
+        |> List.filter (fun v ->
+            match v.Kind with ModelFidelity.LengthOrTypeOverflow _ -> true | _ -> false)
+    Assert.Empty(overflows)
+
+[<Fact>]
+let ``Unique altitude: the columns of a COMPOSITE unique index are not singly unique-backed`` () =
+    // A composite unique declaration constrains the TUPLE; each member column
+    // can carry duplicates while the tuple stays distinct — per-column
+    // duplicate evidence cannot witness a composite violation. The prior
+    // reading fired one finding per member column of every composite business
+    // key (the column-by-column reading), flooding real estates.
+    let compositeCustomer : Kind =
+        { Kind.create customerKey (name "Customer") (tableId "OSUSR_CUSTOMER")
+            [ mkAttr custIdKey "Id" Integer true false
+              mkAttr custEmailKey "Email" Text false false
+              mkAttr custNoteKey "Note" Text false false ]
+            with
+            Indexes =
+                [ { Index.create (idxKey "UX_Customer_Email_Note") (name "UX_Customer_Email_Note")
+                      [ IndexColumn.create custEmailKey IndexColumnDirection.Ascending
+                        IndexColumn.create custNoteKey IndexColumnDirection.Ascending ]
+                      with Uniqueness = IndexUniqueness.Unique } ] }
+    let salesModule = Module.create (modKey "Sales") (name "Sales") [ compositeCustomer ] true [] |> mustOk
+    let catalog = Catalog.create [ salesModule ] [] |> mustOk
+    let profile =
+        { Profile.empty with
+            AttributeRealities =
+                [ { AttributeReality.create custEmailKey with HasDuplicates = true }
+                  { AttributeReality.create custNoteKey with HasDuplicates = true } ] }
+    let report = ModelFidelity.compose "ACME" catalog profile { Decisions = [] } []
+    let unique =
+        violationsOf report |> List.filter (fun v -> v.Kind = ModelFidelity.UniqueButDuplicatesPresent)
+    Assert.Empty(unique)
+
+[<Fact>]
+let ``Unique altitude: a single-column unique index still witnesses its violation`` () =
+    // The fixture catalog's UX_Customer_Email is single-column — the
+    // per-column duplicate evidence IS the declared grain; the violation
+    // stands (the altitude fix narrows, it does not blind).
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let unique =
+        violationsOf report |> List.filter (fun v -> v.Kind = ModelFidelity.UniqueButDuplicatesPresent)
+    Assert.Equal(1, List.length unique)
+
+[<Fact>]
+let ``Unique altitude: the attributes of a composite primary key are not singly unique-backed`` () =
+    let compositePkKind : Kind =
+        { Kind.create customerKey (name "CustomerRole") (tableId "OSUSR_CUSTOMER_ROLE")
+            [ mkAttr custIdKey "CustomerId" Integer true false
+              mkAttr custEmailKey "RoleId" Integer true false ]
+            with Indexes = [] }
+    let salesModule = Module.create (modKey "Sales") (name "Sales") [ compositePkKind ] true [] |> mustOk
+    let catalog = Catalog.create [ salesModule ] [] |> mustOk
+    let profile =
+        { Profile.empty with
+            AttributeRealities =
+                [ { AttributeReality.create custIdKey with HasDuplicates = true }
+                  { AttributeReality.create custEmailKey with HasDuplicates = true } ] }
+    let report = ModelFidelity.compose "ACME" catalog profile { Decisions = [] } []
+    let unique =
+        violationsOf report |> List.filter (fun v -> v.Kind = ModelFidelity.UniqueButDuplicatesPresent)
+    Assert.Empty(unique)
+
+[<Fact>]
+let ``Render: each non-clean category states its interpretation and ends on the move`` () =
+    let report = ModelFidelity.compose "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let lines = ModelFidelity.render report
+    // The NOT-NULL category carries the platform grounding.
+    Assert.Contains(lines, fun l -> l.Contains "run time only")
+    // Every non-clean category ends on a "Next:" move line.
+    Assert.Contains(lines, fun l -> l.Trim().StartsWith "Next:" && l.Contains "manifest.remediation.sql")
+    Assert.Contains(lines, fun l -> l.Trim().StartsWith "Next:" && l.Contains "Review each declared key")
+    // Register: no second person anywhere.
+    for line in lines do
+        Assert.DoesNotContain(" your ", line.ToLowerInvariant())
+
+[<Fact>]
+let ``Codec: recommendations round-trip through fidelity.json — lever, config path, and value survive`` () =
+    let report = ModelFidelity.composeWithBand 3L "ACME" fixtureCatalog profiledEvidence { Decisions = [] } []
+    let json = ModelFidelity.toJsonString report
+    match ModelFidelity.fromJson json with
+    | None -> Assert.Fail "fidelity.json failed to parse back"
+    | Some restored ->
+        let recsOf (r: ModelFidelity.ModelFidelityReport) =
+            r.DataViolations |> List.map (fun v -> v.Recommendation)
+        Assert.Equal<ModelFidelity.Recommendation option list>(recsOf report, recsOf restored)
+        // The render — recommendation lines included — is identical across
+        // the round-trip.
+        Assert.Equal<string list>(ModelFidelity.render report, ModelFidelity.render restored)
+
+[<Fact>]
+let ``Codec: a legacy fidelity.json without recommendation nodes parses with Recommendation = None`` () =
+    // A pre-recommendation document (the shape earlier runs recorded).
+    let legacy =
+        """{ "estate": "ACME", "moduleCount": 1, "entityCount": 2,
+             "dataViolations": { "total": 1, "entities": 1, "categories": [
+               { "category": "NOT NULL declared, NULLs present", "count": 1, "entities": 1,
+                 "violations": [ { "entity": "Customer", "column": "Email",
+                                   "kind": { "axis": "notNullButNullsPresent", "nullCount": 4 } } ] } ] },
+             "acceptedDivergences": [], "uniquenessCandidates": [] }"""
+    match ModelFidelity.fromJson legacy with
+    | None -> Assert.Fail "legacy document failed to parse"
+    | Some restored ->
+        match restored.DataViolations with
+        | [ v ] ->
+            Assert.Equal<ModelFidelity.Recommendation option>(None, v.Recommendation)
+            // The render stays total — the category falls back to its
+            // generic both-arm imperative.
+            let lines = ModelFidelity.render restored
+            Assert.Contains(lines, fun l -> l.Trim().StartsWith "Next:")
+        | other -> Assert.Fail(sprintf "expected one violation, got %A" other)

--- a/sidecar/projection/tests/Projection.Tests/OssysTypeMappingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysTypeMappingTests.fs
@@ -24,10 +24,25 @@ let ``tryParse: date-only and time-only store as DATETIME, the platform mapping 
     Assert.Equal(Some (DateTime, SqlStorageType.DateTime), OssysTypeMapping.tryParse "time" None None None)
 
 [<Fact>]
-let ``tryParse: currency is the imposed DECIMAL(37,8); decimal defaults to (18,0)`` () =
+let ``tryParse: currency is the imposed DECIMAL(37,8); decimal reads precision from the Length property, defaulting to the platform (37,8)`` () =
+    // Database Data Types (OutSystems 11): Decimal deploys as decimal() whose
+    // "precision and scale match the Length and Decimals properties"; the
+    // Service-Studio defaults are Length = 37, Decimals = 8. OSSYS carries the
+    // digit budget in `Length` (standard estates have no `Precision` column),
+    // so the reader takes precision ← explicit precision, else positive
+    // Length, else 37 — retiring the invented (18, 0) fallback that made every
+    // standard Decimal diverge from its deployed decimal(37, 8).
     Assert.Equal(Some (Decimal, SqlStorageType.Decimal (37, 8)), OssysTypeMapping.tryParse "currency" None None None)
-    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (18, 0)), OssysTypeMapping.tryParse "decimal" None None None)
-    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (12, 4)), OssysTypeMapping.tryParse "decimal" None (Some 12) (Some 4))
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (37, 8)), OssysTypeMapping.tryParse "decimal" None None None)
+    // The standard estate shape: digits in Length, fraction via Decimals→scale.
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (37, 8)), OssysTypeMapping.tryParse "decimal" (Some 37) None (Some 8))
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (20, 2)), OssysTypeMapping.tryParse "decimal" (Some 20) None (Some 2))
+    // An explicit Precision column (or external override) wins over Length.
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (12, 4)), OssysTypeMapping.tryParse "decimal" (Some 37) (Some 12) (Some 4))
+    // A non-positive Length carries no digit budget — the platform default applies.
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (37, 8)), OssysTypeMapping.tryParse "decimal" (Some 0) None None)
+    // An explicit zero scale (an integer-valued decimal) is preserved, never defaulted.
+    Assert.Equal(Some (Decimal, SqlStorageType.Decimal (18, 0)), OssysTypeMapping.tryParse "decimal" (Some 18) None (Some 0))
 
 [<Fact>]
 let ``email/phone map to the OutSystems 11 platform VARCHAR(250)/(20), with the default width overridden by a declared length (DECISIONS 2026-07-18)`` () =

--- a/sidecar/projection/tests/Projection.Tests/ReadinessTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReadinessTests.fs
@@ -40,7 +40,7 @@ let private mkReport
 
 let private aDealbreaker : ModelFidelity.DataViolation =
     let ec : ModelFidelity.EntityColumn = { Entity = "User"; Column = "Email" }
-    { Reference = ec; Kind = ModelFidelity.NotNullButNullsPresent 3L }
+    { Reference = ec; Kind = ModelFidelity.NotNullButNullsPresent 3L; Recommendation = None }
 
 // -- Per-env verdict ---------------------------------------------------------
 


### PR DESCRIPTION
## What this is

`fidelity.json` found useful risks but reported them as facts. This PR adds the **recommendation layer**: every data violation now carries a typed `Recommendation` — the interpretation its evidence supports, the next move as a bare imperative, and the lever the move ends on. The model-read notices additionally state the model-vs-deployed authority choice explicitly, with the reason.

## Per-category dispositions

| Category | Interpretation (grounded) | Lever |
|---|---|---|
| **NOT NULL, NULLs present** | Mandatory is a *runtime-only* platform validation (DB constraints exist only for PKs + references) — so these rows are a tightening decision, not corruption | ≤ band: `manifest.remediation.sql` backfill block · > band: `keepNullable` config edit (overlay vocabulary verbatim) |
| **UNIQUE/PK, duplicates** | Frequently a narrower-than-business-key declaration or a stale one — data cleanup cannot settle which | Constraint review, never automatic cleanup |
| **FK orphans** | Split by `ConstraintState`: `NoDbConstraint` = the **Ignore delete rule** shape (creates no FK — orphans accumulate by platform design); NOCHECK = never-validated rows | ≤ band: cleanup block · > band: `keepUntracked` config edit |
| **Length/type overflow** | Values already past the width — the declared width cannot deploy without loss | The width ruling: widen the model or truncate (D4) |

The fix-vs-relax **band** is now ONE source of truth (`ModelFidelity.repairBandDefault`, Estate aliases it) so fidelity arms and estate-board lanes cannot disagree. Config edits carry the exact `$.policy.tightening.interventions[+]` entries the tightening binder accepts (A44 both ways). Render: each non-clean category states its interpretation and ends on `Next:` — THE_VOICE throughout. Codec round-trips; legacy documents parse with `Recommendation = None`.

## Three metadata-interpretation corrections (research-grounded)

1. **Decimal precision reads the `Length` property** — the platform contract is *"precision and scale match the Length and Decimals properties"*, defaults (37,8). Our invented `(18,0)` fallback made **every standard Decimal** diverge from its deployed `decimal(37,8)` — the reported decimal(18,\*)-vs-(37,\*) "drift" was the reader, not the estate. Storage-divergence notices now fire only on genuine divergence.
2. **Overflow: `Length ≤ 0` declares no width** (aligns with the storage lane's positive-length reading) — retires the "observed 5, declared 0" false class.
3. **Unique-backing altitude: single-column witnesses only.** Per-column duplicate evidence cannot witness a composite-key violation — the column-by-column reading of composite business keys was the 131-finding flood. Tuple-grain declared-unique evidence is a named follow-on.

## Authority question (drift)

Deployed-authoritative stays the standing default pre-cutover — live data occupies the deployed shape and a narrowing publish is blocked by the DacFx data-loss gate. What changed: the posture is now **stated with its reason and the move that would change it** (model-authority = a tightening ruling taken with profile evidence). Emission behavior unchanged.

References: OutSystems 11 *Database Data Types* (mapping table incl. Decimal/Length·Decimals, Text >2000 → `nvarchar(max)`, Email/Phone `varchar`), *Delete Rules* (Ignore creates no constraint), *Is Mandatory* property + *Database Constraints* (runtime-only), Microsoft *DacDeployOptions.BlockOnPossibleDataLoss*. DECISIONS entry: **2026-07-18 — The fidelity recommendation layer**.

## Gates

- Pure pool **4,553/0** (205 Docker-gated soft-skips)
- Focused suites (fidelity/mapping/divergence/notice/estate/readiness) **211/211**
- `OssysComprehensiveFixture` against the warm container **15/15** (real 40s run; the 53ms soft-skip signature diagnosed and bypassed via `warm-sql.sh conn`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)