### PR TITLE
σ: content-address value streams to the cell — stability across schema versions (S-stable)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -29762,3 +29762,64 @@ then applies all with one edit — or declares the intended indexes UNIQUE in th
 model). The other keep-reasons stay non-config-actionable (duplicates need a
 data fix; missing evidence needs profiling; policy-disabled is the operator's
 own toggle). Closes the machine-readable-candidate-list residual named above.
+
+## 2026-07-19 — σ's value streams are content-addressed to the cell: stability across schema versions (`S-stable`), the Twin's load-bearing property
+
+**Status:** ADOPTED. The kernel change lands with its executable witness
+(`SyntheticDataTests``S-stable``, three facts) and no other test churn — the
+pure pool stays green.
+
+**The property this serves.** The Twin's reason to exist is schema-change
+testing: spin up a local DB, make a schema edit, and see whether a test behaves
+differently. That signal is only trustworthy if the DATA is held fixed across
+the edit — otherwise a diff between v1 and v2 could be the dice, not the schema
+change. So determinism-within-a-schema (T1: same seed → byte-identical) is not
+enough; we need **stability across schema versions**: an edit perturbs only the
+columns it touches, and every other column is byte-identical between the two
+versions.
+
+**The gap.** σ already content-addressed at the KIND grain — `kindSeed master
+kind` made each kind's stream independent, stable under kind reordering. But
+WITHIN a kind it threaded ONE `Rng` over rows × attributes in declaration order
+("pass-2 rng, salted off the PK-pool rng"). A column consumes a variable number
+of draws (an FK draws 1–2, a categorical 2, a null-decision 0–1), so inserting a
+column mid-table shifts every DOWNSTREAM column's draws — and, because the thread
+was row-major, every LATER row of every column too. Adding one column changed
+the synthetic data wholesale, between exactly the two versions the operator is
+trying to diff. This is the failure mode `THE_SYNTHETIC_DATA_DESIGN.md` §6
+("schema-drift handling, free via SsKey") did NOT cover: §6 keeps the PROFILE
+lookup stable across renames; it said nothing about the DRAW stream.
+
+**The fix — one law, seeded from the coordinate.** Extend the content-address
+down to the cell: `column_seed = mix(kind_seed ⊕ hash(column_name))`, and each
+cell's stream is `cell_seed = mix(column_seed + γ·(row+1))` (a splitmix step over
+the row index). Every value σ emits is now a pure function of
+`(master, kind, column, row)` and that column's own evidence/config — never of a
+sibling column's presence, order, or draw count. The one deliberately-shared
+stream is the F5b correlated-FK tuple, keyed `(kind, row)` via `rowStreamSeed`
+(it MUST correlate its participating columns; an unrelated column's arrival still
+cannot move it). PK pools were already index-based (`surrogateRaw … i`), so row
+identity was stable before and stays so.
+
+**Why no other test moved.** The existing σ suite is property/range/determinism-
+shaped, not golden-literal: T1 (`generate = generate`), zero-orphans, null-rate
+within ε, the privacy contract, F5/F5b/H-072 skews, and the no-op-config
+byte-identity pairs (empty `ProvidedPools`/`AugmentPools`, cross-cluster) all
+hold under any deterministic re-seed that preserves the distributions and the
+equal-path draws — which per-cell seeding does. The actual emitted bytes for a
+FIXED schema DID change (a re-seed), but nothing pins them, and the Twin's mint
+re-mints on every schema change today (`THE_TWIN.md` §9), so there is no
+persisted dataset to migrate.
+
+**Distributional note.** Per-cell fresh seeding is the counter-based-RNG posture
+(seed = hash(key ‖ counter)): splitmix64's finalizer over disjoint seeds yields
+independent uniform streams, and the design's correctness claim is distributional
+("within ε"), not a uniformity proof (`THE_SYNTHETIC_DATA_DESIGN.md` §3). The
+null-rate-ε, range, and skew facts confirm the shapes survive.
+
+**Boundary named (adjacent, deferred).** The essay that opened this work also
+asks for a `--dry-run --explain` that prints, per column, which resolution rule
+won (explicit → heuristic → profile → constraint → type-default) and why. That
+inspectability is real and load-bearing for trust in the defaults layer, but it
+is a CLI/reporting surface, not the data-stability axis this branch owns — left
+as the next slice, not smuggled in here.

--- a/sidecar/projection/THE_SYNTHETIC_DATA_DESIGN.md
+++ b/sidecar/projection/THE_SYNTHETIC_DATA_DESIGN.md
@@ -185,6 +185,21 @@ Generate rows for the **target schema B** (what we load into), drawing evidence 
 columns (no profile) get type-defaults; A-only columns are ignored. So profiled-legacy →
 cloud-preview works even under schema drift, as long as identity is preserved.
 
+### 6.1 Stability across schema versions (`S-stable`, DECISIONS 2026-07-19)
+
+§6 keeps the *profile lookup* stable across the drift; the **draw stream** is kept stable
+by the same discipline, one grain finer. σ's values are **content-addressed to the cell**:
+`table_seed = mix(master ⊕ hash(table))`, `column_seed = mix(table_seed ⊕ hash(column))`,
+and each cell draws from `mix(column_seed + γ·(row+1))`. Every emitted value is a pure
+function of `(master, kind, column, row)` — never threaded positionally across a kind's
+columns. So inserting, removing, or reordering a column perturbs **only that column's
+cells**; every other column is byte-identical between the two schema versions. This is the
+property that makes local schema-change testing trustworthy (the Twin's whole reason to
+exist): when a test behaves differently between v1 and v2, the data is the fixed variable,
+so the schema change is the only cause — not the dice. The one deliberately row-shared
+stream is the F5b correlated-FK tuple, keyed `(kind, row)`; the marginal columns each own
+their stream. Witnessed by `SyntheticDataTests``S-stable`` (insert / reorder / remove).
+
 ---
 
 ## 7. Scope boundaries (named, not silent — surface each in `THE_CLI.md` §12)

--- a/sidecar/projection/THE_TWIN.md
+++ b/sidecar/projection/THE_TWIN.md
@@ -60,8 +60,11 @@ shaped from day one to peel off as a standalone tool (§8).
 5. **Twin self-description** — the `[twin]` schema (one single-row state table) is the
    tool's only write outside the estate's own objects, excluded from schema comparison.
 6. **Inherited and re-asserted at the twin's grain** — T1 determinism of the mint
-   (`TwinMintLoopTests``T1``; byte-identical re-mints by construction under K1c), zero
-   FK orphans (`K1 + L1`), the privacy contract (the evidence-loop E2E's
+   (`TwinMintLoopTests``T1``; byte-identical re-mints by construction under K1c),
+   `S-stable` stability across schema versions (σ content-addresses every value to
+   `(master, kind, column, row)`, so a schema edit re-mints only the changed columns and
+   holds the rest byte-identical — `SyntheticDataTests``S-stable``; DECISIONS 2026-07-19),
+   zero FK orphans (`K1 + L1`), the privacy contract (the evidence-loop E2E's
    never-re-emitted source emails), and π ∘ σ ≈ id productized as `twin check`
    (model → publish → lanes → mint ×2 → zero orphans + identical digests +
    preserved-vocabulary re-profile).
@@ -204,7 +207,14 @@ scenario, coordinate, and expected shape named.
   pool length is the row range).
 - **`perParent` lands the MEAN fan-out via volumes**; skewed fan-out is the evidence
   plane's (`ForeignKeySelectivity`, F5a).
-- **v1 re-mints on every schema change** (data-preserving refresh is future work).
+- **v1 re-mints on every schema change** (data-preserving refresh is future work) — but
+  the re-mint is **stable across the schema change** (`S-stable`, DECISIONS 2026-07-19):
+  σ content-addresses every value to `(master, kind, column, row)`, so a schema edit
+  perturbs only the columns it touches and every other column re-mints byte-identical. This
+  is the axis the whole test bed hangs on — the re-mint being deterministic is not enough;
+  it must hold the unchanged data FIXED so a v1↔v2 test difference is the schema, not the
+  dice. The `--dry-run --explain` view of the per-column resolution chain is the adjacent,
+  still-deferred inspectability slice (named in the DECISIONS entry).
 - **Evidence-free realism needs a corrections artifact** — without one, columns mint as
   shaped tokens; `twin init`'s proposer scaffolds the classification (M5 wires it).
 - **`--watch`** deferred behind the same reconcile loop (operator decision 2026-07-18).

--- a/sidecar/projection/src/Projection.Core/SyntheticData.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticData.fs
@@ -235,6 +235,28 @@ module SyntheticData =
     let private kindSeed (master: uint64) (key: SsKey) : uint64 =
         mix (master ^^^ fnv1a (SsKey.serialize key))
 
+    /// The per-column base seed: the kind seed mixed with a stable hash of the
+    /// column's identity. Independent per column and stable under column
+    /// reordering — the content-address the stability-across-schema-change law
+    /// (`S-stable`) is built on: `column_seed = hash(table_seed, column_name)`.
+    let private columnSeed (master: uint64) (kindKey: SsKey) (attrKey: SsKey) : uint64 =
+        mix (kindSeed master kindKey ^^^ fnv1a (SsKey.serialize attrKey))
+
+    /// The seed for ONE cell — column `attrKey` at row `rowIndex`. A splitmix
+    /// step over the row index gives each row an independent draw stream while
+    /// the column seed keeps the streams disjoint across columns. So every value
+    /// σ emits is a pure function of (master, kind, column, row): inserting,
+    /// removing, or reordering a SIBLING column cannot move it — the whole point.
+    let private cellSeed (master: uint64) (kindKey: SsKey) (attrKey: SsKey) (rowIndex: int) : uint64 =
+        mix (columnSeed master kindKey attrKey + SplitGamma * (uint64 rowIndex + 1UL))
+
+    /// The seed for one ROW's correlated-FK-tuple stream (F5b). Keyed by
+    /// (kind, row) only — the joint columns' values ride this one draw, so an
+    /// unrelated column's arrival never disturbs the tuple. Salted apart from
+    /// every column stream (the historical pass-2 salt) so the two never collide.
+    let private rowStreamSeed (master: uint64) (kindKey: SsKey) (rowIndex: int) : uint64 =
+        mix ((kindSeed master kindKey ^^^ 0xD1B54A32D192ED03UL) + SplitGamma * (uint64 rowIndex + 1UL))
+
     // -- Type-rendered surrogates and defaults (raw-form; design §3 / §8) -----
 
     let private ticksPerDay : int64 = 864000000000L
@@ -406,10 +428,14 @@ module SyntheticData =
     // (raw strings keyed by attribute Name). A column at NULL is omitted.
 
     /// Build one kind's rows. `pkPools` carries every kind's PK pool (raw PK
-    /// values, one per row) so FK columns draw from the target's pool. The
-    /// per-kind `Rng` is threaded over rows × attributes in a fixed order
-    /// (declaration order, ascending row index) — deterministic by
-    /// construction.
+    /// values, one per row) so FK columns draw from the target's pool. Each
+    /// cell's `Rng` is CONTENT-ADDRESSED — seeded from (master, kind, column,
+    /// row) via `cellSeed`, never threaded positionally across the kind's
+    /// columns — so σ is deterministic AND stable across schema versions
+    /// (`S-stable`): inserting/removing/reordering a column moves only that
+    /// column's cells. The one exception is the row's correlated-FK tuple
+    /// (F5b), drawn once from a (kind, row)-keyed stream shared by the joint's
+    /// participating columns.
     /// H-072 — the leading fraction of a parent pool that intra-cluster FK draws
     /// concentrate on (opt-in). 0.3 = intra-cluster references land in the top 30%
     /// of the pool, so a cluster's rows share a small parent set (the cluster reads
@@ -534,24 +560,33 @@ module SyntheticData =
                         && (pkPools |> Map.tryFind target |> Option.defaultValue [] |> List.isEmpty) ->
                     Some (SyntheticDiagnostic.unsatisfiableForeignKey kind.SsKey attr.SsKey target)
                 | _ -> None)
-        // pass-2 rng, salted off the PK-pool rng so FK / distribution draws
-        // don't correlate with surrogate minting.
-        let mutable state = rngOf (kindSeed master kind.SsKey ^^^ 0xD1B54A32D192ED03UL)
-        let nextDraw () =
-            let v, s = draw state in state <- s; v
+        // Content-addressed value streams (the `S-stable` law). Every draw is
+        // seeded from the coordinate it fills — (master, kind, column, row) —
+        // never threaded positionally across a kind's columns. So inserting,
+        // removing, or reordering a column perturbs ONLY that column's cells;
+        // every other column is byte-identical across the schema change. The
+        // salt `^^^ 0xD1B5…` that once separated this "pass-2" stream from the
+        // PK-pool minting now lives in `rowStreamSeed` / `cellSeed`.
         let rows =
           [ for i in 0 .. rowCount - 1 ->
-            // §6.3 F5b — draw the row's correlated FK tuple ONCE (when a joint
-            // exists); the joint FK columns below take their value from it.
+            // §6.3 F5b — the row's correlated FK tuple, drawn ONCE from the row's
+            // own (kind, row)-keyed stream; the joint FK columns below take their
+            // value from it. Keyed by the row (not any column position), so an
+            // unrelated column's arrival never moves the tuple.
             let jointAssignment =
                 match jointDraw with
-                | Some draw -> let m, s = draw state in state <- s; m
+                | Some draw -> fst (draw (rngOf (rowStreamSeed master kind.SsKey i)))
                 | None      -> Map.empty
             let cells =
                 kind.Attributes
                 |> List.choose (fun attr ->
                     let attrHash = fnv1a (SsKey.serialize attr.SsKey)
                     let nullable = attr.Column.IsNullable
+                    // This column's own stream at this row — independent of every
+                    // sibling column's presence, declaration order, or draw count.
+                    let mutable state = rngOf (cellSeed master kind.SsKey attr.SsKey i)
+                    let nextDraw () =
+                        let v, s = draw state in state <- s; v
                     // §3 precedence: PK → FK → unique → distribution/default.
                     let raw =
                         if attr.IsPrimaryKey then

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -594,3 +594,94 @@ let ``K1b: augmented generation keeps its own rows' keys and stays deterministic
     // beyond the row range.
     let baseline = SyntheticData.generate catalog profile cfg 3UL
     Assert.Equal<string list>(valuesOf baseline custKey "Id", valuesOf a custKey "Id")
+
+// ---------------------------------------------------------------------------
+// S-stable (DECISIONS 2026-07-19) — stability across schema versions. σ's value
+// streams are content-addressed by (master, kind, column, row): a draw is
+// seeded from the coordinate it fills, never threaded positionally across a
+// kind's columns. So a schema edit perturbs ONLY the columns it touches —
+// inserting, removing, or reordering a column leaves every other column
+// byte-identical. This is the Twin's load-bearing property: when a test behaves
+// differently between two schema versions the DATA is the same variable held
+// fixed, so the schema change is the only cause — not the dice.
+//
+// The naive one-RNG-per-kind, threaded-in-declaration-order design fails all
+// three of these: a mid-table column consumes a different number of draws,
+// shifting every downstream column and (through the row-major thread) every
+// later row. These tests are that law's executable witness.
+// ---------------------------------------------------------------------------
+
+let private custMiddle = attrKey ["C"; "Middle"]
+
+/// Customer with one extra NOT NULL text column inserted in the MIDDLE of the
+/// attribute list (between Status and Email) — the adversarial position for a
+/// positional generator.
+let private customerWithMiddle : Kind =
+    { Kind.create custKey (name "Customer") (mkTableId "dbo" "CUSTOMER")
+        [ attr custId    "Id"     Integer true  false
+          attr custStat  "Status" Text    false false
+          attr custMiddle "Middle" Text   false false
+          attr custEmail "Email"  Text    false false
+          attr custScore "Score"  Integer false false
+          attr custNotes "Notes"  Text    false true  ] with
+        Modality = [] }
+
+[<Fact>]
+let ``S-stable: inserting a column mid-table perturbs only that column — every other column byte-identical`` () =
+    let catalogV2 =
+        Catalog.create [ mkModule (modKey "M") (name "M") [ customerWithMiddle; order ] ] [] |> mkOk
+    // The new column carries its own row count (100, no nulls); the kind's
+    // volume is unchanged (max over the columns' RowCounts is still 100).
+    let profileV2 = { profile with Columns = col custMiddle 100L 0L :: profile.Columns }
+    let v1 = SyntheticData.generate catalog   profile   cfg 7UL
+    let v2 = SyntheticData.generate catalogV2 profileV2 cfg 7UL
+    // Every column that survived the edit is byte-identical across the versions.
+    for attrName in [ "Id"; "Status"; "Email"; "Score"; "Notes" ] do
+        Assert.Equal<string list>(valuesOf v1 custKey attrName, valuesOf v2 custKey attrName)
+    // The child kind — its FKs draw from the (unchanged) Customer PK pool — is
+    // wholly untouched by the parent's new column.
+    for attrName in [ "Id"; "CustomerId"; "OptCustomerId" ] do
+        Assert.Equal<string list>(valuesOf v1 ordKey attrName, valuesOf v2 ordKey attrName)
+    // The new column is the ONLY difference: present in v2, absent from v1.
+    Assert.Equal(100, valuesOf v2 custKey "Middle" |> List.length)
+    Assert.Empty(valuesOf v1 custKey "Middle")
+
+[<Fact>]
+let ``S-stable: reordering a kind's columns is byte-identical to the original`` () =
+    // A pure permutation of the attribute list (Id stays the PK, just no longer
+    // first). Content-addressed streams ignore declaration order entirely, so
+    // the whole dataset — values AND row identities — is unchanged.
+    let customerReordered : Kind =
+        { customer with
+            Attributes =
+                [ attr custStat  "Status" Text    false false
+                  attr custEmail "Email"  Text    false false
+                  attr custId    "Id"     Integer true  false
+                  attr custNotes "Notes"  Text    false true
+                  attr custScore "Score"  Integer false false ] }
+    let catalogReordered =
+        Catalog.create [ mkModule (modKey "M") (name "M") [ customerReordered; order ] ] [] |> mkOk
+    let v1 = SyntheticData.generate catalog          profile cfg 7UL
+    let v2 = SyntheticData.generate catalogReordered profile cfg 7UL
+    Assert.Equal<Map<SsKey, StaticRow list>>(v1, v2)
+
+[<Fact>]
+let ``S-stable: removing a column leaves every surviving column byte-identical`` () =
+    // Drop Score from the middle of Customer. The columns around it — and the
+    // child kind — must be exactly what they were before the drop.
+    let customerNoScore : Kind =
+        { customer with
+            Attributes =
+                [ attr custId    "Id"     Integer true  false
+                  attr custStat  "Status" Text    false false
+                  attr custEmail "Email"  Text    false false
+                  attr custNotes "Notes"  Text    false true  ] }
+    let catalogV2 =
+        Catalog.create [ mkModule (modKey "M") (name "M") [ customerNoScore; order ] ] [] |> mkOk
+    let v1 = SyntheticData.generate catalog   profile cfg 7UL
+    let v2 = SyntheticData.generate catalogV2 profile cfg 7UL
+    for attrName in [ "Id"; "Status"; "Email"; "Notes" ] do
+        Assert.Equal<string list>(valuesOf v1 custKey attrName, valuesOf v2 custKey attrName)
+    for attrName in [ "Id"; "CustomerId"; "OptCustomerId" ] do
+        Assert.Equal<string list>(valuesOf v1 ordKey attrName, valuesOf v2 ordKey attrName)
+    Assert.Empty(valuesOf v2 custKey "Score")


### PR DESCRIPTION
> Note on template: `.github/PULL_REQUEST_TEMPLATE/schema-change.md` is a named template for `.sqlproj` / table-definition changes. This PR touches no `.sqlproj` — it changes the pure-F# synthetic-data generator and its tests/docs — so that record's sections (data remediation, deployment evidence, sqlpackage version, rollback) don't apply. Body written to fit the actual diff.

## Summary

The Twin exists to make a local schema change trustworthy: edit the schema, re-mint, and know that a difference in test behavior between v1 and v2 is *the schema change*, not the dice. That only holds if the synthetic data is held fixed across the edit — an edit may perturb **only the columns it touches**.

σ already content-addressed at the **kind** grain (`kindSeed` makes each kind's stream independent and stable under kind reordering), but **within** a kind it threaded one RNG over rows × attributes in declaration order. A column consumes a variable number of draws, so inserting a column mid-table shifted every downstream column — and, because the thread was row-major, every later row too. One added column changed the synthetic data wholesale, between exactly the two versions the operator is diffing. `THE_SYNTHETIC_DATA_DESIGN` §6 (drift-by-SsKey) kept the *profile lookup* stable across renames; it said nothing about the *draw stream*.

This PR extends the content-address down to the **cell**.

## The change

- `column_seed = mix(kind_seed ⊕ hash(column))`; each cell draws from `mix(column_seed + γ·(row+1))`. Every value σ emits is now a pure function of `(master, kind, column, row)` and that column's own evidence — never of a sibling column's presence, declaration order, or draw count.
- The one deliberately row-shared stream is the F5b correlated-FK tuple, keyed `(kind, row)` via `rowStreamSeed` (it *must* correlate its participating columns; an unrelated column's arrival still can't move it).
- PK pools were already index-based (`surrogateRaw … i`), so row identity was stable before and stays so.

## Changes

| File | Change |
|---|---|
| `sidecar/projection/src/Projection.Core/SyntheticData.fs` | New `columnSeed` / `cellSeed` / `rowStreamSeed` helpers; per-kind threaded RNG replaced by per-cell content-addressed streams; docstring corrected. |
| `sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs` | Three new `S-stable` facts: insert-mid-table, reorder, remove. |
| `sidecar/projection/DECISIONS.md` | 2026-07-19 entry recording the law, the gap, and the reasoning. |
| `sidecar/projection/THE_SYNTHETIC_DATA_DESIGN.md` | New §6.1 (stability across schema versions). |
| `sidecar/projection/THE_TWIN.md` | Law 6 and §9 updated to cite `S-stable`. |

No renames, no schema/DDL changes, no `.sqlproj` touched.

## Testing

- Red→green: the three `S-stable` facts **fail** on the unmodified generator (proving the gap) and **pass** after the change.
- Full pure pool (`scripts/test.sh fast`): **4575 passed**, with the three new facts green and no regressions. The suite is property/range/determinism-shaped (T1 determinism, zero orphans, null-rate ε, the privacy contract, F5/F5b/H-072 skews, and the no-op-config byte-identity pairs), so it stays green under the re-seed.
- One unrelated failure — `BtReferenceFkFlowTests` `ComputedExpressionRefused ("Product","DisplayLabel","nvarchar")` — was confirmed **pre-existing on `main`** by reproducing it with this PR's changes stashed. It lives in DDL emission, a path this diff never touches.

## Notes

Emitted bytes for a *fixed* schema did change (this is a re-seed), but nothing pins them and the Twin re-mints on every schema change, so there is no persisted dataset to migrate.

The `--dry-run --explain` view of the per-column resolution chain (explicit → heuristic → profile → constraint → type-default), also raised in the originating design note, is called out in the DECISIONS entry as the adjacent, still-deferred inspectability slice — a CLI/reporting surface, not the data-stability axis this branch owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMSU373Y1QNbmpgonSM6RS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMSU373Y1QNbmpgonSM6RS)_