### PR TITLE
Sidecar/projection: six V1↔V2 emission-parity fixes (authored defaults, nullability overrides, xprop style, attribute/index order, FK NOCHECK)

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30297,3 +30297,47 @@ re-recorded via `GOLDEN_RECORD=1` — a pure reordering (201 insertions / 201 de
 schema-object bytes added or removed). The `CanonicalizeIdentityTests` ordering-contract tests
 were rewritten to the new (authored-order, SsKey) contract, including a witness that a PK with a
 non-minimal SsKey no longer floats to the front.
+
+## 2026-07-21 — FK tightening: missing/unreliable evidence under `AllowNoCheckCreation` creates the FK WITH NOCHECK rather than dropping it
+
+**Context (V1↔V2 emission-parity review).** A cluster of resolvable **logical** FKs (references
+whose target kind is present in the catalog, but with no source-backed DB constraint —
+`hasDbConstraint = false`) were being dropped by V2. With an FK tightening intervention registered
+(`EvidenceDriven`), a reference with no reliable orphan probe fell to
+`DoNotEnforce(EvidenceMissing) → DropFk`, so the FK never reached the emitted DDL. The root
+asymmetry: with **no** intervention every deployable reference emits (empty overlay ⇒ empty
+`DropFk`), but registering an `EvidenceDriven` intervention could only ever *remove* FKs relative
+to that baseline — a resolvable logical FK with no profile evidence silently disappeared.
+
+**The decision.** When no reliable orphan evidence exists (no probe ran, or the probe outcome is
+`FallbackTimeout`/`Cancelled`/`AmbiguousMapping`) and the operator has opted into
+`AllowNoCheckCreation = true` (with `EnableCreation = true`), `ForeignKeyRules.evaluate` now
+decides `EnforceConstraint(NoCheckWithoutEvidence)` instead of `DoNotEnforce(EvidenceMissing)`.
+The FK is emitted `WITH NOCHECK` via the existing two-step untrusted-alter path
+(`DecisionOverlay.NoCheckFk` → `SsdtDdlEmitter.untrustedFkAltersUsing`): new rows are enforced,
+existing rows are not validated. Without the `AllowNoCheckCreation` opt-in, V2's collapsed-mode
+strict default is unchanged (`EvidenceMissing` ⇒ dropped). The structural **cross-schema gate
+still applies** on this path — the opt-in accepts *unverified* FKs, not *cross-schema* ones.
+
+**Why NOCHECK, not trusted.** With no evidence we cannot know whether existing rows have orphans;
+a trusted (`WITH CHECK`) constraint would validate at deploy and fail if any orphan exists. NOCHECK
+enforces new rows and defers the existing-row check — the honest, deployable choice under an
+explicit opt-in.
+
+**Honesty surface (downgrades-never-silent).** A dedicated evidence variant
+`ForeignKeyEvidence.NoCheckWithoutEvidence` (not `ScriptWithNoCheck 0L`, which would falsely claim
+zero observed orphans) carries the fact, and `ForeignKeyPass` emits a named
+`tightening.foreignKey.noCheckWithoutEvidence` Warning per such creation, so the export report
+carries the accepted divergence rather than a silent constraint. `ForeignKeyPass.version` bumps
+3 → 4.
+
+**Estate pre-check (interaction with the composite-PK FK blocker, audit B-3/EF-17).** Enabling
+these FKs surfaces any whose target has a **composite** primary key: V2's `Reference` IR is a
+single `sourceAttribute → targetKind` with no referenced-column list, so a multi-leg FK is
+truncated to one leg and the DDL fails to deploy (`Msg 1776`). Inventory composite-PK FK targets
+before turning `AllowNoCheckCreation` on for a real estate; that blocker is tracked separately.
+
+**Unaffected.** The golden corpus uses `allowNoCheckCreation = false`
+(`GoldenEmissionTests.ejectFkIntervention`), so this change is byte-invisible to the goldens; the
+source-backed carve-out (`DatabaseConstraintPresent`), the orphan-observed `ScriptWithNoCheck`
+path, and the relaxation-only/override directions are all untouched.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30260,3 +30260,40 @@ inline extended-property unit assertions (`SsdtExtendedPropertyEmissionTests`,
 `ModuleExtendedPropertyEmissionTests`, `LogicalNameRoundtripTests`) are fragment-level
 `Contains`/`Matches` on `@name = …` / `@value = …` / `@levelNtype = …`, all of which survive the
 reshaping (the fragments just move onto their own lines), so they stay green unchanged.
+
+## 2026-07-21 — Attribute emission order: the PK-first reorder is retired for V1 authored-order parity (CanonicalizeIdentity v3); index / extended-property display order follows the emitted name — golden re-record
+
+**Context (V1↔V2 emission-parity review).** V1 orders emitted attributes by authored
+`Order_Num`, then `AttrId` — never PK-first. V2 had layered a PK-first rank on top (attributes
+sorted PK-first, then authored order, then SsKey), both in `CanonicalizeIdentity` (the single
+emission-ordering site) and in the extraction SQL's ORDER BY. The two diverged on any table whose
+PK is not its lowest-authored-order attribute.
+
+**The decision (Fix 2 — attribute order).** Retire the PK-first rank.
+`CanonicalizeIdentity.attributeSortKey` is now `(authored-order rank, SsKey)` (pass `version`
+2 → 3), and the extraction SQL's two attribute `ORDER BY` clauses drop the
+`CASE WHEN IsIdentifier … THEN 0 …` PK-first key and tiebreak on `AttrId` (matching V1).
+`Order_Num` is already COALESCEd to the creation `Id` at `#Attr` population, so it is non-null; a
+hand-built catalog (every `Order = None`) falls to the SsKey tiebreak, so determinism (T1) still
+holds for every source. Nothing structural depended on PK columns leading — the emitted PK
+constraint names its key columns regardless of their position in the CREATE TABLE body. On a real
+OSSYS estate the identifier's `Order_Num = 1` keeps it first on its own authored merit.
+
+**The decision (Fix 5 — index / extended-property display order).** Emitted non-PK indexes, their
+`ALTER INDEX … DISABLE` statements, and their extended-property owners now sort by the EMITTED
+index name (case-insensitive, SsKey tiebreak) rather than by SsKey, for V1 display-order parity
+(V1 orders emitted index-name lists case-insensitively). The collision-dedup ordinal in
+`IndexNaming.emittedNames` stays SsKey-based, so only the display order changes. Column extended
+properties already followed column order (the `for attr in k.Attributes` loop), so they inherit
+the Fix-2 authored order for free.
+
+**V2 extraction SQL is now independently maintained.** V2's `outsystems_metadata_rowsets.sql`
+(the ordering change above, plus the earlier PERSISTED carriage) no longer tracks V1's
+`src/AdvancedSql/` copy; the V1-comparison fork / line-count tests in `MetadataExtractionSqlTests`
+are retired.
+
+**Golden re-record (blessing protocol).** 10 files under `tests/Projection.Tests/Golden/`
+re-recorded via `GOLDEN_RECORD=1` — a pure reordering (201 insertions / 201 deletions; no
+schema-object bytes added or removed). The `CanonicalizeIdentityTests` ordering-contract tests
+were rewritten to the new (authored-order, SsKey) contract, including a witness that a PK with a
+non-minimal SsKey no longer floats to the front.

--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30222,3 +30222,41 @@ never silent" discipline; also in `THE_FIDELITY_PROOFS.md` §4 and the `BACKLOG`
 manifest (surrogate-excluded, for sink-minting targets); offline per-row naming (embed
 `GoldenDataset` rows so a reconcile names the cell, not just the kind); non-OSSYS source estates
 (the three de-OSSYS gating seams become archetype/config-gated).
+
+## 2026-07-21 — Extended-property emission gets a polished house style (typed ScriptDom builder kept; post-format reshaped) — golden re-record
+
+**Context (V1↔V2 emission-parity review).** The audit (`AUDIT_2026_07_17_V1_V2_PARITY.md`
+§4) named the extended-property style as one of the genuine aesthetic deltas: V2 emitted the
+whole `EXECUTE [sys].[sp_addextendedproperty]` call with `@name`/`@value` riding the EXECUTE
+line and no trailing `;`. The operator's call: **keep** V2's typed-AST builder
+(`ScriptDomBuild.buildSetExtendedProperty`) — do NOT revert to V1's hand-built
+`EXEC sys.sp_addextendedproperty` text — but give the post-format a deliberate house style.
+
+**The decision.** `ConstraintFormatter.formatExtendedPropertyExec` (the text post-processor at
+the `Render.toText` boundary, already the owner of V1's elegant constraint ladder) now reshapes
+the ScriptDom-emitted single line into:
+
+```
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'…',
+    @value = N'…',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE',  @level1name = N'…'[,
+    @level2type = N'COLUMN'|N'INDEX', @level2name = N'…'];
+```
+
+— the `EXECUTE` alone on the first line; `@name` and `@value` each on their own 4-space
+continuation line; each `@levelNtype`/`@levelNname` pair on one line; a trailing semicolon on
+the final line. The parameter markers partition the line, so a schema / table / column / index
+target wraps stably with whatever subset of levels it carries (the wrapping is level-count-driven,
+not target-shape-special-cased). The typed builder still owns the SQL surface; this owns only the
+layout. The `@name`/`@value` split is the one behavioral delta versus the prior post-format (which
+left them inline); the level-pair wrapping and 4-space indent are unchanged in spirit.
+
+**Golden re-record (blessing protocol, THE_GOLDEN_EMISSION.md §2).** 18 files under
+`tests/Projection.Tests/Golden/{master,pruned-platform-auto}/` re-recorded via `GOLDEN_RECORD=1`
+— the only change is the extended-property block layout above; no schema-object bytes moved. The
+inline extended-property unit assertions (`SsdtExtendedPropertyEmissionTests`,
+`ModuleExtendedPropertyEmissionTests`, `LogicalNameRoundtripTests`) are fragment-level
+`Contains`/`Matches` on `@name = …` / `@value = …` / `@levelNtype = …`, all of which survive the
+reshaping (the fragments just move onto their own lines), so they stay green unchanged.

--- a/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/outsystems_metadata_rowsets.sql
+++ b/sidecar/projection/src/Projection.Adapters.OssysSql/Resources/outsystems_metadata_rowsets.sql
@@ -840,12 +840,14 @@ SELECT
     LEFT JOIN #ColumnReality cr ON cr.AttrId = a.AttrId
     LEFT JOIN #AttrCheckJson chk ON chk.AttrId = a.AttrId
     WHERE a.EntityId = en.EntityId
-    -- WP8 / NM-72 — emission column order: PK first, then the authored
-    -- Service-Studio `Order_Num` ascending, then `AttrName` as the
-    -- stable tiebreak (deterministic when two attributes share an order).
-    ORDER BY CASE WHEN COALESCE(a.IsIdentifier, CASE WHEN a.AttrSSKey = en.PrimaryKeySSKey THEN 1 ELSE 0 END) = 1 THEN 0 ELSE 1 END,
-             a.OrderNum,
-             a.AttrName
+    -- WP8 / NM-72 — emission column order: the authored Service-Studio
+    -- `Order_Num` ascending (already COALESCEd to the creation `Id` at
+    -- #Attr population, so non-null), then `AttrId` as the stable
+    -- tiebreak. The PK-first reorder was retired 2026-07-21 for V1
+    -- authored-order parity (V1 orders by Order_Num, AttrId — never
+    -- PK-first).
+    ORDER BY a.OrderNum,
+             a.AttrId
     FOR JSON PATH
   ), '[]') AS AttributesJson
 INTO #AttrJson
@@ -1068,14 +1070,15 @@ SELECT
   -- reads it at ordinal 23 into `OssysAttributeRow.Order`.
   a.OrderNum
 FROM #Attr AS a
--- WP8 / NM-72 — PK first, then authored `OrderNum`, then `AttrName` as
--- the stable tiebreak (CanonicalizeIdentity re-derives the canonical
--- order downstream; this keeps the snapshot rowset itself deterministic
--- and authored-ordered).
+-- WP8 / NM-72 — authored `OrderNum` ascending (COALESCEd to the creation
+-- `Id` at #Attr population, so non-null), then `AttrId` as the stable
+-- tiebreak. The PK-first reorder was retired 2026-07-21 for V1
+-- authored-order parity; CanonicalizeIdentity re-derives the canonical
+-- order downstream, this keeps the snapshot rowset itself deterministic
+-- and authored-ordered.
 ORDER BY a.EntityId,
-         CASE WHEN ISNULL(a.IsIdentifier, 0) = 1 THEN 0 ELSE 1 END,
          a.OrderNum,
-         a.AttrName;
+         a.AttrId;
 
 SELECT
   rr.AttrId,

--- a/sidecar/projection/src/Projection.Core/DecisionOverlay.fs
+++ b/sidecar/projection/src/Projection.Core/DecisionOverlay.fs
@@ -34,8 +34,9 @@ type DecisionOverlay =
         /// ReferenceKeys decided `ForeignKeyOutcome.DoNotEnforce` — drop the
         /// inline FK constraint at emission.
         DropFk : Set<SsKey>
-        /// ReferenceKeys decided `EnforceConstraint (ScriptWithNoCheck _)` —
-        /// emit the FK but `WITH NOCHECK` (untrusted).
+        /// ReferenceKeys decided `EnforceConstraint (ScriptWithNoCheck _)` or
+        /// `EnforceConstraint NoCheckWithoutEvidence` — emit the FK but
+        /// `WITH NOCHECK` (untrusted).
         NoCheckFk : Set<SsKey>
     }
 
@@ -98,6 +99,7 @@ module DecisionOverlay =
     let private isNoCheckFk (o: ForeignKeyOutcome) : bool =
         match o with
         | ForeignKeyOutcome.EnforceConstraint (ScriptWithNoCheck _) -> true
+        | ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence -> true
         | _ -> false
 
     let private fkKeys

--- a/sidecar/projection/src/Projection.Core/Passes/CanonicalizeIdentity.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/CanonicalizeIdentity.fs
@@ -7,8 +7,9 @@ open Projection.Core
 ///
 ///   * modules within a catalog — by SsKey,
 ///   * kinds within a module — by SsKey,
-///   * attributes within a kind — by `(PK first, then authored
-///     Service-Studio order ascending, then SsKey)` (WP8 / NM-72),
+///   * attributes within a kind — by `(authored Service-Studio order
+///     ascending, then SsKey)` (WP8 / NM-72; PK-first reorder retired
+///     2026-07-21 for V1 authored-order parity),
 ///   * references within a kind — by SsKey,
 ///   * static-row populations (when present) — by identifier.
 ///
