### PR TITLE
Estate/shape checks: scope OSSYS reads to model.modules (exclude clones)

### DIFF
--- a/sidecar/projection/src/Projection.Cli/Faces/Diff.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Diff.fs
@@ -121,13 +121,16 @@ let runCompare (refAText: string) (refBText: string) (asJson: bool) : int =
 
 /// `projection check shape` — the espace-safe cross-environment readiness gate
 /// (CROSS_ENVIRONMENT_READINESS.md §4/§5). Reads the agreed shape + every
-/// `confirm` environment via OSSYS (`Source.ofOssys` → native GUID identity, so
-/// the comparison is espace-safe), profiles each env's data, rolls a
-/// `Readiness.ReadinessReport`, prints the roll-up (or `--format json`), writes
-/// `readiness.json`, and exits 0 (estate ready) / 5 (not ready — a real schema
-/// divergence or a data dealbreaker) / 6 (an env could not be read). Read-only.
-let runCheckShape (agreedLabel: string) (agreedRef: string) (confirm: (string * string) list) (asJson: bool) : int =
-    let readCatalog (refStr: string) = (Source.read (Source.ofOssys refStr)).GetAwaiter().GetResult()
+/// `confirm` environment via OSSYS (native GUID identity, stable across
+/// environments, so the comparison is espace-safe), SCOPED to `model.modules`
+/// (via `ScopedRead` — excludes clone / deleted / test / system eSpaces whose
+/// cloned entities would otherwise duplicate the cutover module's SS_Keys),
+/// profiles each env's data, rolls a `Readiness.ReadinessReport`, prints the
+/// roll-up (or `--format json`), writes `readiness.json`, and exits 0 (estate
+/// ready) / 5 (not ready — a real schema divergence or a data dealbreaker) / 6
+/// (an env could not be read). Read-only.
+let runCheckShape (agreedLabel: string) (agreedRef: string) (confirm: (string * string) list) (model: Config.ModelSection) (asJson: bool) : int =
+    let readCatalog (refStr: string) = (ScopedRead.readOssysScoped model refStr).GetAwaiter().GetResult()
     match readCatalog agreedRef with
     | Error errs ->
         Console.Error.WriteLine(sprintf "projection check shape: could not read the agreed shape '%s':" agreedLabel)
