### PR TITLE
ssdt-agent: deployment-script lifecycle rails, Twin-deterministic substrate, and the certification plan

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30222,3 +30222,49 @@ never silent" discipline; also in `THE_FIDELITY_PROOFS.md` §4 and the `BACKLOG`
 manifest (surrogate-excluded, for sink-minting targets); offline per-row naming (embed
 `GoldenDataset` rows so a reconcile names the cell, not just the kind); non-OSSYS source estates
 (the three de-OSSYS gating seams become archetype/config-gated).
+
+---
+
+## 2026-07-20 — The Twin excludes VIEWS from the wipe and the mint (a view carries no data); + the `Readback` "furniture" → "state schema" rename
+
+**The decision (a new named rule).** A **view carries no data — it is excluded from the twin's
+pre-mint wipe and from the mint, and retained in the published schema.** This sits beside law 5
+(the `[twin]` state schema is the tool's own, never estate) and law 6 (zero-orphan mint): the
+data plane is estate *tables* only; views and the state schema are the two classes of non-estate
+kinds the read-back drops before wipe/mint sees the catalog.
+
+**The bug it fixes.** `twin up` against an estate containing a view (the ssdt-agent proving
+ground's `vOrderSummary`) refused with `twin.wipe.failed` — the clean-slate wipe issued
+`DELETE FROM dbo.vOrderSummary`, which SQL Server refuses for a view over multiple base tables
+("not updatable because the modification affects multiple base tables"). The mint was equally
+broken (an `INSERT` into the view under `WipeAndLoad`). **Root cause:** `ReadSide.readSchemaCombined`
+builds the kind set from `INFORMATION_SCHEMA.COLUMNS` with no `BASE TABLE` restriction, so view
+columns are grouped into a `Kind` indistinguishable from a base table; `ActConsent.wipeTargets`
+and the mint then treat it as a data-bearing kind.
+
+**Fix site — Twin-local, zero blast radius (not the shared kernel).** Excluded at the twin
+read-back boundary (`Twin.Runtime/Readback.fs`) via a `sys.views` probe (`readViewKeys`) feeding a
+`stripNonEstate` that drops both the state schema and every view from `read` (the mint) and
+`readSchema` (the wipe/status). The alternative — a global `TABLE_TYPE = 'BASE TABLE'` predicate in
+`ReadSide` — was rejected: `ReadSide` is the shared adapter the canary round-trip, the transfer
+contract, and `LiveProfiler` all rest on, and changing its reconstruction semantics would demand
+canary re-validation for a Twin-only need. The view stays **published** (the schema fingerprint is
+computed from estate files, not the read-back), so `status.LiveTables` also stops miscounting views
+as tables — more correct.
+
+**Naming (DDD, ubiquitous language).** While in `Readback`, the opaque ad-hoc metaphor
+**"furniture"** (for the `[twin]` state table) was renamed to **"state schema"** — the term the
+codebase already uses (`TwinDatabase.StateSchema`, `[twin].[__state]`, `readState`/`StoredState`)
+and the charter's law-5 "self-description". `isTwinFurniture`/`stripTwinFurniture` →
+`isTwinStateSchema` + a shared `stripKinds`/`stripNonEstate`; the `TwinDatabase.fs` doc comments
+follow. Private helpers only; no behavior change from the rename. (A vernacular sweep of
+`Twin.Runtime` found "furniture" the lone offender — `fingerprint`/`mint`/`pin`/`scenario`/
+`coordinate`/`lane` are the deliberate domain vocabulary and stay.)
+
+**Verified.** Live: `twin up` against the proving ground (with `vOrderSummary`) now materializes —
+schema published, 9 lane tables + synthetic mass minted, the view present in `sys.views` and
+queryable, the re-run an idempotent no-op. Regression: `TwinViewLoopTests` (Docker collection
+`Twin-Docker`, its own `twin-e2e-view`/21733 fixture) asserts `up` returns `Ok` with a multi-base-
+table view present, base tables mint, the view stays published, and a re-seed stays deterministic.
+Charter note added to `THE_TWIN.md` (§3 laws / §6 data-flow). **Re-open trigger:** a need to mint
+*into* an updatable single-table view (none today; all estate views are read models).

--- a/sidecar/projection/THE_TWIN.md
+++ b/sidecar/projection/THE_TWIN.md
@@ -132,8 +132,10 @@ clean slate: nullable deferred-FK columns nulled → child-first wipe →
         identity counters reseeded to the declared seed (the last_value guard
         normalizes SQL Server's virgin-vs-deleted RESEED asymmetry)
 apply the estate's static lanes (its own reference data, verbatim)
-ReadSide read-back → twin catalog; row-carrying kinds ARE the lane-seeded set
-        (by observation — no config names it) → K1 provided pools
+ReadSide read-back → twin catalog; the [twin] state schema AND every VIEW are
+        excluded (a view carries no data — it is not wiped or minted, but stays
+        published; DECISIONS 2026-07-20) → row-carrying kinds ARE the lane-seeded
+        set (by observation — no config names it) → K1 provided pools
 σ mint (Transfer.runSynthetic; corrections realize at the boundary) → load
 write fingerprints to [twin].[__state] → the VOICE report
 ```

--- a/sidecar/projection/src/Twin.Runtime/Readback.fs
+++ b/sidecar/projection/src/Twin.Runtime/Readback.fs
@@ -14,43 +14,77 @@ open Twin.Core
 /// carries none), `ReadSide` synthesizes deterministic name-based keys,
 /// so coordinate binding is stable run to run by construction.
 ///
-/// Two twin-specific projections happen here:
-///   - the `[twin]` furniture is excluded (law 5 — the state table is
-///     the tool's own, never part of the estate);
-///   - kinds whose rows the estate itself seeded (the static-data
-///     lanes) become the K1 provided pools: their PK values feed child
-///     FK draws, and σ neither generates nor wipes them.
+/// Three twin-specific projections happen here, all removing objects that
+/// are not estate DATA before the wipe/mint sees the catalog:
+///   - the `[twin]` STATE SCHEMA is excluded (law 5 — the twin's own
+///     single-row `__state` table is the tool's self-description, never
+///     part of the estate);
+///   - VIEWS are excluded — a view carries no data to wipe or mint, and a
+///     view over multiple base tables is not even deletable (it refuses
+///     `DELETE`); it stays published in the schema but is never a
+///     data-bearing kind (`DECISIONS 2026-07-20`);
+///   - kinds whose rows the estate itself seeded (the static-data lanes)
+///     become the K1 provided pools: their PK values feed child FK draws,
+///     and σ neither generates nor wipes them.
 [<RequireQualifiedAccess>]
 module Readback =
 
-    let private isTwinFurniture (k: Kind) : bool =
+    /// The `[twin]` state schema — the twin's own `__state` table (law 5,
+    /// its self-description), which lives outside the estate.
+    let private isTwinStateSchema (k: Kind) : bool =
         TableId.schemaTextEquals "twin" k.Physical
 
-    /// Drop the `[twin]` furniture from a read-back catalog. Plain
-    /// record surgery — the reconstructed catalog is a single module, so
-    /// emptied modules are removed rather than left hollow.
-    let private stripTwinFurniture (catalog: Catalog) : Catalog =
+    /// Remove every kind matching `drop` from a read-back catalog. Plain
+    /// record surgery — the reconstructed catalog is a single module, so a
+    /// module left empty is removed rather than left hollow.
+    let private stripKinds (drop: Kind -> bool) (catalog: Catalog) : Catalog =
         { catalog with
             Modules =
                 catalog.Modules
-                |> List.map (fun m -> { m with Kinds = m.Kinds |> List.filter (fun k -> not (isTwinFurniture k)) })
+                |> List.map (fun m -> { m with Kinds = m.Kinds |> List.filter (fun k -> not (drop k)) })
                 |> List.filter (fun m -> not (List.isEmpty m.Kinds)) }
+
+    /// The normalized `schema.table` keys of every VIEW in the twin
+    /// database. Read from `sys.views` so a view can be told from a base
+    /// table (the read-back catalog does not distinguish them — both
+    /// arrive as `Kind`s). A view has no rows to wipe or mint.
+    let private readViewKeys (twinCnn: SqlConnection) : Task<Set<string>> =
+        task {
+            use cmd = twinCnn.CreateCommand()
+            cmd.CommandText <- "SELECT SCHEMA_NAME([schema_id]) AS s, [name] AS n FROM sys.views;"
+            use! reader = cmd.ExecuteReaderAsync()
+            let acc = System.Collections.Generic.HashSet<string>()
+            let mutable more = true
+            while more do
+                let! has = reader.ReadAsync()
+                if has then acc.Add(TableId.normalizedKeyOf (reader.GetString 0) (reader.GetString 1)) |> ignore
+                else more <- false
+            return Set.ofSeq acc
+        }
+
+    /// Exclude the `[twin]` state schema and every view from a read-back
+    /// catalog, so the wipe and the mint see estate data only.
+    let private stripNonEstate (views: Set<string>) (catalog: Catalog) : Catalog =
+        let isView (k: Kind) = Set.contains (TableId.normalizedKey k.Physical) views
+        stripKinds (fun k -> isTwinStateSchema k || isView k) catalog
 
     /// Read the twin database's catalog, rows lifted (`ReadSide.read` —
     /// row-carrying kinds arrive with `Modality.Static` populations, the
-    /// provided-pool source), `[twin]` furniture excluded.
+    /// provided-pool source); the state schema and views excluded.
     let read (twinCnn: SqlConnection) : Task<Result<Catalog>> =
         task {
             let! catalog = ReadSide.read twinCnn
-            return catalog |> Result.map stripTwinFurniture
+            let! views = readViewKeys twinCnn
+            return catalog |> Result.map (stripNonEstate views)
         }
 
     /// Read the twin database's schema only (no row drain) — the
-    /// status/check path.
+    /// status/check path; the state schema and views excluded.
     let readSchema (twinCnn: SqlConnection) : Task<Result<Catalog>> =
         task {
             let! catalog = ReadSide.readSchema twinCnn
-            return catalog |> Result.map stripTwinFurniture
+            let! views = readViewKeys twinCnn
+            return catalog |> Result.map (stripNonEstate views)
         }
 
     /// The K1 provided pools of a read-back catalog: for every kind

--- a/sidecar/projection/src/Twin.Runtime/TwinDatabase.fs
+++ b/sidecar/projection/src/Twin.Runtime/TwinDatabase.fs
@@ -13,13 +13,13 @@ open Projection.Core
 open Projection.Pipeline
 open Twin.Core
 
-/// THE TWIN — the twin database's own furniture (Twin.Runtime).
+/// THE TWIN — the twin database's own state schema (Twin.Runtime).
 ///
 /// The `[twin]` schema is the tool's only write outside the estate's own
 /// objects (law 5): one single-row state table holding the fingerprints,
 /// so the twin describes what it holds and `status`/`up` never consult
 /// hidden local state. A schema publish with drop-not-in-source removes
-/// the furniture (the estate does not define it); `ensureState` re-lays
+/// the state schema (the estate does not define it); `ensureState` re-lays
 /// it afterward — cheap, idempotent, and honest about ownership.
 [<RequireQualifiedAccess>]
 module TwinDatabase =
@@ -55,7 +55,7 @@ module TwinDatabase =
             return not (isNull result) && result <> box System.DBNull.Value
         }
 
-    /// Lay the `[twin]` furniture (schema + state table) if absent.
+    /// Lay the `[twin]` state schema (its single-row `__state` table) if absent.
     let ensureState (twinCnn: SqlConnection) : Task<Result<unit>> =
         task {
             try
@@ -80,7 +80,7 @@ IF NOT EXISTS (SELECT 1 FROM [twin].[__state])
                 return Result.failureOf (sqlFailure "ensureState" ex.Message)
         }
 
-    /// Read the stored state; `emptyState` when the furniture is absent
+    /// Read the stored state; `emptyState` when the state schema is absent
     /// (a twin that has never materialized).
     let readState (twinCnn: SqlConnection) : Task<StoredState> =
         task {
@@ -165,7 +165,7 @@ IF NOT EXISTS (SELECT 1 FROM [twin].[__state])
             | None -> return Result.success applied
         }
 
-    /// Total rows held by the estate's tables (the `[twin]` furniture
+    /// Total rows held by the estate's tables (the `[twin]` state schema
     /// and system objects excluded) — the status report's headline count.
     let totalRows (twinCnn: SqlConnection) : Task<int64> =
         task {

--- a/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
+++ b/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
@@ -91,32 +91,48 @@ The defects, ranked by what they cost:
 
 ## 3 — The certification spine (the design)
 
+> **Amendment (2026-07-20) — trust is not agent-to-agent.** The earlier framing of §3.1 (an
+> author capsule and a reviewer capsule that must *agree* to make "reproduced" true) is
+> **retired**. Reproducibility is a property of the **Twin**, not of two agents matching: the
+> Twin's determinism means the base dataset regenerates byte-identically for anyone, so no
+> second agent's re-run is what earns trust. Trust now rests on two anchors — the Twin's
+> determinism (§3.1) and the plain showcase of the risk-averse checks the agent ran (§3.1) —
+> and the process the agent walks to place, prove, and retire deployment scripts is
+> `skills/deploy-scripts` (the deployment-script lifecycle rails). The pieces below are
+> re-aimed accordingly; the golden corpus (§3.2) is reframed as evidence-presentation
+> exemplars, not agent-diff fixtures.
+
 Six pieces, smallest first. Each is independently useful; together they close the loop from
-"the agent says" to "the machine re-verified and any developer can see that it did."
+"the agent says" to "the substrate is reproducible by construction and the evidence is on the
+record for any developer to read."
 
-### 3.1 The evidence capsule — the proof as data
+### 3.1 The two trust anchors — Twin determinism + the evidence showcase
 
-Every proving run already produces the facts; capture them once, structured, beside the prose:
-a small `proof.json` written by the agent at the end of the loop (it is **data the agent
-writes, not a wrapper that runs the loop** — the no-orchestration constraint stands).
+Trust comes from two places, **neither of them a second agent**:
 
-Fields (schema versioned): run id · date · sqlpackage version · dacpac SHA-256 · the
-substrate fingerprint (on the Twin: the `[twin].[__state]` fingerprint + the `(seed,
-scenario, evidence-pack hash)` triple, §3.5; on the hand-authored sample: the seed-file
-SHA-256) · target DB name · per-step records (command, outcome, the extracted block
-signature `Msg`/`SQL72xxx` when one fired, probe SQL + returned count) · `delta.sql` SHA-256 +
-the guard excerpt · the two findings (how it ships / who reviews) + added scrutiny · the
-Not-verified list. The PR body remains the human surface per `THE_RECORD.md` and
-`author-pr`'s "nothing attached for the reviewer to run" rule — the capsule is for the
-reviewer *agent* and CI, and it is what makes "reproduced" checkable: two capsules from two
-isolated runs must agree on every deterministic field (block fired y/n, signatures, counts,
-delta shape). Disagreement is itself the finding.
+- **The Twin's inherent determinism** (`../THE_TWIN.md`). `twin up` mints a deterministic,
+  masked, distribution-faithful dataset over the estate's own definitions; `twin check` proves
+  π∘σ≈id, mints are byte-identical (T1), and a schema edit re-mints only the columns it touches
+  (S-stable). The evidence-profiling config (`twin.json`) is version-controlled beside the model
+  and **evolves as the schema evolves** — this is the local dev environment the agent proves
+  against, and its base dataset is reproducible *by construction*, so a reviewer regenerates the
+  identical data without re-running the agent. The substrate is the guarantee.
+- **The plain showcase of the risk-averse checks the agent ran.** Presented as evidence and
+  little else, in the record register (`THE_RECORD.md` §2, pushed evidence-forward): the exact
+  pre-/post-deployment scripts (each with its permanence class + header + retirement condition),
+  the **idempotency proof** (the no-op redeploy's three assertions — 0 rows · identical content
+  digest · 0 CDC captures if tracked), and the sanity/verification SQL run before the change was
+  allowed to land. The precise changes required, **no more and no less** (Gate 0 refuses a script
+  when the diff already does the work). This is what `skills/deploy-scripts` + `skills/author-pr`
+  now produce; it needs no separate machine artifact for another agent to match.
 
 ### 3.2 The golden corpus — one certified exemplar per family × flip
 
 Grow `self-test/golden/` from 1 pair to ~14: for each op family, the case whose outcome flips
-on data, captured from a live run as (PR body + conversation + **capsule + `delta.sql` +
-publish-log excerpt**). Candidates: make-mandatory triple (exists — add its capsule) ·
+on data, captured from a live run as an **evidence bundle** — PR body + conversation + the
+scripts shipped + the silent-redeploy assertions + `delta.sql` + publish-log excerpt. These are
+**evidence-presentation exemplars** (the existing make-mandatory PR already is one), not
+agent-diff fixtures. Candidates: make-mandatory triple (exists) ·
 rename-attribute with/without refactorlog · create-fk-orphan · add-unique on dupes · narrow
 past the data · delete-entity populated (the principal-review exemplar) ·
 recreate-capture-instance · split-table multi-phase · edit-seed idempotency ·
@@ -129,8 +145,9 @@ each one is simultaneously teaching material, a scoring fixture, and a drift can
 The rubric has an objective half a script can assert (probe ran before publish; expected block
 fired with the expected signature; flip twins produced different outcomes from the same op;
 teardown ran; the capsule's counts match the prompt's legend) and a subjective half only a
-reader can judge (voice, teaching, the one question). Split them: the scorer consumes capsules
-and emits per-case verdicts; the human rubric keeps the register and pedagogy. Seed variants
+reader can judge (voice, teaching, the one question). Split them: the scorer reads the presented
+evidence (the scripts shipped, the silent-redeploy assertions, the delta) and emits per-case
+verdicts; the human rubric keeps the register and pedagogy. Seed variants
 (empty / clean / violating) become named Twin scenarios (§3.5) instead of hand-typed scratch
 edits — declarative, refused-by-name when wrong, byte-identical on every re-mint.
 

--- a/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
+++ b/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
@@ -1,11 +1,13 @@
 # CERTIFICATION PLAN — making the ssdt-agent's word machine-checkable
 
 > **Status: PLAN (nothing wired yet).** Companion to `ACCELERANT_PLAN.md` (which wires the F#
-> engine as a fast-path); this plan wires **trust**. It is the staged, verify-first path from
-> "a well-written PR the reviewer believes" to "a PR whose proof is reproduced by machines and
-> whose evidence any team member can check in one read." Grounded in a 2026-07-20 audit of the
-> whole tree (all 48 op skills, the 6 `_index` concerns, `self-test/`, `proving-ground/`,
-> `.github/`), summarized in §2.
+> engine as a fast-path) and married to `../THE_TWIN.md` (the post-eject synthetic-data
+> sidecar, charter-complete 2026-07-18) — the Twin is this plan's proving substrate, §3.6.
+> This plan wires **trust**: the staged, verify-first path from "a well-written PR the
+> reviewer believes" to "a PR whose proof is reproduced by machines and whose evidence any
+> team member can check in one read." Grounded in a 2026-07-20 audit of the whole tree (all
+> 48 op skills, the 6 `_index` concerns, `self-test/`, `proving-ground/`, `.github/`),
+> summarized in §2.
 
 ## 1 — The problem this plan solves
 
@@ -76,7 +78,8 @@ The defects, ranked by what they cost:
   moves.
 - **F10 — Proofs run against a 9-table sample, not the estate.** `ACCELERANT_PLAN.md` stages
   0–2 (engine-emitted proving ground from a real catalog, `profile.json` block prediction,
-  `diff` dependency maps) are designed and unwired.
+  `diff` dependency maps) are designed and unwired — and since 2026-07-18 the Twin
+  (`../THE_TWIN.md`) productizes the substrate half of this gap outright (§3.5).
 - **F11 — No estate memory.** "This operation has not been performed on this estate before" is
   a standing added-scrutiny line no one can actually answer; nothing records what shipped, with
   what proof, decided by whom.
@@ -88,7 +91,7 @@ The defects, ranked by what they cost:
 
 ## 3 — The certification spine (the design)
 
-Five pieces, smallest first. Each is independently useful; together they close the loop from
+Six pieces, smallest first. Each is independently useful; together they close the loop from
 "the agent says" to "the machine re-verified and any developer can see that it did."
 
 ### 3.1 The evidence capsule — the proof as data
@@ -97,8 +100,10 @@ Every proving run already produces the facts; capture them once, structured, bes
 a small `proof.json` written by the agent at the end of the loop (it is **data the agent
 writes, not a wrapper that runs the loop** — the no-orchestration constraint stands).
 
-Fields (schema versioned): run id · date · sqlpackage version · dacpac SHA-256 · seed
-fingerprint · target DB name · per-step records (command, outcome, the extracted block
+Fields (schema versioned): run id · date · sqlpackage version · dacpac SHA-256 · the
+substrate fingerprint (on the Twin: the `[twin].[__state]` fingerprint + the `(seed,
+scenario, evidence-pack hash)` triple, §3.5; on the hand-authored sample: the seed-file
+SHA-256) · target DB name · per-step records (command, outcome, the extracted block
 signature `Msg`/`SQL72xxx` when one fired, probe SQL + returned count) · `delta.sql` SHA-256 +
 the guard excerpt · the two findings (how it ships / who reviews) + added scrutiny · the
 Not-verified list. The PR body remains the human surface per `THE_RECORD.md` and
@@ -126,12 +131,14 @@ fired with the expected signature; flip twins produced different outcomes from t
 teardown ran; the capsule's counts match the prompt's legend) and a subjective half only a
 reader can judge (voice, teaching, the one question). Split them: the scorer consumes capsules
 and emits per-case verdicts; the human rubric keeps the register and pedagogy. Seed variants
-(empty / clean / violating) become parameterized fixtures instead of hand-typed scratch edits.
+(empty / clean / violating) become named Twin scenarios (§3.5) instead of hand-typed scratch
+edits — declarative, refused-by-name when wrong, byte-identical on every re-mint.
 
 ### 3.4 The reproduction gate + the knowledge canary — CI
 
-Two jobs, both on a container runner (SQL Server in Docker + sqlpackage as a dotnet tool —
-the same substrate `warm-sql.sh` already assumes):
+Two jobs, both on a container runner (SQL Server in Docker + sqlpackage as a dotnet tool;
+once §3.5 lands, the runner pulls the `twin bake` pre-seeded image instead of deploying and
+seeding from scratch):
 
 - **Smoke gate (per PR touching the tree):** build the proving-ground dacpac; run the
   make-mandatory triple + rename-with/without-refactorlog + create-fk-orphan against fresh
@@ -149,7 +156,55 @@ Resolution: CI scripts live under `ssdt-agent/ci/` (or `.github/`), are never re
 any skill body, and the skills continue to scaffold commands only. Record this as the standing
 exception when Stage 3 lands.
 
-### 3.5 The estate logbook — memory that compounds
+### 3.5 The Twin substrate — the proving ground grows real, and survives the eject
+
+The Twin (`../THE_TWIN.md`) is the marriage this plan was missing when first drafted: **one
+command (`twin up`) holds a local SQL Server current with the estate's own definitions and
+fills it with deterministic, masked, distribution-faithful synthetic data.** That is exactly
+what "a disposable copy of Dev, populated with real-shaped data" wants to be — and after the
+eject there IS no Dev upstream to copy, so the disposable copy *becomes* the Twin by
+necessity, not preference. Marry them now so the agent's habits survive the eject unchanged.
+What each Twin property buys this plan:
+
+- **The BEFORE state comes from `twin up`/`twin seed`** — real estate schema (the SSDT repo's
+  own definitions, coordinate-total), real-shaped rows — instead of the 9-table hand-authored
+  sample. The agent's loop is unchanged on top: edit the CREATE, build, then the Strict /
+  Permissive sqlpackage publishes against the Twin-established state. The two-profile
+  discipline stays skill-owned (the `ACCELERANT_PLAN.md` §4 guardrail, unchanged); the Twin
+  supplies the substrate, never the verdict.
+- **Scenarios are the seed-variant harness §3.3 needs.** The self-test's flip twins — empty /
+  clean / violating — stop being hand-typed scratch edits and become named scenario overlays
+  (volumes, weights, date windows, pins), compiled and refused-by-name by
+  `Twin.Core/ScenarioCompiler.fs`. The `prove-on-dacpac` violating-row probe (the injected
+  orphan / dup / over-length / NULL) becomes a **pin**: an operator-authored exact row,
+  declared in the scenario, merged after realization, reproducible forever.
+- **Determinism makes capsules comparable by construction.** T1 byte-identical re-mints plus
+  `S-stable` (a schema edit re-mints only the columns it touches; everything else holds
+  byte-identical) mean two capsules over the same `(estate, evidence, scenario, corrections,
+  seed)` fingerprint may differ **only in what the change did**. That is the exact property
+  §3.1's "deterministic fields must agree" check needs, and the Twin provides it as law, not
+  hope. The capsule carries the fingerprint; fingerprint equality is what makes
+  "reproduced" a mechanical word.
+- **`twin bake` is the CI substrate.** The §3.4 smoke gate and canary pull the baked,
+  pre-seeded image instead of paying schema-deploy + mint time per run — deterministic
+  starting state, minutes saved, no seed drift between CI runs.
+- **Masking makes the goldens committable.** The shape tier is literal-free (Twin law 3), a
+  real high-cardinality value is never emitted, and PII renders through the seeded Faker
+  realization — so golden captures, capsules, and logbook entries built on Twin data carry
+  no production literal and can live in the repo without a data-governance question. A golden
+  corpus captured from restored real Dev data could never say that.
+- **`twin check` joins the reviewer's independent corroboration** (beside `projection check` /
+  `check data` / `compare` from `ACCELERANT_PLAN.md` §C): the π ∘ σ ≈ id proof on a throwaway
+  database, marshaled as evidence the substrate itself is sound.
+
+The honesty boundary, named plainly: Twin data is **evidence-faithful synthetic, not the
+environment's rows**. A proof on the Twin establishes the *mechanism* — what SSDT's publish
+engine does to data of this shape — which is what classification needs. It does not establish
+the *instance* — whether UAT or Prod holds the orphan the shape tier didn't see. The PR's
+**Verification** queries (run in each environment) and the standing **Not verified** section
+carry that gap, exactly as they do today; nothing about the record register changes.
+
+### 3.6 The estate logbook — memory that compounds
 
 An append-only `logbook/` of shipped changes: date · op-slug(s) · object · the two findings ·
 capsule reference · disposition · the business decision and its decider. It makes
@@ -175,9 +230,16 @@ logbook chapter, so the agent enters day one already carrying the estate's histo
   over a full self-test fleet once by hand; fix what it exposes (it will expose things).
 - **Stage 3 — CI.** The smoke gate, then the knowledge canary. Gate on the goldens from
   Stage 1–2. Record the CI-exception decision (§3.4).
-- **Stage 4 — estate anchoring.** `ACCELERANT_PLAN.md` stages 0–2 as written (engine bundle →
-  real schema; `profile.json` → predicted blocks + CDC awareness across the ~200 tracked
-  tables; `diff` → dependency scope), plus the logbook seeded from the cutover dry-runs.
+- **Stage 4 — estate anchoring, riding the Twin.** The proving substrate moves to
+  `twin up`/`twin seed` over the real estate definition (§3.5) — this supersedes
+  `ACCELERANT_PLAN.md` stage 1's engine-emitted proving-ground schema where they overlap
+  (the Twin reads the SSDT repo itself post-eject, and imports evidence from either
+  rendition — logical on-prem or physical cloud through the capture-side catalog — so it
+  covers both eras). The accelerant's other pieces stay engine-side and complementary:
+  `profile.json` predicts the per-environment block + CDC awareness across the ~200 tracked
+  tables, `diff` feeds dependency scope. Flip-twin scenarios land here; goldens re-capture on
+  the Twin (committable now — literal-free by law); the logbook seeds from the cutover
+  dry-runs.
 - **Stage 5 — adoption + the funnel.** Wire `CONNECTORS.md` §1 so intake is a slash-command
   away; surface the reviewer disposition as a PR check; start counting the funnel — % of
   changes approved by reading alone, reproduction-mismatch rate, disposition mix
@@ -197,9 +259,15 @@ infrastructure spend; 4–5 ride existing plans (`ACCELERANT_PLAN.md`, `CONNECTO
 - **No wrapper for the developer loop.** The agent still runs `docker`/`dotnet`/`sqlpackage`
   itself; the capsule is output, not orchestration. CI's scripts are the named exception and
   live outside `skills/`.
-- **The engine stays optional** (`ACCELERANT_PLAN.md` governing principle). The generic path —
-  hand-authored sample + raw probes — must keep passing the self-test with capsules, engine
-  absent.
+- **The engine and the Twin stay optional** (`ACCELERANT_PLAN.md` governing principle,
+  extended). The generic path — hand-authored sample + raw probes — must keep passing the
+  self-test with capsules, engine and Twin absent. `proving-ground/SampleCatalog` is not
+  deleted at Stage 4; it remains the deterministic fixture and the fallback.
+- **The Twin supplies substrate, never verdicts.** The two-profile Strict/Permissive
+  discipline, the content-hash check, and the capsule stay skill-owned
+  (`ACCELERANT_PLAN.md` §4 guardrail). And the proving loop never touches the warm
+  projection container from the Twin side: Twin containers are the Twin's own, per
+  `../THE_TWIN.md` §6.
 - **Goldens are re-captured, never hand-edited.** A golden that no longer matches the engine
   is re-proven and re-stamped with the new sqlpackage version, per `self-test/golden/README.md`
   — the canary exists to force exactly that, loudly.
@@ -218,3 +286,23 @@ infrastructure spend; 4–5 ride existing plans (`ACCELERANT_PLAN.md`, `CONNECTO
   first (grep-able, PR-diffable); revisit at the ADO seam (`CONNECTORS.md` §5).
 - **Runner provisioning:** the smoke gate needs Docker + the sqlpackage tool on a hosted or
   self-hosted runner; verify image pull + license posture before Stage 3 is scheduled.
+- **Violating pins vs the Twin's laws:** zero FK orphans is a mint law (K1), but the flip
+  twins need violating states — an orphan seeded *before* the FK the change introduces, a
+  dup before the unique, an over-length value before the narrow, a NULL before the
+  tightening. Verify each is expressible as a scenario pin against the pre-change estate
+  (the constraint under proof does not exist yet, so coordinate totality should accept the
+  row) before Stage 2 commits to scenarios; any state a pin cannot express keeps its
+  documented scratch edit.
+- **Parallel executors on one Twin:** the Twin maintains one persistent twin per config;
+  the self-test fleet needs per-executor isolation. Candidates: unique databases on the twin
+  container (today's `PG_<id>` pattern), per-executor `twin.json` with a unique container
+  name + port, or the `twin check`-style throwaway database. Decide before the fleet rides
+  the Twin; until then `PROTOCOL.md` isolation stands as-is.
+- **`twin up` mid-proof is a hazard:** the proving loop *deliberately* diverges the twin
+  from the estate definition (it publishes the edited dacpac). A `twin up` run mid-proof
+  would read the fingerprint mismatch and reconcile the edit away. The loop's rule: the Twin
+  establishes the BEFORE state; from that point until teardown, only sqlpackage touches the
+  proving database.
+- **CDC stays outside the Twin:** the Twin does not manage capture instances; the
+  enable-cdc / recreate-capture-instance family keeps its isolated-instance,
+  serialized discipline (`PROTOCOL.md` §8) regardless of substrate.

--- a/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
+++ b/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
@@ -1,0 +1,220 @@
+# CERTIFICATION PLAN — making the ssdt-agent's word machine-checkable
+
+> **Status: PLAN (nothing wired yet).** Companion to `ACCELERANT_PLAN.md` (which wires the F#
+> engine as a fast-path); this plan wires **trust**. It is the staged, verify-first path from
+> "a well-written PR the reviewer believes" to "a PR whose proof is reproduced by machines and
+> whose evidence any team member can check in one read." Grounded in a 2026-07-20 audit of the
+> whole tree (all 48 op skills, the 6 `_index` concerns, `self-test/`, `proving-ground/`,
+> `.github/`), summarized in §2.
+
+## 1 — The problem this plan solves
+
+The tree's stated intent (`README.md`): help an OutSystems-native developer make a safe SSDT
+data-model change, and hand the reviewer a pull request they can approve by reading. The
+organizational fact underneath it: most of the team knows Advanced SQL, only a handful are
+qualified to review DDL, and fewer still know the lifecycle gotchas (`handbook/03`,
+`handbook/23`). The principals are the backstop, and that is the bottleneck the cutover cannot
+afford — ~300 tables, ~200 CDC-tracked, four environments (`AGENTS.md`).
+
+Today the chain of trust ends at the agent's prose. The proving loop is genuinely rigorous —
+a real sqlpackage delta against a real isolated database is the oracle — but everything above
+the engine is human-read text: the PR body asserts what the publish did, the reviewer persona
+reproduces it *if run*, the self-test is scored by a person reading a rubric, and nothing runs
+in CI. An agent that wrote fluent prose about a proof it never ran would today be caught only
+by a diligent human reading the transcript. That is exactly the failure mode a trusted team
+member cannot have.
+
+**The thesis of this plan: the proof already exists at the engine boundary — capture it as
+data, reproduce it by machine, and let the human read findings that a green check has already
+re-verified.** The record register (`THE_RECORD.md`) stays the human surface, unchanged; the
+certification layer sits beneath it.
+
+## 2 — Audit findings (2026-07-20), each with its owner
+
+Strengths to preserve (do not rebuild): the classify-by-proving thesis and the Strict/Permissive
+two-profile discipline (`skills/prove-on-dacpac`); the uniform 48-op template with the
+two-findings model held everywhere; the pointer discipline (ops cite `_index/`, never
+re-derive); the two-register voice spec (`THE_RECORD.md`); the reviewer persona's
+reproduce-first posture; the PR template mirror (`.github/PULL_REQUEST_TEMPLATE/schema-change.md`).
+
+The defects, ranked by what they cost:
+
+- **F1 — One golden exemplar of ~69 self-test cases.** `self-test/golden/` holds only the
+  make-mandatory pair, as prose to imitate, not fixtures to diff. No expected `delta.sql`, no
+  expected block signature, no expected probe counts exist for the other ~60 authoring cases
+  and all 8 review scenarios.
+- **F2 — Zero CI.** No workflow builds the dacpac, runs a single publish, or exercises any
+  self-test case. The three `.github/workflows/*` all target the F# codebase.
+- **F3 — Scoring is human.** `self-test/rubric.md` / `review-rubric.md` are prose checklists;
+  no scorer reads `delta.sql` + the publish log and emits a verdict. The rubric's "engine wins
+  ties; fix the stale prompt" rule cannot distinguish tool-version drift from a wrong
+  expectation without a pinned fixture.
+- **F4 — A promised op does not exist.** The data-plane backfill / idempotent-UPDATE op is
+  routed to by `skills/op/add-default/SKILL.md:26` (which mis-points at `make-mandatory`),
+  `op/modify-default/SKILL.md:32`, `operations/constraints.md:26`, and
+  `_index/idempotent-seed`. "Add a default AND backfill existing rows" is among the most common
+  real requests; today it dead-ends.
+- **F5 — Block signatures are uneven.** The tightening class names its exact evidence
+  (`Msg 50000, Level 16, State 127`, `SQL72014`, `Msg 515`); the constraint-is-a-claim family
+  carries **zero** error codes — `define-pk`, `add-unique`, `add-check` describe blocks in
+  prose with no `Msg 2627`/`1505`/`547`/`8152` an agent could grep publish output for.
+- **F6 — README drift.** `README.md`'s tree map omits three live skill directories:
+  `skills/os-vocabulary/` (load-bearing, cited by `confirm-intent`), `skills/ask-the-developer/`,
+  `skills/author-review/`. Index drift is a first-class defect by the sidecar's own law
+  (`../CLAUDE.md` §0).
+- **F7 — The substrate is pinned to one machine.** Five files hardcode
+  `C:/Users/danny/...` (`prove-on-dacpac`, `talk-to-local-sql`, `proving-ground/README.md`,
+  `self-test/PROTOCOL.md` ×2). A new team member — or a CI runner — cannot run the loop
+  without hand-editing scaffolds.
+- **F8 — The block verdict rides a string match.** A blocked publish does not reliably exit
+  non-zero (`PROTOCOL.md:73-80`); the loop greps output text. Fine for an agent; fatal for
+  automation unless the signature set is pinned (F5) and asserted per case.
+- **F9 — The knowledge is version-bound with no re-verification trigger.** The tree's central
+  empirical findings (table-has-rows guard; `Msg 515` seed-vs-tightened-column; the non-atomic
+  FK block leaving `is_not_trusted = 1`; `sp_refreshsqlmodule` auto-refresh; refactorlog →
+  `sp_rename`) are all stamped "sqlpackage 170.4.83." Nothing re-proves them when the tool
+  moves.
+- **F10 — Proofs run against a 9-table sample, not the estate.** `ACCELERANT_PLAN.md` stages
+  0–2 (engine-emitted proving ground from a real catalog, `profile.json` block prediction,
+  `diff` dependency maps) are designed and unwired.
+- **F11 — No estate memory.** "This operation has not been performed on this estate before" is
+  a standing added-scrutiny line no one can actually answer; nothing records what shipped, with
+  what proof, decided by whom.
+- **F12 — Adoption is manual.** `CONNECTORS.md` §1 (`.claude/skills/` wiring) is designed and
+  unwired; the front door is "read this file."
+- **F13 — Realistic op gaps.** Computed columns (a cutover dealbreaker class —
+  `CUTOVER_BOARD_POPULATION_PLAN.md` decision 12), collation change, and procedures/functions
+  have no op; triggers/sequences/partitioning deserve a one-line route-to-DBA note.
+
+## 3 — The certification spine (the design)
+
+Five pieces, smallest first. Each is independently useful; together they close the loop from
+"the agent says" to "the machine re-verified and any developer can see that it did."
+
+### 3.1 The evidence capsule — the proof as data
+
+Every proving run already produces the facts; capture them once, structured, beside the prose:
+a small `proof.json` written by the agent at the end of the loop (it is **data the agent
+writes, not a wrapper that runs the loop** — the no-orchestration constraint stands).
+
+Fields (schema versioned): run id · date · sqlpackage version · dacpac SHA-256 · seed
+fingerprint · target DB name · per-step records (command, outcome, the extracted block
+signature `Msg`/`SQL72xxx` when one fired, probe SQL + returned count) · `delta.sql` SHA-256 +
+the guard excerpt · the two findings (how it ships / who reviews) + added scrutiny · the
+Not-verified list. The PR body remains the human surface per `THE_RECORD.md` and
+`author-pr`'s "nothing attached for the reviewer to run" rule — the capsule is for the
+reviewer *agent* and CI, and it is what makes "reproduced" checkable: two capsules from two
+isolated runs must agree on every deterministic field (block fired y/n, signatures, counts,
+delta shape). Disagreement is itself the finding.
+
+### 3.2 The golden corpus — one certified exemplar per family × flip
+
+Grow `self-test/golden/` from 1 pair to ~14: for each op family, the case whose outcome flips
+on data, captured from a live run as (PR body + conversation + **capsule + `delta.sql` +
+publish-log excerpt**). Candidates: make-mandatory triple (exists — add its capsule) ·
+rename-attribute with/without refactorlog · create-fk-orphan · add-unique on dupes · narrow
+past the data · delete-entity populated (the principal-review exemplar) ·
+recreate-capture-instance · split-table multi-phase · edit-seed idempotency ·
+identity-swap · widen (the clean collapse-to-verdict exemplar) · create-view + the out-of-band
+`SELECT *` trap. These are the "real examples that demonstrate a certifiably valid result" —
+each one is simultaneously teaching material, a scoring fixture, and a drift canary.
+
+### 3.3 The mechanical scorer — split the rubric
+
+The rubric has an objective half a script can assert (probe ran before publish; expected block
+fired with the expected signature; flip twins produced different outcomes from the same op;
+teardown ran; the capsule's counts match the prompt's legend) and a subjective half only a
+reader can judge (voice, teaching, the one question). Split them: the scorer consumes capsules
+and emits per-case verdicts; the human rubric keeps the register and pedagogy. Seed variants
+(empty / clean / violating) become parameterized fixtures instead of hand-typed scratch edits.
+
+### 3.4 The reproduction gate + the knowledge canary — CI
+
+Two jobs, both on a container runner (SQL Server in Docker + sqlpackage as a dotnet tool —
+the same substrate `warm-sql.sh` already assumes):
+
+- **Smoke gate (per PR touching the tree):** build the proving-ground dacpac; run the
+  make-mandatory triple + rename-with/without-refactorlog + create-fk-orphan against fresh
+  DBs; assert each capsule against its golden. ~5 cases, minutes, catches both skill-text rot
+  and substrate rot.
+- **Knowledge canary (scheduled + on sqlpackage version bump):** re-prove the §2-F9 findings
+  and diff against the goldens. On divergence, the canary opens the issue that says "the
+  curriculum's central claim changed under sqlpackage X.Y — re-capture and re-stamp," instead
+  of a developer discovering it mid-change. This is what keeps a written-down empirical
+  finding *certified* rather than merely remembered.
+
+The no-wrapper constraint governs the developer-facing skill loop, where the agent must reason
+through each command; CI is a different reader whose whole job is deterministic reproduction.
+Resolution: CI scripts live under `ssdt-agent/ci/` (or `.github/`), are never referenced by
+any skill body, and the skills continue to scaffold commands only. Record this as the standing
+exception when Stage 3 lands.
+
+### 3.5 The estate logbook — memory that compounds
+
+An append-only `logbook/` of shipped changes: date · op-slug(s) · object · the two findings ·
+capsule reference · disposition · the business decision and its decider. It makes
+"first time on this estate" a lookup instead of a shrug (F11), lets a PR cite precedent
+("matches the widen shipped 2026-08-12, entry 47") — the single cheapest trust-builder for a
+wary reviewer — and turns every real change into a golden-corpus candidate. Seed it during the
+cutover dry-runs themselves: the UAT dry-run the T-30 gate requires is the estate's first
+logbook chapter, so the agent enters day one already carrying the estate's history.
+
+## 4 — Staged, verify-first
+
+- **Stage 0 — paper cuts (docs-only, no infra).** Author `op/backfill-rows` and fix the four
+  routes to it (F4); lift the violation-block signatures into
+  `_index/constraint-is-a-claim` and cite them from `define-pk`/`add-unique`/`add-check` (F5);
+  fix the README tree map (F6); parameterize the five hardcoded paths behind documented env
+  vars with per-OS worked examples (F7); add the F13 route-to-DBA note. Every item is a
+  same-day edit.
+- **Stage 1 — capsule + goldens.** Define `proof.json` (schema + a worked example); amend
+  `prove-on-dacpac` and `review-change` to end every loop by writing one; re-run the
+  make-mandatory golden capturing its capsule; capture 4–5 more goldens (3.2), each from a
+  live run.
+- **Stage 2 — the scorer.** The capsule-reader that asserts the objective rubric half; run it
+  over a full self-test fleet once by hand; fix what it exposes (it will expose things).
+- **Stage 3 — CI.** The smoke gate, then the knowledge canary. Gate on the goldens from
+  Stage 1–2. Record the CI-exception decision (§3.4).
+- **Stage 4 — estate anchoring.** `ACCELERANT_PLAN.md` stages 0–2 as written (engine bundle →
+  real schema; `profile.json` → predicted blocks + CDC awareness across the ~200 tracked
+  tables; `diff` → dependency scope), plus the logbook seeded from the cutover dry-runs.
+- **Stage 5 — adoption + the funnel.** Wire `CONNECTORS.md` §1 so intake is a slash-command
+  away; surface the reviewer disposition as a PR check; start counting the funnel — % of
+  changes approved by reading alone, reproduction-mismatch rate, disposition mix
+  (any-team-member / dev-lead / principal), returned-to-author reasons, escalations carrying
+  one question + the map. The funnel numbers are how "the principals stopped being the
+  bottleneck" is demonstrated instead of asserted — and the returned-to-author reasons are the
+  next curriculum chapter, discovered rather than guessed.
+
+Stages 0–2 need no new infrastructure and de-risk everything after; 3 is the first
+infrastructure spend; 4–5 ride existing plans (`ACCELERANT_PLAN.md`, `CONNECTORS.md`).
+
+## 5 — Guardrails
+
+- **The human surfaces do not change.** `THE_RECORD.md`'s two registers, the PR body shape,
+  and the conversation stay exactly as specified; the capsule sits beneath the record, never
+  in it.
+- **No wrapper for the developer loop.** The agent still runs `docker`/`dotnet`/`sqlpackage`
+  itself; the capsule is output, not orchestration. CI's scripts are the named exception and
+  live outside `skills/`.
+- **The engine stays optional** (`ACCELERANT_PLAN.md` governing principle). The generic path —
+  hand-authored sample + raw probes — must keep passing the self-test with capsules, engine
+  absent.
+- **Goldens are re-captured, never hand-edited.** A golden that no longer matches the engine
+  is re-proven and re-stamped with the new sqlpackage version, per `self-test/golden/README.md`
+  — the canary exists to force exactly that, loudly.
+- **The logbook is append-only** and carries decisions with their deciders, in the record
+  register.
+
+## 6 — Open questions
+
+- **Capsule extraction discipline:** the block signature must be extracted from publish output
+  by rule (F8's string-match, now load-bearing). Pin the exact grep set per signature in the
+  capsule schema, and version it with sqlpackage.
+- **CDC cases in CI:** `sp_cdc_enable_db` is instance-wide and capture timing is
+  agent-dependent (`PROTOCOL.md` §8) — the smoke gate should exclude the CDC family; the
+  canary runs them serialized with poll-and-timeout, or on a dedicated instance.
+- **Where the logbook lives:** in-repo markdown vs the deploy repo vs ADO work items. In-repo
+  first (grep-able, PR-diffable); revisit at the ADO seam (`CONNECTORS.md` §5).
+- **Runner provisioning:** the smoke gate needs Docker + the sqlpackage tool on a hosted or
+  self-hosted runner; verify image pull + license posture before Stage 3 is scheduled.

--- a/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
+++ b/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
@@ -144,7 +144,7 @@ each one is simultaneously teaching material, a scoring fixture, and a drift can
 
 The rubric has an objective half a script can assert (probe ran before publish; expected block
 fired with the expected signature; flip twins produced different outcomes from the same op;
-teardown ran; the capsule's counts match the prompt's legend) and a subjective half only a
+teardown ran; the evidence's counts match the prompt's legend) and a subjective half only a
 reader can judge (voice, teaching, the one question). Split them: the scorer reads the presented
 evidence (the scripts shipped, the silent-redeploy assertions, the delta) and emits per-case
 verdicts; the human rubric keeps the register and pedagogy. Seed variants
@@ -159,7 +159,7 @@ seeding from scratch):
 
 - **Smoke gate (per PR touching the tree):** build the proving-ground dacpac; run the
   make-mandatory triple + rename-with/without-refactorlog + create-fk-orphan against fresh
-  DBs; assert each capsule against its golden. ~5 cases, minutes, catches both skill-text rot
+  DBs; assert each evidence bundle against its golden. ~5 cases, minutes, catches both skill-text rot
   and substrate rot.
 - **Knowledge canary (scheduled + on sqlpackage version bump):** re-prove the §2-F9 findings
   and diff against the goldens. On divergence, the canary opens the issue that says "the
@@ -195,19 +195,19 @@ What each Twin property buys this plan:
   `Twin.Core/ScenarioCompiler.fs`. The `prove-on-dacpac` violating-row probe (the injected
   orphan / dup / over-length / NULL) becomes a **pin**: an operator-authored exact row,
   declared in the scenario, merged after realization, reproducible forever.
-- **Determinism makes capsules comparable by construction.** T1 byte-identical re-mints plus
-  `S-stable` (a schema edit re-mints only the columns it touches; everything else holds
-  byte-identical) mean two capsules over the same `(estate, evidence, scenario, corrections,
-  seed)` fingerprint may differ **only in what the change did**. That is the exact property
-  §3.1's "deterministic fields must agree" check needs, and the Twin provides it as law, not
-  hope. The capsule carries the fingerprint; fingerprint equality is what makes
-  "reproduced" a mechanical word.
+- **Determinism makes the base data reproducible by construction.** T1 byte-identical re-mints
+  plus `S-stable` (a schema edit re-mints only the columns it touches; everything else holds
+  byte-identical) mean a run over the same `(estate, evidence, scenario, corrections, seed)`
+  fingerprint stands on the **identical base data every time** — a reviewer regenerates it exactly
+  without re-running the agent. That is what makes "reproduced" a mechanical word: the substrate is
+  the guarantee, not an agent-to-agent match. Evidence captured against a fixed fingerprint differs
+  only in what the change did.
 - **`twin bake` is the CI substrate.** The §3.4 smoke gate and canary pull the baked,
   pre-seeded image instead of paying schema-deploy + mint time per run — deterministic
   starting state, minutes saved, no seed drift between CI runs.
 - **Masking makes the goldens committable.** The shape tier is literal-free (Twin law 3), a
   real high-cardinality value is never emitted, and PII renders through the seeded Faker
-  realization — so golden captures, capsules, and logbook entries built on Twin data carry
+  realization — so golden captures, evidence bundles, and logbook entries built on Twin data carry
   no production literal and can live in the repo without a data-governance question. A golden
   corpus captured from restored real Dev data could never say that.
 - **`twin check` joins the reviewer's independent corroboration** (beside `projection check` /
@@ -224,7 +224,7 @@ carry that gap, exactly as they do today; nothing about the record register chan
 ### 3.6 The estate logbook — memory that compounds
 
 An append-only `logbook/` of shipped changes: date · op-slug(s) · object · the two findings ·
-capsule reference · disposition · the business decision and its decider. It makes
+evidence-bundle reference · disposition · the business decision and its decider. It makes
 "first time on this estate" a lookup instead of a shrug (F11), lets a PR cite precedent
 ("matches the widen shipped 2026-08-12, entry 47") — the single cheapest trust-builder for a
 wary reviewer — and turns every real change into a golden-corpus candidate. Seed it during the
@@ -239,52 +239,58 @@ logbook chapter, so the agent enters day one already carrying the estate's histo
   fix the README tree map (F6); parameterize the five hardcoded paths behind documented env
   vars with per-OS worked examples (F7); add the F13 route-to-DBA note. Every item is a
   same-day edit.
-- **Stage 1 — capsule + goldens.** Define `proof.json` (schema + a worked example); amend
-  `prove-on-dacpac` and `review-change` to end every loop by writing one; re-run the
-  make-mandatory golden capturing its capsule; capture 4–5 more goldens (3.2), each from a
-  live run.
-- **Stage 2 — the scorer.** The capsule-reader that asserts the objective rubric half; run it
-  over a full self-test fleet once by hand; fix what it exposes (it will expose things).
-- **Stage 3 — CI.** The smoke gate, then the knowledge canary. Gate on the goldens from
-  Stage 1–2. Record the CI-exception decision (§3.4).
-- **Stage 4 — estate anchoring, riding the Twin.** The proving substrate moves to
-  `twin up`/`twin seed` over the real estate definition (§3.5) — this supersedes
-  `ACCELERANT_PLAN.md` stage 1's engine-emitted proving-ground schema where they overlap
-  (the Twin reads the SSDT repo itself post-eject, and imports evidence from either
-  rendition — logical on-prem or physical cloud through the capture-side catalog — so it
-  covers both eras). The accelerant's other pieces stay engine-side and complementary:
-  `profile.json` predicts the per-environment block + CDC awareness across the ~200 tracked
-  tables, `diff` feeds dependency scope. Flip-twin scenarios land here; goldens re-capture on
-  the Twin (committable now — literal-free by law); the logbook seeds from the cutover
-  dry-runs.
-- **Stage 5 — adoption + the funnel.** Wire `CONNECTORS.md` §1 so intake is a slash-command
-  away; surface the reviewer disposition as a PR check; start counting the funnel — % of
-  changes approved by reading alone, reproduction-mismatch rate, disposition mix
-  (any-team-member / dev-lead / principal), returned-to-author reasons, escalations carrying
-  one question + the map. The funnel numbers are how "the principals stopped being the
-  bottleneck" is demonstrated instead of asserted — and the returned-to-author reasons are the
-  next curriculum chapter, discovered rather than guessed.
+- **Stage 1 — the lifecycle rails + the Twin re-anchor (DONE).** Authored `skills/deploy-scripts`
+  (the deployment-script lifecycle: folder = permanence class, header = death certificate, silent
+  redeploy = proof, retirement = tracked act, the six gates); re-anchored trust on Twin determinism
+  + the evidence showcase; sharpened the evidence-only record register; added the proving-ground
+  class folders. **The agent-to-agent `proof.json` capsule is retired** — reproducibility is the
+  Twin's property (§3.1), so no per-loop capsule is written. What the loop presents is the evidence
+  bundle (the scripts + the silent-redeploy assertions + the delta), plain, in the record.
+- **Stage 2 — make the Twin substrate real (this stage).** Author `proving-ground/twin.json` (the
+  first real evidence-profiling config, resolving against the config dir); operationalize the
+  substrate in `talk-to-local-sql` + `prove-on-dacpac` (detect `twin.json` + the `twin` CLI →
+  `twin up` establishes the deterministic BEFORE state on its own container via DacFx, no sqlpackage;
+  the sqlpackage proof targets the Twin; the isolation rules); the sample stays the fallback.
+  Supersedes the old "Stage 4 — estate anchoring" for the substrate half. The real-estate twin.json
+  (with evidence `sources` in logical/physical rendition, covering the ~200 tracked tables) is the
+  production sibling and follows. **Discovered gap (2026-07-20):** the Twin's pre-mint wipe fails on a
+  view over multiple base tables (`vOrderSummary`); the schema publishes but the data mint blocks —
+  the proper fix is a small Twin-engine change (skip non-updatable views in the wipe), out of this
+  tree's scope. Verified here through container-start + DacFx schema publish; the sample fallback is
+  unaffected.
+- **Stage 3 — the scorer.** A script that reads the **evidence bundle** the Twin loop produces (the
+  captured `delta.sql`, the silent-redeploy assertions, the block text with its signature) and
+  asserts the objective half of the rubric (probe-ran-before-publish, expected block + signature,
+  flip twins differ, teardown ran); run it over a full self-test fleet once by hand; fix what it
+  exposes. Not a "capsule-reader" — it reads the plain evidence, structured only as far as the
+  objective checks need. The human rubric keeps the register and pedagogy.
+- **Stage 4 — CI.** The smoke gate, then the knowledge canary (§3.4); once Stage 2 matures, the
+  runner pulls the `twin bake` pre-seeded image. Gate on the goldens. Record the CI-exception.
+- **Stage 5 — adoption + the funnel.** Wire `CONNECTORS.md` §1 so intake is a slash-command away;
+  surface the reviewer disposition as a PR check; count the funnel — % approved by reading alone,
+  disposition mix, returned-to-author reasons, escalations. The funnel is how "the principals stopped
+  being the bottleneck" is demonstrated instead of asserted, and the returned-to-author reasons are
+  the next curriculum chapter, discovered rather than guessed.
 
-Stages 0–2 need no new infrastructure and de-risk everything after; 3 is the first
-infrastructure spend; 4–5 ride existing plans (`ACCELERANT_PLAN.md`, `CONNECTORS.md`).
+Stages 0–2 need no new infrastructure and de-risk everything after; Stage 4 is the first CI spend;
+5 rides existing plans (`ACCELERANT_PLAN.md`, `CONNECTORS.md`).
 
 ## 5 — Guardrails
 
 - **The human surfaces do not change.** `THE_RECORD.md`'s two registers, the PR body shape,
-  and the conversation stay exactly as specified; the capsule sits beneath the record, never
-  in it.
-- **No wrapper for the developer loop.** The agent still runs `docker`/`dotnet`/`sqlpackage`
-  itself; the capsule is output, not orchestration. CI's scripts are the named exception and
-  live outside `skills/`.
+  and the conversation stay exactly as specified; the evidence bundle is the plain scripts +
+  proof already in the record, not a separate artifact beneath it.
+- **No wrapper for the developer loop.** The agent still runs `docker`/`dotnet`/`sqlpackage`/`twin`
+  itself. CI's scripts are the named exception and live outside `skills/`.
 - **The engine and the Twin stay optional** (`ACCELERANT_PLAN.md` governing principle,
   extended). The generic path — hand-authored sample + raw probes — must keep passing the
-  self-test with capsules, engine and Twin absent. `proving-ground/SampleCatalog` is not
-  deleted at Stage 4; it remains the deterministic fixture and the fallback.
+  self-test, engine and Twin absent. `proving-ground/SampleCatalog` is not deleted; it remains
+  the deterministic fixture and the fallback.
 - **The Twin supplies substrate, never verdicts.** The two-profile Strict/Permissive
-  discipline, the content-hash check, and the capsule stay skill-owned
-  (`ACCELERANT_PLAN.md` §4 guardrail). And the proving loop never touches the warm
-  projection container from the Twin side: Twin containers are the Twin's own, per
-  `../THE_TWIN.md` §6.
+  discipline and the content-hash check stay skill-owned (`ACCELERANT_PLAN.md` §4 guardrail),
+  and the sqlpackage proof — not the Twin — establishes the refactorlog / rename / pre-post-deploy
+  verdict on top of the Twin base. The proving loop never touches the warm projection container
+  from the Twin side: Twin containers are the Twin's own, per `../THE_TWIN.md` §6.
 - **Goldens are re-captured, never hand-edited.** A golden that no longer matches the engine
   is re-proven and re-stamped with the new sqlpackage version, per `self-test/golden/README.md`
   — the canary exists to force exactly that, loudly.
@@ -293,33 +299,45 @@ infrastructure spend; 4–5 ride existing plans (`ACCELERANT_PLAN.md`, `CONNECTO
 
 ## 6 — Open questions
 
-- **Capsule extraction discipline:** the block signature must be extracted from publish output
-  by rule (F8's string-match, now load-bearing). Pin the exact grep set per signature in the
-  capsule schema, and version it with sqlpackage.
+- **Block-signature extraction (was "capsule extraction"):** the block signature must be extracted
+  from publish output by rule (F8's string-match, now load-bearing) — there is no capsule schema to
+  pin it in anymore. Pin the exact grep set per signature where the Stage-3 scorer reads the evidence
+  bundle, and version it with sqlpackage. The signatures themselves are already lifted into
+  `_index/constraint-is-a-claim` (F5, Stage 0).
 - **CDC cases in CI:** `sp_cdc_enable_db` is instance-wide and capture timing is
   agent-dependent (`PROTOCOL.md` §8) — the smoke gate should exclude the CDC family; the
   canary runs them serialized with poll-and-timeout, or on a dedicated instance.
 - **Where the logbook lives:** in-repo markdown vs the deploy repo vs ADO work items. In-repo
   first (grep-able, PR-diffable); revisit at the ADO seam (`CONNECTORS.md` §5).
 - **Runner provisioning:** the smoke gate needs Docker + the sqlpackage tool on a hosted or
-  self-hosted runner; verify image pull + license posture before Stage 3 is scheduled.
-- **Violating pins vs the Twin's laws:** zero FK orphans is a mint law (K1), but the flip
-  twins need violating states — an orphan seeded *before* the FK the change introduces, a
-  dup before the unique, an over-length value before the narrow, a NULL before the
-  tightening. Verify each is expressible as a scenario pin against the pre-change estate
-  (the constraint under proof does not exist yet, so coordinate totality should accept the
-  row) before Stage 2 commits to scenarios; any state a pin cannot express keeps its
-  documented scratch edit.
-- **Parallel executors on one Twin:** the Twin maintains one persistent twin per config;
-  the self-test fleet needs per-executor isolation. Candidates: unique databases on the twin
-  container (today's `PG_<id>` pattern), per-executor `twin.json` with a unique container
-  name + port, or the `twin check`-style throwaway database. Decide before the fleet rides
-  the Twin; until then `PROTOCOL.md` isolation stands as-is.
-- **`twin up` mid-proof is a hazard:** the proving loop *deliberately* diverges the twin
-  from the estate definition (it publishes the edited dacpac). A `twin up` run mid-proof
-  would read the fingerprint mismatch and reconcile the edit away. The loop's rule: the Twin
-  establishes the BEFORE state; from that point until teardown, only sqlpackage touches the
-  proving database.
-- **CDC stays outside the Twin:** the Twin does not manage capture instances; the
-  enable-cdc / recreate-capture-instance family keeps its isolated-instance,
-  serialized discipline (`PROTOCOL.md` §8) regardless of substrate.
+  self-hosted runner; verify image pull + license posture before Stage 4 is scheduled.
+- **Flip-twin variants — seed-based for the sample, scenario/pin-based for synthetic estates
+  (resolved).** Traced in the Twin code: the proving-ground's data comes from the **static seed**
+  (`Data/Seed.sql`), and the Twin treats lane-seeded kinds as *provided*, not synthetically minted —
+  so Twin scenarios/pins do **not** drive the sample's empty/clean/violating variants; those stay
+  seed-based (the self-test scratch-edit path). Scenarios + pins are the flip mechanism for a
+  **synthetically-minted real estate**, where evidence-profiled data fills the tables. The original
+  concern (zero-FK-orphan mint law K1 vs a violating pin) applies there: verify each violating pin
+  binds against the pre-change estate before Stage 3's synthetic-estate scenarios rely on it.
+- **`twin up` mid-proof is a hazard (resolved — rule encoded).** The loop deliberately diverges the
+  twin (it publishes the edited dacpac). The rule, now in `talk-to-local-sql`: the Twin sets BEFORE;
+  from then until `twin reset`, only sqlpackage touches the DB. A second `twin up` would reconcile
+  the edit away.
+- **`twin check` may share the warm container (new).** `twin check` acquires a throwaway DB via
+  `PROJECTION_MSSQL_CONN_STR`; if that points at `projection-mssql-warm` it lands there transiently.
+  Give the proving-ground Twin its own throwaway container/env so `twin check` never shares the warm
+  instance. Encoded as an isolation rule in `talk-to-local-sql`.
+- **Twin view-wipe gap (new, Stage 2 finding).** The Twin's pre-mint wipe issues a DELETE against
+  every read-back object, and a view over multiple base tables is not deletable —
+  `twin up` publishes the schema but the data mint blocks on `vOrderSummary`. The proper fix is a
+  small Twin-engine change (skip non-updatable views in the wipe); out of this tree's scope. Owner:
+  the Twin (`Twin.Runtime`). Until then the Twin path establishes the schema base but not the data;
+  the sample fallback is unaffected.
+- **Parallel executors on one Twin:** the Twin maintains one persistent twin per config; the
+  self-test fleet needs per-executor isolation. Candidates: unique databases on the twin container,
+  per-executor `twin.json` with a unique container name + port, or the `twin check`-style throwaway
+  database. Decide before the fleet rides the Twin (Stage 3); until then `PROTOCOL.md` isolation
+  stands as-is.
+- **CDC stays outside the Twin:** the Twin does not manage capture instances; the enable-cdc /
+  recreate-capture-instance family keeps its isolated-instance, serialized discipline
+  (`PROTOCOL.md` §8) regardless of substrate.

--- a/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
+++ b/sidecar/projection/ssdt-agent/CERTIFICATION_PLAN.md
@@ -327,12 +327,11 @@ Stages 0–2 need no new infrastructure and de-risk everything after; Stage 4 is
   `PROJECTION_MSSQL_CONN_STR`; if that points at `projection-mssql-warm` it lands there transiently.
   Give the proving-ground Twin its own throwaway container/env so `twin check` never shares the warm
   instance. Encoded as an isolation rule in `talk-to-local-sql`.
-- **Twin view-wipe gap (new, Stage 2 finding).** The Twin's pre-mint wipe issues a DELETE against
-  every read-back object, and a view over multiple base tables is not deletable —
-  `twin up` publishes the schema but the data mint blocks on `vOrderSummary`. The proper fix is a
-  small Twin-engine change (skip non-updatable views in the wipe); out of this tree's scope. Owner:
-  the Twin (`Twin.Runtime`). Until then the Twin path establishes the schema base but not the data;
-  the sample fallback is unaffected.
+- **Twin view-wipe gap (resolved 2026-07-20).** The Twin's read-back now excludes views from the
+  wipe and the mint (a view carries no data), while leaving them published — `Twin.Runtime/Readback.fs`
+  `stripNonEstate` via a `sys.views` probe; `DECISIONS 2026-07-20`; witness `TwinViewLoopTests`.
+  `twin up` against the proving-ground (with `vOrderSummary`) now materializes; `vOrderSummary`
+  stays a first-class dependency-scope fixture.
 - **Parallel executors on one Twin:** the Twin maintains one persistent twin per config; the
   self-test fleet needs per-executor isolation. Candidates: unique databases on the twin container,
   per-executor `twin.json` with a unique container name + port, or the `twin check`-style throwaway

--- a/sidecar/projection/ssdt-agent/README.md
+++ b/sidecar/projection/ssdt-agent/README.md
@@ -93,6 +93,7 @@ ssdt-agent/
 │   ├── confirm-intent/ ····· OutSystems phrasing → catalog operation + the implicit destination
 │   ├── classify-mechanism/ · the decision cascade → a provisional how-it-ships + who-reviews
 │   ├── prove-on-dacpac/ ····· the proving loop that confirms or flips the classification
+│   ├── deploy-scripts/ ······ the deployment-script lifecycle rails (folder=contract, silence=proof, retirement tracked)
 │   ├── talk-to-local-sql/ ··· the disposable-copy substrate + the content-hash check
 │   ├── os-vocabulary/ ······ the OutSystems↔SQL conversation vocabulary (nouns, gestures, anchors)
 │   ├── ask-the-developer/ ·· the one mid-flow question a human must answer (options + consequences)
@@ -123,9 +124,11 @@ ssdt-agent/
    which hands a structured change-order to `change-author.md`, which proves the change and
    authors the pull request. Persona 2 is `reviewer.md`, which reproduces the change and returns
    a disposition.
-3. **`skills/`** — the four capability skills (`confirm-intent` → `classify-mechanism` →
-   `prove-on-dacpac`, riding on `talk-to-local-sql`), with `os-vocabulary` and `ask-the-developer`
-   owning the conversation surface (the two-way vocabulary and the one human question); the
+3. **`skills/`** — the capability skills (`confirm-intent` → `classify-mechanism` →
+   `prove-on-dacpac`, riding on `talk-to-local-sql`, with `deploy-scripts` owning the
+   deployment-script lifecycle a scripted change walks), with `os-vocabulary` and
+   `ask-the-developer` owning the conversation surface (the two-way vocabulary and the one human
+   question); the
    per-operation skills in `skills/op/` (with the shared reasoning in `skills/_index/` and the family
    TOC in `skills/operations/`), `skills/author-pr/` — the pull request they all feed — and
    `skills/review/` + `skills/author-review/` for Persona 2 (the review procedure and its

--- a/sidecar/projection/ssdt-agent/README.md
+++ b/sidecar/projection/ssdt-agent/README.md
@@ -84,6 +84,7 @@ ssdt-agent/
 ├── THE_RECORD.md ··········· the register every surface is written in (record vs conversation)
 ├── CONNECTORS.md ··········· future wiring seams (.claude/skills, Copilot, F# engine, ADO)
 ├── ACCELERANT_PLAN.md ······ the staged, verify-first plan to wire the F# engine as an accelerant
+├── CERTIFICATION_PLAN.md ··· the staged plan to make the agent's proof machine-checkable (the Twin, capsules, CI)
 ├── agents/
 │   ├── intake.md ··········· Persona-1 front door: confirm intent, name the op, get the four facts
 │   ├── change-author.md ···· edit the CREATE, prove on a disposable copy, author the pull request
@@ -93,10 +94,13 @@ ssdt-agent/
 │   ├── classify-mechanism/ · the decision cascade → a provisional how-it-ships + who-reviews
 │   ├── prove-on-dacpac/ ····· the proving loop that confirms or flips the classification
 │   ├── talk-to-local-sql/ ··· the disposable-copy substrate + the content-hash check
-│   ├── op/ ················· the 48 per-operation skills — each proves, then feeds the PR
+│   ├── os-vocabulary/ ······ the OutSystems↔SQL conversation vocabulary (nouns, gestures, anchors)
+│   ├── ask-the-developer/ ·· the one mid-flow question a human must answer (options + consequences)
+│   ├── op/ ················· the 49 per-operation skills — each proves, then feeds the PR
 │   ├── operations/ ········· the family TOC over op/ (tables · columns · keys · indexes · …)
 │   ├── _index/ ············· the shared reasoning ops cite (tightening-class, cdc, …)
-│   ├── author-pr/ ·········· the terminal artifact: the pull request a reviewer approves by reading
+│   ├── author-pr/ ·········· the authoring terminal artifact: the PR a reviewer approves by reading
+│   ├── author-review/ ······ the review terminal artifact: the four dispositions, record register
 │   └── review/ ············· Persona 2: reproduce-first review, dependency scope, dispositions
 ├── proving-ground/ ········· the hand-authored, self-contained sample project (the disposable copy)
 │   ├── SampleCatalog.sqlproj   Modules/*.sql   Script.Pre/PostDeployment.sql   Data/Seed.sql
@@ -120,9 +124,12 @@ ssdt-agent/
    authors the pull request. Persona 2 is `reviewer.md`, which reproduces the change and returns
    a disposition.
 3. **`skills/`** — the four capability skills (`confirm-intent` → `classify-mechanism` →
-   `prove-on-dacpac`, riding on `talk-to-local-sql`), the per-operation skills in `skills/op/`
-   (with the shared reasoning in `skills/_index/` and the family TOC in `skills/operations/`),
-   `skills/author-pr/` — the pull request they all feed — and `skills/review/` for Persona 2.
+   `prove-on-dacpac`, riding on `talk-to-local-sql`), with `os-vocabulary` and `ask-the-developer`
+   owning the conversation surface (the two-way vocabulary and the one human question); the
+   per-operation skills in `skills/op/` (with the shared reasoning in `skills/_index/` and the family
+   TOC in `skills/operations/`), `skills/author-pr/` — the pull request they all feed — and
+   `skills/review/` + `skills/author-review/` for Persona 2 (the review procedure and its
+   written disposition).
 4. **`proving-ground/README.md`** — the runbook. Read it before you run a single command.
 
 ## Scope

--- a/sidecar/projection/ssdt-agent/agents/change-author.md
+++ b/sidecar/projection/ssdt-agent/agents/change-author.md
@@ -126,8 +126,12 @@ DB is warm before proving.
 - Delta shows a **shadow-table rebuild / drop-by-absence** → name it to the developer explicitly.
 
 ### 5. Remediate per the operation knowledge
-The proof told you what the data does; the operation entry tells you the fix. Author it as a
-**change set**, not a verbal recommendation:
+The proof told you what the data does; the operation entry tells you the fix. When the remedy is a
+**deployment script** (pre-deploy, post-deploy, or ad-hoc), walk `skills/deploy-scripts` — its six
+gates decide whether a script is needed at all (pure-declarative first — the precise change is often
+*no script*), where it goes, its permanence class and header (the folder is the contract), the
+idempotency proof, and its retirement condition. Author the fix as a **change set**, not a verbal
+recommendation:
 - **Pre-deploy backfill** (`Script.PreDeployment.sql`) — fill the NULLs / dedupe before the
   declarative NOT NULL or unique constraint lands. Use the business answer from intake for the value.
   (For make-mandatory, remember the backfill is *necessary but not sufficient* — pair it with the

--- a/sidecar/projection/ssdt-agent/proving-ground/AdHoc/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/AdHoc/README.md
@@ -1,0 +1,29 @@
+# AdHoc/ — outside the deploy (the escape hatch and the drift frontier)
+
+Scripts here are **checked in but NOT run by the DACPAC** — they live outside the source of truth,
+which is why they are the most dangerous class and carry **principal review by default**. A script
+leaves the deploy path for exactly two legitimate reasons, and only two:
+
+1. **Scale / lock** — too long-running or too lock-heavy for the single deploy transaction (a batched
+   backfill of millions of rows, an online index rebuild, a chunked re-key). The transaction boundary
+   makes riding in pre/post a rollback-and-timeout hazard.
+2. **True one-off** — a production correction under a change ticket that does not belong in the
+   versioned deploy path at all.
+
+If neither holds, it is **not** ad-hoc — it belongs in `../OneTime/` (or `../Migrations/`) as a proper
+in-pipeline script.
+
+The four obligations that earn an ad-hoc script back to trustworthy (owned by
+`../../skills/deploy-scripts/SKILL.md` §"Ad-hoc"):
+- **Justify** — the header states the scale/lock or true-one-off reason.
+- **Idempotent · chunked · resumable** — a human runs it, possibly interrupted, possibly against a
+  lagging env.
+- **Leave a trace** — ticket, date, operator, **environments-applied**, and the batching parameters
+  actually used. A thing that ran against prod with no mark in source control *is* drift.
+- **Reconcile** — after the motion, update the declarative model and any permanent seed so a fresh
+  deploy reproduces the resulting state, then prove no drift: a clean schema compare and a matching
+  content hash.
+
+Nothing in this folder is `:r`-included by `../Script.PostDeployment.sql` — that is the point.
+"Removal" for an ad-hoc script means archiving it out of this folder once reconciled and
+prod-confirmed.

--- a/sidecar/projection/ssdt-agent/proving-ground/Migrations/001_backfill_customer_region.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Migrations/001_backfill_customer_region.sql
@@ -1,0 +1,18 @@
+/*
+  [PERMANENT · idempotent]  Migrations/001_backfill_customer_region.sql
+  Ticket:  (sample — illustrative exemplar, the standard to imitate)
+  What:    Populates Region for Customer rows that predate a Region value, with a neutral default.
+  Silent:  guarded by `WHERE Region IS NULL` — on a seed with no NULL Region it moves 0 rows and
+           leaves an identical content hash. Prove the silent redeploy on a disposable copy before
+           trusting it (see ../../skills/_index/idempotent-seed/SKILL.md).
+  Retire:  never — model-restoring; re-establishes state on any fresh deploy. No death certificate.
+
+  This is the permanent-class pattern to imitate. It is NOT wired into the active post-deploy by
+  default (its :r include is commented in ../Script.PostDeployment.sql) so it does not perturb the
+  standing seed the self-test scenarios pin. When an agent proves a real permanent backfill, it
+  authors the script here and adds the live :r include under the migrations heading.
+*/
+UPDATE dbo.Customer
+   SET Region = N'Unknown'
+ WHERE Region IS NULL;
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/Migrations/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/Migrations/README.md
@@ -1,0 +1,20 @@
+# Migrations/ — permanent · idempotent (the folder is the contract)
+
+Scripts here are **permanent and idempotent**: model-restoring backfills and one-off-shaped data
+motions that earn a permanent home by **proving silent on re-run**. They carry **no death
+certificate** — they re-establish the intended state on any fresh deploy, so they stay forever.
+
+Contract for every file in this folder:
+- **Guard** — natural idempotency (`WHERE … IS NULL`, `IF NOT EXISTS`, a guarded `MERGE`), never a
+  `MigrationHistory` marker (a marker means the operation wasn't naturally idempotent — that is the
+  *guarded · marker-inert* class, and the marker is a smell to convert away from).
+- **Silent on redeploy** — the no-op redeploy touches **0 rows**, leaves an **identical content
+  hash**, and captures **0 CDC** rows if the table is tracked. That silence is the proof
+  (`../../skills/_index/idempotent-seed/SKILL.md`).
+- **Header** — `[PERMANENT · idempotent]`, what it does, why it is silent, and `Retire: never` with
+  the reason. See `../../skills/deploy-scripts/SKILL.md` §"The header is the memory".
+- **Review** — usually any team member (a permanent idempotent seed is additive); the class does not
+  set review level — the operation does (`../../skills/classify-mechanism/SKILL.md`).
+
+`001_backfill_customer_region.sql` is the worked exemplar. Wire a script into the deploy by adding
+its `:r` include, grouped under the migrations heading, in `../Script.PostDeployment.sql`.

--- a/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderSummary.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Modules/OrderSummary.sql
@@ -1,41 +1,36 @@
 /*
-  dbo.vOrderSummary — the authored view (enumerated columns) and the base for the SELECT * View
-  trap variant.
+  dbo.vOrderSummary — the dependency-scope + SELECT * View fixture (enumerated columns).
 
-  CREATE-only schema item. The authored view lists its columns explicitly, never SELECT *. That
-  is the correct, stable shape: a column added to Order, Customer, or Status does not silently
-  change the view's contract, and the view is a safe base for a compatibility or indexed view.
+  CREATE-only schema item. The authored view lists its columns explicitly, never SELECT *. That is
+  the correct, stable shape: a column added to Order, Customer, or Status does not silently change
+  the view's contract.
 
   PARALLEL EXECUTORS — READ FIRST: do not edit this authored file in place. Copy the tree, publish
-  to a unique database per `../self-test/PROTOCOL.md`.
+  to a unique database per `../../self-test/PROTOCOL.md`.
 
-  WHAT THIS VIEW UNLOCKS
-  ----------------------
-  - create-view (VIE-01): an OutSystems Advanced Query / view over a join. The authored,
-    enumerated form is the clean destination: it ships as a single schema change, applied in
-    place, and no data is read or written. See skills/op/create-view/.
-  - the SELECT * View trap (handbook 16 = §19): the SELECT * variant below is proven in a scratch
-    copy. Replace the enumerated SELECT with `SELECT *`, and the view's column set is frozen at
-    first bind and drifts against the base tables — a base column add is not reflected, and a base
-    column drop breaks the view at runtime, not at deploy. The authored view stays enumerated so
-    VIE-01 positive passes; the trap is a scratch edit only. See skills/op/create-view/ and
-    skills/op/compat-view/.
-  - compat-view target (VIE-02): after a rename, a view carrying the old name over the new table
-    is the backward-compatibility bridge — the identity survives the move, and the name is just an
-    address. See skills/op/compat-view/ and skills/_index/identity-and-refactorlog/.
-  - indexed-view (VIE-04): a scratch edit adds WITH SCHEMABINDING and a UNIQUE CLUSTERED index to
-    materialize an aggregation. SCHEMABINDING is why the enumerated column list matters. See
-    skills/op/indexed-view/.
+  WHY THIS FIXTURE STAYS (though authoring views is principal-only)
+  ----------------------------------------------------------------
+  Authoring a view — create-view, compat-view, indexed-view — is PRINCIPAL-ONLY for this team (out
+  of the developer catalog on purpose; see skills/operations/views-synonyms.md). But this view is a
+  load-bearing FIXTURE for the developer curriculum, independent of those ops:
 
-  synonym (VIE-03) needs no table here — it targets an external database or server and is proven
-  by the runtime-resolution gap: the dacpac cannot validate the far side. See skills/op/synonym/.
+  - Dependency scope (the primary use): vOrderSummary is the canonical "this column feeds a view"
+    example — a change to Order/Customer must account for the view that reads it. Used by
+    skills/review/dependency-scope, the REV-08 named-risk review scenario, and THE_RECORD.md's
+    worked correction. The view stays here so that lesson has a real object.
+  - The SELECT * View trap (handbook 16 = §19): the enumerated form is the stable destination; a
+    `SELECT *` variant (a scratch edit) drifts against the base tables — a base column add is not
+    reflected until sp_refreshview, with no reviewable diff. Taught in skills/op/create-view/
+    (principal-only) and proven as a scratch edit only.
+  - The Twin holds it: a view carries no data, so the Twin publishes vOrderSummary but never wipes
+    or mints it (DECISIONS 2026-07-20). Faithful on both substrates.
 
-  The SELECT * View trap and the indexed-view variants are scratch edits — do not bake them into
-  this file. The authored view must stay enumerated and non-schemabound so VIE-01 positive
-  publishes clean.
+  The authored view MUST stay enumerated and non-schemabound. The SELECT * and indexed-view variants
+  are scratch edits — do not bake them into this file.
 
-  UNLOCKS self-test ids: VIE-01 (create-view), VIE-02 (compat-view target),
-  VIE-04 (indexed-view — scratch edit), and the SELECT * View trap (scratch edit).
+  Self-test: the view-authoring cases VIE-01 (create-view), VIE-02 (compat-view), VIE-04
+  (indexed-view) are downgraded to principal-route negatives; synonym (VIE-03) is unaffected — it
+  authors no view.
 */
 
 CREATE VIEW dbo.vOrderSummary

--- a/sidecar/projection/ssdt-agent/proving-ground/OneTime/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/OneTime/README.md
@@ -1,0 +1,21 @@
+# OneTime/ — transient · one-time (born with a death certificate)
+
+Scripts here are **transient**: release-specific corrections and one-shot data motions. They are
+**born with a death certificate** and stay only until confirmed applied in production, then are
+removed on the next deprecation-train sweep as a tracked PR (removal leaves the deploy path but keeps
+git history).
+
+Contract for every file:
+- **Idempotent** so a lagging environment can safely re-run it — the reason a one-time script is
+  *not* deleted the instant it runs.
+- **Header IS a death certificate** — `[TRANSIENT · one-time · REMOVE AFTER PROD]`, the guard, a
+  `Prod-applied:` stamp slot, and a `Removal:` line naming the work item that will sweep it (or, for
+  a phase-bound script, the phase/release that ends it — see
+  `../../skills/_index/multi-phase/SKILL.md`). A script with no stated retirement is not finished.
+- **Review** — matches the operation it serves; a one-time `DELETE` of populated rows still needs a
+  principal because the data is gone irreversibly (`../../skills/classify-mechanism/SKILL.md`).
+
+The named failure this folder exists to prevent: the one-time script left in past prod, re-executing
+stale logic on every publish until the post-deploy is a monolith nobody trusts. The death-certificate
+header + the deprecation train is the antidote. See `../../skills/deploy-scripts/SKILL.md`
+§"Retirement is a tracked act". `Release_2026.07_email_normalize.sql` is the worked exemplar.

--- a/sidecar/projection/ssdt-agent/proving-ground/OneTime/Release_2026.07_email_normalize.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/OneTime/Release_2026.07_email_normalize.sql
@@ -1,0 +1,21 @@
+/*
+  [TRANSIENT · one-time · REMOVE AFTER PROD]  OneTime/Release_2026.07_email_normalize.sql
+  Ticket:        (sample — illustrative exemplar, the standard to imitate)
+  What:          One-shot normalization of legacy-import Email casing to lower-case.
+  Guard:         idempotent (`WHERE Email <> LOWER(Email)`) — safe to re-run in a lagging env;
+                 a redeploy after it lands moves 0 rows and leaves an identical hash.
+  Prod-applied:  <stamp on the prod deploy>
+  Removal:       <work item> — sweep on the next deprecation train once prod-confirmed.
+                 Delete this file; keep git history.
+
+  This is the transient-class pattern to imitate: the header is the death certificate. It is NOT
+  wired into the active post-deploy by default (its :r include is commented in
+  ../Script.PostDeployment.sql) — a standing sample must not carry a one-time fix that re-runs on
+  every publish. When an agent proves a real one-time correction, it authors the script here and
+  adds the live :r include under the one-time heading, then names the removal work item on the PR.
+*/
+UPDATE dbo.Customer
+   SET Email = LOWER(Email)
+ WHERE Email IS NOT NULL
+   AND Email <> LOWER(Email);
+GO

--- a/sidecar/projection/ssdt-agent/proving-ground/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/README.md
@@ -199,8 +199,29 @@ this — each owns a fresh unique DB per `../self-test/PROTOCOL.md`.)
 Rename with no refactorlog entry · Optimistic NOT NULL · Forgotten FK Check · Ambitious
 Narrowing · CDC Surprise · Refactorlog Cleanup · SELECT * View.
 
+## Deployment-script class folders (the folder is the contract)
+
+The proving ground carries the deployment-script class folders the lifecycle rails require
+(`../skills/deploy-scripts/SKILL.md`) so a script's *permanence class is its location*:
+
+- `Migrations/` · `ReferenceData/` — **permanent · idempotent** (model-restoring backfills, guarded
+  reference seeds). No death certificate; `Retire: never`; proven by the silent redeploy.
+- `OneTime/` — **transient · one-time**. The header **is a death certificate** (a removal work item,
+  or the phase that ends it). Swept on the deprecation train once prod-confirmed.
+- `AdHoc/` — **outside the DACPAC** (scale/lock or a true one-off). Principal review; the four
+  obligations (justify · idempotent-chunked-resumable · trace · reconcile).
+
+Each folder's `README.md` states its contract; `Migrations/001_backfill_customer_region.sql` and
+`OneTime/Release_2026.07_email_normalize.sql` are the worked exemplars. Their `:r` includes in
+`Script.PostDeployment.sql` are **commented** so the standing seed the self-test pins is not
+perturbed — when you prove a real script, author it in the right folder and add its include under the
+matching class heading. The `SampleCatalog.sqlproj` reclassifies all four folders' `*.sql` out of the
+schema `Build` glob (as `None`, like `Data/`), so a script is never compiled as a schema object.
+
 ## Connector point
 
 The hand-authored `SampleCatalog` can be replaced by the F# engine's
 `SqlprojEmitter`/`DacpacEmitter`/`PostDeployEmitter` output from a real OutSystems catalog —
-the prove loop above is unchanged, just real schema. See `../CONNECTORS.md` §3.
+the prove loop above is unchanged, just real schema. See `../CONNECTORS.md` §3. And the substrate of
+record is the **Twin** (`../../THE_TWIN.md`) when present — a deterministic, evidence-profiled dataset
+over the real estate definition that evolves with the schema; the sample here is the fallback.

--- a/sidecar/projection/ssdt-agent/proving-ground/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/README.md
@@ -19,6 +19,25 @@ worked commands; read them, then run them in order.
 > That is how a hundred provers share the warm container without colliding on the same `.sql`,
 > the same `bin/`, or the same DB.
 
+## The Twin substrate (preferred) vs this warm-container runbook
+
+`twin.json` (beside this file) wires the proving ground as a **Twin** — the deterministic,
+evidence-profiled local dev environment (`../../THE_TWIN.md`). When the `twin` CLI is present, prefer
+it for the BEFORE state:
+
+```bash
+cd sidecar/projection/ssdt-agent/proving-ground
+twin up      # stands up twin-ssdt-agent on localhost,21434; DacFx-publishes Modules/**/*.sql;
+             # applies Data/Seed.sql; mints deterministically (no sqlpackage). `twin reset` tears down.
+```
+
+The Twin establishes the deterministic BEFORE state; the sqlpackage proving loop below then targets
+`localhost,21434 / twin` (see `../skills/talk-to-local-sql/SKILL.md` §"substrate of record" and
+`../skills/prove-on-dacpac/SKILL.md` §"On the Twin substrate"). This warm-container runbook
+(`localhost,11433 / ProvingGround`) is the **fallback** when the Twin is not wired. The Twin gives
+the sample its reproducible base; the flip-twin variants (empty / clean / violating) stay **seed-based**
+here — the Twin's scenario/pin flip mechanism is for synthetically-minted estates, not the static seed.
+
 ## 0 — The runtime shim (REQUIRED on this machine)
 
 `sqlpackage` is installed as a dotnet tool targeting .NET 8; wherever that runtime is not the

--- a/sidecar/projection/ssdt-agent/proving-ground/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/README.md
@@ -21,17 +21,19 @@ worked commands; read them, then run them in order.
 
 ## 0 — The runtime shim (REQUIRED on this machine)
 
-`sqlpackage` is installed as a dotnet tool targeting .NET 8, but this box has .NET 9 at a
-non-standard path. Export these in the shell that runs `sqlpackage`, or the tool fails to
-start:
+`sqlpackage` is installed as a dotnet tool targeting .NET 8; wherever that runtime is not the
+default, export these in the shell that runs `sqlpackage`, or the tool fails to start (`<you>` =
+your OS user; `../skills/talk-to-local-sql/SKILL.md` carries the per-OS values):
 
 ```bash
-export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROOT="${DOTNET_ROOT:-$HOME/.dotnet}"   # Git Bash e.g. C:/Users/<you>/AppData/Local/Microsoft/dotnet
 export DOTNET_ROLL_FORWARD=Major
-export MSYS_NO_PATHCONV=1   # Git Bash: keep /Action: switches and /opt/... docker paths intact
+export MSYS_NO_PATHCONV=1   # Git Bash ONLY: keep /Action: switches and /opt/... docker paths intact
 ```
 
-`sqlpackage` lives at `C:\Users\danny\.dotnet\tools\sqlpackage.exe` (version 170.4.83).
+`sqlpackage` is the global dotnet tool `microsoft.sqlpackage` — on PATH as `sqlpackage`, or at
+`C:/Users/<you>/.dotnet/tools/sqlpackage.exe` on Windows / `$HOME/.dotnet/tools/sqlpackage`
+elsewhere; the findings here were captured on version 170.4.83 (stamp the version in every proof).
 (Alternative to the shim: install the .NET 8 runtime — then the env vars are unnecessary.)
 
 ## 1 — Warm the disposable substrate

--- a/sidecar/projection/ssdt-agent/proving-ground/ReferenceData/README.md
+++ b/sidecar/projection/ssdt-agent/proving-ground/ReferenceData/README.md
@@ -1,0 +1,18 @@
+# ReferenceData/ — permanent · idempotent (reference-data seeds)
+
+The same permanence class as `../Migrations/`, scoped to **reference / static-entity seeds** — the
+small enumerated tables (Status, Country, OrderType) whose rows *are* the model, not user input.
+Seeds are **permanent and idempotent** and carry **no death certificate**.
+
+Contract:
+- **Guarded, null-safe `MERGE`** — `WHEN MATCHED AND <value differs>` (never an unconditional
+  `WHEN MATCHED`, which rewrites every row on every deploy — the CDC-silence violation); explicit
+  IDs, not IDENTITY, so a constant means the same row in every environment; deactivate
+  (`IsActive = 0`), never hard-delete a referenced value. Owned by
+  `../../skills/_index/idempotent-seed/SKILL.md` — do not re-derive it here.
+- **Silent on redeploy** — 0 rows · identical hash · 0 CDC.
+- **Header** — `[PERMANENT · idempotent]`, `Retire: never`.
+
+The proving-ground's live reference seed is `../Data/Seed.sql` (the make-mandatory / FK / dedupe
+scenarios ride on it), included by `../Script.PostDeployment.sql`. New reference seeds an agent
+authors during a proof go here and are `:r`-included under the reference-data heading.

--- a/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.sqlproj
+++ b/sidecar/projection/ssdt-agent/proving-ground/SampleCatalog.sqlproj
@@ -48,6 +48,26 @@
   </ItemGroup>
 
   <!--
+    The deployment-script class folders (see skills/deploy-scripts/SKILL.md — the folder is the
+    contract). Scripts in these folders are DATA, not schema: reclassify them OUT of the **/*.sql
+    Build glob so they are not compiled as schema objects, and mark them None (they enter the
+    build only when the post-deploy `:r`-includes one — see Script.PostDeployment.sql). AdHoc/
+    is never included (it runs outside the DACPAC by definition) but is reclassified all the same
+    so its scripts never leak into the schema model.
+  -->
+  <ItemGroup>
+    <Build Remove="Migrations\**\*.sql" />
+    <Build Remove="ReferenceData\**\*.sql" />
+    <Build Remove="OneTime\**\*.sql" />
+    <Build Remove="AdHoc\**\*.sql" />
+
+    <None Include="Migrations\**\*.sql" />
+    <None Include="ReferenceData\**\*.sql" />
+    <None Include="OneTime\**\*.sql" />
+    <None Include="AdHoc\**\*.sql" />
+  </ItemGroup>
+
+  <!--
     The refactorlog is how a rename survives as sp_rename instead of becoming DROP+CREATE
     (the Naked Rename catastrophe). When the agent proves a rename, the refactorlog entry is
     the artifact that must exist. It is created here as an empty scaffold; the rename proof

--- a/sidecar/projection/ssdt-agent/proving-ground/Script.PostDeployment.sql
+++ b/sidecar/projection/ssdt-agent/proving-ground/Script.PostDeployment.sql
@@ -20,5 +20,25 @@
 
 GO
 
+/*
+  Deployment scripts by permanence class (skills/deploy-scripts/SKILL.md — the folder is the
+  contract). Group `:r` includes by class so the order and the class are legible at a glance.
+  The example includes below are COMMENTED: the standing sample must not run the exemplar scripts
+  (they would perturb the seed the self-test scenarios pin). When an agent proves a real change, it
+  authors the script in the right folder and UNCOMMENTS (or adds) its include under the matching
+  heading. AdHoc/ is never included here — it runs outside the DACPAC by definition.
+*/
+
+-- Migrations (permanent · idempotent) — model-restoring backfills; Retire: never.
+-- PRINT 'Running migrations...';        :r .\Migrations\001_backfill_customer_region.sql
+
+-- Reference data (permanent · idempotent) — guarded MERGE seeds; Retire: never.
+--   (The live reference seed is Data\Seed.sql, included above.)
+
+-- One-time (transient · REMOVE AFTER PROD) — each carries a death certificate + a removal work item.
+-- PRINT 'One-time (remove after prod)...'; :r .\OneTime\Release_2026.07_email_normalize.sql
+
+GO
+
 PRINT 'Post-deploy complete: seed MERGEs applied (idempotent).';
 GO

--- a/sidecar/projection/ssdt-agent/proving-ground/twin.json
+++ b/sidecar/projection/ssdt-agent/proving-ground/twin.json
@@ -1,0 +1,14 @@
+{
+  "estate": {
+    "tables": "Modules/**/*.sql",
+    "staticData": ["Data/Seed.sql"]
+  },
+  "container": {
+    "name": "twin-ssdt-agent",
+    "port": 21434
+  },
+  "seed": 7,
+  "scenarios": {
+    "default": {}
+  }
+}

--- a/sidecar/projection/ssdt-agent/self-test/PROTOCOL.md
+++ b/sidecar/projection/ssdt-agent/self-test/PROTOCOL.md
@@ -32,18 +32,19 @@ the instance grain.
 
 ## 0 — The runtime environment (REQUIRED, every shell)
 
-`sqlpackage` is a .NET-8 dotnet tool and must find a runtime before it starts. The block below is
-**one developer's box** — a .NET-8 tool on a .NET-9 runtime at a non-standard Windows path,
-invoked from Git Bash — kept verbatim as the worked example. Export its equivalents in **every**
-shell you call `sqlpackage` from, or it fails to start:
+`sqlpackage` is a .NET-8 dotnet tool and must find a runtime before it starts. The block below is a
+**worked example** — a .NET-8 tool on a .NET-9 runtime at a non-standard Windows path, invoked from
+Git Bash. Replace `<you>` (and the path) with yours; the portable form for non-Windows boxes
+follows. Export these in **every** shell you call `sqlpackage` from, or it fails to start:
 
 ```bash
-export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+export DOTNET_ROOT="${DOTNET_ROOT:-C:/Users/<you>/AppData/Local/Microsoft/dotnet}"   # your dotnet root
 export DOTNET_ROLL_FORWARD=Major
 export MSYS_NO_PATHCONV=1   # REQUIRED on Git Bash for sqlpackage /Action: args AND docker-exec /opt/... paths
 ```
 
-`sqlpackage` lives at `C:\Users\danny\.dotnet\tools\sqlpackage.exe`. The host has **no
+`sqlpackage` is on PATH as `sqlpackage` (a global `dotnet tool install`), or at
+`C:/Users/<you>/.dotnet/tools/sqlpackage.exe` on that box. The host has **no
 sqlcmd** — issue SQL through the container:
 
 ```bash
@@ -86,7 +87,7 @@ TESTID="COL-03"                        # the test-matrix id you are proving
 RAND=$(openssl rand -hex 4)            # 8 hex chars; uniqueness across parallel executors
 DB="PG_${TESTID//-/_}_${RAND}"         # e.g. PG_COL_03_9f2a1c4e  (no dashes — valid DB identifier)
 SCRATCH="$CLAUDE_SCRATCHPAD/pg-${TESTID}-${RAND}"   # your private scratch dir
-SRC="C:/Users/danny/code/outsystems-ddl-exporter/sidecar/projection/ssdt-agent/proving-ground"
+SRC="<your-repo-checkout>/sidecar/projection/ssdt-agent/proving-ground"  # absolute path to the authored tree
 ```
 
 `DB` and `SCRATCH` both carry `TESTID` + `RAND`, so they are globally unique among parallel

--- a/sidecar/projection/ssdt-agent/self-test/prompts.md
+++ b/sidecar/projection/ssdt-agent/self-test/prompts.md
@@ -32,7 +32,7 @@ op maps to one of the enriched Modules, each of which the enriched-sample author
 | `OrderLine` (new) | IDENTITY PK; `OrderId` FK to Order; `LineNumber`; `Amount`; 2–3 lines/Order | define-PK composite (KEY-01), change-delete-rule cascade dependency-scope (KEY-04), FK-graph depth |
 | `OrderStatusText` (new) | adds free-text `StatusText NVARCHAR(20) NOT NULL` to Order, values `Pending`/`Shipped`/`Cancelled` mapping to Status | extract-to-lookup (STA-03) + its total-mapping negative |
 | `CdcCandidate` (new) | plain `Id/Name/Notes` table, seeded, header carries the survival-rule-1 / PROTOCOL §8 CDC-isolation warning | enable-cdc (AUD-04), recreate-capture-instance (AUD-05), change-tracking (AUD-06), drop-CDC-table (AUD-07N), nullable-add-to-CDC (TRAP-01N) |
-| `OrderSummary` (new) | authored VIEW `dbo.vOrderSummary` with **enumerated** columns joining Order+Customer+Status, plus a documented `SELECT *` variant for the trap | create-view (VIE-01), compat-view target (VIE-02), indexed-view (VIE-04) |
+| `OrderSummary` (new) | authored VIEW `dbo.vOrderSummary` with **enumerated** columns joining Order+Customer+Status, plus a documented `SELECT *` variant for the trap | dependency-scope fixture ("a column feeds a view") + the SELECT * trap; the view-authoring cases VIE-01/02/04 are principal-only route negatives (VIE-03 synonym unaffected) |
 
 **Seed discipline (mirrors PROTOCOL step 5):** the **authored** positive seed is never edited to
 produce a negative/flip — you edit **your scratch copy** (`$SCRATCH/Data/Seed.sql`) for the
@@ -865,7 +865,15 @@ flag it against the op skill, not the run.
 
 ## Family: views-synonyms — `skills/operations/views-synonyms.md` (family index)
 
-### VIE-01 — create-view · positive
+> **⚠️ Views are PRINCIPAL-ONLY (2026-07-20).** Authoring a view — `create-view`, `compat-view`,
+> `indexed-view` — is out of the developer catalog on purpose. **VIE-01, VIE-02, and VIE-04 are
+> therefore route-to-principal NEGATIVES** (`…N`): the correct outcome is that the agent does NOT
+> author the view — it names the request, says views are a principal's call, and routes it up (the
+> pattern of IDX-04N / CON-04N). The prompt bodies below are retained as the principal's authoring
+> reference. **VIE-03 (synonym) is unaffected** — it authors no view and stays a developer positive.
+> The `vOrderSummary` fixture stays (dependency-scope; see its header) — only the *ops* are gated.
+
+### VIE-01 — create-view · positive (now a route-to-principal negative — see the family note)
 > **"Give me a view that joins Order and Customer for active customers."**
 - **op:** `skills/op/create-view/SKILL.md`
 - **How it ships:** as a single schema change applied in place — a clean `CREATE/ALTER VIEW`; it
@@ -1136,7 +1144,7 @@ pending its own prompt and golden capture (`../CERTIFICATION_PLAN.md` Stage 1). 
 - **static-data:** create-static-seed=STA-01 · edit-seed=STA-02 (+IDEM-01N) · extract-to-lookup=STA-03/03N ·
   delete-seed-value=STA-04N
 - **structural:** split-table=STR-01 · merge-tables=STR-02/02N · move-attribute=STR-03 · identity-swap=STR-04
-- **views-synonyms:** create-view=VIE-01 · compat-view=VIE-02 · synonym=VIE-03 · indexed-view=VIE-04
+- **views-synonyms:** synonym=VIE-03 (developer positive) · create-view=VIE-01, compat-view=VIE-02, indexed-view=VIE-04 — **PRINCIPAL-ONLY, route-to-principal negatives** (see the family note)
 - **audit-cdc:** temporal-new=AUD-01 · temporal-convert=AUD-02 · audit-columns=AUD-03 · enable-cdc=AUD-04 ·
   recreate-capture-instance=AUD-05 · change-tracking=AUD-06 (delete-entity on a CDC table=AUD-07N)
 

--- a/sidecar/projection/ssdt-agent/self-test/prompts.md
+++ b/sidecar/projection/ssdt-agent/self-test/prompts.md
@@ -1119,7 +1119,9 @@ discovering the backfill-then-still-blocked reality has classified from text and
 
 ## Coverage map (every per-op skill has at least one case)
 
-The ~48 per-op skills each have at least one prompt above. The mapping:
+Each per-op skill has at least one prompt above, with one known gap: the newer `backfill-rows` op
+(the data-plane UPDATE companion to add-default / make-mandatory) has **no case yet** — it is
+pending its own prompt and golden capture (`../CERTIFICATION_PLAN.md` Stage 1). The mapping:
 
 - **tables:** create-entity=TBL-01 · rename-entity=TBL-02/02N · delete-entity=TBL-03 (+AUD-07N) ·
   move-schema=TBL-04 · archive-entity=TBL-05 · junction=TBL-06

--- a/sidecar/projection/ssdt-agent/skills/_index/constraint-is-a-claim/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/constraint-is-a-claim/SKILL.md
@@ -38,6 +38,28 @@ Run the probe **first** to know what to look for; let the Strict publish **prove
 The probe **predicts**; the Strict publish **proves.** A clean probe is *necessary* — but you still
 publish, because the publish delta is the honest proof.
 
+## The block's signature (what the refusal actually says)
+
+When the claim is violated, the block is a specific SQL Server error, and the **number names the
+cause.** These are the signatures to read in the publish output and carry into the proof packet:
+
+| The op / cause | The block, as SQL Server reports it on publish |
+|---|---|
+| define-PK · add-unique · modify-index→unique — **duplicate values** | `Msg 1505` — "The CREATE UNIQUE INDEX statement terminated because a duplicate key was found …", naming the duplicate key value (a PK/unique constraint builds a unique index) |
+| define-PK — **NULL in a column declared nullable** | `Msg 8111` — "Cannot define PRIMARY KEY constraint on nullable column …". A NOT NULL tightening of a *populated* key column is instead the tightening-class block — `Msg 515` / `Msg 50000` behind the data-loss guard (`../tightening-class/SKILL.md`) |
+| add-check — **rows violating the predicate** (added WITH CHECK) | `Msg 547` — "The ALTER TABLE statement conflicted with the CHECK constraint …", naming the table and column |
+| create-fk-clean · create-fk-orphan — **orphan children** (added WITH CHECK) | `Msg 547` — "… conflicted with the FOREIGN KEY constraint …", naming the parent table and column |
+
+> **Read the number; it tells you which claim broke.** `Msg 1505` = a duplicate, `Msg 547` = an
+> orphan or a failing predicate, `Msg 8111` = a NULL in a key. sqlpackage surfaces the inner SQL
+> Server error during publish — commonly wrapped as `SQL72014: .NET SqlClient Data Provider: Msg
+> NNNN, Level 16, State S, …` above the `Could not deploy package` line, so parse the **text**, not
+> the exit code (a blocked publish does not reliably exit non-zero — see `self-test/PROTOCOL.md`).
+> These are engine- and version-bound: **capture the verbatim `Msg` and the offending value from the
+> blocked run** (`../../prove-on-dacpac/SKILL.md`'s violating-row probe does exactly this), rather
+> than asserting them from memory. This is the value-violation counterpart to tightening-class's
+> data-blind `Msg 515` / `Msg 50000` — a different number for a different cause.
+
 ## The discriminator: clean data lands in place, dirty data needs a script
 
 - **Data satisfies the claim** → the constraint lands clean → it **ships as a single schema change,

--- a/sidecar/projection/ssdt-agent/skills/_index/idempotent-seed/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/_index/idempotent-seed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idempotent-seed
-description: Cross-cutting KNOWLEDGE shared by create-static-seed, edit-seed, delete-seed-value, extract-to-lookup (its seed leg), and data-plane row ops. Owns the idempotent guarded MERGE (WHEN MATCHED ... AND value-differs, null-safe with NULL distinct from ''), explicit-IDs-not-IDENTITY for lookup keys (a constant must mean the same row across environments), deactivate-don't-delete (IsActive=0, never a hard DELETE that orphans fact rows), and silence-is-the-proof (0 rows affected + identical content-hash + 0 CDC captures on a no-op redeploy). Per-op skills POINT here. Points to _index/cdc for the CDC-silence face; the hash check lives in talk-to-local-sql.
+description: Cross-cutting KNOWLEDGE shared by create-static-seed, edit-seed, delete-seed-value, extract-to-lookup (its seed leg), and the data-plane backfill-rows op. Owns the idempotent guarded MERGE (WHEN MATCHED ... AND value-differs, null-safe with NULL distinct from ''), explicit-IDs-not-IDENTITY for lookup keys (a constant must mean the same row across environments), deactivate-don't-delete (IsActive=0, never a hard DELETE that orphans fact rows), and silence-is-the-proof (0 rows affected + identical content-hash + 0 CDC captures on a no-op redeploy). Per-op skills POINT here. Points to _index/cdc for the CDC-silence face; the hash check lives in talk-to-local-sql.
 ---
 
 # Idempotent seed — re-running changes nothing, and silence is the proof
@@ -83,9 +83,11 @@ non-silent redeploy as a bug even when the data ends up correct.
 - **extract-to-lookup (seed leg only)** — seeding the new lookup with the distinct existing values
   is idempotent-MERGE work; the *rest* of extract-to-lookup (the FK backfill + old-column drop) is
   multi-phase, see `../multi-phase/SKILL.md`.
-- **data-plane row ops** — the four row fates (insert / guarded update / unchanged / careful
-  delete) under one null-safe MERGE; a bulk DELETE of populated rows removes data irreversibly, so a
-  principal must review it.
+- **backfill-rows** (`../../op/backfill-rows/SKILL.md`) — the data-plane UPDATE of existing business
+  rows (fill the blanks, re-stamp to a new value). Same guard, same silence proof: a `WHERE` that
+  touches only the differing rows, and a redeploy that reports 0 rows + an identical hash. A dev lead
+  reviews it because existing data is modified; a bulk DELETE of populated rows is a different op and
+  removes data irreversibly, so a principal must review that.
 
 ## The CDC-silence face (pointer)
 

--- a/sidecar/projection/ssdt-agent/skills/author-pr/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/author-pr/SKILL.md
@@ -182,6 +182,16 @@ sections: its **Review & release** findings, its **Verification** query, its **R
 and its standing **Not verified** items. Assemble the body from those fragments; the operation skill
 owns the specifics, this skill owns the shape and the register.
 
+When the change ships a **deployment script**, `../deploy-scripts/SKILL.md` contributes the
+script-lifecycle evidence — almost exclusively evidence, no narration: each script's permanence class
+and header (in **Changes**); the idempotency proof, stated as the no-op redeploy's three assertions
+verbatim — **0 rows affected · identical content digest before/after · 0 CDC captures** if tracked —
+alongside the sanity/verification SQL run before the change was allowed to land (in **Deployment
+evidence**); and the **retirement condition** for every transient/guarded/ad-hoc script (the trigger
++ work item, or the phase that ends it), or "Retire: never" with the reason for a permanent one. The
+retirement line rides in **Changes** beside the file, or in **Deployment evidence** — do not drop it;
+a script with no stated retirement is not finished.
+
 A complete **captured** example from a live run — every count, error, and digest in it observed on a
 disposable copy — is `../../self-test/golden/make-mandatory-pr.md`, with its developer conversation
 alongside. That pair is the standard to imitate.

--- a/sidecar/projection/ssdt-agent/skills/classify-mechanism/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/classify-mechanism/SKILL.md
@@ -49,6 +49,11 @@ removes data gets under-reviewed on the strength of how simply it ships.
 The plain "how it ships" statement each shape surfaces on the record is in `THE_RECORD.md` §5 — the
 shape name is internal; the §5 sentence is what a reviewer reads.
 
+When the shape carries a **script** — declarative + post-deploy, pre-deploy + declarative, or
+script-only — `../deploy-scripts/SKILL.md` owns its lifecycle: where it goes (pre vs post vs
+out-of-DACPAC), its permanence class (the folder is the contract), the idempotency proof, and when it
+retires. Name the shape here; `deploy-scripts` places, proves, and retires the script.
+
 **Shape -> release-bucket map** (the team's release vocabulary):
 
 - **SINGLE-PHASE** = pure declarative: no script, one publish.

--- a/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
@@ -110,10 +110,10 @@ Two disambiguations the table now forces you to make (the op split lives here, n
 | "merge these two entities" | `merge-tables` | `skills/op/merge-tables/SKILL.md` | multi-phase: prove 1:1 cardinality, absorb, drop |
 | "this field is on the wrong entity" | `move-attribute` | `skills/op/move-attribute/SKILL.md` | copy-then-drop across tables (NOT a rename) |
 | "Auto Number" on/off | `identity-swap` | `skills/op/identity-swap/SKILL.md` | **cannot ALTER** — shadow rebuild + `IDENTITY_INSERT` + reseed |
-| "a view" / "an Advanced Query joining …" | `create-view` | `skills/op/create-view/SKILL.md` | `CREATE VIEW`, enumerated columns (**SELECT * View** trap) |
-| "keep the old name working after a rename" | `compat-view` | `skills/op/compat-view/SKILL.md` | view bearing the old name over the new (temporary) |
+| "a view" / "an Advanced Query joining …" | `create-view` | `skills/op/create-view/SKILL.md` | **PRINCIPAL-ONLY — route up** (views are out of the developer catalog; a principal authors them) |
+| "keep the old name working after a rename" | `compat-view` | `skills/op/compat-view/SKILL.md` | **PRINCIPAL-ONLY — route up** (the compat bridge is a principal's step; the rename itself is the developer's) |
 | "point at a table in another database" | `synonym` | `skills/op/synonym/SKILL.md` | `CREATE SYNONYM` (runtime-resolution gap) |
-| "materialize / cache the joined view" | `indexed-view` | `skills/op/indexed-view/SKILL.md` | `WITH SCHEMABINDING` + `UNIQUE CLUSTERED` |
+| "materialize / cache the joined view" | `indexed-view` | `skills/op/indexed-view/SKILL.md` | **PRINCIPAL-ONLY — route up** (a materialized view; a principal authors it) |
 | "full history on a NEW entity" | `temporal-new` | `skills/op/temporal-new/SKILL.md` | `SYSTEM_VERSIONING=ON` from birth (declarative) |
 | "add history to an EXISTING populated entity" | `temporal-convert` | `skills/op/temporal-convert/SKILL.md` | multi-phase: period cols + backfill + enable versioning |
 | "CreatedBy/CreatedOn/ModifiedBy/ModifiedOn" | `audit-columns` | `skills/op/audit-columns/SKILL.md` | nullable = M1; NOT NULL on populated = backfill |
@@ -134,6 +134,13 @@ columns** (a cutover dealbreaker class), a **column collation change**, and **st
 functions** — handle them the same way (flag and route) until an op is authored for them
 (`../../CERTIFICATION_PLAN.md` F13). Do not force any of these into a near-match op; a wrong op
 proven perfectly is still wrong.
+
+**Views are principal-only for this team.** `create-view`, `compat-view`, and `indexed-view` have
+skills, but views are **out of the developer catalog on purpose** — the team does not author views at
+the outset; if the org adopts them, a **principal** authors them. Do not route a developer to a view
+op: name the request, say views are a principal's call, and route it up. The skills stay as the
+principal's reference. (A rename is the developer's; if it needs a compat view for external consumers
+of the old name, *that bridge* is the principal's step — see `compat-view`.)
 
 **The op skill IS the change-author's entry.** The op-slug you name resolves to
 `skills/op/<op-slug>/SKILL.md` — that per-op skill is the exact file the change-author will open

--- a/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/confirm-intent/SKILL.md
@@ -98,6 +98,7 @@ Two disambiguations the table now forces you to make (the op split lives here, n
 | "rebuild it, it's fragmented" | `rebuild-index` | `skills/op/rebuild-index/SKILL.md` | **OPERATIONAL** — no declarative destination; route out |
 | "default to X" (new default) | `add-default` | `skills/op/add-default/SKILL.md` | `DEFAULT` constraint `DF_Table_Col` |
 | "change the default" / "stop defaulting" | `modify-default` | `skills/op/modify-default/SKILL.md` | DROP-then-ADD the `DEFAULT` constraint |
+| "fill in the existing rows too" / "backfill the blanks" / "re-stamp the old rows" | `backfill-rows` | `skills/op/backfill-rows/SKILL.md` | post-deploy guarded idempotent UPDATE of existing rows (data-plane, not a schema edit) |
 | "no duplicates" / "must be unique" | `add-unique` | `skills/op/add-unique/SKILL.md` | `UNIQUE` index (dups fail; one NULL only) |
 | "only allow these values" / "must be positive" | `add-check` | `skills/op/add-check/SKILL.md` | `CHECK` constraint (existing violations fail) |
 | "trust the constraint now" / "flip it on" | `toggle-trust` | `skills/op/toggle-trust/SKILL.md` | **OPERATIONAL** — `WITH CHECK CHECK`, not a CREATE edit |
@@ -123,6 +124,16 @@ Two disambiguations the table now forces you to make (the op split lives here, n
 If the developer's words don't fit any row, say so and ask a clarifying question — do not stretch
 a near-match. "External Entity" (an OutSystems entity backed by a table you don't own) means the
 destination edit may be out of your control; flag it and stop.
+
+**Out of the catalog on purpose (route, don't stretch).** Some SQL objects have no op here because
+an OutSystems-native developer does not author them from Service Studio and the change is a DBA's
+call: **triggers, sequences, filegroups / partitioning, and index compression** — name the request,
+say it is outside this tree, and route it to a DBA or principal. Three others are **genuine gaps an
+OutSystems SSDT estate does hit and this catalog does not yet cover** — **computed / persisted
+columns** (a cutover dealbreaker class), a **column collation change**, and **stored procedures /
+functions** — handle them the same way (flag and route) until an op is authored for them
+(`../../CERTIFICATION_PLAN.md` F13). Do not force any of these into a near-match op; a wrong op
+proven perfectly is still wrong.
 
 **The op skill IS the change-author's entry.** The op-slug you name resolves to
 `skills/op/<op-slug>/SKILL.md` — that per-op skill is the exact file the change-author will open
@@ -216,7 +227,7 @@ you are routing to its owner. The six concerns and their triggers:
 | `split-table`, `merge-tables`, `move-attribute`, `extract-to-lookup`, `archive-entity`, `retype-explicit`, `temporal-convert`, `delete-attribute` (4-phase) | `skills/_index/multi-phase/SKILL.md` (old + new coexist; conservation proof) |
 | `enable-cdc`, `recreate-capture-instance`, `change-tracking`, **any op on a CDC-enabled table** | `skills/_index/cdc/SKILL.md` (the added-scrutiny tripwire, frozen capture shape) |
 | `define-pk`, `create-fk-clean`, `create-fk-orphan`, `add-unique`, `add-check`, `toggle-trust`, `modify-index`→unique | `skills/_index/constraint-is-a-claim/SKILL.md` (a constraint is a data claim) |
-| `create-static-seed`, `edit-seed`, `delete-seed-value`, the seed leg of `extract-to-lookup`, the no-op redeploy | `skills/_index/idempotent-seed/SKILL.md` (guarded MERGE, silence is the proof) |
+| `create-static-seed`, `edit-seed`, `delete-seed-value`, the seed leg of `extract-to-lookup`, `backfill-rows`, the no-op redeploy | `skills/_index/idempotent-seed/SKILL.md` (guarded MERGE / UPDATE, silence is the proof) |
 
 A change on a **CDC-enabled table** always pre-flags `_index/cdc` *in addition to* the op's own
 concern — the added scrutiny rides on top of the base op (that is the whole `TRAP-01N` lesson).

--- a/sidecar/projection/ssdt-agent/skills/deploy-scripts/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/deploy-scripts/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: deploy-scripts
+description: The deployment-script lifecycle rails. Use whenever a change needs a pre-deployment, post-deployment, or ad-hoc script — reason about whether a script is needed at all (pure-declarative first), where it goes (pre vs post vs out-of-DACPAC), what permanence class it is (the folder is the contract), how it proves idempotent (silence on redeploy), and when it retires (a tracked act, not a vibe). Walks the six gates the change-author follows when authoring scripts. Composes classify-mechanism (the five mechanisms), _index/idempotent-seed (silence-is-the-proof), _index/tightening-class (the pre-deploy trap), _index/multi-phase (phase-bound death), and prove-on-dacpac/talk-to-local-sql (the proof). Does NOT re-derive those concerns — it points to them.
+---
+
+# Deployment scripts — the lifecycle rails
+
+> **The one line.** The folder is the contract; the header is the memory; the no-op redeploy is the
+> proof; retirement is a tracked act. Hold those four and the post-deploy stays an instrument of
+> execution instead of an accreting monument to everything the team was once afraid to delete.
+
+SSDT is **state-based**: you declare the end state and `sqlpackage` computes the delta. But two of
+the five mechanisms (`classify-mechanism`; handbook file 15 = §18.1, the mechanism axis) hand SSDT a
+T-SQL script it runs *around* that delta — pre-deployment before it, post-deployment after it. The
+fact everything here hangs on:
+
+> **`Script.PostDeployment.sql` is not a migration runner. It has no "which scripts already ran"
+> ledger. It executes in full, top to bottom, on every single publish.**
+
+Three consequences, and they are why "how long does a script stay in the file?" is even a question:
+
+1. **Permanence is the default.** A script you add re-runs forever until a human deletes the file.
+2. **Idempotency is mandatory, not a nicety.** Anything that runs on every publish must be safe to
+   run on every publish. A script correct only the first time is a latent production incident.
+3. **Transience must be actively managed.** A one-time fix does not remove itself. If you want it
+   gone, that is a tracked act — a PR that deletes the file. Left undone, the post-deploy accretes
+   into a monolith nobody trusts and every deploy re-executes.
+
+The discipline is the answer to (3): at the moment a script is born, decide what will end it, and
+write that decision where the next reader cannot miss it.
+
+## The permanence-class spine (the folder is the contract)
+
+Every deployment script belongs to exactly one class. The class is not a comment — it is the
+**folder**, and the folder is a contract about lifespan, guard, re-run behaviour, and review. Get the
+class right and the rest is mechanical.
+
+| Class | Folder | Guard that keeps it silent | Re-run | Lifespan | Retirement trigger | Default review |
+|---|---|---|---|---|---|---|
+| **Pure declarative** (no script) | — (the `.sql` model) | n/a — SSDT computes the delta | n/a | forever (it *is* the model) | never | per the op |
+| **Permanent · idempotent** | `/Migrations/`, `/ReferenceData/` | natural: `WHERE … IS NULL`, `IF NOT EXISTS`, guarded `MERGE` | **silent** — 0 rows, identical hash | **forever** | **never** | usually any team member |
+| **Guarded · marker-inert** | `/Migrations/` | a `MigrationHistory` marker row, not natural idempotency | inert after first success per env | forever *until every env is past it* | eligible once the marker exists in all envs | reviewer, sometimes principal |
+| **Transient · one-time** | `/OneTime/` | idempotent so a lagging env can re-run safely | silent, but slated to leave | until prod-confirmed + one sweep | **prod-applied → deprecation-train PR removes the file** | matches the op it serves |
+| **Ad-hoc · outside the deploy** | `/AdHoc/` (checked in, *not* run by the DACPAC) | idempotent + chunked + resumable | run by a human, possibly interrupted | until reconciled + prod-confirmed | archived after reconciliation proves no drift | **principal** (runs outside the safety net) |
+
+The two `classify-mechanism` findings stay independent here too: **how a script ships is not who must
+review it.** A one-time `DELETE` of populated rows ships as a single transient post-deploy script, yet
+a principal must review it because the data is gone irreversibly. Never fold review level into how
+simply the script ships.
+
+**The classes in one breath.** *Pure declarative* is the first and best answer — no script at all;
+SSDT already does add-column, widen, add-nullable, add-index, rename-with-refactorlog. *Permanent ·
+idempotent* is a reference-data seed or a model-restoring backfill — an invariant made executable,
+earning permanence by proving silent on re-run, carrying no death certificate. *Guarded · marker-inert*
+is a migration that can't be written as a natural idempotent statement; the marker is a smell (prefer
+converting it). *Transient · one-time* is born with a death certificate. *Ad-hoc* is the escape hatch
+and the drift frontier (below).
+
+## Placement — pre vs post, and the trap in it
+
+Execution order (handbook file 06 = Pre-Deployment-and-Post-Deployment-Scripts):
+
+```
+1. PRE-DEPLOYMENT   → runs BEFORE the schema delta; DB still in the OLD shape
+2. SCHEMA DELTA     → SSDT's ALTER/CREATE/DROP; OLD → NEW
+3. POST-DEPLOYMENT  → runs AFTER the delta; DB now in the NEW shape
+```
+
+Placement is dependency direction:
+- **Pre-deployment** when the data work must happen **to unblock** the schema change — drop a
+  dependency blocking an `ALTER`, delete orphans before an FK is trusted, clear a violation before a
+  constraint is added.
+- **Post-deployment** when the data work **depends on the new shape existing** — backfill a new
+  column, seed a lookup, migrate into a new structure, populate the far side of a reshape.
+
+**The trap: the plan is computed before the pre-deploy runs.** SSDT computes the whole deployment plan
+*before* the pre-deployment script executes. So a pre-deploy that backfills NULLs **cannot** license a
+`NULL → NOT NULL` tightening in the *same* deploy on a **populated** table — the
+`BlockOnPossibleDataLoss` guard fires on **row presence**, not NULL content. The backfill is necessary
+but not sufficient. This is the tightening class; its WHY is owned by
+`../_index/tightening-class/SKILL.md` — do not re-derive it. **Rail:** never tell a developer a
+pre-deploy backfill "solves" a tightening on a populated table; that change is genuinely multi-phase,
+or it needs a *logged* `BlockOnPossibleDataLoss` relaxation scoped to one deploy (a principal's call).
+Probe to predict (`../talk-to-local-sql/SKILL.md`), let the Strict publish prove
+(`../prove-on-dacpac/SKILL.md`).
+
+**The transaction boundary.** Pre-/post-deploy scripts run inside the deployment's transaction by
+default — a failed statement rolls the whole deploy back. That is the safety you want for small, fast
+data work, and exactly the wrong container for a long-running or lock-heavy operation. That boundary
+is the hinge that sends the largest operations *out* of the DACPAC entirely.
+
+## Ad-hoc — the escape hatch and the drift frontier
+
+Ad-hoc lives **outside** the source of truth, which is why it is the most dangerous. A script leaves
+the DACPAC for exactly two legitimate reasons — **scale/lock** (too long or too lock-heavy for the
+single deploy transaction) or a **true one-off** (a production correction under a change ticket that
+does not belong in the versioned deploy path). If neither holds, it is not ad-hoc — it belongs in
+pre/post as a proper transient script.
+
+Because it runs outside the pipeline, an ad-hoc script earns its way back to trustworthy through four
+obligations: **justify** (state in the header why it can't ride in pre/post) · **idempotent · chunked ·
+resumable** (a human runs it, possibly interrupted) · **leave a trace** (check it into `/AdHoc/` with
+ticket, date, operator, environments-applied, and the batching parameters used — a thing that ran
+against prod with no mark in source control *is* drift) · **reconcile** (after the motion, the
+declarative model and any permanent seed must still describe the resulting state; update the seed so a
+fresh deploy reproduces it, then prove no drift — a clean schema compare and, where data is governed,
+a matching content hash via `../talk-to-local-sql/SKILL.md`). Highest scrutiny; **principal review by
+default.** "Removal" for ad-hoc means archiving out of `/AdHoc/` once reconciled and prod-confirmed.
+
+## The header is the memory (birth writes the death certificate)
+
+Every script carries a provenance header, and the decision that ends it is written at birth. A
+**permanent** script asserts it will never leave; a **transient** header *is a death certificate*
+naming the trigger and the work item that removes it; a **guarded** header names the marker and the
+all-environments-past-it out.
+
+```sql
+/*
+  [TRANSIENT · one-time · REMOVE AFTER PROD]  OneTime/Release_2025.02_PhoneFix.sql
+  Ticket:        JIRA-1456
+  What:          One-shot correction of legacy-import phone formats.
+  Guard:         idempotent (WHERE PhoneNumber NOT LIKE '+%') — safe to re-run in a lagging env.
+  Prod-applied:  <stamp on the prod deploy>
+  Removal:       JIRA-1502 — sweep on the deprecation train once prod-confirmed. Delete file; keep git history.
+*/
+```
+
+A permanent header ends `Retire: never — model-restoring; re-establishes state on any fresh deploy.`
+A phase-bound header names the **phase/release** that ends it, not just "after prod" (see retirement).
+
+## Silence is the proof (do not re-derive — point)
+
+Anything that runs every publish is proven by what it *doesn't do* on the second run. The no-op
+redeploy asserts all three: **0 rows affected** · **identical content hash** (order-independent
+`SHA2_256(FOR XML RAW)`, NULL distinct from `''`) · **0 CDC captures** if the table (or its consumer)
+is CDC-tracked. A non-zero result on a no-op redeploy is the anti-proof — the guard is wrong (usually
+an unconditional `WHEN MATCHED`); fix it and confirm silence. This is owned by
+`../_index/idempotent-seed/SKILL.md` and run by `../prove-on-dacpac/SKILL.md` over
+`../talk-to-local-sql/SKILL.md`. *"The values match" is not the same as "the redeploy was silent."*
+
+## Retirement is a tracked act, on a cadence
+
+The direct answer to "how long does it stay?": a one-time script is **not** deleted the instant it
+runs — a downstream env may still be behind, and you may need to re-run it there (which is why it
+stays idempotent). It stays, dated and work-item-attached, **until confirmed applied in production,
+then removed on the next deprecation-train sweep as a tracked PR** (removal leaves the deploy path but
+keeps git history). Permanent scripts carry **no** death certificate and stay forever — they earn that
+by proving silent on re-run. Neither *delete-immediately* (you lose re-apply to a lagging env) nor
+*leave-forever* (the post-deploy monolith) is the rail; **prod-confirmed → next deprecation train →
+tracked removal PR** is.
+
+**Multi-stage changes stagger the deaths.** A single logical change (expand/contract, split, retype,
+extract-to-lookup) spawns scripts across releases, each with its own lifecycle. The rail specific to
+it: **a transient script must be retired no later than the phase that invalidates its assumptions** —
+a backfill that populates `ColumnB` from `ColumnA` dies when `ColumnA` is dropped; leave it and the
+build breaks (it references a missing column) or re-runs stale logic against a vanished shape. The
+header's `Removal:` names the phase/release, not just "after prod". The full multi-phase reasoning
+(cardinality, coexistence, the forward-only limit) is owned by `../_index/multi-phase/SKILL.md`; this
+is only the script-lifecycle limb of it.
+
+## The six gates (the ordered protocol)
+
+For any change that might need a deployment script, walk these in order. Each gate is provisional
+until `../prove-on-dacpac/SKILL.md` confirms it — classification from the `.sql` text alone is a guess;
+the data decides.
+
+- **Gate 0 — Does this need a script at all?** Default to **pure declarative**. If SSDT's own delta
+  does the work (add-column, widen, add-nullable, add-index, rename-with-refactorlog), write **no
+  script**. Refuse script sprawl. This is the "no more and no less" rail — the precise change is
+  often *no script*.
+- **Gate 1 — Pre, post, or ad-hoc?** Dependency direction decides pre vs post; the transaction
+  boundary + scale/lock decides whether it leaves the DACPAC. If ad-hoc, escalate to principal now and
+  attach the four obligations.
+- **Gate 2 — Permanence class → folder + guard + header.** Assign the class; it dictates the folder,
+  the guard style, and the header template. If transient, the header **must** carry a death
+  certificate with a removal work item.
+- **Gate 3 — Prove idempotent (the gate nothing skips).** The no-op redeploy on a disposable copy:
+  0 rows · identical hash · 0 CDC. A non-silent redeploy is a bug even when the final data is correct.
+- **Gate 4 — State the retirement condition explicitly.** Permanent → "Retire: never". Transient →
+  the trigger (prod-confirmed → deprecation train) + work item. Phase-bound → the phase/release.
+  Guarded → the all-environments-past-it condition. A script with no stated retirement is not done.
+- **Gate 5 — Reconcile (no drift).** Confirm the model + any permanent seed still describe the
+  resulting state; after ad-hoc motion, update the governing seed and prove a clean schema compare +
+  matching content hash. Drift is the failure this gate catches.
+- **Gate 6 — Record the fragment.** Contribute to `../author-pr/SKILL.md`: the mechanism, the
+  permanence class, the retirement condition, the idempotency proof (the three silent-redeploy
+  assertions), and the review level with any added scrutiny — *how it ships* and *who reviews it* kept
+  as two independent findings.
+
+## The named traps (recognize on sight, stop)
+
+- **Unconditional `WHEN MATCHED`** — rewrites every seed row on every deploy; the CDC-silence
+  violation (`../_index/idempotent-seed/SKILL.md`).
+- **Pre-deploy backfill mistaken for a tightening solution** — the plan is computed before the
+  pre-deploy runs; the guard is row-presence, not NULL-content (`../_index/tightening-class/SKILL.md`).
+- **One-time script left in past prod** — the `/OneTime/` folder that never gets swept; the post-deploy
+  monolith. The death-certificate header + deprecation train is the antidote.
+- **Transient script that outlives the column it references** — a phase-bound backfill not retired in
+  the contract phase (`../_index/multi-phase/SKILL.md`).
+- **Ad-hoc run with no source-control trace** — a sanctioned bypass that forked the truth; `/AdHoc/`
+  check-in + reconciliation closes it.
+- **Marker table used to fake idempotency** — a `MigrationHistory` guard papering over a
+  non-idempotent operation that should have been rewritten. The marker is a smell, not a destination.
+- **Long-running migration inside the deploy transaction** — rollback-and-timeout hazard; belongs in
+  ad-hoc, chunked and resumable.
+- **Hard `DELETE` of a referenced lookup value** — orphans fact rows, breaks the app's constant.
+  Deactivate, don't delete (`../op/delete-seed-value/SKILL.md`).
+
+## Honest limits (state them; don't let a green run overclaim)
+
+The disposable substrate (`../talk-to-local-sql/SKILL.md`) is real-*shaped*, not real-*sized*, and
+runs the **forward** publish only. It cannot prove production-scale timing or blocking (`>1M rows` is
+added scrutiny — schedule a window); it cannot prove reversibility or that the running application
+still works against the new shape (`@app-owner`, not verified here); it holds one catalog — other
+environments may hold rows this copy does not, and External-Entity / ETL / report consumers are
+dependency scope, not proven here.
+
+## The verdict — to the developer (the mentor register)
+
+Match the conversation register of `../../THE_RECORD.md` §3: teach the *why* briefly, tie back to
+owned phrases, make the change easy.
+
+> "This needed a post-deploy backfill, not just a schema edit, because SSDT can't know what value to
+> put in the new column for existing rows. I put it in `/Migrations/` as a permanent, idempotent
+> script — guarded by `WHERE … IS NULL`, so on a disposable copy of your data the second deploy moved
+> **zero rows** and left an identical hash. That silence is the proof it's safe to re-run every
+> publish. It carries no removal date because it re-establishes state on any fresh deploy — that's
+> what earns it a permanent home. Contrast last release's phone-format fix: that one lives in
+> `/OneTime/` with a death certificate and gets swept on the next deprecation train once it's
+> confirmed in prod."
+
+## On the record — the evidence fragment (for author-pr)
+
+What this skill contributes to the pull request (`../author-pr/SKILL.md`), in the record register —
+**almost exclusively presentation of evidence**, the precise scripts required and nothing more:
+
+**Review & release**
+- Who must review, and why — from the permanence class (any team member for a permanent idempotent
+  seed; a principal for an ad-hoc or an irreversible one-time `DELETE`), independent of how it ships.
+- How it ships — the mechanism (pre-deploy prepares then the delta lands; the delta then a post-deploy;
+  a scripted change; staged across releases), plus the permanence class and folder.
+- Added scrutiny, if any — CDC-tracked / `>1M rows` / first-time on this estate, each on its own line.
+
+**Deployment evidence** — findings with proof beneath, no narration:
+- the exact pre-/post-deployment script(s) shipped, each with its permanence class and header;
+- the idempotency proof — the no-op redeploy's three assertions verbatim (0 rows affected · identical
+  content digest before/after · 0 CDC captures if tracked);
+- the sanity/verification SQL run before the change was allowed to land, with its expected result.
+
+**Retirement** — the stated condition for every transient/guarded/ad-hoc script (the trigger + work
+item, or the phase that ends it); "Retire: never" for permanent scripts, with the reason.
+
+**Not verified** — the standing limits above, specific to this change.
+
+## Hard rules
+
+- **Gate 0 is a refusal.** No script when the schema diff already does the work. Precise means *no
+  more and no less*.
+- **Compose; duplicate nothing.** Silence-proof → `../_index/idempotent-seed/`; the tightening trap →
+  `../_index/tightening-class/`; phase-bound death → `../_index/multi-phase/`; deactivate-don't-delete
+  → `../op/delete-seed-value/`; the five mechanisms → `../classify-mechanism/`; the proof loop →
+  `../prove-on-dacpac/` + `../talk-to-local-sql/`. Point to each owner; never re-derive its WHY here.
+- **You scaffold; you do not ship a wrapper.** The agent authors the scripts and runs the proof
+  commands itself.
+- **Everything authored lives under `ssdt-agent/`.** Scripts under proof live in the
+  `proving-ground/` class folders (or a per-executor scratch under `../../self-test/PROTOCOL.md`).

--- a/sidecar/projection/ssdt-agent/skills/op/add-check/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-check/SKILL.md
@@ -45,9 +45,9 @@ NOCHECK mechanics here.
 
 ## Prove it
 Run the violation probe FIRST: `SELECT COUNT(*) FROM <table> WHERE NOT (<predicate>)`. Then build +
-Strict publish (adds WITH CHECK): clean → zero violations; a build failure ("conflicted with the
-CHECK constraint") means the deployment is blocked. Author the pre-deploy fix-up, re-run Strict
-clean. If anyone proposes WITH NOCHECK, prove the cost:
+Strict publish (adds WITH CHECK): clean → zero violations; a build failure — `Msg 547`, "conflicted
+with the CHECK constraint" — means the deployment is blocked. Author the pre-deploy fix-up, re-run
+Strict clean. If anyone proposes WITH NOCHECK, prove the cost:
 `SELECT is_not_trusted FROM sys.check_constraints WHERE name='CK_…'` returns 1. See
 `../../prove-on-dacpac/SKILL.md` + `../../talk-to-local-sql/SKILL.md`.
 

--- a/sidecar/projection/ssdt-agent/skills/op/add-default/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-default/SKILL.md
@@ -23,17 +23,18 @@ existing rows.
 The **unnamed default**: letting SSDT auto-name the constraint (`DF__Table__Col__<hash>`) yields a
 name that differs per environment, and diffing and refactoring become fragile — always name it
 `DF_<Table>_<Col>`. Second surprise: the default does not fill existing NULLs. It touches only new
-rows; backfilling the existing rows is a separate op (see `../make-mandatory/SKILL.md` for the
-NOT-NULL-with-backfill path).
+rows; backfilling the existing rows is a separate op — `../backfill-rows/SKILL.md` (and if the
+column is also becoming required, `../make-mandatory/SKILL.md` for the NOT-NULL path).
 
 ## How it flips (the specifics only)
 - adding a default → ships as a single schema change, applied in place; any team member can review
   it, in any data state.
-- the developer also wants existing rows backfilled → a separate op. It ships as one release: the
-  schema change, then a post-deployment script that runs an idempotent UPDATE after it lands (see
-  `../../_index/idempotent-seed/SKILL.md`). If the column is also becoming NOT NULL, follow
-  `../make-mandatory/SKILL.md` instead. The default itself still ships in place and stays reviewable
-  by any team member.
+- the developer also wants existing rows backfilled → a separate op, `../backfill-rows/SKILL.md`. It
+  ships as one release: the schema change, then a post-deployment guarded UPDATE that runs after it
+  lands (the discipline is `../../_index/idempotent-seed/SKILL.md`), and a dev lead reviews the
+  backfill because existing data is modified. If the column is also becoming NOT NULL, follow
+  `../make-mandatory/SKILL.md` for the tightening. The default itself still ships in place and stays
+  reviewable by any team member.
 - CDC-enabled table → CDC does not track constraints (handbook file 15 = §18.5), so a default on a
   CDC-tracked table needs no added scrutiny on its own.
 

--- a/sidecar/projection/ssdt-agent/skills/op/add-unique/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/add-unique/SKILL.md
@@ -43,8 +43,9 @@ do not re-derive the claim mechanics here.
 ## Prove it
 Run the duplicate probe FIRST: `SELECT <Col>, COUNT(*) FROM <table> GROUP BY <Col> HAVING COUNT(*)
 > 1` (and a NULL count for nullable columns). Then build + Strict publish: clean → uniqueness holds;
-a build failure ("duplicate key was found") means the deployment is blocked. Author the pre-deploy
-de-dupe (or the filtered index), re-run Strict clean. See `../../prove-on-dacpac/SKILL.md` +
+a build failure — `Msg 1505`, "duplicate key was found" (the same error a second NULL row raises on
+a nullable column) — means the deployment is blocked. Author the pre-deploy de-dupe (or the filtered
+index), re-run Strict clean. See `../../prove-on-dacpac/SKILL.md` +
 `../../talk-to-local-sql/SKILL.md`. Seed: Status's `UX_Status_Code` is the clean positive; Product's
 `DUPE` rows drive the flip to a blocked deploy.
 

--- a/sidecar/projection/ssdt-agent/skills/op/backfill-rows/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/backfill-rows/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: backfill-rows
+description: Use when the developer says "fill in the existing rows too", "set every existing Region to Unknown", "the default only covers new rows — update the old ones", "backfill the blanks" — a data-plane UPDATE of existing rows, not a schema change. The companion to add-default / modify-default / make-mandatory when the ask includes existing data. Ships as a post-deployment idempotent guarded UPDATE; a dev lead must review it because existing data is modified.
+---
+
+# Backfill existing rows (the data-plane UPDATE)
+
+> **Default (provisional — the data decides).** Ships as one release: after any schema change
+> lands, a post-deployment **guarded, idempotent UPDATE** re-stamps only the rows that need it.
+> A dev lead must review this: existing data is modified. Prove the UPDATE touches exactly the
+> rows it should — and that a redeploy touches zero — before classifying.
+
+## OutSystems phrasing
+"fill in the existing rows too", "set every existing Region to Unknown", "the default only covers
+new rows — update the old ones as well", "backfill the blanks", "re-stamp the old orders to the
+new status".
+
+## SSDT meaning
+A **data-plane UPDATE** of existing rows, carried in `Script.PostDeployment.sql` so it runs
+**after** the schema lands. It is **not** a schema change and **never** an ALTER — the CREATE is
+untouched. This is the op the default/tightening skills hand off to: `add-default` and
+`modify-default` govern only *future* rows; `make-mandatory` needs the blanks gone before a
+populated table can tighten. Filling the *existing* rows is this op, and it is proven the same
+way — on a disposable copy, by what a redeploy does **not** do.
+
+## The named trap
+The **unguarded UPDATE** that re-stamps every row on **every** deploy — the same failure the seed
+MERGE guards against, now on business data. It is owned by `../../_index/idempotent-seed/SKILL.md`
+(the guarded, null-safe write; silence-is-the-proof); do not re-derive the guard here. Two faces of
+the same trap:
+- **CDC over-capture** — on a CDC-tracked table an unguarded re-stamp floods the capture feed with
+  phantom changes on every redeploy (`../../_index/cdc/SKILL.md`).
+- **The full-table write at scale** — an ungated `UPDATE <t> SET …` locks and runs long at
+  production row counts; guard it to the rows that differ, and batch it when the count is large.
+
+A backfill that *removes* data (a bulk `DELETE`, or overwriting values that cannot be reconstructed)
+is not this op — route a deletion of populated rows to `../delete-attribute/SKILL.md` /
+`../delete-seed-value/SKILL.md`; a principal must review an irreversible removal.
+
+## How it flips (the specifics only)
+- fill the blanks / re-stamp existing rows to a value → ships as one release: the schema change (if
+  any), then a post-deployment **guarded** UPDATE that touches only the rows whose value differs. A
+  dev lead must review it: existing data is modified. Record the original values for the audit trail.
+- paired with `make-mandatory` on a populated table → the backfill clears the NULLs but **does not**
+  clear the tightening block (the guard is table-has-rows, not column-has-NULLs) — the NOT NULL
+  still needs the deliberate gate call in `../make-mandatory/SKILL.md`. The backfill is necessary,
+  never sufficient, there.
+- no row needs the change (every value already matches) → the guarded UPDATE touches **0 rows**; it
+  is a semantic no-op, and its silence is the proof it was idempotent.
+- **+ CDC-tracked** → added scrutiny: the guard is mandatory so a redeploy captures 0, not the whole
+  table (`../../_index/cdc/SKILL.md`).
+- **+ >1M rows** → added scrutiny: a single-statement UPDATE blocks writes or runs long at
+  production scale; batch it and schedule a window (the small copy cannot show the duration).
+
+## Prove it
+1. **Predict** — probe how many rows need the change: `SELECT COUNT(*) FROM <t> WHERE <col> IS NULL`
+   (or `WHERE <col> <> <newvalue>`, null-safe). That count is what the UPDATE must touch, and no more.
+2. Author the guarded UPDATE in `Script.PostDeployment.sql` — a `WHERE` that selects only the rows
+   whose value actually differs (null-safe: `NULL` is distinct from `''`), so a re-run is a no-op.
+3. Deploy → prove the UPDATE touched **exactly** the predicted count (not the table size).
+4. **Redeploy unchanged** → prove **0 rows affected** + an **identical content-hash** (+ **0 CDC
+   captures** if the table is tracked). That silence is the idempotency proof — see
+   `../../_index/idempotent-seed/SKILL.md` for the discipline and `../../talk-to-local-sql/SKILL.md`
+   for the hash and rowcount probes; `../../prove-on-dacpac/SKILL.md` for the deploy-twice loop.
+
+On the sample, backfilling `dbo.Customer.Region` (blank on some rows) to `N'Unknown'` exercises the
+guarded UPDATE and the silent redeploy. (No self-test case is registered for this op yet — see
+`../../../CERTIFICATION_PLAN.md` Stage 1.)
+
+## The verdict (to the developer)
+You asked to fill in the existing rows, not just the new ones. That's a change to data you already
+have, so it rides in the post-deployment script as a guarded update — it touches only the rows that
+actually need it, and I proved that: it updated exactly the blank rows, and a second deploy moved
+nothing. Because it edits existing values, a dev lead reviews it, and I've recorded the original
+values so it can be backed out. Do the blanks all get the same value, or does it depend on the row?
+
+## The reasoning (in conversation)
+A default is a rule about future writes; a backfill reaches back and changes rows that already
+exist — different risk, different reviewer. The discipline that keeps it safe is the same one the
+seed data uses: guard the write so it only touches rows that differ, and a redeploy stays silent.
+The failure this avoids is the ungated `UPDATE … SET` that re-stamps every row on every deploy — on
+a change-data-capture table that reports the whole table as changed, phantom edits that never
+happened. Silence on the second run is the proof it was done right
+(`../../_index/idempotent-seed/SKILL.md`).
+
+## On the record
+Fragments for the pull request (`../../author-pr/SKILL.md`), record register.
+
+**Review & release**
+- A dev lead must review this: existing data is modified — an existing column's values are
+  re-stamped on the rows that need it.
+- Ships as one release: after the schema change lands, a post-deployment guarded UPDATE re-stamps
+  only the differing rows. No table rebuild; the CREATE is unchanged.
+- Added scrutiny, when it applies: the table feeds a change-data-capture stream (the guard is
+  mandatory so the redeploy captures only the changed rows); or at production row counts the UPDATE
+  blocks writes or runs long — batch it and schedule a window.
+
+**Verification** — run in each environment after deployment
+```sql
+-- expect 0 rows: no row still holds the pre-backfill value
+SELECT COUNT(*) AS unfilled FROM dbo.Customer WHERE Region IS NULL;
+```
+
+**Rollback**
+The forward UPDATE is not auto-reversed — a backfill overwrites values in place. The original values
+recorded under Data remediation are what a manual restore uses; without them the change is not
+losslessly reversible. State that plainly rather than claiming a clean rollback.
+
+**Not verified**
+- Application impact — code paths that distinguished a blank from the backfilled value now see the
+  value everywhere; whether any logic relied on the blank is not confirmed here (@app-owner).
+- Other environments — Test, UAT, and Prod may hold a different set of rows needing the backfill;
+  run the predict probe in each before promotion, since the count and the affected rows differ.
+- Production scale and timing — on a large table the UPDATE may block writes or run long; the small
+  copy does not show the duration.
+- Reversibility — the forward backfill is proven; restoring the pre-backfill values is not exercised
+  here and depends on the recorded originals.

--- a/sidecar/projection/ssdt-agent/skills/op/compat-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/compat-view/SKILL.md
@@ -5,15 +5,22 @@ description: Use when the developer says "I renamed Customer to Account but the 
 
 # Backward-compatibility view (SELECT * / forgotten-it-is-temporary trap) — recipe AUTHORED HERE
 
+> **⚠️ PRINCIPAL-ONLY — out of the developer catalog on purpose.** A compat view is still a view, so
+> this team treats authoring it as a **principal's** call. It is the bridge a rename/split may need
+> for external consumers of the old name — `rename-entity`, `rename-attribute`, and `merge-tables`
+> route here — but building that bridge routes **up to a principal**, not to the developer. The
+> developer's rename is theirs; if external consumers need the old name kept readable, that is a
+> principal's step. This skill stays as the principal's reference.
+
 > **AUTHORED-HERE NOTICE.** Handbook file 14 references §17.8 "backward-compatibility view" as the companion to a rename/split, but the template body is empty. The recipe below is authored here to fill the gap; treat it as the working contract and fold it back when file 14 is completed.
 
 > **Default (provisional — the data decides).** The view itself ships as a single declarative
 > schema change — a `CREATE VIEW`, applied in place, reading and writing no data. It is one release
 > in a staged rename/split program: the view lands with the rename to keep the old name readable,
-> and a later release drops it once every external consumer has migrated. A dev lead or an
-> experienced developer should review it, because the dependency scope reaches outside the dacpac to
-> consumers the SSDT model cannot see. Provisional until the rename delta and the view's transparency
-> are proven.
+> and a later release drops it once every external consumer has migrated. **A principal must review
+> it: views are a principal-only concern for this team**, and the dependency scope reaches outside
+> the dacpac to consumers the SSDT model cannot see. Provisional until the rename delta and the
+> view's transparency are proven.
 
 ## OutSystems phrasing
 "I renamed Customer to Account but the old reports still ask for Customer", "keep the old entity name working after the rename", "don't break the integrations that read the old table".
@@ -52,8 +59,9 @@ The refactorlog's reach stops at the model boundary. So a rename's real dependen
 The fragment this change contributes to the pull request (`../../author-pr/SKILL.md`):
 
 **Review & release**
-- A dev lead or an experienced developer should review this: external consumers outside the SSDT
-  model read the old name, and those consumers must migrate to the new name to keep working.
+- A principal must review this: views are a principal-only concern for this team (out of the
+  developer catalog on purpose — see the banner). External consumers outside the SSDT model read the
+  old name, and those consumers must migrate to the new name to keep working.
 - Ships across releases: the compat view lands with the rename so the old name stays readable, and a
   later release drops it once every external consumer has moved.
 - Added scrutiny: the dependency scope reaches outside the dacpac — SSIS, Power BI, hand-written

--- a/sidecar/projection/ssdt-agent/skills/op/create-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/create-view/SKILL.md
@@ -5,9 +5,16 @@ description: Use when the developer says "give me a view that joins Order and Cu
 
 # Create a view (SELECT * View trap)
 
+> **⚠️ PRINCIPAL-ONLY — out of the developer catalog on purpose.** This team does not author views at
+> the outset; if the org adopts views later, a **principal** authors them. At intake, name the
+> request, say views are a principal's call, and route it up — `confirm-intent` routes "a view" to a
+> principal, not to a developer. This skill stays as the principal's reference; the mechanics below
+> are kept for when a principal picks it up.
+
 > **Default (provisional — the data decides).** Ships as a single schema change, applied in place —
-> no data is read or written. Any team member can review it: the change is additive and the running
-> application is unaffected. Enumerate the columns explicitly rather than `SELECT *`.
+> no data is read or written. **A principal must review this: views are a principal-only concern for
+> this team** (the technical change is otherwise additive and the running application is unaffected).
+> Enumerate the columns explicitly rather than `SELECT *`.
 
 ## OutSystems phrasing
 "give me a view that joins Order and Customer", "an Advanced Query entity for active customers", "expose a read-only combined entity".
@@ -37,7 +44,7 @@ A view written as `SELECT *` has no shape of its own — it defers its contract 
 The fragment this contributes to the pull request (feeds `../../author-pr/SKILL.md`):
 
 **Review & release**
-- Any team member can review this: the change is additive and the running application is unaffected. If downstream apps, reports, or ETL read the view, a dev lead should review instead — a later change to it becomes a cross-system change.
+- A principal must review this: views are a principal-only concern for this team (out of the developer catalog on purpose — see the banner). The technical change is otherwise additive and the running application is unaffected; if downstream apps, reports, or ETL read the view, that dependency scope is a further reason it is a principal's call.
 - Ships as a single schema change, applied in place. No data is read or written.
 - Added scrutiny: none. A `SELECT *` definition is a latent defect to fix before shipping, not added scrutiny.
 

--- a/sidecar/projection/ssdt-agent/skills/op/define-pk/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/define-pk/SKILL.md
@@ -35,9 +35,11 @@ trap: confusing an IDENTITY surrogate with a natural key — see `../identity-sw
 - existing table, key column already unique and non-NULL: ships as a single in-place schema change,
   but the clustered-index build scans and reorders every row — a dev lead or an experienced
   developer should review it, because the build runs over live data.
-- existing table with duplicate or NULL key values: the index build is blocked on the actual
-  duplicate or NULL rows, and the error names the offending keys. Ships as one release with a
-  pre-deployment script that dedupes or assigns keys, after which the primary key lands validated —
+- existing table with duplicate or NULL key values: the index build is blocked — `Msg 1505` on
+  duplicate keys (naming the duplicate value), or `Msg 8111` for a NULL in a column declared
+  nullable — and the error names the offending keys (`../../_index/constraint-is-a-claim/SKILL.md`
+  owns the full signature table). Ships as one release with a pre-deployment script that dedupes or
+  assigns keys, after which the primary key lands validated —
   or across several releases when old and new application code must coexist while the key is
   introduced. A dev lead must review this: existing data is modified to make the key hold. See
   `../../_index/constraint-is-a-claim/SKILL.md`.
@@ -49,7 +51,8 @@ trap: confusing an IDENTITY surrogate with a natural key — see `../identity-sw
 ## Prove it
 Run the op-specific probes FIRST: `SELECT <keycols>, COUNT(*) FROM <table> GROUP BY <keycols> HAVING
 COUNT(*) > 1` (the duplicate probe) and a NULL count on each key column. Then a Strict publish: with
-duplicates or NULLs the index build is blocked (show the offending keys); clean, the delta is the
+duplicates or NULLs the index build is blocked (`Msg 1505` duplicate / `Msg 8111` NULL — show the
+offending keys); clean, the delta is the
 primary key inline in the CREATE (new table) or a clean clustered-index build (existing table).
 Author the dedupe/assign-keys pre-deployment script, then re-run the Strict publish clean. See
 `../../prove-on-dacpac/SKILL.md` for the publish loop and `../../talk-to-local-sql/SKILL.md` for

--- a/sidecar/projection/ssdt-agent/skills/op/indexed-view/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/indexed-view/SKILL.md
@@ -5,12 +5,17 @@ description: Use when the developer says "materialize this aggregation for speed
 
 # Indexed / materialized view (SCHEMABINDING) (deterministic-only / base-column-binding trap)
 
+> **⚠️ PRINCIPAL-ONLY — out of the developer catalog on purpose.** This team does not author views
+> (a materialized view least of all) at the outset; if the org adopts them, a **principal** authors
+> them. At intake, name the request, say it is a principal's call, and route it up — `confirm-intent`
+> routes it to a principal, not to a developer. This skill stays as the principal's reference.
+
 > **Default (provisional — the data decides).** On a small or empty base it ships as a single
-> declarative change — the view and its unique clustered index, applied in place — and an
-> experienced developer or a dev lead reviews it, because it is a stored object that binds its base
-> tables, not a plain view. As the base grows, the unique-clustered-index build becomes expensive
-> and blocking, and it ships as a scripted or staged change instead. Prove it on a disposable copy
-> before classifying.
+> declarative change — the view and its unique clustered index, applied in place. **A principal must
+> review this: views are a principal-only concern for this team** — and this one is a stored object
+> that binds its base tables, not a plain view, so the call is doubly a principal's. As the base
+> grows, the unique-clustered-index build becomes expensive and blocking, and it ships as a scripted
+> or staged change instead. Prove it on a disposable copy before classifying.
 
 ## OutSystems phrasing
 "materialize this aggregation for speed", "cache the joined view", "make the summary view fast".
@@ -68,9 +73,9 @@ nobody scheduled — which is exactly what proving the rebuild in the delta lets
 The fragment this operation contributes to the pull request (`../../author-pr/SKILL.md`), in the record register.
 
 **Review & release**
-- An experienced developer or a dev lead should review this: it adds a stored object that binds its
-  base tables and maintains a materialized result on every base-table write, not a plain view. On a
-  large base, a dev lead must review it.
+- A principal must review this: views are a principal-only concern for this team (out of the
+  developer catalog on purpose — see the banner), and this one adds a stored object that binds its
+  base tables and maintains a materialized result on every base-table write, not a plain view.
 - Ships as a single declarative change on a small or empty base — the view and its unique clustered
   index, applied in place. On a large base it ships as a scripted single release scheduled with
   care, or staged across releases, because the unique-clustered-index build reads and materializes

--- a/sidecar/projection/ssdt-agent/skills/op/merge-tables/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/merge-tables/SKILL.md
@@ -52,8 +52,9 @@ The inverse of a split. ADD the absorbing columns to the surviving table's CREAT
   clean. A dev lead or an experienced developer should review this: the running application must
   change to dual-write into the new columns.
 - **Phase 2 (cutover):** repoint app reads, FKs, and views from the absorbed entity to the
-  survivor's new columns. Leave a backward-compat view named for the absorbed entity if any external
-  consumer still references it (`../compat-view/SKILL.md`).
+  survivor's new columns. If any external consumer still references the absorbed entity, a
+  backward-compat view named for it holds the bridge (`../compat-view/SKILL.md`) — **principal-only,
+  route that bridge up to a principal.**
 - **Phase 3 (subtractive):** drop the absorbed table. Strict must block the drop under
   `BlockOnPossibleDataLoss` until the Phase-1 hashes prove every value is now in the survivor.
 

--- a/sidecar/projection/ssdt-agent/skills/op/modify-default/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/modify-default/SKILL.md
@@ -23,15 +23,15 @@ only ever governed future inserts.
 Same as add-default: the **unnamed default** makes the DROP-then-ADD fragile across environments —
 insist the constraint is named `DF_<Table>_<Col>`. And a modified default still does not retro-change
 existing rows that were written under the old default; if the developer wants old rows re-stamped,
-that is a separate backfill (see `../add-default/SKILL.md` and
-`../../_index/idempotent-seed/SKILL.md`).
+that is a separate backfill — `../backfill-rows/SKILL.md`.
 
 ## How it flips (the specifics only)
 - modify / remove a default → ships as a single schema change, applied in place; any team member
   can review it, in any data state — no existing row values change.
-- the developer also wants existing rows re-stamped to the new value → a separate op. It ships as
-  one release: the schema change, then a post-deployment script that runs an idempotent UPDATE after
-  it lands (see `../../_index/idempotent-seed/SKILL.md`).
+- the developer also wants existing rows re-stamped to the new value → a separate op,
+  `../backfill-rows/SKILL.md`. It ships as one release: the schema change, then a post-deployment
+  guarded UPDATE that runs after it lands (the discipline is `../../_index/idempotent-seed/SKILL.md`),
+  and a dev lead reviews the backfill because existing data is modified.
 - CDC-enabled table → CDC does not track constraints (handbook file 15 = §18.5), so a modified or
   removed default on a CDC-tracked table needs no added scrutiny on its own.
 

--- a/sidecar/projection/ssdt-agent/skills/op/rename-attribute/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/rename-attribute/SKILL.md
@@ -34,7 +34,9 @@ Cleanup** (§19.6). This is the identity-vs-name concern — see
 - CDC-enabled → the capture instance names the old column and is frozen to the table's current
   columns, so it must be recreated → added scrutiny (see `../../_index/cdc/SKILL.md`)
 - external consumers must keep the old name → a backward-compatibility view holds it
-  (`../compat-view/SKILL.md`) → the change stages across releases so both names coexist
+  (`../compat-view/SKILL.md`) → the change stages across releases so both names coexist. **The rename
+  is yours; the compat view is principal-only — route that bridge up to a principal** (see
+  `../compat-view/SKILL.md`).
 
 ## Prove it
 Script the delta and **read it** — it MUST be `sp_rename ... 'COLUMN'`. If you see `DROP

--- a/sidecar/projection/ssdt-agent/skills/op/rename-entity/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/op/rename-entity/SKILL.md
@@ -33,8 +33,9 @@ A rename with no refactorlog entry (handbook 16 = §19.1), with its companion Re
 - table is CDC-enabled → the capture instance still names the old table → ships as a scripted, staged
   change that recreates the capture instance, with added scrutiny because the table feeds a
   change-data-capture stream (see `../../_index/cdc/SKILL.md`)
-- external consumers must keep the old name → add a backward-compat view (`../compat-view/SKILL.md`),
-  pushing toward a staged, multi-release coexistence
+- external consumers must keep the old name → a backward-compat view (`../compat-view/SKILL.md`),
+  pushing toward a staged, multi-release coexistence. **The rename is yours; the compat view is
+  principal-only — route that bridge up to a principal.**
 
 ## Prove it
 Run `sqlpackage /Action:Script` and **read the delta** — it MUST be `sp_rename`. If you see

--- a/sidecar/projection/ssdt-agent/skills/operations/columns.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/columns.md
@@ -27,6 +27,7 @@ computes the ALTER.
 | retype-explicit | `../op/retype-explicit/SKILL.md` | Value-reshaping/lossy cast (Text→Date). Ships across releases (multi-phase); the TRY_CONVERT count drives it. |
 | rename-attribute | `../op/rename-attribute/SKILL.md` | Rename at column grain. A refactorlog entry makes it `sp_rename` (data preserved); a rename with no refactorlog entry becomes DROP COLUMN + ADD and loses the column's data. |
 | delete-attribute | `../op/delete-attribute/SKILL.md` | Drop a column. The 4-phase deprecation; a populated column is blocked on row-presence; a principal must review once data would be lost. |
+| backfill-rows | `../op/backfill-rows/SKILL.md` | **Data-plane, not schema** — fill the existing rows a default only covers going forward, or re-stamp them to a new value. A post-deployment guarded, idempotent UPDATE; a dev lead reviews it because existing data is modified. |
 
 ## Shared concerns for this family (the `_index` layer)
 
@@ -34,6 +35,7 @@ computes the ALTER.
 - `../_index/identity-and-refactorlog/SKILL.md` — governs **rename-attribute**: identity is separate from name.
 - `../_index/multi-phase/SKILL.md` — **retype-explicit, delete-attribute** coexistence + conservation proof.
 - `../_index/cdc/SKILL.md` — the added-scrutiny face of every column op on a CDC-tracked table (a new tracked column is silent until the capture instance is recreated).
+- `../_index/idempotent-seed/SKILL.md` — governs **backfill-rows** (the data-plane member): the guarded, null-safe UPDATE and silence-is-the-proof, the same discipline the static seeds use.
 
 ## Handbook citation reminder
 

--- a/sidecar/projection/ssdt-agent/skills/operations/constraints.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/constraints.md
@@ -23,7 +23,7 @@ lives in `_index/`. Nothing here restates a guard or the deploy-time specifics.
 
 - **The UNIQUE / CHECK deploy-time block, the NOCHECK→re-trust ladder, UNIQUE-one-NULL + filtered index** — a constraint is a claim proven at apply time → `../_index/constraint-is-a-claim/SKILL.md`.
 - **Multi-phase** when violators can't be fixed in-place (grandfather / quarantine) → `../_index/multi-phase/SKILL.md`.
-- **Backfill** of existing rows after a default (the separate idempotent-UPDATE op) → `../_index/idempotent-seed/SKILL.md`.
+- **Backfill** of existing rows after a default (the separate data-plane UPDATE op) → `../op/backfill-rows/SKILL.md` (its guard discipline is owned by `../_index/idempotent-seed/SKILL.md`).
 - **CDC** adds scrutiny on a tracked table → `../_index/cdc/SKILL.md` (CDC does not track constraints; the added scrutiny is the high-stakes-table rule).
 
 ## Handbook offset reminder

--- a/sidecar/projection/ssdt-agent/skills/operations/views-synonyms.md
+++ b/sidecar/projection/ssdt-agent/skills/operations/views-synonyms.md
@@ -5,6 +5,12 @@
 > The AUTHORED-HERE backward-compat-view recipe (§17.8) has moved its full body into
 > `../op/compat-view/SKILL.md` with the AUTHORED-HERE notice preserved verbatim.
 
+> **⚠️ Views are PRINCIPAL-ONLY for this team.** `create-view`, `compat-view`, and `indexed-view` are
+> **out of the developer catalog on purpose** — the team does not author views at the outset; if the
+> org adopts them, a **principal** authors them. Their skills stay as the principal's reference.
+> **`synonym` is the family's developer op** — it authors no view (a cross-database pointer). Route a
+> view request up to a principal; do not hand a developer a view op.
+
 **Family framing.** Views, synonyms, and their materialized cousins are the *indirection layer*.
 Most are benign changes applied in place — a view is a saved SELECT with no data to lose. The
 danger here is rarely data loss; it is **stale shape** (a `SELECT *` view that silently drifts as
@@ -16,10 +22,10 @@ stands in for (an OutSystems "External Entity" / "Advanced Query" is often a vie
 
 | Op | Per-op skill | What it is / how it flips |
 |---|---|---|
-| create-view | `../op/create-view/SKILL.md` | a saved SELECT; ships in place, no data touched, any team member can review; **enumerate columns** — `SELECT *` is a latent defect (the SELECT-* trap) |
-| compat-view | `../op/compat-view/SKILL.md` | a view bearing the OLD name after a rename/split; ships in place, but as one step of a multi-PR program a dev lead or an experienced developer should review it — the dependency scope reaches outside the dacpac, to consumers the model cannot see still using the old name; temporary, enumerated *(AUTHORED-HERE §17.8)* |
-| synonym | `../op/synonym/SKILL.md` | a runtime-resolved alias to an external object; ships in place, any team member can review one inside the project — a dev lead when it points outside it; target NOT validated at publish |
-| indexed-view | `../op/indexed-view/SKILL.md` | SCHEMABINDING + unique clustered index; stores data, binds base columns; flips to a staged, multi-release change as the base grows |
+| create-view | `../op/create-view/SKILL.md` | **PRINCIPAL-ONLY** (see banner) — a saved SELECT; ships in place, no data touched; **enumerate columns** — `SELECT *` is a latent defect (the SELECT-* trap) |
+| compat-view | `../op/compat-view/SKILL.md` | **PRINCIPAL-ONLY** (see banner) — a view bearing the OLD name after a rename/split; ships in place as one step of a multi-PR program; the dependency scope reaches outside the dacpac, to consumers the model cannot see still using the old name; temporary, enumerated *(AUTHORED-HERE §17.8)* |
+| synonym | `../op/synonym/SKILL.md` | **the family's developer op** — a runtime-resolved alias to an external object (authors no view); ships in place, any team member can review one inside the project — a dev lead when it points outside it; target NOT validated at publish |
+| indexed-view | `../op/indexed-view/SKILL.md` | **PRINCIPAL-ONLY** (see banner) — SCHEMABINDING + unique clustered index; stores data, binds base columns; flips to a staged, multi-release change as the base grows |
 
 ## Shared concerns for this family
 - **`../_index/identity-and-refactorlog/SKILL.md`** — the refactorlog `sp_rename` that makes a

--- a/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
@@ -66,16 +66,16 @@ executors. (Single-developer, one-at-a-time use can target `ProvingGround` direc
 
 > All commands assume the repo root as the working directory and a warm disposable copy — see
 > `talk-to-local-sql` for the container, the connection string, and the **runtime shim** (the
-> `DOTNET_ROOT` + `DOTNET_ROLL_FORWARD=Major` exports are **required on this machine**, because
-> `sqlpackage` targets .NET 8 and the box has .NET 9 at a non-standard path). On Git Bash also
-> export `MSYS_NO_PATHCONV=1` so the `/Action:` / `/SourceFile:` switches and any `/opt/...`
-> docker-exec paths are not mangled.
+> `DOTNET_ROOT` + `DOTNET_ROLL_FORWARD=Major` exports are **required wherever the .NET 8 runtime
+> `sqlpackage` targets is not the default** — point `DOTNET_ROOT` at your dotnet root; per-OS
+> values live in `talk-to-local-sql`). On Git Bash also export `MSYS_NO_PATHCONV=1` so the
+> `/Action:` / `/SourceFile:` switches and any `/opt/...` docker-exec paths are not mangled.
 
 ```bash
-# 0. Runtime shim (REQUIRED here) + warm DB — details in talk-to-local-sql
-export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+# 0. Runtime shim (env-specific) + warm DB — full details + per-OS values in talk-to-local-sql
+export DOTNET_ROOT="${DOTNET_ROOT:-$HOME/.dotnet}"   # your dotnet root (Git Bash: C:/Users/<you>/AppData/Local/Microsoft/dotnet)
 export DOTNET_ROLL_FORWARD=Major
-export MSYS_NO_PATHCONV=1                  # Git Bash: keep /Action: + /opt/... paths intact
+export MSYS_NO_PATHCONV=1                  # Git Bash ONLY: keep /Action: + /opt/... paths intact
 scripts/warm-sql.sh start                 # container projection-mssql-warm, localhost,11433
 
 # 1. Establish the BEFORE state once: deploy current CREATEs + seed (the 'real-shaped data')

--- a/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
@@ -433,7 +433,15 @@ proves the refusal; Permissive, only after, shows the consequence.
 
 ## Connector points
 
-The hand-authored `SampleCatalog` can be replaced by the F# engine's `SqlprojEmitter` /
+The substrate of record is the **Twin** (`../../../THE_TWIN.md`) when present: `twin up` mints a
+deterministic, evidence-profiled dataset over the real estate definition that evolves with the schema,
+and the proving loop above runs against it **unchanged**. The trust is the Twin's own determinism
+(`twin check` = π∘σ≈id, T1 byte-identical, S-stable) — the base data is reproducible by construction,
+so the proof rests on a dataset a reviewer regenerates identically without re-running the agent. See
+`../talk-to-local-sql/SKILL.md`'s substrate-of-record section; the hand-authored `SampleCatalog` is
+the fallback.
+
+The hand-authored `SampleCatalog` can also be replaced by the F# engine's `SqlprojEmitter` /
 `DacpacEmitter` / `PostDeployEmitter` output (in `src/Projection.Targets.SSDT`) from a **real**
 OutSystems catalog — same proving loop, real schema. The engine emits the artifacts but never
 *drives* `sqlpackage`; **this skill is that missing driver**, kept as agent-run commands by

--- a/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/prove-on-dacpac/SKILL.md
@@ -109,6 +109,27 @@ sqlpackage /Action:Publish \
 > For a **parallel** run, every command above also carries `/TargetDatabaseName:PG_<testId>_<rand>`
 > and points at a scratch copy of the tree — see `self-test/PROTOCOL.md`.
 
+### On the Twin substrate (when `proving-ground/twin.json` + the `twin` CLI are present)
+
+The loop is unchanged; only the BEFORE state and the publish target move. Replace step 1 (deploy the
+current CREATEs + seed on the warm container) with `twin up` from `proving-ground/`, which stands up
+the deterministic base on `localhost,21434 / twin` (DacFx, no sqlpackage — see
+`../talk-to-local-sql/SKILL.md`). Then point every `sqlpackage` publish at the Twin by overriding the
+profile's connection:
+
+```bash
+sqlpackage /Action:Publish \
+  /SourceFile:.../bin/Release/SampleCatalog.dacpac \
+  /Profile:.../profiles/ProvingGround.Strict.publish.xml \
+  /TargetConnectionString:"Server=localhost,21434;Initial Catalog=twin;User ID=sa;Password=Twin@Strong1;TrustServerCertificate=True;Encrypt=False"
+```
+
+The `/TargetConnectionString` overrides the profile's `TargetConnectionString`; the block/smart-default
+settings (Strict vs Permissive) still come from the profile. Obey the isolation rules in
+`../talk-to-local-sql/SKILL.md`: the Twin sets BEFORE, then only sqlpackage touches `twin` until
+teardown (`twin reset`). The Twin is the base data, never the verdict — the refactorlog / rename /
+pre-post-deploy semantics are proven by *this* sqlpackage publish on top of it.
+
 ## Reading the result -> how it ships
 
 **Read the generated `delta.sql` AND the Strict publish outcome together.** Map what they show:

--- a/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
@@ -86,20 +86,14 @@ flip mechanism for a **synthetically-minted real estate**, where evidence-profil
 tables — that is where empty/clean/violating become named `twin.json` scenarios. Do not claim
 scenarios drive the static sample's variants.
 
-### Known limitation — a view in the estate blocks the Twin mint (verified 2026-07-20)
+### Views in the estate (resolved 2026-07-20)
 
-`twin up` against the proving-ground stands up the container and **DacFx-publishes all 12 Modules**,
-then its **pre-mint wipe fails on the view**: `twin.wipe.failed · View or function 'dbo.vOrderSummary'
-is not updatable because the modification affects multiple base tables`. The Twin's clean-slate wipe
-issues a DELETE against every read-back object, and a view over multiple base tables is not deletable.
-Verified up to that point: `twin status` reads `twin.json`, globs the 12 tables, and reports them; the
-container starts; DacFx publishes the schema. Only the **data mint** is blocked, and only by the view.
-The proper fix is a small Twin-engine change — the pre-mint wipe should **skip non-updatable views**
-(a view carries no data to wipe or mint); it is out of this tree's scope (the Twin is the F# sidecar).
-Until it lands, the Twin path establishes the *schema* base but not the *data*; the hand-authored
-sample fallback is unaffected and remains the working substrate. (A workaround — excluding views from
-the Twin estate — trades this off against the view's presence in the BEFORE state, which the
-indexed-view / SELECT\* curriculum depends on; not taken here.)
+A view carries no data, so the Twin's read-back **excludes views from the wipe and the mint** while
+leaving them **published** in the schema (`../../../DECISIONS.md` 2026-07-20; `../../../THE_TWIN.md`
+§6). Verified: `twin up` against the proving-ground (which holds `dbo.vOrderSummary`) materializes —
+schema published, the base tables minted, the view present in `sys.views` and queryable through to
+its base rows, the re-run an idempotent no-op. No workaround needed; `vOrderSummary` stays a
+first-class dependency-scope fixture (a column feeding a view), and the Twin holds it faithfully.
 
 The commands and SQL are scaffolded here; the developer's agent runs them. There is **no wrapper
 script** — the existing `scripts/warm-sql.sh` (plain bash, already in the repo) is reused, and

--- a/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
@@ -18,6 +18,25 @@ This skill owns the substrate `prove-on-dacpac` publishes against: a disposable 
 database, real-*shaped* but safe to drop, standing in for the Dev database. Nothing here ever
 touches production; the database is reset between scenarios and dropped without ceremony.
 
+## The substrate of record: the Twin (deterministic), the sample as fallback
+
+The substrate that earns trust is **the Twin** (`../../../THE_TWIN.md`): one command (`twin up`)
+holds a local SQL Server current with the estate's own definitions and fills it with a
+**deterministic, masked, distribution-faithful** dataset. Its trust is a property of the *system*,
+not of any agent re-running it — `twin check` proves π∘σ≈id, mints are byte-identical (T1), and a
+schema edit re-mints only the columns it touches (**S-stable**), so a reviewer regenerates the exact
+same base data without re-running the agent. The **evidence-profiling config (`twin.json`) is
+version-controlled beside the model and evolves as the schema evolves** — that is the local dev
+environment the agent proves changes against. The Twin runs in **its own** container
+(`../../../THE_TWIN.md` §6), never the warm projection container the fallback below uses. Do not
+restate the Twin's laws here — point.
+
+The hand-authored `ProvingGround` sample on the warm container (the rest of this file) is the
+**fallback** — the deterministic fixture the self-test pins and the substrate when the Twin is not
+wired. The proving loop is identical on either: build → Script → Strict → Permissive, then the silent
+redeploy. When the Twin is present, prefer it — the base dataset is real-estate-shaped and evolves
+with the schema; when it is absent, the sample keeps the loop working.
+
 The commands and SQL are scaffolded here; the developer's agent runs them. There is **no wrapper
 script** — the existing `scripts/warm-sql.sh` (plain bash, already in the repo) is reused, and
 `sqlcmd` (via `docker exec`, see below) / `sqlpackage` run directly.

--- a/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
@@ -20,22 +20,86 @@ touches production; the database is reset between scenarios and dropped without 
 
 ## The substrate of record: the Twin (deterministic), the sample as fallback
 
-The substrate that earns trust is **the Twin** (`../../../THE_TWIN.md`): one command (`twin up`)
-holds a local SQL Server current with the estate's own definitions and fills it with a
-**deterministic, masked, distribution-faithful** dataset. Its trust is a property of the *system*,
-not of any agent re-running it — `twin check` proves π∘σ≈id, mints are byte-identical (T1), and a
-schema edit re-mints only the columns it touches (**S-stable**), so a reviewer regenerates the exact
-same base data without re-running the agent. The **evidence-profiling config (`twin.json`) is
-version-controlled beside the model and evolves as the schema evolves** — that is the local dev
-environment the agent proves changes against. The Twin runs in **its own** container
-(`../../../THE_TWIN.md` §6), never the warm projection container the fallback below uses. Do not
-restate the Twin's laws here — point.
+The substrate that earns trust is **the Twin** (`../../../THE_TWIN.md`): `twin up` holds a local SQL
+Server current with the estate's own definitions and fills it with a **deterministic, masked,
+distribution-faithful** dataset. Trust is a property of the *system*, not of any agent re-running it —
+`twin check` proves π∘σ≈id, mints are byte-identical (T1), and a schema edit re-mints only the
+columns it touches (**S-stable**), so a reviewer regenerates the same base data without re-running
+the agent. The **evidence-profiling config (`twin.json`) is version-controlled beside the model and
+evolves as the schema evolves**. Do not restate the Twin's laws here — point.
 
-The hand-authored `ProvingGround` sample on the warm container (the rest of this file) is the
-**fallback** — the deterministic fixture the self-test pins and the substrate when the Twin is not
-wired. The proving loop is identical on either: build → Script → Strict → Permissive, then the silent
-redeploy. When the Twin is present, prefer it — the base dataset is real-estate-shaped and evolves
-with the schema; when it is absent, the sample keeps the loop working.
+### Detect the substrate
+- `proving-ground/twin.json` present **and** the `twin` CLI available (`twin` on PATH, or
+  `dotnet run --project sidecar/projection/src/Twin.Cli --`) → **the Twin substrate**.
+- else → the hand-authored `ProvingGround` sample on the warm container (the rest of this file).
+
+The proving **loop is identical** on either substrate — only the BEFORE-state setup differs.
+
+### Establish the BEFORE state on the Twin
+Run from the config's directory — `root` is the `twin.json` directory, so the estate globs resolve
+against `proving-ground/`:
+
+```bash
+cd sidecar/projection/ssdt-agent/proving-ground
+twin up            # stands up twin-ssdt-agent on localhost,21434; DacFx-publishes Modules/**/*.sql;
+                   #   applies Data/Seed.sql; mints deterministically. ~1s no-op when already current.
+twin status        # schema + data current? the stored seed / scenario.
+```
+
+The Twin mints via **DacFx — no sqlpackage** and runs in its **own** container, distinct from the
+warm one the fallback uses:
+
+| Field | Twin | Sample fallback |
+|---|---|---|
+| Container | `twin-ssdt-agent` | `projection-mssql-warm` |
+| Server (from host) | `localhost,21434` | `localhost,11433` |
+| Database | `twin` | `ProvingGround` |
+| User / Password | `sa` / `Twin@Strong1` | `sa` / `Projection@Strong1` |
+
+### The Twin is the BEFORE state; sqlpackage is the proof
+The Twin establishes the deterministic base data; it is **not** the publish-under-test. Its own
+publish drops-objects-not-in-source, **ignores the refactorlog**, and runs **only** the `staticData`
+lane (not the pre/post-deploy `:r` chain). So the refactorlog / rename / pre-post-deploy semantics
+the curriculum turns on are proven by **SSDT's `sqlpackage` on top of the Twin base** — point the
+proving loop's Strict/Permissive publishes at `localhost,21434 / twin` (see `../prove-on-dacpac`).
+
+### Isolation rules (encode these)
+- **Twin sets BEFORE; sqlpackage owns the rest.** Once `twin up` establishes the base, only
+  `sqlpackage` touches the DB until teardown. A second `twin up` mid-proof reads the fingerprint
+  mismatch (your edited dacpac ≠ the estate files) and would reconcile your edit away.
+- **`twin check` may share the warm container.** It acquires a throwaway DB via
+  `PROJECTION_MSSQL_CONN_STR`; if that points at `projection-mssql-warm` it lands there transiently.
+  For hard separation, unset it (or give the Twin its own throwaway container) before `twin check`.
+- **Parallel executors.** The Twin holds one DB per config; the self-test fleet still isolates per
+  `../../self-test/PROTOCOL.md` (unique `PG_<id>` DBs on the warm container) or a per-executor
+  `twin.json`/port. Until that is decided, the fleet uses the sample path.
+
+### What the Twin does and does NOT do for the sample
+For the static-seeded sample the Twin gives the **deterministic, reproducible base** (schema +
+`Data/Seed.sql`), standing up in one command and re-minting deterministically when a Module changes
+(S-stable: only edited columns move; a **rename** perturbs its own object's values, because the
+Twin's identity is name-based). The seed-planted flip states (NULL Emails, orphan Order, DUPE Codes)
+are the **static seed's** — the Twin reproduces them, it does not generate them. So the flip-twin
+**variants** (empty / clean / violating) stay **seed-based** for the sample (the self-test's
+scratch-edit path). Twin **scenarios + pins** (rows / weights / date windows / exact pins) are the
+flip mechanism for a **synthetically-minted real estate**, where evidence-profiled data fills the
+tables — that is where empty/clean/violating become named `twin.json` scenarios. Do not claim
+scenarios drive the static sample's variants.
+
+### Known limitation — a view in the estate blocks the Twin mint (verified 2026-07-20)
+
+`twin up` against the proving-ground stands up the container and **DacFx-publishes all 12 Modules**,
+then its **pre-mint wipe fails on the view**: `twin.wipe.failed · View or function 'dbo.vOrderSummary'
+is not updatable because the modification affects multiple base tables`. The Twin's clean-slate wipe
+issues a DELETE against every read-back object, and a view over multiple base tables is not deletable.
+Verified up to that point: `twin status` reads `twin.json`, globs the 12 tables, and reports them; the
+container starts; DacFx publishes the schema. Only the **data mint** is blocked, and only by the view.
+The proper fix is a small Twin-engine change — the pre-mint wipe should **skip non-updatable views**
+(a view carries no data to wipe or mint); it is out of this tree's scope (the Twin is the F# sidecar).
+Until it lands, the Twin path establishes the *schema* base but not the *data*; the hand-authored
+sample fallback is unaffected and remains the working substrate. (A workaround — excluding views from
+the Twin estate — trades this off against the view's presence in the BEFORE state, which the
+indexed-view / SELECT\* curriculum depends on; not taken here.)
 
 The commands and SQL are scaffolded here; the developer's agent runs them. There is **no wrapper
 script** — the existing `scripts/warm-sql.sh` (plain bash, already in the repo) is reused, and

--- a/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
+++ b/sidecar/projection/ssdt-agent/skills/talk-to-local-sql/SKILL.md
@@ -30,14 +30,20 @@ any `dotnet`/`sqlpackage` call in the session, or the tool fails to start. On Gi
 sqlcmd paths below are not mangled:
 
 ```bash
-export DOTNET_ROOT="C:/Users/danny/AppData/Local/Microsoft/dotnet"
+# Point DOTNET_ROOT at YOUR local dotnet root — sqlpackage (a .NET 8 tool) needs a runtime there,
+# and ROLL_FORWARD lets it use a newer one. `<you>` = your OS user.
+export DOTNET_ROOT="${DOTNET_ROOT:-$HOME/.dotnet}"   # Windows/Git Bash e.g. "C:/Users/<you>/AppData/Local/Microsoft/dotnet"
 export DOTNET_ROLL_FORWARD=Major
-export MSYS_NO_PATHCONV=1   # Git Bash: keep /Action: + /SourceFile: + /opt/... paths intact
+export MSYS_NO_PATHCONV=1   # Git Bash ONLY: keep /Action: + /SourceFile: + /opt/... paths intact (drop it elsewhere)
 ```
 
-(The durable alternative is installing the .NET 8 runtime; until then, these exports are the fix.)
-`sqlpackage` itself is the dotnet tool `microsoft.sqlpackage` at
-`C:\Users\danny\.dotnet\tools\sqlpackage.exe`.
+`sqlpackage` is the dotnet tool `microsoft.sqlpackage`. Install it globally
+(`dotnet tool install -g microsoft.sqlpackage`) so it is on PATH as `sqlpackage`, or set
+`SQLPACKAGE` to its full path — Windows `C:/Users/<you>/.dotnet/tools/sqlpackage.exe`,
+Linux/macOS `$HOME/.dotnet/tools/sqlpackage`. (The durable alternative to the shim is installing
+the .NET 8 runtime; then `DOTNET_ROOT` / `ROLL_FORWARD` are unnecessary.) The proving-ground
+findings in this tree were captured on sqlpackage 170.4.83 — that version stamp belongs in every
+proof, because the guard behaviour is version-bound.
 
 ## sqlcmd lives in the CONTAINER, not on the host (IMPORTANT)
 

--- a/sidecar/projection/tests/Twin.Tests.Integration/Twin.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Twin.Tests.Integration/Twin.Tests.Integration.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="TwinEstateFixture.fs" />
     <Compile Include="TwinSchemaLoopTests.fs" />
     <Compile Include="TwinMintLoopTests.fs" />
+    <Compile Include="TwinViewLoopTests.fs" />
     <Compile Include="TwinEvidenceLoopTests.fs" />
   </ItemGroup>
 

--- a/sidecar/projection/tests/Twin.Tests.Integration/TwinEstateFixture.fs
+++ b/sidecar/projection/tests/Twin.Tests.Integration/TwinEstateFixture.fs
@@ -142,3 +142,14 @@ type TwinSchemaEstateFixture () =
 /// The mint-loop fixture (its own container + port).
 type TwinMintEstateFixture () =
     inherit TwinEstateFixture ("twin-e2e-mint", 21633)
+
+/// The view-loop fixture (its own container + port): the base estate plus a
+/// multi-base-table VIEW. A view over multiple base tables is not updatable
+/// (it refuses `DELETE`), which is exactly what tripped the pre-mint wipe
+/// before the fix (`twin.wipe.failed`). The regression witness: a view must
+/// publish, but never be wiped or minted.
+type TwinViewEstateFixture () as this =
+    inherit TwinEstateFixture ("twin-e2e-view", 21733)
+    do
+        this.Rewrite "Tables/dbo.vCustomerOrders.sql"
+            "CREATE VIEW [dbo].[vCustomerOrders] AS SELECT o.[Id] AS [OrderId], c.[Name] AS [CustomerName] FROM [dbo].[Order] AS o JOIN [dbo].[Customer] AS c ON c.[Id] = o.[CustomerId];\n"

--- a/sidecar/projection/tests/Twin.Tests.Integration/TwinViewLoopTests.fs
+++ b/sidecar/projection/tests/Twin.Tests.Integration/TwinViewLoopTests.fs
@@ -1,0 +1,61 @@
+module Twin.Tests.Integration.TwinViewLoopTests
+
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Xunit
+open Twin.Core
+open Twin.Runtime
+open Twin.Tests.Integration
+
+// ---------------------------------------------------------------------------
+// A view in the estate publishes, but is never wiped or minted. A view over
+// multiple base tables is not updatable (it refuses DELETE), which tripped
+// the clean-slate wipe before the fix (`twin.wipe.failed`). Readback now
+// excludes views from the wipe/mint (they carry no data), while leaving them
+// published in the schema. (DECISIONS 2026-07-20.)
+// ---------------------------------------------------------------------------
+
+[<Collection("Twin-Docker")>]
+type TwinViewLoopTests (fixture: TwinViewEstateFixture) =
+
+    interface IClassFixture<TwinViewEstateFixture>
+
+    member private _.Scalar (sql: string) : Task<int64> =
+        task {
+            use cnn = new SqlConnection(fixture.TwinConnectionString)
+            do! cnn.OpenAsync()
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! v = cmd.ExecuteScalarAsync()
+            return System.Convert.ToInt64 v
+        }
+
+    [<Fact>]
+    member this.``A view in the estate: twin up succeeds, base tables mint, the view stays published and data-free`` () : Task =
+        task {
+            // Pre-fix this refused with `twin.wipe.failed` — a DELETE against
+            // the multi-base-table view. It must now succeed.
+            let! outcome = Runs.up fixture.Root fixture.Config TwinConfig.BaselineScenario false
+            match outcome with
+            | Error es -> return failwithf "up refused (the view broke the wipe): %A" (es |> List.map (fun e -> e.Code, e.Message))
+            | Ok _ ->
+                // The base tables still mint with a view present.
+                let! customers = this.Scalar "SELECT COUNT(*) FROM [dbo].[Customer];"
+                Assert.True(customers > 0L, "base tables must still mint with a view present")
+
+                // The view is published in the schema plane...
+                let! views = this.Scalar "SELECT COUNT(*) FROM sys.views WHERE [name] = 'vCustomerOrders';"
+                Assert.Equal(1L, views)
+
+                // ...and reads through to its base rows (proving it is a real,
+                // resolvable view over the minted data), while never being a
+                // wipe/mint target itself.
+                let! throughView = this.Scalar "SELECT COUNT(*) FROM [dbo].[vCustomerOrders];"
+                Assert.True(throughView >= 0L, "the published view must be queryable")
+
+                // A re-seed stays deterministic — the view does not perturb the mint.
+                let! reseed = Runs.seed fixture.Root fixture.Config TwinConfig.BaselineScenario
+                match reseed with
+                | Error es -> return failwithf "re-seed refused: %A" (es |> List.map (fun e -> e.Code, e.Message))
+                | Ok _ -> return ()
+        }


### PR DESCRIPTION
## What this is

Raising the ssdt-agent's work quality toward its stated intent — making an OutSystems→SSDT schema change *easy and trustworthy* for a developer, with the agent as a senior-DBA mentor peer, proving changes against a deterministic evidence-profiled local dev environment (the Twin).

## Latest — views: deprecated for developers + the Twin engine fix

- **View authoring is now principal-only.** `create-view`, `compat-view`, `indexed-view` are gated out of the developer catalog (the team won't author views at the outset; if the org adopts them, a principal does) — banners + who-reviews flipped to principal, `confirm-intent` routes view requests up, and the compat-view entanglement (rename/merge ops) is re-routed. Files kept as the principal's reference (the rebuild-index/toggle-trust precedent); `synonym` stays a developer op. The `vOrderSummary` **fixture stays** — it's the load-bearing dependency-scope example.
- **Twin engine fix (verified live + regression test):** the Twin's pre-mint wipe failed on a multi-base-table view (`twin.wipe.failed`). Fixed at the readback boundary (`Twin.Runtime/Readback.fs`) — views are excluded from the wipe and mint (they carry no data) but stay published. Verified: `twin up` against the proving-ground now materializes, the view is published + queryable + data-free, the re-run idempotent; `TwinViewLoopTests` passes; `DECISIONS 2026-07-20` + `THE_TWIN` note.
- **Naming/DDD:** renamed the opaque `"furniture"` metaphor → `"state schema"` (the codebase's own term, law 5's "self-description"); a vernacular sweep found it the lone ad-hoc offender.

## Earlier stages

- **Stage 2 — Twin substrate wired:** `proving-ground/twin.json` + the runnable Twin path in `talk-to-local-sql`/`prove-on-dacpac` (detect → `twin up` establishes the deterministic BEFORE state via DacFx, no sqlpackage → the proof targets the Twin). Re-sequenced the certification plan (Twin = Stage 2, scorer = Stage 3), retired the agent-to-agent capsule.
- **Stage 1 — deployment-script lifecycle rails** (`skills/deploy-scripts/`: folder=permanence class, header=death certificate, silent redeploy=proof, retirement=tracked act, the six gates); trust re-anchored on Twin determinism + a plain evidence showcase; proving-ground class folders (`dotnet build` green).
- **Stage 0 — audit + paper cuts:** the certification plan, the missing `backfill-rows` op, violation-block signatures into `constraint-is-a-claim`, README drift, path parameterization, the route-to-DBA note.

## Verification

Link-checked throughout; `dotnet build` of the proving-ground and the Twin CLI green; the Twin CLI exercised end-to-end (`twin up`/`status`/`check`/`reset`) against the proving-ground; `TwinViewLoopTests` passed (Docker, own container). The sqlpackage-gated proof (Strict/Permissive + silent redeploy on the Twin) is deferred — sqlpackage is absent in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeYTnwb3nRhak7kt2sGShF