### PR TITLE
CI: run the three projection guardrails on every PR (prep for required-check gating)

### DIFF
--- a/.github/workflows/analyzers-projection.yml
+++ b/.github/workflows/analyzers-projection.yml
@@ -31,10 +31,14 @@ name: analyzers-projection
 # ubuntu-latest — adding it here would be a flaky gate, not a fitness signal.
 
 on:
+  # Runs on EVERY pull request (no `paths:` filter) so it is safe to make this
+  # a REQUIRED status check on `main`: a path-filtered workflow that is skipped
+  # leaves its required check pending forever and blocks the merge. With no
+  # filter the check always reports — and passes trivially when
+  # `sidecar/projection/Projection.Core` is unchanged (the analyzer finds
+  # nothing new), so it only ever blocks a real determinism-spine violation.
+  # (This gate runs `dotnet`, ~3 min; the trade for guaranteed blocking.)
   pull_request:
-    paths:
-      - 'sidecar/projection/**'
-      - '.github/workflows/analyzers-projection.yml'
   push:
     branches:
       - main

--- a/.github/workflows/lint-projection.yml
+++ b/.github/workflows/lint-projection.yml
@@ -16,10 +16,13 @@ name: lint-projection
 # acknowledgement.
 
 on:
+  # Runs on EVERY pull request (no `paths:` filter) so it is safe to make this
+  # a REQUIRED status check on `main`: a path-filtered workflow that is skipped
+  # leaves its required check pending forever and blocks the merge (GitHub's
+  # "skipped but required" behavior). With no filter the check always reports —
+  # and it passes trivially when `sidecar/projection/` is unchanged (the scan
+  # finds nothing new), so it only ever blocks a real projection-lint violation.
   pull_request:
-    paths:
-      - 'sidecar/projection/**'
-      - '.github/workflows/lint-projection.yml'
   push:
     branches:
       - main

--- a/.github/workflows/verifiability-projection.yml
+++ b/.github/workflows/verifiability-projection.yml
@@ -23,10 +23,13 @@ name: verifiability-projection
 # a stale matrix.
 
 on:
+  # Runs on EVERY pull request (no `paths:` filter) so it is safe to make this
+  # a REQUIRED status check on `main`: a path-filtered workflow that is skipped
+  # leaves its required check pending forever and blocks the merge. With no
+  # filter the check always reports — and passes trivially when
+  # `sidecar/projection/` is unchanged (the matrix regenerates identically), so
+  # it only ever blocks a stale matrix / phantom-coverage claim.
   pull_request:
-    paths:
-      - 'sidecar/projection/**'
-      - '.github/workflows/verifiability-projection.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
Makes the three projection guardrails — **lint-discipline**, **verifiability + matrix-ladder**, and **custom FSharp analyzers** — run on *every* pull request by removing the `pull_request` `paths:` filter.

**Why:** to make them **required (blocking)** status checks on `main` without the footgun. A path-filtered workflow that a PR skips (one not touching `sidecar/projection/`) leaves its required check *pending forever* and blocks the merge (GitHub's documented "skipped but required" behavior). With no PR filter the check always reports — and passes trivially when `sidecar/projection/` is unchanged — so it only ever blocks a real projection violation.

The `push:` triggers keep their `sidecar/projection/**` path filter (post-merge runs stay projection-scoped). After this merges, branch protection on `main` will require these three check contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)