@@ -20,11 +21,14 @@ open Projection.Core
 ///
 /// WP8 / NM-72 — the attribute ordering honors the operator's authored
 /// Service-Studio order (`Attribute.Order`, sourced from the real
-/// `ossys_Entity_Attr.Order_Num`). PK columns lead (they are emitted
-/// first in OutSystems-faithful DDL); within the non-PK body, authored
-/// order ascending governs; `Order = None` (hand-built catalogs, the
-/// ReadSide reflection path) sorts last and falls back to the SsKey
-/// tiebreak, so determinism holds for every source. Emission is
+/// `ossys_Entity_Attr.Order_Num`). Authored order ascending governs
+/// directly — the PK-first reorder was retired 2026-07-21 for V1
+/// authored-order parity: V1 emits columns in `Order_Num, AttrId` order,
+/// never PK-first, and the emitted PK constraint names its key columns
+/// regardless of their position in the CREATE TABLE body, so nothing
+/// structural depends on PK columns leading. `Order = None` (hand-built
+/// catalogs, the ReadSide reflection path) sorts last and falls back to
+/// the SsKey tiebreak, so determinism holds for every source. Emission is
 /// inherited uniformly — the SSDT, dacpac, and data-lane emitters all
 /// iterate `Kind.Attributes` in list order, so ordering here is the
 /// single ordering site.
@@ -40,9 +44,12 @@ module CanonicalizeIdentity =
     /// Bump in the same commit that changes the canonicalization rules.
     /// v2 (WP8 / NM-72): attribute ordering is `(PK first, then authored
     /// `Attribute.Order` ascending, then SsKey)`, replacing the v1
-    /// SsKey-only sort.
+    /// SsKey-only sort. v3 (2026-07-21): the PK-first rank is retired —
+    /// ordering is `(authored `Attribute.Order` ascending, then SsKey)`
+    /// for V1 authored-order parity (V1 emits columns in Order_Num, AttrId
+    /// order, never PK-first).
     [<Literal>]
-    let version : int = 2
+    let version : int = 3
 
     [<Literal>]
     let private passName : string = "canonicalizeIdentity"
@@ -63,23 +70,22 @@ module CanonicalizeIdentity =
         | Temporal _    -> m
 
     /// WP8 / NM-72 — the total order on attributes within a kind.
-    /// `(PK rank, authored-order rank, SsKey)`:
-    ///   * PK rank 0 for primary keys, 1 otherwise — PKs lead.
+    /// `(authored-order rank, SsKey)` (the PK-first rank retired
+    /// 2026-07-21 for V1 authored-order parity):
     ///   * authored-order rank `(0, n)` for `Order = Some n`, `(1, 0)`
     ///     for `Order = None` — authored attributes precede unauthored,
     ///     ascending within the authored band.
     ///   * SsKey is the final stable tiebreak — when two attributes share
-    ///     PK rank and authored rank (e.g. both `Order = None`), the order
-    ///     is the prior SsKey order, so a hand-built catalog (every
-    ///     `Order = None`) is byte-identical to the v1 SsKey sort within
-    ///     each PK band, and determinism (T1) holds for every source.
-    let private attributeSortKey (a: Attribute) : (int * (int * int) * SsKey) =
-        let pkRank = if a.IsPrimaryKey then 0 else 1
+    ///     the authored rank (e.g. both `Order = None`), the order is the
+    ///     prior SsKey order, so a hand-built catalog (every `Order =
+    ///     None`) is byte-identical to the v1 SsKey sort, and determinism
+    ///     (T1) holds for every source.
+    let private attributeSortKey (a: Attribute) : ((int * int) * SsKey) =
         let orderRank =
             match a.Order with
             | Some n -> (0, n)
             | None   -> (1, 0)
-        (pkRank, orderRank, a.SsKey)
+        (orderRank, a.SsKey)
 
     let private canonicalizeKind (k: Kind) : Kind =
         { k with
@@ -134,6 +140,6 @@ module CanonicalizeIdentity =
           Sites =
             [ { SiteName = "canonicalize"
                 Classification = classification
-                Rationale = "Catalog-wide deterministic re-sort at every level (modules / kinds / references by SsKey; attributes by PK-first, then authored Service-Studio order, then SsKey per WP8 / NM-72) plus modality-mark normalization. No operator opinion enters; the authored order is source evidence, not policy; reachable from Project(catalog, Policy.empty, profile)." } ]
+                Rationale = "Catalog-wide deterministic re-sort at every level (modules / kinds / references by SsKey; attributes by authored Service-Studio order, then SsKey per WP8 / NM-72 — PK-first retired 2026-07-21 for V1 parity) plus modality-mark normalization. No operator opinion enters; the authored order is source evidence, not policy; reachable from Project(catalog, Policy.empty, profile)." } ]
           Run = fun c -> run c |> Lineage.map Diagnostics.ofValue
           Status = Active }

--- a/sidecar/projection/src/Projection.Core/Passes/ForeignKeyPass.fs
+++ b/sidecar/projection/src/Projection.Core/Passes/ForeignKeyPass.fs
@@ -72,8 +72,12 @@ module ForeignKeyPass =
     ///       never enter FK decisions, so the spurious per-inverse
     ///       `evidenceMissing` warnings (and the accidental-DropFk
     ///       suppression they fed) disappear.
+    /// v4 — missing/unreliable evidence under `AllowNoCheckCreation` now
+    ///       decides `EnforceConstraint(NoCheckWithoutEvidence)` instead of
+    ///       dropping (DECISIONS 2026-07-21), adding the
+    ///       `tightening.foreignKey.noCheckWithoutEvidence` diagnostic.
     [<Literal>]
-    let version : int = 3
+    let version : int = 4
 
     [<Literal>]
     let private passName : string = "foreignKey"
@@ -218,6 +222,18 @@ module ForeignKeyPass =
                     (sprintf
                         "Foreign-key constraint scripted with NOCHECK because %d orphan row(s) were observed and operator policy allows it. Row-validation is deferred; remediate orphan rows before re-enabling enforcement."
                         orphanCount)
+                    None)
+        | ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence ->
+            // Accepted divergence (DECISIONS 2026-07-21): a resolvable
+            // logical FK created WITH NOCHECK without profile evidence,
+            // because AllowNoCheckCreation is enabled. New rows are
+            // enforced; existing rows are not validated. Surfaced so the
+            // creation is never silent — the export report carries it.
+            Some (mkEntry
+                    DiagnosticSeverity.Warning
+                    "tightening.foreignKey.noCheckWithoutEvidence"
+                    (sprintf
+                        "Foreign-key constraint scripted with NOCHECK without profile evidence because AllowNoCheckCreation is enabled. The reference resolves but no reliable orphan probe ran; new rows are enforced, existing rows are not validated. Collect evidence or remediate before promoting to a trusted constraint.")
                     None)
         | ForeignKeyOutcome.DoNotEnforce PolicyDisabled ->
             // H-024: if cardinality shows active use, suggest re-enabling.

--- a/sidecar/projection/src/Projection.Core/SqlLiteral.fs
+++ b/sidecar/projection/src/Projection.Core/SqlLiteral.fs
@@ -262,30 +262,50 @@ module SqlLiteral =
         && trimmed.Substring(0, trimmed.Length - 2)
            |> Seq.forall (fun c -> System.Char.IsLetterOrDigit c || c = '_' || c = '$')
 
+    /// Unwrap a quoted authored text form: strip the outer `quote` chars
+    /// and undo that quote's doubled-escape (`''`→`'` for the SQL
+    /// single-quote form; `""`→`"` for the OutSystems double-quote
+    /// expression form). Precondition: `trimmed` is `quote`-delimited and
+    /// at least two chars long (the caller's `isQuotedWith` guard).
+    let private unwrapAuthoredQuoted (quote: char) (trimmed: string) : string =
+        let q = System.String(quote, 1)
+        trimmed.Substring(1, trimmed.Length - 2).Replace(q + q, q)
+
     /// Classify an AUTHORED default (`ossys_Entity_Attr.Default_Value` /
     /// the JSON `default` field) into its typed literal (DECISIONS
     /// 2026-07-18; the #669 M-1 finding). The authored channel carries
-    /// three shapes the value lift (`ofRaw`) cannot discriminate:
+    /// shapes the value lift (`ofRaw`) cannot discriminate:
     ///   - a niladic function call (`getutcdate()`) — an EXPRESSION;
     ///     lifted as a value it rendered `CAST('getutcdate()' …)`, which
     ///     deployed and then failed at first insert;
-    ///   - a SQL-quoted text form (`''`, `'Draft'`) — the VALUE inside
-    ///     the quotes; lifted verbatim the quotes doubled (`N''''''`);
+    ///   - a SQL single-quoted text form (`''`, `'Draft'`) — the VALUE
+    ///     inside the quotes; lifted verbatim the quotes doubled (`N''''''`);
+    ///   - an OutSystems double-quoted text form (`"outsystems"`, `"*"`) —
+    ///     Service Studio's expression-language string literal; the VALUE
+    ///     inside the quotes. Lifted verbatim the double quotes survived
+    ///     into the literal (`N'"outsystems"'`) instead of V1's `N'outsystems'`.
     ///   - the bare value forms `ofRaw` already carries faithfully.
     /// An absent or whitespace-only raw carries nothing — a nullable
     /// column's implicit NULL is normal SQL behavior, not a configured
     /// default.
     let ofAuthoredDefault (typ: PrimitiveType) (raw: string) : SqlLiteral option =
         let trimmed = raw.Trim()
+        // A `quote`-delimited Text form of at least two chars — the shared
+        // guard for both the SQL single-quote and OutSystems double-quote
+        // authored string shapes. Char-indexed (ordinal), so a stray
+        // culture-sensitive `StartsWith` cannot misjudge the delimiter.
+        let isQuotedWith (quote: char) : bool =
+            typ = Text
+            && trimmed.Length >= 2
+            && trimmed.[0] = quote
+            && trimmed.[trimmed.Length - 1] = quote
         if trimmed = "" then None
         elif isNiladicCall trimmed then Some (ExpressionLit trimmed)
-        elif typ = Text
-             && trimmed.Length >= 2
-             && trimmed.StartsWith "'" && trimmed.EndsWith "'" then
-            // The SQL-quoted authored form: unwrap the outer quotes and
-            // undo the standard single-quote doubling. `''` is the
-            // authored EMPTY STRING (`DEFAULT N''`), the estate's most
-            // common authored default.
-            let inner = trimmed.Substring(1, trimmed.Length - 2).Replace("''", "'")
-            Some (TextLit inner)
+        // The SQL single-quoted authored form: `''` is the authored EMPTY
+        // STRING (`DEFAULT N''`), the estate's most common authored default.
+        elif isQuotedWith '\'' then Some (TextLit (unwrapAuthoredQuoted '\'' trimmed))
+        // The OutSystems double-quoted expression form: authored text
+        // defaults (`"outsystems"`, `"*"`) are Service Studio string
+        // literals — the value lives inside the quotes, not the quotes.
+        elif isQuotedWith '"' then Some (TextLit (unwrapAuthoredQuoted '"' trimmed))
         else Some (ofRaw typ (Some raw))

--- a/sidecar/projection/src/Projection.Core/Strategies/ForeignKeyRules.fs
+++ b/sidecar/projection/src/Projection.Core/Strategies/ForeignKeyRules.fs
@@ -32,6 +32,16 @@ type ForeignKeyEvidence =
     /// shape emits untouched. Identity at emission — the decision lands
     /// in neither `DropFk` nor `NoCheckFk`.
     | DeclaredShapeCarried
+    /// No reliable orphan evidence (no probe ran, or the probe was
+    /// unreliable), but the operator opted into `AllowNoCheckCreation`
+    /// (with `EnableCreation`), so a resolvable logical FK whose target
+    /// resolves is created WITH NOCHECK rather than dropped (DECISIONS
+    /// 2026-07-21): it enforces new rows and defers validating existing
+    /// ones. Distinct from `ScriptWithNoCheck`, which observed a concrete
+    /// orphan count — here no count exists because no reliable probe ran.
+    /// Surfaced as a named accepted-divergence diagnostic so it is never a
+    /// silent creation (the downgrades-never-silent law).
+    | NoCheckWithoutEvidence
 
 
 /// Why an FK constraint stays un-enforced.
@@ -150,6 +160,7 @@ module ForeignKeyEvidence =
             StructuredString.create "ScriptWithNoCheck"
                 [ "orphanCount", Inv.int64 orphanCount ]
         | DeclaredShapeCarried -> StructuredString.tag "DeclaredShapeCarried"
+        | NoCheckWithoutEvidence -> StructuredString.tag "NoCheckWithoutEvidence"
 
     let toDiagnosticString (e: ForeignKeyEvidence) : string =
         toStructured e |> StructuredString.render
@@ -241,10 +252,14 @@ module ForeignKeyRules =
     ///      caller chose; reported without further reasoning. New
     ///      constraints only, per the carve-out above.
     ///   4. Profile-driven decision:
-    ///        - Probe missing or unreliable ⇒ EvidenceMissing
-    ///          (V2 collapsed-mode strict default; V1 implicitly
-    ///          falls through to `EnableCreation` gate). V2 surfaces
-    ///          the missing evidence explicitly.
+    ///        - Probe missing or unreliable ⇒ under `AllowNoCheckCreation`,
+    ///          EnforceConstraint(NoCheckWithoutEvidence) — the resolvable
+    ///          logical FK is created WITH NOCHECK (enforce new rows, defer
+    ///          validating existing ones), honoring the cross-schema gate
+    ///          (DECISIONS 2026-07-21). Otherwise DoNotEnforce(EvidenceMissing),
+    ///          V2's collapsed-mode strict default (V1 implicitly falls
+    ///          through to `EnableCreation`); either way V2 surfaces the
+    ///          missing evidence explicitly.
     ///        - Profile shows orphans + AllowNoCheckCreation=false ⇒
     ///          DoNotEnforce(DataHasOrphans).
     ///        - Profile shows orphans + AllowNoCheckCreation=true ⇒
@@ -312,6 +327,23 @@ module ForeignKeyRules =
                 mkDecision (ForeignKeyOutcome.DoNotEnforce PolicyDisabled)
             else
                 // 4. Profile-driven decision on orphan signals.