@@ -135,12 +138,13 @@ let runCheckShape (agreedLabel: string) (agreedRef: string) (confirm: (string * 
         6
     | Ok agreedCatalog ->
         let agreedOperand : Compare.Operand = { Label = agreedLabel; Catalog = agreedCatalog; Profile = None }
-        // Each confirm env: its OSSYS catalog (schema) + a profile of its live
-        // data (the dealbreaker evidence). A profile failure degrades to
-        // advisory-silent (the schema verdict still leads), never aborts.
+        // Each confirm env: its OSSYS catalog (schema, scoped to `model.modules`)
+        // + a profile of its live data (the dealbreaker evidence). A profile
+        // failure degrades to advisory-silent (the schema verdict still leads),
+        // never aborts. The scoped `Source` keeps read + profile under ONE scope.
         let resolveEnv (label: string, refStr: string) : Result<string * Compare.Operand> =
-            let src = Source.ofOssys refStr
-            match (Source.read src).GetAwaiter().GetResult() with
+            let src = ScopedRead.scopedOssysSource model refStr
+            match (Source.read src).GetAwaiter().GetResult() |> Result.bind (ScopedRead.applyScope model) with
             | Error errs -> Result.failure errs
             | Ok catalog ->
                 let profile =

--- a/sidecar/projection/src/Projection.Cli/Faces/Estate.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Estate.fs
@@ -77,9 +77,14 @@ let runCheckEstate (args: CheckEstateArgs) : int =
     let targetCatalog =
         match args.Target with
         | EstateTargetSource.AgreedEnv connRef ->
-            (Source.read (Source.ofOssys connRef)).GetAwaiter().GetResult()
+            // Scoped to `model.modules` (via `ScopedRead`) so the target shape
+            // is the declared cutover surface, not the whole OSSYS estate.
+            (ScopedRead.readOssysScoped args.Scope connRef).GetAwaiter().GetResult()
         | EstateTargetSource.AuthoredModel (modelOssys, modelFile) ->
+            // The authored model is scoped the same way — `resolveCatalog` does
+            // not apply the module filter itself, so scope its result here.
             (ModelResolution.resolveCatalog modelOssys modelFile).GetAwaiter().GetResult()
+            |> Result.bind (ScopedRead.applyScope args.Scope)
     match targetCatalog with
     | Error errs -> unreadable args.TargetLabel errs
     | Ok target ->
@@ -212,8 +217,11 @@ let runCheckEstate (args: CheckEstateArgs) : int =
         let resolveEnv
             (label: string, refStr: string)
             : string * Result<(string * Compare.Operand) * Estate.EvidenceProvenance> =
-            let source = Source.ofOssys refStr
-            match (Source.read source).GetAwaiter().GetResult() with
+            // The scoped `Source` (pushdown to `model.modules`) keeps the schema
+            // read AND the data-plane profile under ONE scope; the `ModuleFilter`
+            // backstop narrows the read catalog before it becomes an operand.
+            let source = ScopedRead.scopedOssysSource args.Scope refStr
+            match (Source.read source).GetAwaiter().GetResult() |> Result.bind (ScopedRead.applyScope args.Scope) with
             | Error errs -> label, Result.failure errs
             | Ok catalog ->
                 let profile, provenance = acquireEvidence label refStr source catalog

--- a/sidecar/projection/src/Projection.Cli/Program.fs
+++ b/sidecar/projection/src/Projection.Cli/Program.fs
@@ -343,7 +343,7 @@ let private runPlan (shaping: Config.Config) (surveyAdvisory: string list) (plan
         Shell.execute
             { Shell.framed "projection check ready" with Register = Shell.ReadOnly }
             Shell.Bracket.SelfBracketed None runReadiness
-    | PlanAction.CheckShape (al, ar, confirm, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm asJson)
+    | PlanAction.CheckShape (al, ar, confirm, model, asJson) -> shellRun "projection check shape" Shell.ReadOnly (fun () -> runCheckShape al ar confirm model asJson)
     | PlanAction.CheckEstate args -> shellRun "projection check environments" Shell.ReadOnly (fun () -> runCheckEstate args)
     | PlanAction.CheckGo args -> shellRun "projection check go" Shell.ReadOnly (fun () -> runCheckGo (SnapshotScopeBinding.fromModel shaping.Model) args)
     | PlanAction.CheckPlan (flow, plan, asJson) -> shellRun "projection check plan" Shell.ReadOnly (fun () -> runTransferPlan flow plan asJson)

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -639,7 +639,10 @@ type PlanAction =
     /// (CROSS_ENVIRONMENT_READINESS.md). The agreed shape (an env's OSSYS model)
     /// and the confirm set, each as (label, D9 conn-ref); the runner reads every
     /// env via OSSYS (native GUID identity) and rolls a `ReadinessReport`.
-    | CheckShape of agreedLabel: string * agreedRef: string * confirm: (string * string) list * asJson: bool
+    /// `model` is the `model` section whose `modules` selection scopes each
+    /// OSSYS read to the cutover module surface (excluding clone / deleted /
+    /// test / system eSpaces) — the reads route through `ScopedRead`.
+    | CheckShape of agreedLabel: string * agreedRef: string * confirm: (string * string) list * model: Config.ModelSection * asJson: bool
     /// `check estate` — the estate-convergence instrument
     /// (CHAPTER_ESTATE_OPEN.md; DECISIONS 2026-07-15). The unification target
     /// (the readiness block's agreed environment by default; the authored
@@ -764,6 +767,15 @@ and CheckEstateArgs =
     { TargetLabel : string
       Target      : EstateTargetSource
       Confirm     : (string * string) list
+      /// The `model` section whose `modules` selection scopes every OSSYS read
+      /// (target + each confirm env) to the declared cutover module surface —
+      /// excluding clone / deleted / test / system eSpaces, whose cloned
+      /// entities would otherwise duplicate the cutover module's SS_Keys and
+      /// fail the estate read (`catalog.kinds.duplicateKey`). The reads route
+      /// through `ScopedRead` (pushdown + `ModuleFilter` backstop). An empty
+      /// `model.modules` is the show-everything identity (byte-identical
+      /// default).
+      Scope       : Config.ModelSection
       AsJson      : bool
       Evidence    : EstateEvidenceMode
       /// `readiness.estate.repairBand` (wave A6) — `None` rides the

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -2359,12 +2359,16 @@ module Command =
                     let errors =
                         (match agreedR with Error es -> es | Ok _ -> [])
                         @ (confirmRs |> List.collect (function Error es -> es | Ok _ -> []))
-                    match errors with
-                    | e :: _ -> PlanAction.Refused (6, e)
-                    | [] ->
+                    // The module scope (`model.modules`) validated once here so a
+                    // bad module name refuses by name (exit 2) before any read;
+                    // the reads themselves route through `ScopedRead`.
+                    match errors, ModuleFilterBinding.fromConfig cfg.Shaping.Model with
+                    | e :: _, _ -> PlanAction.Refused (6, e)
+                    | [], Error (e :: _) -> PlanAction.Refused (2, e)
+                    | [], (Error [] | Ok _) ->
                         let agreed = match agreedR with Ok v -> v | Error _ -> (rs.Schema, "")
                         let confirm = confirmRs |> List.choose (function Ok v -> Some v | Error _ -> None)
-                        PlanAction.CheckShape (fst agreed, snd agreed, confirm, (valueOf "--format" = Some "json"))
+                        PlanAction.CheckShape (fst agreed, snd agreed, confirm, cfg.Shaping.Model, (valueOf "--format" = Some "json"))
             | ("environments" | "estate") :: _ ->
                 // THE ENVIRONMENTS INSTRUMENT (CHAPTER_ESTATE_OPEN.md; DECISIONS
                 // 2026-07-15) — `environments` is the verb; `estate` stays a
@@ -2439,6 +2443,12 @@ module Command =
                             Result.success (Some (v.Substring 1))
                         | Some v ->
                             Result.failureOf (err "cli.check.estateSinceForm" (sprintf "projection check environments: --since takes a run reference in the @runId form; '%s' does not name one." v))
+                    // The module scope (`model.modules`) is validated once here
+                    // so a bad module name refuses by name (exit 2) before any
+                    // read; the reads route through `ScopedRead`.
+                    match ModuleFilterBinding.fromConfig cfg.Shaping.Model with
+                    | Error (e :: _) -> PlanAction.Refused (2, e)
+                    | Error [] | Ok _ ->
                     match target, confirmError, evidence, since with
                     // A missing authored model, a contradictory evidence
                     // flag, or a malformed baseline reference is a
@@ -2458,6 +2468,7 @@ module Command =
                             { TargetLabel = label
                               Target      = source
                               Confirm     = confirm
+                              Scope       = cfg.Shaping.Model
                               AsJson      = (valueOf "--format" = Some "json")
                               Evidence    = evidenceMode
                               RepairBand  = rs.RepairBand

--- a/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
+++ b/sidecar/projection/src/Projection.Pipeline/Projection.Pipeline.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="RenameBinding.fs" />
     <Compile Include="ModuleFilterBinding.fs" />
     <Compile Include="SnapshotScopeBinding.fs" />
+    <Compile Include="ScopedRead.fs" />
     <Compile Include="TighteningBinding.fs" />
     <Compile Include="SpecialCircumstancesBinding.fs" />
     <Compile Include="SpecialCircumstancesDiagnostics.fs" />

--- a/sidecar/projection/src/Projection.Pipeline/ScopedRead.fs
+++ b/sidecar/projection/src/Projection.Pipeline/ScopedRead.fs
@@ -1,0 +1,59 @@
+namespace Projection.Pipeline
+
+open System.Threading.Tasks
+open Projection.Core
+open Projection.Adapters.OssysSql
+
+/// The ONE sanctioned scoped OSSYS-catalog read for a cross-environment
+/// comparison (`check environments` / `check estate` / `check shape`). It
+/// composes the two module-selection seams the full-export and peer-transfer
+/// paths already share — nothing new, just NAMED once so every comparison
+/// face routes through the same door:
+///
+///   1. **Query-time pushdown** — `SnapshotScopeBinding.fromModel` narrows the
+///      OSSYS rowsets server-side (only the `model.modules` estate crosses the
+///      wire), exactly as `Compose.readConfigModel` / `PeerTransfer.
+///      acquireContractsWith` do.
+///   2. **Semantic backstop** — `ModuleFilter.apply` (via
+///      `ModuleFilterBinding.fromConfig`) narrows the read catalog in memory.
+///      Double enforcement is V1's own precedent (the pushdown ≡ filter
+///      equivalence law).
+///
+/// The opt-in gate is byte-identical to those paths: an empty `model.modules`
+/// makes BOTH seams the show-me-everything identity, so an unconfigured scope
+/// reads the whole estate exactly as before.
+///
+/// Governance (THE_CONFIG_CONTROL_PLANE §6, S3): the comparison faces MUST NOT
+/// call `Source.read (Source.ofOssys …)` directly — that reads the WHOLE OSSYS
+/// estate (clone / deleted / test / system eSpaces included), which is not the
+/// cutover surface the operator declared. This module is the only sanctioned
+/// path; a source-scan test enforces it (`EstateScopeGovernanceTests`).
+[<RequireQualifiedAccess>]
+module ScopedRead =
+
+    /// The OSSYS `Source` scoped by the model's query-time pushdown. Retained
+    /// as a `Source` (not just a catalog) so the caller keeps the read + the
+    /// data-plane `profile` capability under ONE scope — the estate profiles
+    /// each environment's live data within the same declared module surface.
+    let scopedOssysSource (model: Config.ModelSection) (conn: string) : Source.Source =
+        Source.ofOssysWith (SnapshotScopeBinding.fromModel model) conn
+
+    /// Apply the in-memory `ModuleFilter` backstop to an already-read catalog
+    /// under the `model` scope. The sibling of `Compose.applyModuleFilter` that
+    /// takes the `ModelSection` directly (so a catalog resolved OUT of the OSSYS
+    /// read path — e.g. an authored `--against model` — is scoped the same way).
+    /// An empty `model.modules` is the identity; a bad module name is the
+    /// structured `moduleFilter.*` refusal (fail-loud, never a silent empty).
+    let applyScope (model: Config.ModelSection) (catalog: Catalog) : Result<Catalog> =
+        ModuleFilterBinding.fromConfig model
+        |> Result.bind (fun opts -> ModuleFilter.apply opts catalog)
+
+    /// Read one environment's OSSYS catalog scoped to `model.modules`: the
+    /// pushdown-scoped read, then the `ModuleFilter` backstop. The single
+    /// sanctioned scoped catalog read for a cross-environment comparison.
+    let readOssysScoped (model: Config.ModelSection) (conn: string) : Task<Result<Catalog>> =
+        task {
+            match! Source.read (scopedOssysSource model conn) with
+            | Error es -> return Result.failure es
+            | Ok catalog -> return applyScope model catalog
+        }

--- a/sidecar/projection/tests/Projection.Tests/EstateScopeGovernanceTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EstateScopeGovernanceTests.fs
@@ -1,0 +1,116 @@
+module Projection.Tests.EstateScopeGovernanceTests
+
+// The cross-environment comparison faces (`check environments` / `check estate`
+// / `check shape`) must read the OSSYS estate SCOPED to `model.modules` — not
+// the whole estate. Reading the whole estate drags in clone / deleted / test /
+// system eSpaces; a cloned module carries the SAME entity SS_Keys as its
+// original, so the whole-estate read fails to construct (`catalog.kinds.
+// duplicateKey`). Scoping excludes the clones and the (stable-across-
+// environments) SS_Key matching is then correct.
+//
+// Two guards here:
+//   1. GOVERNANCE (source-scan) — no face calls the unscoped `Source.ofOssys`
+//      directly; the sanctioned path is `ScopedRead` (or `Source.ofOssysWith`
+//      with a bound scope). This is the "restrict against this happening again"
+//      rail so a future face cannot silently re-introduce the whole-estate read.
+//   2. SCOPE (pure) — `ScopedRead.applyScope` narrows a catalog to the declared
+//      `model.modules`, and an empty selection is the byte-identical identity.
+
+open System.IO
+open System.Text.RegularExpressions
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Tests.Fixtures
+open Projection.Tests.IRBuilders
+
+// -- shared root walk (the AxiomTests idiom) ---------------------------------
+
+let private projectionRoot : string =
+    let sentinel = Path.Combine("tests", "Projection.Tests", "EstateScopeGovernanceTests.fs")
+    let rec findUp (dir: DirectoryInfo option) : string option =
+        match dir with
+        | None -> None
+        | Some d ->
+            if File.Exists(Path.Combine(d.FullName, sentinel)) then Some d.FullName
+            else findUp (Option.ofObj d.Parent)
+    let start =
+        System.Reflection.Assembly.GetExecutingAssembly().Location
+        |> Path.GetDirectoryName
+        |> Option.ofObj
+        |> Option.map (fun d -> DirectoryInfo d)
+    match findUp start with
+    | Some root -> root
+    | None ->
+        failwith "projection root not found above the test assembly — expected tests/Projection.Tests/EstateScopeGovernanceTests.fs"
+
+// -- 1. governance: no unscoped OSSYS read in a comparison face --------------
+
+[<Fact>]
+let ``governance: no face reads the whole OSSYS estate (Source.ofOssys) — the scoped seam is the only path`` () =
+    let facesDir = Path.Combine(projectionRoot, "src", "Projection.Cli", "Faces")
+    Assert.True(Directory.Exists facesDir, sprintf "expected the faces directory at %s" facesDir)
+    // The unscoped constructor `Source.ofOssys` (NOT the scope-bearing
+    // `Source.ofOssysWith`) reads every eSpace in the estate. Comment lines are
+    // stripped first so a doc mention of the name is never a false positive; a
+    // genuine call is never on a `//`-prefixed line.
+    let forbidden = Regex(@"Source\.ofOssys(?!With)")
+    let offenders =
+        Directory.EnumerateFiles(facesDir, "*.fs", SearchOption.AllDirectories)
+        |> Seq.choose (fun file ->
+            let source =
+                File.ReadAllText file
+                |> fun raw -> raw.Split('\n')
+                |> Array.map (fun line -> if line.TrimStart().StartsWith "//" then "" else line)
+                |> String.concat "\n"
+            if forbidden.IsMatch source then Some (Path.GetFileName file |> Option.ofObj |> Option.defaultValue file) else None)
+        |> Seq.toList
+    Assert.True(
+        List.isEmpty offenders,
+        sprintf
+            "these comparison faces read the WHOLE OSSYS estate via Source.ofOssys instead of scoping to model.modules through ScopedRead: %s"
+            (String.concat ", " offenders))
+
+// -- 2. scope: applyScope narrows to model.modules; empty is identity --------
+
+let private twoModuleCatalog : Catalog =
+    // `customer` and `country` carry no cross-references, so two single-kind
+    // modules form a referentially-clean catalog.
+    mkCatalog
+        [ mkModule (modKey "InScope")  (mkName "InScope")  [ customer ]
+          mkModule (modKey "OutScope") (mkName "OutScope") [ country ] ]
+
+let private modelScopedTo (modules: Config.ModuleSelector list) : Config.ModelSection =
+    { Path                   = None
+      Ossys                  = None
+      Modules                = modules
+      IncludeSystemModules   = true
+      IncludeInactiveModules = true
+      OnlyActiveAttributes   = true }
+
+[<Fact>]
+let ``scope: applyScope keeps only the declared model.modules (out-of-scope clone/system eSpace dropped)`` () =
+    let model = modelScopedTo [ Config.ModuleSelector.Whole "InScope" ]
+    let scoped = ScopedRead.applyScope model twoModuleCatalog |> Result.value
+    let moduleNames = scoped.Modules |> List.map (fun m -> Name.value m.Name)
+    Assert.Equal<string list>([ "InScope" ], moduleNames)
+    let kindNames =
+        Catalog.allKinds scoped |> List.map (fun k -> Name.value k.Name) |> List.sort
+    Assert.Equal<string list>([ "Customer" ], kindNames)
+
+[<Fact>]
+let ``scope: an empty model.modules is the show-everything identity (byte-identical default)`` () =
+    let model = modelScopedTo []
+    let scoped = ScopedRead.applyScope model twoModuleCatalog |> Result.value
+    Assert.Equal(2, List.length scoped.Modules)
+    Assert.Equal<string list>(
+        twoModuleCatalog.Modules |> List.map (fun m -> Name.value m.Name),
+        scoped.Modules |> List.map (fun m -> Name.value m.Name))
+
+[<Fact>]
+let ``scope: a model.modules naming a module absent from the estate refuses by name (fail-loud, not silent-empty)`` () =
+    let model = modelScopedTo [ Config.ModuleSelector.Whole "NoSuchModule" ]
+    match ScopedRead.applyScope model twoModuleCatalog with
+    | Ok _ -> Assert.Fail "expected a moduleFilter.modules.missing refusal for an unknown module"
+    | Error errs ->
+        Assert.Contains(errs, fun (e: ValidationError) -> e.Code = "moduleFilter.modules.missing")

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -193,6 +193,7 @@
     <Compile Include="ReadinessTests.fs" />
     <Compile Include="EstateTests.fs" />
     <Compile Include="EstateRemediationTests.fs" />
+    <Compile Include="EstateScopeGovernanceTests.fs" />
     <Compile Include="EstatePostureTests.fs" />
     <Compile Include="EstateHistoryTests.fs" />
     <Compile Include="EstateEvidenceStoreTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReadinessConfigTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReadinessConfigTests.fs
@@ -79,7 +79,7 @@ let ``readiness.estate: a non-positive decisionFloor is a NAMED parse failure`` 
 let ``check shape: resolves to CheckShape with the agreed + confirm conn-refs`` () =
     let cfg = ProjectionConfig.parse estateJson |> mustOk
     match (Command.planCheck cfg [ "shape" ]).Action with
-    | PlanAction.CheckShape (agreedLabel, agreedRef, confirm, _) ->
+    | PlanAction.CheckShape (agreedLabel, agreedRef, confirm, _, _) ->
         Assert.Equal("cloud-dev", agreedLabel)
         Assert.Equal("env:CLOUD_DEV_CONN", agreedRef)
         Assert.Equal<string list>([ "cloud-dev"; "cloud-qa"; "cloud-uat" ], confirm |> List.map fst)


### PR DESCRIPTION
## Problem

`check environments` / `check estate` (and its sibling `check shape`) read each cloud environment's **whole** OSSYS estate via bare `Source.read (Source.ofOssys …)`, ignoring the configured `model.modules` scope. Every other model-bearing verb routes its read through the shared scoped seam (`Compose.applyModuleFilter` → `ModuleFilterBinding.fromConfig` → `ModuleFilter.apply`); these two bypassed it.

The concrete consequence is the **clone collision**: reading the whole estate pulls in clone / deleted / test / system eSpaces, and a cloned module carries the *same* entity SS_Keys as its original. `Catalog.create` refuses duplicate Kind SS_Keys (`catalog.kinds.duplicateKey`), so the estate read **fails loud** (exit 6) on any estate containing clones.

## Why matching is unchanged

SS_Key **is** stable across environments (module SS_Key equal everywhere; entity SS_Key stable per LifeTime lineage; only *clones* share keys). So the fix is **scope-only** — the existing SS_Key-based matching (`CatalogDiff.between`) is correct once clones are scoped out. Re-keying by logical name would be the weaker/unsafe path the codebase explicitly warns against in `NameAlignment.fs` (by-name is A1-bounded, "never auto-detected" — it can silently align a mis-wired pair).

## Changes

- **New `ScopedRead.fs`** — the one sanctioned scoped OSSYS read: `SnapshotScopeBinding.fromModel` query-time pushdown + `ModuleFilter.apply` semantic backstop (the same composition full-export and `PeerTransfer.acquireContractsWith` already use, named once).
- Thread the `model.modules` scope (`Config.ModelSection`) into `CheckEstateArgs` and `PlanAction.CheckShape`; validate at plan construction so a bad module name refuses by name (exit 2) before any read.
- Route **every** estate/shape read through the seam: the agreed-env target, the `--against model` authored target (`ModelResolution.resolveCatalog` did not filter itself, so it was unscoped too), and each confirm env. The scoped `Source` also carries the data-plane profile, so profiling stays in scope.
- **Governance:** `EstateScopeGovernanceTests` source-scans `src/Projection.Cli/Faces/*.fs` for `Source.ofOssys` (not `…With`) so no future face can silently re-introduce a whole-estate read, plus pure scope canaries (narrows to `model.modules`; empty selection is the byte-identical identity; an unknown module refuses).

`check shape` gets the same scope fix. `diff` / `compare` are general two-ref tools (not the configured-model surface) and are intentionally left as-is.

## Verification

- Build 0/0 (Cli + Tests).
- **944 + 166 focused pure tests pass, 0 failed** — planning/CLI/config, estate, readiness, and the (unchanged) peer-transfer / name-alignment suites.

## Follow-up (not in this PR)

`check shape` is largely superseded by `check environments`. Worth a separate decision on whether to keep maintaining it or steer users to the newer instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)