+                //
+                // When no reliable orphan evidence exists (no probe ran, or
+                // the probe was unreliable), a resolvable logical FK is NOT
+                // dropped if the operator opted into `AllowNoCheckCreation`
+                // (DECISIONS 2026-07-21): it is created WITH NOCHECK
+                // (enforce new rows; defer validating existing ones),
+                // honoring the cross-schema gate exactly as the clean path
+                // does. Without the opt-in, V2's collapsed-mode strict
+                // default declines on missing evidence. `EnableCreation` is
+                // already `true` here (step 3 gated the disabled case).
+                let onMissingEvidence () : ForeignKeyDecision =
+                    if not config.AllowNoCheckCreation then
+                        mkDecision (ForeignKeyOutcome.DoNotEnforce EvidenceMissing)
+                    elif not config.AllowCrossSchema && crossesSchema sourceKind targetKind then
+                        mkDecision (ForeignKeyOutcome.DoNotEnforce CrossSchemaBlocked)
+                    else
+                        mkDecision (ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence)
                 let realityOpt = Profile.tryFindForeignKey reference.SsKey profile
                 match realityOpt with
                 | Some reality when ProbeStatus.isReliable reality.ProbeStatus ->
@@ -346,14 +378,12 @@ module ForeignKeyRules =
                                     (NoEvidenceObstacle reality.ProbeStatus.SampleSize))
                 | Some _ ->
                     // Probe outcome is unreliable (FallbackTimeout /
-                    // Cancelled / AmbiguousMapping).
-                    mkDecision
-                        (ForeignKeyOutcome.DoNotEnforce EvidenceMissing)
+                    // Cancelled / AmbiguousMapping) → missing-evidence path.
+                    onMissingEvidence ()
                 | None ->
-                    // No probe at all. V2 collapsed-mode strict
-                    // default: do not enforce on missing evidence.
-                    mkDecision
-                        (ForeignKeyOutcome.DoNotEnforce EvidenceMissing)
+                    // No probe at all → missing-evidence path (NOCHECK under
+                    // the operator's opt-in; strict-decline otherwise).
+                    onMissingEvidence ()
 
 
     // -----------------------------------------------------------------------
@@ -372,4 +402,5 @@ module ForeignKeyRules =
     let scriptsWithNoCheck (decision: ForeignKeyDecision) : bool =
         match decision.Outcome with
         | ForeignKeyOutcome.EnforceConstraint (ScriptWithNoCheck _) -> true
+        | ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence -> true
         | _ -> false

--- a/sidecar/projection/src/Projection.Pipeline/TighteningBinding.fs
+++ b/sidecar/projection/src/Projection.Pipeline/TighteningBinding.fs
@@ -91,14 +91,16 @@ module TighteningBinding =
 
     /// Build the RELAXATION-ONLY `TighteningIntervention.Nullability`
     /// from a config entry (DECISIONS 2026-07-15, the estate A6
-    /// amendment — amends 2026-06-22). Only budget-less entries reach
-    /// this binder (`fromConfig` drops the coercion direction), so the
-    /// bound intervention's ONLY reachable acts are its resolved
-    /// `keepNullable` overrides — they relax emission below the declared
-    /// shape (`DecisionOverlay.KeepNullable`) until the reopen probe
-    /// retires them. `allowMandatoryRelaxation` binds verbatim for the
-    /// policy fingerprint; under RelaxationOnly no budget hierarchy runs
-    /// to consult it.
+    /// amendment — amends 2026-06-22; extended 2026-07-21). Entries
+    /// reaching this binder are budget-less OR budget-bearing-with-
+    /// overrides — either way `fromConfig` has stripped the coercion, and
+    /// this binder never consults `NullBudget`, so the bound
+    /// intervention's ONLY reachable acts are its resolved `keepNullable`
+    /// overrides — they relax emission below the declared shape
+    /// (`DecisionOverlay.KeepNullable`) until the reopen probe retires
+    /// them. `allowMandatoryRelaxation` binds verbatim for the policy
+    /// fingerprint; under RelaxationOnly no budget hierarchy runs to
+    /// consult it.
     let private bindNullability
         (catalog: Catalog)
         (entry: Config.TighteningInterventionEntry)
@@ -249,21 +251,28 @@ module TighteningBinding =
             // DECISIONS 2026-06-22 (config-driven nullable→NOT NULL coercion
             // disabled — the team's declared nullability is authoritative, not
             // the tool's), AS AMENDED 2026-07-15 (the estate chapter's A6
-            // relaxation-direction re-opening): a `kind:"nullability"` entry
-            // that names a `nullBudget` is the COERCION direction and stays
-            // dropped (not refused, so an existing config does not hard-fail;
-            // null-density stays a profiling statistic only). An entry WITHOUT
-            // a budget binds as a RELAXATION-ONLY intervention — its
-            // `keepNullable` overrides (and nothing else) act, relaxing
-            // emission below the declared shape. That is the estate overlay's
-            // nullability arm, and it closes the A44 gap the 2026-06-22 drop
-            // opened: `overrides` was expressible-but-inert; now every
-            // expressible key binds and reaches emission. The sibling
-            // blessing surface, `tighteningRelaxations` (F7), is DIFFERENT
-            // machinery — the migrate face's data-compat gate honoring, scoped
-            // to tightening-work violations — and stays untouched.
+            // relaxation-direction re-opening) and 2026-07-21 (the
+            // budget-alongside-overrides fix): the COERCION a `nullBudget`
+            // carries is always dropped (not refused, so an existing config
+            // does not hard-fail; null-density stays a profiling statistic
+            // only) — but that drop is now scoped to the coercion ALONE. A
+            // `kind:"nullability"` entry binds as a RELAXATION-ONLY
+            // intervention whenever it carries `keepNullable` overrides,
+            // whether or not it also names a budget, because `bindNullability`
+            // never consults the budget. Only a PURE-coercion entry (a budget
+            // and no overrides) has nothing left to bind and is filtered out.
+            // This closes the last A44 gap: a budget sitting beside overrides
+            // previously dropped the whole entry, so those overrides were
+            // expressible-but-inert; now every expressible key binds and
+            // reaches emission. The sibling blessing surface,
+            // `tighteningRelaxations` (F7), is DIFFERENT machinery — the
+            // migrate face's data-compat gate honoring, scoped to
+            // tightening-work violations — and stays untouched.
             s.Interventions
-            |> List.filter (fun e -> not (e.Kind = "nullability" && e.NullBudget.IsSome))
+            |> List.filter (fun e ->
+                not (e.Kind = "nullability"
+                     && e.NullBudget.IsSome
+                     && List.isEmpty e.NullabilityOverrides))
             |> List.map (bindEntry catalog)
             |> Result.aggregate
             |> Result.map (fun interventions -> { Interventions = interventions })

--- a/sidecar/projection/src/Projection.Targets.SSDT/ConstraintFormatter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ConstraintFormatter.fs
@@ -104,7 +104,7 @@ module ConstraintFormatter =
               TransformSite.operatorIntent "tableLevelCheck" Emission
                 "Split table-level `CONSTRAINT [CK_*] CHECK (expr)` into 2-line shape (constraint name / CHECK body at +4). V2 emits `Kind.ColumnChecks` at the table-constraint section. Operator emission-axis intent."
               TransformSite.operatorIntent "extendedPropertyExecWrap" Emission
-                "Wrap `EXEC sys.sp_addextendedproperty` calls at @level0type / @level1type / @level2type boundaries with 4-space continuation indent. Mirrors V1's MS_Description emission shape. Operator emission-axis intent." ]
+                "Reshape `EXECUTE [sys].[sp_addextendedproperty]` into the house style: the EXECUTE on its own line, @name / @value each on a 4-space continuation line, each @levelNtype/@levelNname pair on one line, trailing semicolon. Stable across schema/table/column/index targets. Operator emission-axis intent." ]
 
     // LF, not Environment.NewLine: this formatter reshapes ScriptDom's
     // CREATE TABLE constraint lines into the emitted SSDT artifact, so
@@ -297,50 +297,57 @@ module ConstraintFormatter =
             true
 
     // ---------------------------------------------------------------
-    // EXECUTE sys.sp_addextendedproperty multi-line formatting:
-    // wrap each @level-pair onto its own continuation line.
+    // EXECUTE [sys].[sp_addextendedproperty] house-style multi-line
+    // formatting (DECISIONS 2026-07-21). The typed ScriptDom builder
+    // owns the call; this post-format owns the polished layout:
+    //   * `EXECUTE [sys].[sp_addextendedproperty]` alone on the first line;
+    //   * `@name` and `@value` each on their own continuation line;
+    //   * each `@levelNtype = …, @levelNname = …` pair on one line;
+    //   * a trailing semicolon on the final line.
     //
     // Input:  `EXECUTE [sys].[sp_addextendedproperty] @name = N'V2.LogicalName', @value = N'Customer', @level0type = N'SCHEMA', @level0name = N'dbo', @level1type = N'TABLE', @level1name = N'Customer'`
-    // Output: `EXECUTE [sys].[sp_addextendedproperty] @name = N'V2.LogicalName', @value = N'Customer',\n`
+    // Output: `EXECUTE [sys].[sp_addextendedproperty]\n`
+    //         `    @name = N'V2.LogicalName',\n`
+    //         `    @value = N'Customer',\n`
     //         `    @level0type = N'SCHEMA', @level0name = N'dbo',\n`
-    //         `    @level1type = N'TABLE', @level1name = N'Customer'\n`
+    //         `    @level1type = N'TABLE', @level1name = N'Customer';\n`
     //
-    // Slice D.2.b — mirrors V1's emission shape for sp_addextendedproperty
-    // (reference: tests/Fixtures/emission/edge-case/Modules/AppCore/
-    // dbo.Customer.sql lines 34-43). Splits at the boundary BEFORE
-    // each `@levelNtype` token (where N ∈ {0, 1, 2}); pass-through
-    // for EXEC lines without level pairs.
+    // The parameter markers partition the line. @name / @value take their
+    // own lines; each present @levelNtype (N ∈ {0,1,2}) carries its level
+    // pair — so a schema / table / column / index target wraps stably with
+    // whatever subset of levels it uses. The segments already carry their
+    // inter-parameter commas from the inline form; only the final segment
+    // gains the semicolon. Pass-through for a call with no `@name` marker.
     // ---------------------------------------------------------------
     let private formatExtendedPropertyExec
         (sb: StringBuilder)
         (line: string)
         : bool =
-        let level0Idx = line.IndexOf(" @level0type", StringComparison.OrdinalIgnoreCase)
-        if level0Idx < 0 then
-            false
-        else
-            let level1Idx = line.IndexOf(" @level1type", StringComparison.OrdinalIgnoreCase)
-            let level2Idx = line.IndexOf(" @level2type", StringComparison.OrdinalIgnoreCase)
+        let markers =
+            [ " @name"; " @value"; " @level0type"; " @level1type"; " @level2type" ]
+            |> List.choose (fun m ->
+                let i = line.IndexOf(m, StringComparison.OrdinalIgnoreCase)
+                if i >= 0 then Some i else None)
+            |> List.sort
+        match markers with
+        | [] -> false
+        | firstMarker :: _ ->
             let continuationIndent = "    "  // LINT-ALLOW: V1 4-space convention
-            // Segment 1: head (everything before @level0type).
-            let head = line.Substring(0, level0Idx).TrimEnd()
+            // Head: `EXECUTE [sys].[sp_addextendedproperty]` — everything
+            // before the first parameter marker.
+            let head = line.Substring(0, firstMarker).TrimEnd()
             sb.Append(head).Append(newLine) |> ignore
-            // Segment 2: @level0type ... @level0name pair, ending at @level1type or @level2type or end-of-line.
-            let level0End =
-                if level1Idx > 0 then level1Idx
-                elif level2Idx > 0 then level2Idx
-                else line.Length
-            let level0Segment = line.Substring(level0Idx + 1, level0End - level0Idx - 1).TrimEnd()
-            sb.Append(continuationIndent).Append(level0Segment).Append(newLine) |> ignore
-            // Segment 3 (optional): @level1type ... @level1name pair, ending at @level2type or end-of-line.
-            if level1Idx > 0 then
-                let level1End = if level2Idx > 0 then level2Idx else line.Length
-                let level1Segment = line.Substring(level1Idx + 1, level1End - level1Idx - 1).TrimEnd()
-                sb.Append(continuationIndent).Append(level1Segment).Append(newLine) |> ignore
-            // Segment 4 (optional): @level2type ... @level2name pair.
-            if level2Idx > 0 then
-                let level2Segment = line.Substring(level2Idx + 1).TrimEnd()
-                sb.Append(continuationIndent).Append(level2Segment).Append(newLine) |> ignore
+            // Each marker's segment runs to the next marker (or end of
+            // line); the final segment closes with the semicolon.
+            let markerArr = List.toArray markers
+            let lastIdx = markerArr.Length - 1
+            markerArr
+            |> Array.iteri (fun i start ->
+                let stop = if i < lastIdx then markerArr.[i + 1] else line.Length
+                let segment = line.Substring(start + 1, stop - start - 1).TrimEnd()
+                sb.Append(continuationIndent).Append(segment) |> ignore
+                if i = lastIdx then sb.Append(";") |> ignore
+                sb.Append(newLine) |> ignore)
             true
 
     // -----------------------------------------------------------------

--- a/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/SsdtDdlEmitter.fs
@@ -536,8 +536,11 @@ module SsdtDdlEmitter =
     /// Build the CREATE INDEX statements for a Kind's non-PK indexes.
     /// Per chapter pre-scope §8 slice 3: PK-marked indexes are
     /// skipped (PK is inlined in CREATE TABLE per V1 convention);
-    /// remaining indexes are sorted by SsKey for deterministic
-    /// emission ordering (A33).
+    /// remaining indexes are sorted by their EMITTED name
+    /// (case-insensitive, SsKey tiebreak — 2026-07-21, V1 display-order
+    /// parity: V1 orders emitted index-name lists case-insensitively).
+    /// The dedup ordinal in `IndexNaming.emittedNames` stays SsKey-based,
+    /// so only the display order changes; A33 determinism holds.
     // Wave-2 slice 2.3 — apply the UNIQUE tightening decision at emission.
     // Additive-only (`field || enforce`): an index is emitted UNIQUE iff the
     // source already declared it unique OR a registered UniqueIndex
@@ -546,7 +549,7 @@ module SsdtDdlEmitter =
     let private indexStatementsWith (emittedNames: Map<SsKey, string>) (overlay: DecisionOverlay) (k: Kind) : Statement list =
         k.Indexes
         |> List.filter (fun idx -> not (IndexUniqueness.isPrimaryKey idx.Uniqueness))
-        |> List.sortBy (fun idx -> idx.SsKey)
+        |> List.sortBy (fun idx -> (Map.find idx.SsKey emittedNames).ToUpperInvariant(), idx.SsKey)
         |> List.map (fun idx ->
             // Chapter 4.9 slice γ — Index.Columns now carries
             // IndexColumn (SsKey + direction). Resolve to
@@ -617,7 +620,7 @@ module SsdtDdlEmitter =
     let private disabledIndexAltersWith (emittedNames: Map<SsKey, string>) (k: Kind) : Statement list =
         k.Indexes
         |> List.filter (fun idx -> not (IndexUniqueness.isPrimaryKey idx.Uniqueness) && idx.IsDisabled)
-        |> List.sortBy (fun idx -> idx.SsKey)
+        |> List.sortBy (fun idx -> (Map.find idx.SsKey emittedNames).ToUpperInvariant(), idx.SsKey)
         |> List.map (fun idx ->
             // Same emitted name as the CREATE INDEX — the ALTER must
             // reference the identifier the CREATE introduced.
@@ -817,8 +820,13 @@ module SsdtDdlEmitter =
 
             // Index extended-property owners follow the EMITTED index
             // name (the identifier the CREATE INDEX / PK constraint
-            // introduced), never the source physical name.
-            for idx in k.Indexes do
+            // introduced), never the source physical name — and emit in
+            // the same emitted-name order (case-insensitive, SsKey
+            // tiebreak) as the CREATE INDEX statements (2026-07-21, V1
+            // display-order parity).
+            for idx in
+                (k.Indexes
+                 |> List.sortBy (fun idx -> (Map.find idx.SsKey emittedNames).ToUpperInvariant(), idx.SsKey)) do
                 for ep in idx.ExtendedProperties do
                     yield Statement.SetExtendedProperty (
                         IndexProperty (table, Map.find idx.SsKey emittedNames), ep.Name, ep.Value)

--- a/sidecar/projection/tests/Projection.Tests/CanonicalizeIdentityTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CanonicalizeIdentityTests.fs
@@ -144,24 +144,20 @@ let ``canonicalizeIdentity: kinds within a module are ordered by SsKey`` () =
     Assert.Equal<SsKey list>(keys, List.sort keys)
 
 [<Fact>]
-let ``canonicalizeIdentity: attributes within a kind are PK-first then SsKey-ordered (Order=None fixture)`` () =
-    // WP8 / NM-72 — the sample fixture carries no authored `Order`
-    // (every attribute is `Order = None`), so the ordering reduces to
-    // (PK first, then SsKey) within each kind. PKs lead; the non-PK body
-    // stays SsKey-ordered (the v1 contract within each band).
+let ``canonicalizeIdentity: attributes within a kind are SsKey-ordered when Order=None (no PK-first reorder)`` () =
+    // WP8 / NM-72, as amended 2026-07-21 (the PK-first reorder retired for
+    // V1 authored-order parity): the sample fixture carries no authored
+    // `Order` (every attribute is `Order = None`), so the ordering reduces
+    // to pure SsKey order across ALL attributes — PK and non-PK alike, no
+    // PK-first band.
     let result = (ciRun (reverseAllCollections sampleCatalog)).Value
     for k in Catalog.allKinds result do
         // No attribute in the fixture carries an authored order.
         Assert.All(k.Attributes, fun a -> Assert.True(Option.isNone a.Order))
-        // PK rank is monotone non-decreasing: every PK precedes every non-PK.
-        let pkRanks = k.Attributes |> List.map (fun a -> if a.IsPrimaryKey then 0 else 1)
-        Assert.Equal<int list>(pkRanks, List.sort pkRanks)
-        // Within the non-PK band, SsKey order holds.
-        let nonPkKeys = k.Attributes |> List.filter (fun a -> not a.IsPrimaryKey) |> List.map (fun a -> a.SsKey)
-        Assert.Equal<SsKey list>(nonPkKeys, List.sort nonPkKeys)
-        // Within the PK band, SsKey order holds.
-        let pkKeys = k.Attributes |> List.filter (fun a -> a.IsPrimaryKey) |> List.map (fun a -> a.SsKey)
-        Assert.Equal<SsKey list>(pkKeys, List.sort pkKeys)
+        // Every attribute (PK or not) sits in SsKey order — the retired
+        // PK-first rule no longer floats primary keys to the front.
+        let keys = k.Attributes |> List.map (fun a -> a.SsKey)
+        Assert.Equal<SsKey list>(keys, List.sort keys)
 
 [<Fact>]
 let ``canonicalizeIdentity: static populations are ordered by Identifier`` () =
@@ -218,9 +214,10 @@ let ``canonicalizeIdentity: idempotent under collection reversal`` (reverseFlag:
     once = twice
 
 // ---------------------------------------------------------------------------
-// WP8 / NM-72 — attribute ordering: (PK first, then authored Order
-// ascending, then SsKey). These pure tests pin the ordering contract
-// without Docker; the OSSYS extraction canary proves the end-to-end path.
+// WP8 / NM-72 — attribute ordering: (authored Order ascending, then SsKey).
+// The PK-first rank was retired 2026-07-21 for V1 authored-order parity.
+// These pure tests pin the ordering contract without Docker; the OSSYS
+// extraction canary proves the end-to-end path.
 // ---------------------------------------------------------------------------
 
 module private OrderFixtures =
@@ -240,8 +237,9 @@ module private OrderFixtures =
 let ``canonicalizeIdentity: attributes emit in authored Order, not SsKey/alphabetical order`` () =
     let open' = OrderFixtures.attrWith
     // SsKey/alphabetical order would be: Id, Apple, Banana, Cherry, Date.
-    // Authored order (PK first, then Order ascending) is: Id, Date(10),
-    // Cherry(20), Banana(30), Apple(40) — the reverse of alphabetical.
+    // Authored order ascending (no PK-first; 2026-07-21) is: Id(1),
+    // Date(10), Cherry(20), Banana(30), Apple(40) — the PK Id leads on its
+    // own authored Order=1, not by a PK-first rule.
     let attrs =
         [ open' 1 "Id"     true  (Some 1)
           open' 2 "Apple"  false (Some 40)
@@ -262,15 +260,16 @@ let ``canonicalizeIdentity: attributes emit in authored Order, not SsKey/alphabe
     Assert.Equal<string list>([ "Id"; "Date"; "Cherry"; "Banana"; "Apple" ], ordered)
 
 [<Fact>]
-let ``canonicalizeIdentity: Order=None falls back to PK-first then SsKey order (determinism preserved)`` () =
+let ``canonicalizeIdentity: Order=None yields pure SsKey order — the PK does NOT lead unless its SsKey does (2026-07-21)`` () =
     let open' = OrderFixtures.attrWith
-    // No authored order anywhere — the result must be the old v1
-    // behaviour within each PK band: PK first, then SsKey order.
+    // No authored order anywhere → pure SsKey order across every attribute.
+    // The PK (Id) is deliberately given key 3 — NOT the lowest — to witness
+    // that the retired PK-first rule no longer floats it to the front.
     let attrs =
         [ open' 4 "Cherry" false None
           open' 2 "Apple"  false None
-          open' 1 "Id"     true  None
-          open' 3 "Banana" false None ]
+          open' 3 "Id"     true  None
+          open' 1 "Banana" false None ]
     let kind =
         Kind.create (OrderFixtures.key 100) (OrderFixtures.nm "K")
             (OrderFixtures.tableId "dbo" "K") attrs
@@ -282,8 +281,9 @@ let ``canonicalizeIdentity: Order=None falls back to PK-first then SsKey order (
         (ciRun catalog).Value.Modules
         |> List.head |> fun m -> m.Kinds |> List.head
         |> fun k -> k.Attributes |> List.map (fun a -> Name.value a.Name)
-    // Id is PK (rank 0), then keys 2,3,4 in SsKey order: Apple, Banana, Cherry.
-    Assert.Equal<string list>([ "Id"; "Apple"; "Banana"; "Cherry" ], ordered)
+    // Pure SsKey order: Banana(1), Apple(2), Id(3), Cherry(4). The PK sits
+    // in its SsKey position, not first.
+    Assert.Equal<string list>([ "Banana"; "Apple"; "Id"; "Cherry" ], ordered)
 
 [<Fact>]
 let ``canonicalizeIdentity: authored attributes precede Order=None ones within the non-PK band`` () =

--- a/sidecar/projection/tests/Projection.Tests/DecisionOverlayTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/DecisionOverlayTests.fs
@@ -112,18 +112,23 @@ let ``DecisionOverlay: EnforceUnique outcomes populate EnforceUnique; DoNotEnfor
 let ``DecisionOverlay: FK outcomes partition across DropFk / NoCheckFk, EnforceConstraint(clean) in neither`` () =
     let dropped = key "FK_dropped"
     let noCheck = key "FK_nocheck"
+    let noCheckNoEvidence = key "FK_nocheck_noevidence"
     let clean = key "FK_clean"
     let state =
         stateWith
             [] []
             [ fkDecision dropped (ForeignKeyOutcome.DoNotEnforce ForeignKeyKeepReason.EvidenceMissing)
               fkDecision noCheck (ForeignKeyOutcome.EnforceConstraint (ScriptWithNoCheck 7L))
+              fkDecision noCheckNoEvidence (ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence)
               fkDecision clean (ForeignKeyOutcome.EnforceConstraint (NoEvidenceObstacle 100L)) ]
     let overlay = DecisionOverlay.ofComposeState state
     Assert.True(overlay.DropFk.Contains dropped)
     Assert.False(overlay.NoCheckFk.Contains dropped)
     Assert.True(overlay.NoCheckFk.Contains noCheck)
     Assert.False(overlay.DropFk.Contains noCheck)
+    // NoCheckWithoutEvidence also lands in NoCheckFk (emitted WITH NOCHECK).
+    Assert.True(overlay.NoCheckFk.Contains noCheckNoEvidence)
+    Assert.False(overlay.DropFk.Contains noCheckNoEvidence)
     Assert.False(overlay.DropFk.Contains clean)
     Assert.False(overlay.NoCheckFk.Contains clean)
 

--- a/sidecar/projection/tests/Projection.Tests/ForeignKeyRulesTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ForeignKeyRulesTests.fs
@@ -254,11 +254,14 @@ let ``cross-schema: comparison is case-insensitive`` () =
         decision.Outcome)
 
 // ---------------------------------------------------------------------------
-// EvidenceMissing — probe not reliable / missing entirely.
+// Missing / unreliable evidence — no reliable orphan probe. Under
+// AllowNoCheckCreation=false, V2's strict default declines (EvidenceMissing);
+// under AllowNoCheckCreation=true, the resolvable logical FK is created WITH
+// NOCHECK (NoCheckWithoutEvidence) rather than dropped (DECISIONS 2026-07-21).
 // ---------------------------------------------------------------------------
 
 [<Fact>]
-let ``evidence missing: probe outcome FallbackTimeout ⇒ DoNotEnforce(EvidenceMissing)`` () =
+let ``evidence missing: unreliable probe + AllowNoCheckCreation=false ⇒ DoNotEnforce(EvidenceMissing)`` () =
     let cfg = mkConfig true true false
     let profile =
         { Profile.empty with
@@ -269,7 +272,7 @@ let ``evidence missing: probe outcome FallbackTimeout ⇒ DoNotEnforce(EvidenceM
         decision.Outcome)
 
 [<Fact>]
-let ``evidence missing: no FK reality at all ⇒ DoNotEnforce(EvidenceMissing)`` () =
+let ``evidence missing: no FK reality + AllowNoCheckCreation=false ⇒ DoNotEnforce(EvidenceMissing)`` () =
     let cfg = mkConfig true true false
     let decision = decide cfg sampleCatalog order orderRef Profile.empty
     Assert.Equal(
@@ -277,25 +280,52 @@ let ``evidence missing: no FK reality at all ⇒ DoNotEnforce(EvidenceMissing)``
         decision.Outcome)
 
 [<Fact>]
-let ``evidence missing: Cancelled probe outcome ⇒ DoNotEnforce(EvidenceMissing)`` () =
+let ``no-check without evidence: no FK reality + AllowNoCheckCreation=true ⇒ EnforceConstraint(NoCheckWithoutEvidence)`` () =
+    // The "21 missing FKs" case: a resolvable logical reference with no
+    // probe at all is created WITH NOCHECK under the operator's opt-in,
+    // rather than dropped.
+    let cfg = mkConfig true true true
+    let decision = decide cfg sampleCatalog order orderRef Profile.empty
+    Assert.Equal(
+        ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence,
+        decision.Outcome)
+
+[<Fact>]
+let ``no-check without evidence: Cancelled probe + AllowNoCheckCreation=true ⇒ EnforceConstraint(NoCheckWithoutEvidence)`` () =
     let cfg = mkConfig true true true
     let profile =
         { Profile.empty with
             ForeignKeys = [ mkReality orderRef.SsKey false 0L Cancelled ] }
     let decision = decide cfg sampleCatalog order orderRef profile
     Assert.Equal(
-        ForeignKeyOutcome.DoNotEnforce ForeignKeyKeepReason.EvidenceMissing,
+        ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence,
         decision.Outcome)
 
 [<Fact>]
-let ``evidence missing: AmbiguousMapping probe outcome ⇒ DoNotEnforce(EvidenceMissing)`` () =
+let ``no-check without evidence: AmbiguousMapping probe + AllowNoCheckCreation=true ⇒ EnforceConstraint(NoCheckWithoutEvidence)`` () =
     let cfg = mkConfig true true true
     let profile =
         { Profile.empty with
             ForeignKeys = [ mkReality orderRef.SsKey false 0L AmbiguousMapping ] }
     let decision = decide cfg sampleCatalog order orderRef profile
     Assert.Equal(
-        ForeignKeyOutcome.DoNotEnforce ForeignKeyKeepReason.EvidenceMissing,
+        ForeignKeyOutcome.EnforceConstraint NoCheckWithoutEvidence,
+        decision.Outcome)
+
+[<Fact>]
+let ``no-check without evidence: the cross-schema gate still blocks (missing evidence + AllowNoCheckCreation=true + AllowCrossSchema=false)`` () =
+    // The missing-evidence NOCHECK path honors the structural cross-schema
+    // gate exactly as the clean path does — the opt-in does not bypass it.
+    let altCustomer =
+        { customer with
+            Physical = mkTableId "alt" (TableId.tableText customer.Physical) }
+    let altModule =
+        { salesModule with Kinds = [ altCustomer; order; country ] }
+    let altCatalog : Catalog = IRBuilders.mkCatalog [ altModule ]
+    let cfg = mkConfig true false true    // enableCreation; allowCrossSchema=false; allowNoCheck=true
+    let decision = decide cfg altCatalog order orderRef Profile.empty
+    Assert.Equal(
+        ForeignKeyOutcome.DoNotEnforce CrossSchemaBlocked,
         decision.Outcome)
 
 // ---------------------------------------------------------------------------
@@ -339,7 +369,7 @@ let ``enforces: true for EnforceConstraint, false for DoNotEnforce`` () =
     Assert.True (ForeignKeyRules.enforces allowed)
 
 [<Fact>]
-let ``scriptsWithNoCheck: true only for the ScriptWithNoCheck evidence variant`` () =
+let ``scriptsWithNoCheck: true for both NOCHECK evidence variants, false otherwise`` () =
     let cfg = mkConfig true true true
     let orphanProfile =
         { Profile.empty with
@@ -347,9 +377,11 @@ let ``scriptsWithNoCheck: true only for the ScriptWithNoCheck evidence variant``
     let cleanProfile =
         { Profile.empty with
             ForeignKeys = [ mkReality orderRef.SsKey false 0L Succeeded ] }
-    let withNoCheck = decide cfg sampleCatalog order orderRef orphanProfile
-    let normal      = decide cfg sampleCatalog order orderRef cleanProfile
+    let withNoCheck       = decide cfg sampleCatalog order orderRef orphanProfile  // ScriptWithNoCheck
+    let noEvidenceNoCheck = decide cfg sampleCatalog order orderRef Profile.empty  // NoCheckWithoutEvidence
+    let normal            = decide cfg sampleCatalog order orderRef cleanProfile   // NoEvidenceObstacle
     Assert.True (ForeignKeyRules.scriptsWithNoCheck withNoCheck)
+    Assert.True (ForeignKeyRules.scriptsWithNoCheck noEvidenceNoCheck)
     Assert.False(ForeignKeyRules.scriptsWithNoCheck normal)
 
 // ---------------------------------------------------------------------------
@@ -392,6 +424,7 @@ let ``outcome: ForeignKeyEvidence variants round-trip`` () =
     Assert.Equal<ForeignKeyEvidence>(DatabaseConstraintPresent, DatabaseConstraintPresent)
     Assert.Equal<ForeignKeyEvidence>(NoEvidenceObstacle 100L, NoEvidenceObstacle 100L)
     Assert.Equal<ForeignKeyEvidence>(ScriptWithNoCheck 5L, ScriptWithNoCheck 5L)
+    Assert.Equal<ForeignKeyEvidence>(NoCheckWithoutEvidence, NoCheckWithoutEvidence)
 
 [<Fact>]
 let ``outcome: ForeignKeyKeepReason variants round-trip`` () =

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Data/StaticSeeds.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Data/StaticSeeds.sql
@@ -16,14 +16,14 @@ MERGE INTO [dbo].[Country]
 USING
 (
     VALUES
-        (2, N'CA', N'Canada'),
-        (3, N'MX', N'Mexico'),
-        (1, N'US', N'United States')
-) AS [Source]([Id], [Code], [Label]) ON [Target].[Id] = [Source].[Id]
+        (N'CA', 2, N'Canada'),
+        (N'MX', 3, N'Mexico'),
+        (N'US', 1, N'United States')
+) AS [Source]([Code], [Id], [Label]) ON [Target].[Id] = [Source].[Id]
 WHEN MATCHED THEN UPDATE 
     SET [Target].[Code]  = [Source].[Code],
         [Target].[Label] = [Source].[Label]
-WHEN NOT MATCHED THEN INSERT ([Id], [Code], [Label]) VALUES ([Source].[Id], [Source].[Code], [Source].[Label]);
+WHEN NOT MATCHED THEN INSERT ([Code], [Id], [Label]) VALUES ([Source].[Code], [Source].[Id], [Source].[Label]);
 GO
 -- RegionA (1 row)
 MERGE INTO [dbo].[RegionA]
@@ -72,14 +72,14 @@ MERGE INTO [dbo].[TextFidelity]
 USING
 (
     VALUES
-        (1, N''),
-        (2, NULL),
-        (3, NULL),
-        (4, N'hello')
-) AS [Source]([Id], [Body]) ON [Target].[Id] = [Source].[Id]
+        (N'', 1),
+        (NULL, 2),
+        (NULL, 3),
+        (N'hello', 4)
+) AS [Source]([Body], [Id]) ON [Target].[Id] = [Source].[Id]
 WHEN MATCHED THEN UPDATE 
     SET [Target].[Body] = [Source].[Body]
-WHEN NOT MATCHED THEN INSERT ([Id], [Body]) VALUES ([Source].[Id], [Source].[Body]);
+WHEN NOT MATCHED THEN INSERT ([Body], [Id]) VALUES ([Source].[Body], [Source].[Id]);
 GO
 -- Tier (3 rows)
 SET IDENTITY_INSERT [dbo].[Tier] ON;

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Assignment.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Assignment.sql
@@ -8,55 +8,71 @@ CREATE TABLE [dbo].[Assignment] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Assignment',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Assignment',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Assignment'
+    @level1type = N'TABLE', @level1name = N'Assignment';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:Assignment',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:Assignment',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Assignment'
+    @level1type = N'TABLE', @level1name = N'Assignment';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ProjectId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ProjectId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ProjectId'
+    @level2type = N'COLUMN', @level2name = N'ProjectId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ProjectId'
+    @level2type = N'COLUMN', @level2name = N'ProjectId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ResourceId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ResourceId'
+    @level2type = N'COLUMN', @level2name = N'ResourceId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ResourceId'
+    @level2type = N'COLUMN', @level2name = N'ResourceId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Role',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'Role'
+    @level2type = N'COLUMN', @level2name = N'Role';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'Role'
+    @level2type = N'COLUMN', @level2name = N'Role';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.Heap.sql
@@ -5,41 +5,53 @@ CREATE TABLE [dbo].[Heap] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Heap',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Heap',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Heap'
+    @level1type = N'TABLE', @level1name = N'Heap';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:Heap',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:Heap',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Heap'
+    @level1type = N'TABLE', @level1name = N'Heap';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'LoggedAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'LoggedAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+    @level2type = N'COLUMN', @level2name = N'LoggedAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+    @level2type = N'COLUMN', @level2name = N'LoggedAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Message',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'Message'
+    @level2type = N'COLUMN', @level2name = N'Message';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Heap.Message',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:Heap.Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'Message'
+    @level2type = N'COLUMN', @level2name = N'Message';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
@@ -77,210 +77,270 @@ ALTER INDEX [IX_ScalarGallery_Code_2]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'The scalar gallery: every primitive realization and every DEFAULT-able literal.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'The scalar gallery: every primitive realization and every DEFAULT-able literal.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ScalarGallery',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:113:ScalarGallery',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:113:ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AlarmAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+    @level2type = N'COLUMN', @level2name = N'AlarmAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+    @level2type = N'COLUMN', @level2name = N'AlarmAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Amount',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Amount'
+    @level2type = N'COLUMN', @level2name = N'Amount';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Amount'
+    @level2type = N'COLUMN', @level2name = N'Amount';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Workflow code; defaults to Pending.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Workflow code; defaults to Pending.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'DueDate',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'DueDate'
+    @level2type = N'COLUMN', @level2name = N'DueDate';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'DueDate'
+    @level2type = N'COLUMN', @level2name = N'DueDate';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ExternalKey',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+    @level2type = N'COLUMN', @level2name = N'ExternalKey';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+    @level2type = N'COLUMN', @level2name = N'ExternalKey';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'No default; the contrast column.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'No default; the contrast column.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'FreeText',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'FreeText',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'IsActive',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'IsActive'
+    @level2type = N'COLUMN', @level2name = N'IsActive';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'IsActive'
+    @level2type = N'COLUMN', @level2name = N'IsActive';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Notes',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Notes',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Notes'
+    @level2type = N'COLUMN', @level2name = N'Notes';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Notes'
+    @level2type = N'COLUMN', @level2name = N'Notes';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'OccurredOn',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+    @level2type = N'COLUMN', @level2name = N'OccurredOn';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+    @level2type = N'COLUMN', @level2name = N'OccurredOn';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Payload',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Payload',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Payload'
+    @level2type = N'COLUMN', @level2name = N'Payload';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Payload'
+    @level2type = N'COLUMN', @level2name = N'Payload';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tally',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Tally'
+    @level2type = N'COLUMN', @level2name = N'Tally';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Tally'
+    @level2type = N'COLUMN', @level2name = N'Tally';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Descending scan support.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Descending scan support.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'INDEX', @level2name = N'IX_ScalarGallery_Tally_1'
+    @level2type = N'INDEX', @level2name = N'IX_ScalarGallery_Tally_1';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Forms/dbo.ScalarGallery.sql
@@ -1,7 +1,4 @@
 CREATE TABLE [dbo].[ScalarGallery] (
-    [Id]          INT              IDENTITY (1, 1) NOT NULL
-        CONSTRAINT [PK_ScalarGallery_Id]
-            PRIMARY KEY CLUSTERED,
     [AlarmAt]     TIME             NULL
         CONSTRAINT [DF_ScalarGallery_AlarmAt] DEFAULT CAST ('08:30:00' AS TIME (7)),
     [Amount]      DECIMAL (18, 4)  NULL
@@ -14,6 +11,9 @@ CREATE TABLE [dbo].[ScalarGallery] (
     [ExternalKey] UNIQUEIDENTIFIER NULL
         CONSTRAINT [DF_ScalarGallery_ExternalKey] DEFAULT '00000000-0000-0000-0000-000000000000',
     [FreeText]    NVARCHAR (50)    NULL,
+    [Id]          INT              IDENTITY (1, 1) NOT NULL
+        CONSTRAINT [PK_ScalarGallery_Id]
+            PRIMARY KEY CLUSTERED,
     [IsActive]    BIT              NOT NULL
         CONSTRAINT [DF_ScalarGallery_IsActive] DEFAULT 1,
     [Notes]       NVARCHAR (2000)  NULL
@@ -37,23 +37,23 @@ CREATE INDEX [IX_ScalarGallery_Code_1]
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Tally_1]
-    ON [dbo].[ScalarGallery]([Tally] DESC)
-
-GO
-
 CREATE INDEX [IX_ScalarGallery_Code_2]
     ON [dbo].[ScalarGallery]([Code])
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Tally_2]
-    ON [dbo].[ScalarGallery]([Tally]) WHERE ([Tally] IS NOT NULL)
+CREATE INDEX [IX_ScalarGallery_Code_3]
+    ON [dbo].[ScalarGallery]([Code])
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Code_3]
-    ON [dbo].[ScalarGallery]([Code])
+CREATE INDEX [IX_ScalarGallery_Tally_1]
+    ON [dbo].[ScalarGallery]([Tally] DESC)
+
+GO
+
+CREATE INDEX [IX_ScalarGallery_Tally_2]
+    ON [dbo].[ScalarGallery]([Tally]) WHERE ([Tally] IS NOT NULL)
 
 GO
 
@@ -98,24 +98,6 @@ EXECUTE [sys].[sp_addextendedproperty]
     @value = N'S9:GOLD_KIND1:113:ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -242,6 +224,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'FreeText';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [audit].[ChangeLog] (
+    [At]     DATETIME NOT NULL,
     [Id]     INT      IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_ChangeLog_Id]
             PRIMARY KEY CLUSTERED,
-    [At]     DATETIME NOT NULL,
     [UserId] INT      NOT NULL
         CONSTRAINT [FK_ChangeLog_User_UserId]
             FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id])
@@ -28,24 +28,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
-    @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
@@ -59,6 +41,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
     @level2type = N'COLUMN', @level2name = N'At';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/audit.ChangeLog.sql
@@ -10,55 +10,71 @@ CREATE TABLE [audit].[ChangeLog] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ChangeLog',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ChangeLog',
     @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog'
+    @level1type = N'TABLE', @level1name = N'ChangeLog';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:19:ChangeLog',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:19:ChangeLog',
     @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog'
+    @level1type = N'TABLE', @level1name = N'ChangeLog';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'At',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'At'
+    @level2type = N'COLUMN', @level2name = N'At';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'At'
+    @level2type = N'COLUMN', @level2name = N'At';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UserId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'UserId'
+    @level2type = N'COLUMN', @level2name = N'UserId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'UserId'
+    @level2type = N'COLUMN', @level2name = N'UserId';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Customer.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Customer.sql
@@ -7,41 +7,53 @@ CREATE TABLE [dbo].[Customer] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Customer',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Customer',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Customer'
+    @level1type = N'TABLE', @level1name = N'Customer';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:18:Customer',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:18:Customer',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Customer'
+    @level1type = N'TABLE', @level1name = N'Customer';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:111:Customer.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:111:Customer.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Customer.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Customer.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
@@ -39,111 +39,143 @@ CREATE UNIQUE INDEX [UIX_Engagement_CustomerId_Subject]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Engagement',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement'
+    @level1type = N'TABLE', @level1name = N'Engagement';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:Engagement',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement'
+    @level1type = N'TABLE', @level1name = N'Engagement';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AltCustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CreatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'CreatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+    @level2type = N'COLUMN', @level2name = N'CreatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+    @level2type = N'COLUMN', @level2name = N'CreatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CustomerId'
+    @level2type = N'COLUMN', @level2name = N'CustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CustomerId'
+    @level2type = N'COLUMN', @level2name = N'CustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ParentId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ParentId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'ParentId'
+    @level2type = N'COLUMN', @level2name = N'ParentId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'ParentId'
+    @level2type = N'COLUMN', @level2name = N'ParentId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Subject',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Subject'
+    @level2type = N'COLUMN', @level2name = N'Subject';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Subject'
+    @level2type = N'COLUMN', @level2name = N'Subject';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UpdatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.Engagement.sql
@@ -1,7 +1,4 @@
 CREATE TABLE [dbo].[Engagement] (
-    [Id]            INT            IDENTITY (1, 1) NOT NULL
-        CONSTRAINT [PK_Engagement_Id]
-            PRIMARY KEY CLUSTERED,
     [AltCustomerId] INT            NULL
         CONSTRAINT [DF_Engagement_AltCustomerId] DEFAULT 0,
     [CreatedBy]     INT            NOT NULL
@@ -10,6 +7,9 @@ CREATE TABLE [dbo].[Engagement] (
                 ON DELETE NO ACTION
                 ON UPDATE CASCADE,
     [CustomerId]    INT            NOT NULL,
+    [Id]            INT            IDENTITY (1, 1) NOT NULL
+        CONSTRAINT [PK_Engagement_Id]
+            PRIMARY KEY CLUSTERED,
     [ParentId]      INT            NULL
         CONSTRAINT [FK_Engagement_Engagement_ParentId]
             FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Engagement] ([Id]),
@@ -52,24 +52,6 @@ EXECUTE [sys].[sp_addextendedproperty]
     @value = N'S9:GOLD_KIND1:110:Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -124,6 +106,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'CustomerId';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.EnterpriseCustomerRelationshipManagementProfileSnapshot.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.EnterpriseCustomerRelationshipManagementProfileSnapshot.sql
@@ -6,27 +6,35 @@ CREATE TABLE [dbo].[EnterpriseCustomerRelationshipManagementProfileSnapshot] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot'
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:EcrmSnapshot',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:EcrmSnapshot',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot'
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.InterdepartmentalResourceAllocationAuthorizationLedger.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.InterdepartmentalResourceAllocationAuthorizationLedger.sql
@@ -9,41 +9,53 @@ CREATE TABLE [dbo].[InterdepartmentalResourceAllocationAuthorizationLedger] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'InterdepartmentalResourceAllocationAuthorizationLedger',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger'
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:16:Ledger',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:16:Ledger',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger'
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [dbo].[User] (
+    [Email] NVARCHAR (250) NOT NULL,
     [Id]    INT            IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_User_Id]
-            PRIMARY KEY CLUSTERED,
-    [Email] NVARCHAR (250) NOT NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -33,24 +33,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:17:User.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
@@ -64,4 +46,22 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
     @level2type = N'COLUMN', @level2name = N'Email';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:User.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Relations/dbo.User.sql
@@ -7,47 +7,61 @@ CREATE TABLE [dbo].[User] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'The platform user kind (pure reference target).',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'The platform user kind (pure reference target).',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'User',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'User',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:User',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:User',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:User.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:User.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Email',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Email'
+    @level2type = N'COLUMN', @level2name = N'Email';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:User.Email',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:User.Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Email'
+    @level2type = N'COLUMN', @level2name = N'Email';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [dbo].[Country] (
+    [Code]  NVARCHAR (2)   NOT NULL,
     [Id]    INT            NOT NULL
         CONSTRAINT [PK_Country_Id]
             PRIMARY KEY CLUSTERED,
-    [Code]  NVARCHAR (2)   NOT NULL,
     [Label] NVARCHAR (100) NOT NULL
 )
 
@@ -26,24 +26,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:110:Country.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
@@ -57,6 +39,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
     @level2type = N'COLUMN', @level2name = N'Code';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:Country.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Country.sql
@@ -8,55 +8,71 @@ CREATE TABLE [dbo].[Country] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Country',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Country',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country'
+    @level1type = N'TABLE', @level1name = N'Country';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:Country',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:Country',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country'
+    @level1type = N'TABLE', @level1name = N'Country';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:Country.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:Country.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Country.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:Country.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Label',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Label'
+    @level2type = N'COLUMN', @level2name = N'Label';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Country.Label',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Country.Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Label'
+    @level2type = N'COLUMN', @level2name = N'Label';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionA.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionA.sql
@@ -8,55 +8,71 @@ CREATE TABLE [dbo].[RegionA] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'RegionA',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'RegionA',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionA'
+    @level1type = N'TABLE', @level1name = N'RegionA';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:RegionA',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:RegionA',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionA'
+    @level1type = N'TABLE', @level1name = N'RegionA';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionB.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.RegionB.sql
@@ -8,55 +8,71 @@ CREATE TABLE [dbo].[RegionB] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'RegionB',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'RegionB',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionB'
+    @level1type = N'TABLE', @level1name = N'RegionB';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:RegionB',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:RegionB',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionB'
+    @level1type = N'TABLE', @level1name = N'RegionB';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.ScopedLookup.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.ScopedLookup.sql
@@ -8,55 +8,71 @@ CREATE TABLE [dbo].[ScopedLookup] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ScopedLookup',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ScopedLookup',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScopedLookup'
+    @level1type = N'TABLE', @level1name = N'ScopedLookup';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:ScopedLookup',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:ScopedLookup',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScopedLookup'
+    @level1type = N'TABLE', @level1name = N'ScopedLookup';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TenantId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'TenantId'
+    @level2type = N'COLUMN', @level2name = N'TenantId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'TenantId'
+    @level2type = N'COLUMN', @level2name = N'TenantId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Value',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Value'
+    @level2type = N'COLUMN', @level2name = N'Value';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Value'
+    @level2type = N'COLUMN', @level2name = N'Value';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.TextFidelity.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.TextFidelity.sql
@@ -7,41 +7,53 @@ CREATE TABLE [dbo].[TextFidelity] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TextFidelity',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'TextFidelity',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity'
+    @level1type = N'TABLE', @level1name = N'TextFidelity';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:TextFidelity',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:TextFidelity',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity'
+    @level1type = N'TABLE', @level1name = N'TextFidelity';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Body',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Body'
+    @level2type = N'COLUMN', @level2name = N'Body';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:TextFidelity.Body',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:TextFidelity.Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Body'
+    @level2type = N'COLUMN', @level2name = N'Body';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.TextFidelity.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.TextFidelity.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [dbo].[TextFidelity] (
+    [Body] NVARCHAR (50) NULL,
     [Id]   INT           NOT NULL
         CONSTRAINT [PK_TextFidelity_Id]
-            PRIMARY KEY CLUSTERED,
-    [Body] NVARCHAR (50) NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -25,24 +25,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
@@ -56,4 +38,22 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
     @level2type = N'COLUMN', @level2name = N'Body';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'TextFidelity',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'TextFidelity',
+    @level2type = N'COLUMN', @level2name = N'Id';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Tier.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/Modules/Statics/dbo.Tier.sql
@@ -7,47 +7,61 @@ CREATE TABLE [dbo].[Tier] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Static lookup with an IDENTITY PK — the IDENTITY_INSERT bracket case.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Static lookup with an IDENTITY PK — the IDENTITY_INSERT bracket case.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tier',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Tier',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:Tier',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:Tier',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:Tier.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:Tier.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Tier.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:19:Tier.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
@@ -83,10 +83,10 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [audit].[ChangeLog] (
+    [At]     DATETIME NOT NULL,
     [Id]     INT      IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_ChangeLog_Id]
             PRIMARY KEY CLUSTERED,
-    [At]     DATETIME NOT NULL,
     [UserId] INT      NOT NULL
         CONSTRAINT [FK_ChangeLog_User_UserId]
             FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id])
@@ -112,24 +112,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
-    @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
@@ -143,6 +125,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
     @level2type = N'COLUMN', @level2name = N'At';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+    @level0type = N'SCHEMA', @level0name = N'audit',
+    @level1type = N'TABLE', @level1name = N'ChangeLog',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -165,10 +165,10 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [dbo].[Country] (
+    [Code]  NVARCHAR (2)   NOT NULL,
     [Id]    INT            NOT NULL
         CONSTRAINT [PK_Country_Id]
             PRIMARY KEY CLUSTERED,
-    [Code]  NVARCHAR (2)   NOT NULL,
     [Label] NVARCHAR (100) NOT NULL
 )
 
@@ -192,24 +192,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:110:Country.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
@@ -223,6 +205,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
     @level2type = N'COLUMN', @level2name = N'Code';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:Country.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Country',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -348,9 +348,6 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [dbo].[Engagement] (
-    [Id]            INT            IDENTITY (1, 1) NOT NULL
-        CONSTRAINT [PK_Engagement_Id]
-            PRIMARY KEY CLUSTERED,
     [AltCustomerId] INT            NULL
         CONSTRAINT [DF_Engagement_AltCustomerId] DEFAULT 0,
     [CreatedBy]     INT            NOT NULL
@@ -359,6 +356,9 @@ CREATE TABLE [dbo].[Engagement] (
                 ON DELETE NO ACTION
                 ON UPDATE CASCADE,
     [CustomerId]    INT            NOT NULL,
+    [Id]            INT            IDENTITY (1, 1) NOT NULL
+        CONSTRAINT [PK_Engagement_Id]
+            PRIMARY KEY CLUSTERED,
     [ParentId]      INT            NULL
         CONSTRAINT [FK_Engagement_Engagement_ParentId]
             FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Engagement] ([Id]),
@@ -401,24 +401,6 @@ EXECUTE [sys].[sp_addextendedproperty]
     @value = N'S9:GOLD_KIND1:110:Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -473,6 +455,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
     @level2type = N'COLUMN', @level2name = N'CustomerId';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'Engagement',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -813,9 +813,6 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [dbo].[ScalarGallery] (
-    [Id]          INT              IDENTITY (1, 1) NOT NULL
-        CONSTRAINT [PK_ScalarGallery_Id]
-            PRIMARY KEY CLUSTERED,
     [AlarmAt]     TIME             NULL
         CONSTRAINT [DF_ScalarGallery_AlarmAt] DEFAULT CAST ('08:30:00' AS TIME (7)),
     [Amount]      DECIMAL (18, 4)  NULL
@@ -828,6 +825,9 @@ CREATE TABLE [dbo].[ScalarGallery] (
     [ExternalKey] UNIQUEIDENTIFIER NULL
         CONSTRAINT [DF_ScalarGallery_ExternalKey] DEFAULT '00000000-0000-0000-0000-000000000000',
     [FreeText]    NVARCHAR (50)    NULL,
+    [Id]          INT              IDENTITY (1, 1) NOT NULL
+        CONSTRAINT [PK_ScalarGallery_Id]
+            PRIMARY KEY CLUSTERED,
     [IsActive]    BIT              NOT NULL
         CONSTRAINT [DF_ScalarGallery_IsActive] DEFAULT 1,
     [Notes]       NVARCHAR (2000)  NULL
@@ -851,23 +851,23 @@ CREATE INDEX [IX_ScalarGallery_Code_1]
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Tally_1]
-    ON [dbo].[ScalarGallery]([Tally] DESC)
-
-GO
-
 CREATE INDEX [IX_ScalarGallery_Code_2]
     ON [dbo].[ScalarGallery]([Code])
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Tally_2]
-    ON [dbo].[ScalarGallery]([Tally]) WHERE ([Tally] IS NOT NULL)
+CREATE INDEX [IX_ScalarGallery_Code_3]
+    ON [dbo].[ScalarGallery]([Code])
 
 GO
 
-CREATE INDEX [IX_ScalarGallery_Code_3]
-    ON [dbo].[ScalarGallery]([Code])
+CREATE INDEX [IX_ScalarGallery_Tally_1]
+    ON [dbo].[ScalarGallery]([Tally] DESC)
+
+GO
+
+CREATE INDEX [IX_ScalarGallery_Tally_2]
+    ON [dbo].[ScalarGallery]([Tally]) WHERE ([Tally] IS NOT NULL)
 
 GO
 
@@ -912,24 +912,6 @@ EXECUTE [sys].[sp_addextendedproperty]
     @value = N'S9:GOLD_KIND1:113:ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -1056,6 +1038,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
     @level2type = N'COLUMN', @level2name = N'FreeText';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'ScalarGallery',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -1252,10 +1252,10 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [dbo].[TextFidelity] (
+    [Body] NVARCHAR (50) NULL,
     [Id]   INT           NOT NULL
         CONSTRAINT [PK_TextFidelity_Id]
-            PRIMARY KEY CLUSTERED,
-    [Body] NVARCHAR (50) NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -1278,24 +1278,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
@@ -1309,6 +1291,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
     @level2type = N'COLUMN', @level2name = N'Body';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'TextFidelity',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'TextFidelity',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -1382,10 +1382,10 @@ EXECUTE [sys].[sp_addextendedproperty]
 GO
 
 CREATE TABLE [dbo].[User] (
+    [Email] NVARCHAR (250) NOT NULL,
     [Id]    INT            IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_User_Id]
-            PRIMARY KEY CLUSTERED,
-    [Email] NVARCHAR (250) NOT NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -1416,24 +1416,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:17:User.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
@@ -1447,6 +1429,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
     @level2type = N'COLUMN', @level2name = N'Email';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:User.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'User',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/master/stream.sql
@@ -12,57 +12,73 @@ CREATE TABLE [dbo].[Assignment] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Assignment',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Assignment',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Assignment'
+    @level1type = N'TABLE', @level1name = N'Assignment';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:Assignment',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:Assignment',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Assignment'
+    @level1type = N'TABLE', @level1name = N'Assignment';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ProjectId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ProjectId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ProjectId'
+    @level2type = N'COLUMN', @level2name = N'ProjectId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Assignment.ProjectId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ProjectId'
+    @level2type = N'COLUMN', @level2name = N'ProjectId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ResourceId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ResourceId'
+    @level2type = N'COLUMN', @level2name = N'ResourceId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:Assignment.ResourceId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'ResourceId'
+    @level2type = N'COLUMN', @level2name = N'ResourceId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Role',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'Role'
+    @level2type = N'COLUMN', @level2name = N'Role';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:Assignment.Role',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Assignment',
-    @level2type = N'COLUMN', @level2name = N'Role'
+    @level2type = N'COLUMN', @level2name = N'Role';
 
 GO
 
@@ -78,57 +94,73 @@ CREATE TABLE [audit].[ChangeLog] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ChangeLog',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ChangeLog',
     @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog'
+    @level1type = N'TABLE', @level1name = N'ChangeLog';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:19:ChangeLog',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:19:ChangeLog',
     @level0type = N'SCHEMA', @level0name = N'audit',
-    @level1type = N'TABLE', @level1name = N'ChangeLog'
+    @level1type = N'TABLE', @level1name = N'ChangeLog';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.Id',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'At',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'At'
+    @level2type = N'COLUMN', @level2name = N'At';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:ChangeLog.At',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'At'
+    @level2type = N'COLUMN', @level2name = N'At';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UserId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'UserId'
+    @level2type = N'COLUMN', @level2name = N'UserId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ChangeLog.UserId',
     @level0type = N'SCHEMA', @level0name = N'audit',
     @level1type = N'TABLE', @level1name = N'ChangeLog',
-    @level2type = N'COLUMN', @level2name = N'UserId'
+    @level2type = N'COLUMN', @level2name = N'UserId';
 
 GO
 
@@ -142,57 +174,73 @@ CREATE TABLE [dbo].[Country] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Country',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Country',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country'
+    @level1type = N'TABLE', @level1name = N'Country';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:Country',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:Country',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Country'
+    @level1type = N'TABLE', @level1name = N'Country';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:Country.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:Country.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Country.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:Country.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Label',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Label'
+    @level2type = N'COLUMN', @level2name = N'Label';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Country.Label',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Country.Label',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Country',
-    @level2type = N'COLUMN', @level2name = N'Label'
+    @level2type = N'COLUMN', @level2name = N'Label';
 
 GO
 
@@ -205,43 +253,55 @@ CREATE TABLE [dbo].[Customer] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Customer',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Customer',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Customer'
+    @level1type = N'TABLE', @level1name = N'Customer';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:18:Customer',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:18:Customer',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Customer'
+    @level1type = N'TABLE', @level1name = N'Customer';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:111:Customer.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:111:Customer.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Customer.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Customer.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Customer',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
@@ -253,29 +313,37 @@ CREATE TABLE [dbo].[EnterpriseCustomerRelationshipManagementProfileSnapshot] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot'
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:EcrmSnapshot',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:EcrmSnapshot',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot'
+    @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:EcrmSnapshot.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'EnterpriseCustomerRelationshipManagementProfileSnapshot',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
@@ -320,113 +388,145 @@ CREATE UNIQUE INDEX [UIX_Engagement_CustomerId_Subject]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Engagement',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement'
+    @level1type = N'TABLE', @level1name = N'Engagement';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:Engagement',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:Engagement',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Engagement'
+    @level1type = N'TABLE', @level1name = N'Engagement';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Engagement.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AltCustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:124:Engagement.AltCustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'AltCustomerId'
+    @level2type = N'COLUMN', @level2name = N'AltCustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CreatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'CreatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+    @level2type = N'COLUMN', @level2name = N'CreatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Engagement.CreatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CreatedBy'
+    @level2type = N'COLUMN', @level2name = N'CreatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'CustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CustomerId'
+    @level2type = N'COLUMN', @level2name = N'CustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:Engagement.CustomerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'CustomerId'
+    @level2type = N'COLUMN', @level2name = N'CustomerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ParentId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ParentId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'ParentId'
+    @level2type = N'COLUMN', @level2name = N'ParentId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:Engagement.ParentId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'ParentId'
+    @level2type = N'COLUMN', @level2name = N'ParentId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Subject',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Subject'
+    @level2type = N'COLUMN', @level2name = N'Subject';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:Engagement.Subject',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'Subject'
+    @level2type = N'COLUMN', @level2name = N'Subject';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'UpdatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:Engagement.UpdatedBy',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Engagement',
-    @level2type = N'COLUMN', @level2name = N'UpdatedBy'
+    @level2type = N'COLUMN', @level2name = N'UpdatedBy';
 
 GO
 
@@ -437,43 +537,55 @@ CREATE TABLE [dbo].[Heap] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Heap',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Heap',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Heap'
+    @level1type = N'TABLE', @level1name = N'Heap';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:Heap',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:Heap',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Heap'
+    @level1type = N'TABLE', @level1name = N'Heap';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'LoggedAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'LoggedAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+    @level2type = N'COLUMN', @level2name = N'LoggedAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:Heap.LoggedAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'LoggedAt'
+    @level2type = N'COLUMN', @level2name = N'LoggedAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Message',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'Message'
+    @level2type = N'COLUMN', @level2name = N'Message';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:Heap.Message',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:Heap.Message',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Heap',
-    @level2type = N'COLUMN', @level2name = N'Message'
+    @level2type = N'COLUMN', @level2name = N'Message';
 
 GO
 
@@ -488,43 +600,55 @@ CREATE TABLE [dbo].[InterdepartmentalResourceAllocationAuthorizationLedger] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'InterdepartmentalResourceAllocationAuthorizationLedger',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'InterdepartmentalResourceAllocationAuthorizationLedger',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger'
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:16:Ledger',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:16:Ledger',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger'
+    @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:19:Ledger.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:Ledger.ManagerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'InterdepartmentalResourceAllocationAuthorizationLedger',
-    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId'
+    @level2type = N'COLUMN', @level2name = N'PrimaryResponsibleEnterpriseCustomerRelationshipManagerId';
 
 GO
 
@@ -538,57 +662,73 @@ CREATE TABLE [dbo].[RegionA] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'RegionA',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'RegionA',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionA'
+    @level1type = N'TABLE', @level1name = N'RegionA';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:RegionA',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:RegionA',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionA'
+    @level1type = N'TABLE', @level1name = N'RegionA';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:RegionA.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:RegionA.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:RegionA.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionA',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
@@ -602,57 +742,73 @@ CREATE TABLE [dbo].[RegionB] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'RegionB',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'RegionB',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionB'
+    @level1type = N'TABLE', @level1name = N'RegionB';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:17:RegionB',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:17:RegionB',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'RegionB'
+    @level1type = N'TABLE', @level1name = N'RegionB';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:RegionB.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:112:RegionB.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:RegionB.PartnerId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'RegionB',
-    @level2type = N'COLUMN', @level2name = N'PartnerId'
+    @level2type = N'COLUMN', @level2name = N'PartnerId';
 
 GO
 
@@ -735,210 +891,270 @@ ALTER INDEX [IX_ScalarGallery_Code_2]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'The scalar gallery: every primitive realization and every DEFAULT-able literal.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'The scalar gallery: every primitive realization and every DEFAULT-able literal.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ScalarGallery',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:113:ScalarGallery',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:113:ScalarGallery',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScalarGallery'
+    @level1type = N'TABLE', @level1name = N'ScalarGallery';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:116:ScalarGallery.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'AlarmAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+    @level2type = N'COLUMN', @level2name = N'AlarmAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.AlarmAt',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'AlarmAt'
+    @level2type = N'COLUMN', @level2name = N'AlarmAt';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Amount',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Amount'
+    @level2type = N'COLUMN', @level2name = N'Amount';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:120:ScalarGallery.Amount',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Amount'
+    @level2type = N'COLUMN', @level2name = N'Amount';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Workflow code; defaults to Pending.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Workflow code; defaults to Pending.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:ScalarGallery.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'DueDate',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'DueDate'
+    @level2type = N'COLUMN', @level2name = N'DueDate';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.DueDate',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'DueDate'
+    @level2type = N'COLUMN', @level2name = N'DueDate';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ExternalKey',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+    @level2type = N'COLUMN', @level2name = N'ExternalKey';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:125:ScalarGallery.ExternalKey',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'ExternalKey'
+    @level2type = N'COLUMN', @level2name = N'ExternalKey';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'No default; the contrast column.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'No default; the contrast column.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'FreeText',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'FreeText',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:122:ScalarGallery.FreeText',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'FreeText'
+    @level2type = N'COLUMN', @level2name = N'FreeText';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'IsActive',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'IsActive'
+    @level2type = N'COLUMN', @level2name = N'IsActive';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:122:ScalarGallery.IsActive',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'IsActive'
+    @level2type = N'COLUMN', @level2name = N'IsActive';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Notes',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Notes',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Notes'
+    @level2type = N'COLUMN', @level2name = N'Notes';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Notes',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Notes'
+    @level2type = N'COLUMN', @level2name = N'Notes';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'OccurredOn',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+    @level2type = N'COLUMN', @level2name = N'OccurredOn';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:124:ScalarGallery.OccurredOn',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'OccurredOn'
+    @level2type = N'COLUMN', @level2name = N'OccurredOn';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Payload',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Payload',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Payload'
+    @level2type = N'COLUMN', @level2name = N'Payload';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScalarGallery.Payload',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Payload'
+    @level2type = N'COLUMN', @level2name = N'Payload';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tally',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Tally'
+    @level2type = N'COLUMN', @level2name = N'Tally';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:119:ScalarGallery.Tally',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'COLUMN', @level2name = N'Tally'
+    @level2type = N'COLUMN', @level2name = N'Tally';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Descending scan support.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Descending scan support.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScalarGallery',
-    @level2type = N'INDEX', @level2name = N'IX_ScalarGallery_Tally_1'
+    @level2type = N'INDEX', @level2name = N'IX_ScalarGallery_Tally_1';
 
 GO
 
@@ -965,57 +1181,73 @@ CREATE TABLE [dbo].[ScopedLookup] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'ScopedLookup',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'ScopedLookup',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScopedLookup'
+    @level1type = N'TABLE', @level1name = N'ScopedLookup';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:ScopedLookup',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:ScopedLookup',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'ScopedLookup'
+    @level1type = N'TABLE', @level1name = N'ScopedLookup';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:ScopedLookup.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TenantId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'TenantId'
+    @level2type = N'COLUMN', @level2name = N'TenantId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:121:ScopedLookup.TenantId',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'TenantId'
+    @level2type = N'COLUMN', @level2name = N'TenantId';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Value',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Value'
+    @level2type = N'COLUMN', @level2name = N'Value';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:118:ScopedLookup.Value',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'ScopedLookup',
-    @level2type = N'COLUMN', @level2name = N'Value'
+    @level2type = N'COLUMN', @level2name = N'Value';
 
 GO
 
@@ -1028,43 +1260,55 @@ CREATE TABLE [dbo].[TextFidelity] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'TextFidelity',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'TextFidelity',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity'
+    @level1type = N'TABLE', @level1name = N'TextFidelity';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:112:TextFidelity',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:112:TextFidelity',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'TextFidelity'
+    @level1type = N'TABLE', @level1name = N'TextFidelity';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:TextFidelity.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Body',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Body'
+    @level2type = N'COLUMN', @level2name = N'Body';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:117:TextFidelity.Body',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:117:TextFidelity.Body',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'TextFidelity',
-    @level2type = N'COLUMN', @level2name = N'Body'
+    @level2type = N'COLUMN', @level2name = N'Body';
 
 GO
 
@@ -1077,49 +1321,63 @@ CREATE TABLE [dbo].[Tier] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Static lookup with an IDENTITY PK — the IDENTITY_INSERT bracket case.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Static lookup with an IDENTITY PK — the IDENTITY_INSERT bracket case.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Tier',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Tier',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:Tier',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:Tier',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'Tier'
+    @level1type = N'TABLE', @level1name = N'Tier';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:Tier.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:Tier.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:19:Tier.Name',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:19:Tier.Name',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'Tier',
-    @level2type = N'COLUMN', @level2name = N'Name'
+    @level2type = N'COLUMN', @level2name = N'Name';
 
 GO
 
@@ -1132,49 +1390,63 @@ CREATE TABLE [dbo].[User] (
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'The platform user kind (pure reference target).',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'The platform user kind (pure reference target).',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'User',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'User',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:14:User',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:14:User',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'User'
+    @level1type = N'TABLE', @level1name = N'User';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:17:User.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:17:User.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Email',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Email'
+    @level2type = N'COLUMN', @level2name = N'Email';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:110:User.Email',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:110:User.Email',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'User',
-    @level2type = N'COLUMN', @level2name = N'Email'
+    @level2type = N'COLUMN', @level2name = N'Email';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [dbo].[PruneProbe] (
+    [Code] NVARCHAR (20) NOT NULL,
     [Id]   INT           IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_PruneProbe_Id]
-            PRIMARY KEY CLUSTERED,
-    [Code] NVARCHAR (20) NOT NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -38,24 +38,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
@@ -69,4 +51,22 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
     @level2type = N'COLUMN', @level2name = N'Code';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/Modules/PruneForms/dbo.PruneProbe.sql
@@ -12,47 +12,61 @@ CREATE INDEX [IX_PruneProbe_Code]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Prune one-off probe: a platform-auto index beside a normal one.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Prune one-off probe: a platform-auto index beside a normal one.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PruneProbe',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PruneProbe',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:PruneProbe',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:PruneProbe',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
@@ -1,8 +1,8 @@
 CREATE TABLE [dbo].[PruneProbe] (
+    [Code] NVARCHAR (20) NOT NULL,
     [Id]   INT           IDENTITY (1, 1) NOT NULL
         CONSTRAINT [PK_PruneProbe_Id]
-            PRIMARY KEY CLUSTERED,
-    [Code] NVARCHAR (20) NOT NULL
+            PRIMARY KEY CLUSTERED
 )
 
 GO
@@ -38,24 +38,6 @@ GO
 
 EXECUTE [sys].[sp_addextendedproperty]
     @name = N'Projection.LogicalName',
-    @value = N'Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.SsKey',
-    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
-    @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id';
-
-GO
-
-EXECUTE [sys].[sp_addextendedproperty]
-    @name = N'Projection.LogicalName',
     @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
@@ -69,6 +51,24 @@ EXECUTE [sys].[sp_addextendedproperty]
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
     @level2type = N'COLUMN', @level2name = N'Code';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id';
+
+GO
+
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+    @level0type = N'SCHEMA', @level0name = N'dbo',
+    @level1type = N'TABLE', @level1name = N'PruneProbe',
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
+++ b/sidecar/projection/tests/Projection.Tests/Golden/pruned-platform-auto/stream.sql
@@ -12,49 +12,63 @@ CREATE INDEX [IX_PruneProbe_Code]
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'MS_Description', @value = N'Prune one-off probe: a platform-auto index beside a normal one.',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'MS_Description',
+    @value = N'Prune one-off probe: a platform-auto index beside a normal one.',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'PruneProbe',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'PruneProbe',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_KIND1:110:PruneProbe',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_KIND1:110:PruneProbe',
     @level0type = N'SCHEMA', @level0name = N'dbo',
-    @level1type = N'TABLE', @level1name = N'PruneProbe'
+    @level1type = N'TABLE', @level1name = N'PruneProbe';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:113:PruneProbe.Id',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Id'
+    @level2type = N'COLUMN', @level2name = N'Id';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.LogicalName', @value = N'Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.LogicalName',
+    @value = N'Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 
-EXECUTE [sys].[sp_addextendedproperty] @name = N'Projection.SsKey', @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
+EXECUTE [sys].[sp_addextendedproperty]
+    @name = N'Projection.SsKey',
+    @value = N'S9:GOLD_ATTR1:115:PruneProbe.Code',
     @level0type = N'SCHEMA', @level0name = N'dbo',
     @level1type = N'TABLE', @level1name = N'PruneProbe',
-    @level2type = N'COLUMN', @level2name = N'Code'
+    @level2type = N'COLUMN', @level2name = N'Code';
 
 GO
 

--- a/sidecar/projection/tests/Projection.Tests/MetadataExtractionSqlTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MetadataExtractionSqlTests.fs
@@ -1,47 +1,17 @@
 module Projection.Tests.MetadataExtractionSqlTests
 
-open System.IO
 open Xunit
 open Projection.Adapters.OssysSql
 
 // ---------------------------------------------------------------------------
-// Chapter 5.0 slice α — V1's `outsystems_metadata_rowsets.sql` carbon-
-// copied into V2 as an embedded resource. Verifies the carbon-copy
-// invariant: V2's embedded resource bytes are byte-identical to V1's
-// source file. Per `DECISIONS 2026-05-16 (later)`: V2 is self-contained;
-// V1 is editorial donor only. The SQL is the truth; V2 inherits it
-// verbatim.
-//
-// The parity test depends on V1's trunk being checked out at the
-// expected sibling path. In environments where V1 is absent (V2-only
-// branches), the parity test gates on file presence and skips with a
-// Skip-named reason.
+// Chapter 5.0 slice α — V2's `outsystems_metadata_rowsets.sql` embedded
+// resource. Originally carbon-copied from V1's donor (`DECISIONS 2026-05-16
+// (later)`: V2 is self-contained; V1 is editorial donor only), V2's extraction
+// SQL is now maintained INDEPENDENTLY and no longer tracks V1's
+// `src/AdvancedSql/` copy. These tests pin V2's resource shape directly
+// (parameters, header sentinel); the V1-comparison fork/line-count pins were
+// retired 2026-07-21.
 // ---------------------------------------------------------------------------
-
-let private v1SourcePath : string =
-    // V2 lives at sidecar/projection/...; V1's source is at the repo root
-    // under src/AdvancedSql/. The test resolves the path relative to the
-    // running test assembly (which lives at tests/Projection.Tests/bin/...).
-    let assemblyLoc = System.Reflection.Assembly.GetExecutingAssembly().Location
-    let assemblyDir =
-        match Path.GetDirectoryName(assemblyLoc) with
-        | null -> "."
-        | d -> d
-    // Walk up to the repo root (tests/Projection.Tests/bin/Debug/net9.0 → 5 levels).
-    let repoRoot =
-        Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", "..", "..", "..", "..", ".."))
-    Path.Combine(repoRoot, "src", "AdvancedSql", "outsystems_metadata_rowsets.sql")
-
-[<Fact>]
-let ``Slice α: embedded SQL resource loads with expected line count`` () =
-    let sql = MetadataExtractionSql.read()
-    // V2's copy FORKED from V1's 1253-line donor on 2026-07-18 (#669
-    // EF-21; DECISIONS — the PERSISTED carriage appended to
-    // #ColumnReality). The carbon-copy era's invariant is retired; the
-    // fork is pinned by the divergence test below.
-    let lineCount = sql.Split('\n').Length
-    // Be tolerant of trailing-newline variations.
-    Assert.InRange(lineCount, 1299, 1301)
 
 [<Fact>]
 let ``Slice α: embedded SQL declares the five expected parameters`` () =
@@ -59,31 +29,6 @@ let ``Slice α: embedded SQL declares the five expected parameters`` () =
 let ``Slice α: embedded SQL contains the goal-header sentinel comment`` () =
     let sql = MetadataExtractionSql.read()
     Assert.Contains("OutSystems → JSON (Two-phase, CTE-free)", sql)
-
-[<Fact>]
-let ``Slice α: V2's extraction FORKED from V1's on the PERSISTED carriage — the divergence is exactly the named extension`` () =
-    // The carbon-copy invariant is RETIRED (DECISIONS 2026-07-18; #669
-    // EF-21): V2's extraction evolves. The pin flips from byte-identity
-    // to the NAMED fork — V2 carries the appended `IsPersisted` column;
-    // V1's donor does not. A future V2-side extension extends this pin;
-    // an unnamed drift still fails it.
-    let v2Sql = MetadataExtractionSql.read()
-    Assert.Contains("IsPersisted", v2Sql)
-    if File.Exists v1SourcePath then
-        let v1Sql = File.ReadAllText v1SourcePath
-        Assert.DoesNotContain("IsPersisted", v1Sql)
-        // Stripping the extension's lines recovers the shared spine: every
-        // V1 line still appears in V2 (line-set containment, normalized
-        // for the trailing-comma continuation an appended column adds to
-        // its predecessor — the fork is append-only).
-        let normalize (s: string) = s.TrimEnd().TrimEnd(',')
-        let v1Lines = v1Sql.Split('\n') |> Array.map normalize |> Set.ofArray
-        let v2Lines = v2Sql.Split('\n') |> Array.map normalize |> Set.ofArray
-        let missing = Set.difference v1Lines v2Lines
-        Assert.True(
-            Set.isEmpty missing,
-            sprintf "V1 lines absent from V2's fork (the fork must stay append-only): %A"
-                (missing |> Set.toList |> List.truncate 5))
 
 // ---------------------------------------------------------------------------
 // Slice β — V1 OSSYS bootstrap fixture (`tests/Fixtures/sql/model.edge-case

--- a/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/OssysExtractionCanaryTests.fs
@@ -135,9 +135,10 @@ let ``WP8/NM-72 canary: Customer attributes extract in authored Order_Num order,
     // The seed gives Customer a Service-Studio order (Order_Num) that is
     // DELIBERATELY different from alphabetical: Id(PK,1), LegacyCode(10),
     // FirstName(20), LastName(30), Email(40), CityId(50). The extraction
-    // ORDER BY is (PK-first, Order_Num, AttrName) and CanonicalizeIdentity
-    // re-derives the same key, so the emitted column order honors the
-    // operator's authored order — proving NM-72 closed end-to-end.
+    // ORDER BY is (Order_Num, AttrId) and CanonicalizeIdentity re-derives
+    // the same key (2026-07-21: PK-first retired), so the emitted column
+    // order honors the operator's authored order — Id leads on its own
+    // Order_Num=1, not by a PK-first rule — proving NM-72 closed end-to-end.
     if skipIfNoDocker "ossys-canary-order-num" then
         let result = TaskSync.run extractFromSeed
         match result with
@@ -156,7 +157,7 @@ let ``WP8/NM-72 canary: Customer attributes extract in authored Order_Num order,
                 |> List.find (fun k -> Name.value k.Name = "Customer")
             let authored =
                 customer.Attributes |> List.map (fun a -> Name.value a.Name)
-            // Authored (PK first, then Order_Num ascending):
+            // Authored (Order_Num ascending; Id leads on its own Order_Num=1):
             let expectedAuthored =
                 [ "Id"; "LegacyCode"; "FirstName"; "LastName"; "Email"; "CityId" ]
             Assert.Equal<string list>(expectedAuthored, authored)

--- a/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlLiteralTests.fs
@@ -320,6 +320,25 @@ let ``ofAuthoredDefault: a SQL-quoted text form carries the value inside the quo
     Assert.Equal<SqlLiteral option> (Some (TextLit "it's"),  SqlLiteral.ofAuthoredDefault Text "'it''s'")
 
 [<Fact>]
+let ``ofAuthoredDefault: an OutSystems double-quoted text form carries the value inside the quotes`` () =
+    // Service Studio stores authored text defaults as expression-language
+    // string literals (double-quoted). Lifted verbatim they rendered
+    // N'"outsystems"' (the outer quotes included); classified, they are the
+    // VALUE inside the quotes — V1's 'outsystems' / '*' semantics.
+    Assert.Equal<SqlLiteral option> (Some (TextLit "outsystems"), SqlLiteral.ofAuthoredDefault Text "\"outsystems\"")
+    Assert.Equal<SqlLiteral option> (Some (TextLit "*"),          SqlLiteral.ofAuthoredDefault Text "\"*\"")
+    // The rendered literal now carries the bare value (N-prefixed unicode).
+    Assert.Equal<string> ("N'outsystems'", SqlLiteral.toString (TextLit "outsystems"))
+
+[<Fact>]
+let ``ofAuthoredDefault: the double-quoted form undoes the doubled-quote escape and the empty form`` () =
+    // OutSystems escapes an embedded double-quote by doubling it (""); the
+    // unwrap undoes that, mirroring the single-quote form's '' handling.
+    Assert.Equal<SqlLiteral option> (Some (TextLit "say \"hi\""), SqlLiteral.ofAuthoredDefault Text "\"say \"\"hi\"\"\"")
+    // An empty double-quoted string is the empty VALUE, like ''.
+    Assert.Equal<SqlLiteral option> (Some (TextLit ""),           SqlLiteral.ofAuthoredDefault Text "\"\"")
+
+[<Fact>]
 let ``ofAuthoredDefault: an absent or whitespace-only raw carries nothing`` () =
     Assert.Equal<SqlLiteral option> (None, SqlLiteral.ofAuthoredDefault Text "")
     Assert.Equal<SqlLiteral option> (None, SqlLiteral.ofAuthoredDefault DateTime "   ")

--- a/sidecar/projection/tests/Projection.Tests/TighteningBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TighteningBindingTests.fs
@@ -186,6 +186,33 @@ let ``A6 amendment: a budget-less nullability entry binds RELAXATION-ONLY with i
     | Error es -> failwithf "expected Ok, got %A" es
 
 [<Fact>]
+let ``A6 amendment: a nullability entry naming BOTH a budget and a keepNullable override binds relaxation-only with the override resolved (2026-07-21)`` () =
+    // The budget-alongside-overrides fix: previously an entry carrying a
+    // nullBudget was dropped WHOLESALE, so a keepNullable override sitting
+    // beside it was expressible-but-inert (the A44 gap). Now the coercion
+    // alone is dropped; the entry binds RelaxationOnly and its override
+    // reaches emission. Only a PURE-coercion entry (budget, no overrides)
+    // still filters out.
+    let catalog = loadCatalog ()
+    let entry =
+        { emptyEntry "nullability" "budget-and-override" with
+            NullBudget = Some 0.05m
+            NullabilityOverrides = [ { AttributeRef = "AppCore.User.MiddleName"; Action = "keepNullable" } ] }
+    match TighteningBinding.fromConfig catalog (Some { Interventions = [ entry ] }) with
+    | Ok policy ->
+        match policy.Interventions with
+        | [ TighteningIntervention.Nullability (id, config) ] ->
+            Assert.Equal("budget-and-override", id)
+            Assert.Equal(TighteningDirection.RelaxationOnly, config.Direction)
+            match config.Overrides with
+            | [ o ] ->
+                Assert.Equal(OverrideAction.KeepNullable, o.Action)
+                Assert.True(NullabilityTighteningConfig.shouldKeepNullable o.AttributeKey config)
+            | other -> failwithf "expected the override to bind despite the budget, got %A" other
+        | other -> failwithf "expected one relaxation-only Nullability intervention, got %A" other
+    | Error es -> failwithf "expected Ok, got %A" es
+
+[<Fact>]
 let ``A6 amendment: the physical Schema.Table.Column form resolves a keepNullable override too`` () =
     let catalog = loadCatalog ()
     let entry =


### PR DESCRIPTION
## Summary

Six fixes to the v2 `sidecar/projection` engine, from a V1↔V2 emitted-schema parity review. Each is a separate, self-contained commit. They close authored-default and nullability-override correctness gaps, polish the extended-property house style, restore V1 attribute/index display ordering, and let resolvable logical FKs emit `WITH NOCHECK` under the operator's opt-in instead of being dropped.

> **Note on the repo PR template.** The only template (`.github/PULL_REQUEST_TEMPLATE/schema-change.md`) is a named, opt-in template scoped to `.sqlproj`/database-deployment changes (data remediation, deployment evidence, rollback). This is an engine-code change to no `.sqlproj`, so that layout doesn't apply; body written normally.

## The fixes

**1. `SqlLiteral`: unwrap OutSystems double-quoted authored defaults** (`eef886f`)
OSSYS authored text defaults are Service Studio expression-language string literals — double-quoted (`"outsystems"`, `"*"`). `ofAuthoredDefault` only handled the SQL single-quoted form, so double-quoted defaults rendered `N'"outsystems"'` (quotes included) instead of the value. Now recognized and unwrapped (undoing the doubled-`"` escape), mirroring the `''` handling. Sibling of the #669 M-1 finding.

**2. `TighteningBinding`: bind `keepNullable` overrides even when a `nullBudget` is present** (`1518944`)
A `nullability` entry naming a `nullBudget` was dropped wholesale, so a `keepNullable` override in the same entry was expressible-but-inert (the A44 gap). The drop is now scoped to the coercion alone: an entry with overrides binds relaxation-only regardless of a budget; pure-coercion entries still drop, so V1-style budget-only configs are unchanged.

**3. `ConstraintFormatter`: polished house style for `sp_addextendedproperty`** (`91a5e60`)
Keeps the typed ScriptDom builder; reshapes only the post-format: `EXECUTE [sys].[sp_addextendedproperty]` alone on line 1, `@name`/`@value` each on their own continuation line, each `@levelN` pair on one line, trailing semicolon — stable across schema/table/column/index targets. 18 golden files re-recorded (layout only).

**4. Emission order: retire the PK-first attribute reorder; sort indexes/xprops by emitted name** (`6bbe3a2`)
- *Attributes* now emit in authored `Order_Num` order (then SsKey), never PK-first — matching V1. `CanonicalizeIdentity.attributeSortKey` drops the PK rank (pass version 2→3); the two extraction-SQL `ORDER BY` clauses drop the PK-first `CASE` and tiebreak on `AttrId`. The PK constraint names its columns regardless of body position, so nothing structural depended on PK-first.
- *Indexes*, their `ALTER … DISABLE`, and their extended-property owners now sort by the emitted index name (case-insensitive, SsKey tiebreak); the collision-dedup ordinal stays SsKey-based. Column extended properties already followed column order.
- V2's extraction SQL is now maintained independently of V1's `src/AdvancedSql/` copy; the obsolete V1-comparison test pins are retired. 10 golden files re-recorded (pure reordering).

**5. `ForeignKey`: create resolvable logical FKs `WITH NOCHECK` on missing evidence under `AllowNoCheckCreation`** (`e63e744`)
Resolvable logical FKs (target present, no source-backed constraint) were dropped when an FK intervention was registered and no reliable orphan probe existed. Now, with `AllowNoCheckCreation` opted in, missing/unreliable evidence decides `EnforceConstraint(NoCheckWithoutEvidence)` — the FK emits `WITH NOCHECK` (new rows enforced, existing rows unvalidated) rather than dropped. Without the opt-in the strict default is unchanged; the cross-schema gate still applies. A dedicated evidence variant + a named `tightening.foreignKey.noCheckWithoutEvidence` Warning surface the accepted divergence in the export report. `ForeignKeyPass.version` 3→4.

Each behavior/standing-law change carries a `DECISIONS.md` note; golden re-records follow the blessing protocol.

## Testing

- Full pure pool green except one **pre-existing** failure: `BtReferenceFkFlowTests.bt-resolved reference emits a FOREIGN KEY referencing the target table` fails with `ComputedExpressionRefused ("Product", "DisplayLabel", "nvarchar")` — verified to fail identically at the pre-work base commit `7aad250` (the audit's open M-8/EF-19 computed-column item), unrelated to these changes.
- Docker OSSYS extraction canary (warm container) confirms the new live-lane attribute ordering.
- New/updated unit tests: double-quoted authored defaults; budget+override binding; the new (authored-order, SsKey) ordering contract (incl. a witness that a non-minimal-SsKey PK no longer floats to the front); the `NoCheckWithoutEvidence` decision, its NOCHECK emission, and the cross-schema-gate-still-applies case.

## Not addressed here

The composite-PK FK truncation blocker (audit B-3/EF-17) is unchanged; enabling `AllowNoCheckCreation` on a real estate should be preceded by inventorying FKs that target composite-PK tables (noted in the Fix-5 DECISIONS entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHLNb52Hu78GCAegneUrra)_