### PR TITLE
Approved inline data corrections: publish applies operator-approved row corrections in flight

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30341,3 +30341,97 @@ before turning `AllowNoCheckCreation` on for a real estate; that blocker is trac
 (`GoldenEmissionTests.ejectFkIntervention`), so this change is byte-invisible to the goldens; the
 source-backed carve-out (`DatabaseConstraintPresent`), the orphan-observed `ScriptWithNoCheck`
 path, and the relaxation-only/override directions are all untouched.
+
+## 2026-07-23 — Approved inline data corrections: publish APPLIES operator-approved row corrections in flight (estate proposes · emission approves · publish applies)
+
+**The posture change (amends the estate chapter's 2026-07-15 non-goal).** The estate chapter
+opened (`CHAPTER_ESTATE_OPEN.md` §3) with "No gated remediation executor: the mode emits
+artifacts; execution stays with revert / transfer / migrate under `--go` +
+`PROJECTION_ALLOW_EXECUTE`." That non-goal governed the ESTATE verb. This decision adds a
+distinct, adjacent capability on the PUBLISH verb: `publish` may apply operator-approved inline
+data corrections to acquired row data *in flight*, before the data composers / load plan see it.
+This is NOT a source-database mutation and NOT a gated executor — the source is never written; the
+correction engine transforms the `Map<SsKey, StaticRow list>` the publish already holds, so the
+emitted bundle, the live seed load, the transfer load, the profile-derived evidence, and the
+row-fidelity proof all see the SAME corrected data. The invariant:
+`emitted_or_loaded_rows = apply(receipts, acquired_source_rows)`.
+
+**The three-surface workflow.** *estate proves and proposes · emission approves · publish applies.*
+The proof/proposal side (`readiness.estate.remediations`, and `check estate` emitting proposed
+`emission.dataCorrections` blocks) is DEFERRED — the `policy.tightening` propose→consume loop
+already exists end-to-end (`EstateOverlayEmitter` emits `$.policy.tightening.interventions[+]`;
+`buildPolicyFromConfig` consumes it), so business requirement 3 (relationship posture exception)
+is served today by the existing tightening/overlay surface, NOT by data corrections. This slice
+builds the approve+apply half: `publish` consumes a hand-authored `emission.dataCorrections`.
+
+**Config split.** `emission.dataCorrections : ApprovedDataCorrection list` (default `[]`,
+byte-identical) parsed FAIL-CLOSED in `Config.parseEmission` — an unknown derivation kind / guard
+token / predicate op is a named config error, never a silent drop. Not part of `renderConfig`'s
+A44 surface (emission is not rendered), so parse-only.
+
+**The signoff gate.** A non-empty `emission.dataCorrections` REQUIRES the new
+`WriteSignoff.WriteMode.DataCorrection` (label `data-correction`) in `emission.signoff`;
+`buildPolicyFromConfig` refuses `emission.dataCorrection.ungreenlit` otherwise — the emission-plane
+counterpart of the `delete-scope` gate. Inline data mutation stays auditable.
+
+**Type reuse over new types (operator decision 2026-07-23).** The design named new
+`LogicalAttributeRef` and `RowPredicate` types; both already existed in near-identical form.
+`Subject` / source / parent / evidence refs REUSE `AttributeCoordinate`
+(`SyntheticCorrection.fs`, with its `resolveFull` named-refusal resolver). The row predicate
+REUSES `SliceSpec.Predicate`, EXTENDED with tri-state `IsNull` / `IsNotNull` arms (over
+`StaticRow.value`, preserving `NULL ≠ ''` — survival rule #14 / finding D1×D5) — the existing
+`Equals`/`In` fold NULL and `''` via `valueOrEmpty` and cannot express the NULL tests every
+correction predicate needs. The extend rippled cleanly into the three `Predicate` consumers
+(`SliceSpec.eval`, `SliceCodec`, `ClosureOracle`).
+
+**The pure engine (Core placement).** `ApprovedDataCorrections.fs` (Core, after `SliceSpec.fs`) is
+pure: `apply : Catalog -> ApprovedDataCorrection list -> Map<SsKey,StaticRow list> ->
+Result<CorrectionOutcome>`. Placed in Core (not Pipeline as the design suggested) because the
+engine is pure, `Episode` must carry `DataCorrectionReceipt` (so the durable value vocabulary —
+derivation / guard / guard-result / receipt — lives in `DataCorrectionReceipt.fs`, compiled
+BEFORE `Episode.fs`), and this avoids the "mirror the receipt in Core" duplication. Four
+derivations (same-row / parent / constant / exclude); row-selector guards narrow the change set,
+whole-set assertion guards fail-close. Every refusal is named. Registered as first-class pillar-9
+metadata (`Domain.Data`, `StageBinding.Pipeline`, one `OperatorIntent Insertion` + two `DataIntent`
+sites) in `RegisteredAllTransforms.all` — not hidden inside the emitters.
+
+**Pipelined path: the NAMED two-phase fallback.** The pipelined publish schedule drains and drops
+rows per-kind and never materializes a cross-kind map, so the correction engine (parent joins,
+reference key sets) needs the whole map in hand. `pipelinedPublishGate` therefore falls back to the
+two-phase schedule whenever `emission.dataCorrections` is non-empty — the emitted bundle is
+identical either way (the pipelined toggle is a schedule choice), and the fallback is explicit in
+the gate, not silent. Corrected static-lane populations are re-grafted onto the catalog; the
+bootstrap map keeps only its original keys, so a corrected static kind is not emitted by both lanes
+(T11 keyset agreement preserved).
+
+**Receipts as a first-class intervention ledger.** `apply` returns count-bearing
+`DataCorrectionReceipt`s (rows matched / changed / excluded, guard results, before/after SHA-256
+digest, approval metadata). They thread onto `Episode.DataCorrectionReceipts` (default `[]`,
+preserved by `durableProjection`, serialized forward-compatibly in `LifecycleStore` exactly like
+`tolerances` / `appliedTransforms`), so a load record explains precisely why target rows differ
+from the raw source — no split-brain proof. Receipts are NOT tolerances: a `ToleratedDivergence`
+is a passive, symmetric representation-equivalence; a correction is an active, asymmetric row
+change with provenance.
+
+**Row-fidelity extension (this slice's bounded half + the deferred streaming half).** The proof
+law becomes `target_rows == replay(receipts, transfer_journal, source_rows)`, not
+`target_rows == raw_source_rows`. `RowFidelityReport` carries the correction-receipt ledger and
+surfaces it in the JSON artifact + text render, so a green proof NAMES its approved corrections as
+noted exceptions rather than claiming raw byte-identity. The load-bearing count-reconciliation law
+`ApprovedDataCorrections.reconcile` (a receipt claiming N changed rows that replays to a different
+N fails the proof BY NAME) is pure and unit-tested. The comparator's SOURCE stream replays the
+corrections for corrected kinds — engine-reuse: `FidelityCompareRun` buffers the subject kinds +
+their declared dependency kinds (referenced entity / parent) from the source, runs the SAME publish
+engine (`ApprovedDataCorrections.apply`), and substitutes the corrected rows, so replayed change
+counts match the recorded receipts exactly (no per-quantum reimplementation that could diverge on
+whole-set guards). Corrections thread parser → `CheckFidelityFlowArgs.Corrections` → the fidelity
+face → `run` → `runWith`. Docker-validated (`FidelityRowsDockerTests`): the raw source reds against
+a corrected target, the replayed correction greens it, a tampered recorded receipt count reds the
+proof by name. Also fixed a shared-predicate false positive the same subsystem uncovered:
+`Kind.unresolvedComputedIdentifiers` counted SQL Server's bracketed CAST/CONVERT type name
+(`CONVERT([nvarchar](20), [Price])`) as an unresolved column, falsely refusing a legitimate
+computed column at publish — it now excludes SQL type keywords.
+
+**Non-negotiable semantics (all tested).** Default config with no corrections is byte-identical.
+Corrections fail closed on: unknown subject, unresolved source/parent/sentinel, guard count
+mismatch, absent sentinel, retained inbound reference, missing `data-correction` signoff.

--- a/sidecar/projection/src/Projection.Adapters.Sql/ClosureOracle.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ClosureOracle.fs
@@ -85,6 +85,10 @@ module ClosureOracle =
                 else
                     let names = vs |> List.map (fun v -> let nm = nextName () in pars.Add(nm, v); nm)
                     System.String.Concat(physicalOf kind c, " IN (", String.concat ", " names, ")")  // LINT-ALLOW: terminal SQL-text boundary; column encoded, values parameterized
+            | Predicate.IsNull c ->
+                System.String.Concat(physicalOf kind c, " IS NULL")  // LINT-ALLOW: terminal SQL-text boundary; column encoded, no value
+            | Predicate.IsNotNull c ->
+                System.String.Concat(physicalOf kind c, " IS NOT NULL")  // LINT-ALLOW: terminal SQL-text boundary; column encoded, no value
             | Predicate.And ps ->
                 if List.isEmpty ps then "1 = 1"  // LINT-ALLOW: terminal SQL-text boundary; constant-true predicate
                 else

--- a/sidecar/projection/src/Projection.Cli/Faces/Fidelity.fs
+++ b/sidecar/projection/src/Projection.Cli/Faces/Fidelity.fs
@@ -36,7 +36,7 @@ let runCheckDataRows (args: CheckDataRowsArgs) : int =
                 args.BeforeLabel args.BeforeConn
                 args.AfterLabel args.AfterConn
                 args.ModelRef model
-                args.Kind args.Module args.SampleCap args.Interventions).GetAwaiter().GetResult()
+                args.Kind args.Module args.SampleCap args.Interventions args.Corrections []).GetAwaiter().GetResult()
         match outcome with
         | Error errs ->
             printErrors Console.Error errs
@@ -291,7 +291,7 @@ let runCheckFidelityFlow (model: Catalog) (args: CheckFidelityFlowArgs) : int =
                             args.FromLabel args.SourceConn
                             (sprintf "%s stand-in" args.Flow) scratchConn
                             "the authored model" model
-                            None None args.SampleCap journalForCompare
+                            None None args.SampleCap journalForCompare args.Corrections []
                     return proof |> Result.map (fun report -> outcome, report)
             })
       match (work ()).GetAwaiter().GetResult() with

--- a/sidecar/projection/src/Projection.Core/ApprovedDataCorrections.fs
+++ b/sidecar/projection/src/Projection.Core/ApprovedDataCorrections.fs
@@ -1,0 +1,450 @@
+namespace Projection.Core
+
+/// The **config-authored + pure engine** half of approved inline data
+/// corrections. The durable value vocabulary (derivation / guard / receipt) sits
+/// earlier (`DataCorrectionReceipt.fs`, ahead of `Episode.fs`); this module sits
+/// after `SliceSpec.fs` because a correction gates row membership on a NULL-aware
+/// `Predicate`, and derives values by resolving `AttributeCoordinate`s against
+/// the catalog.
+///
+/// The engine is PURE: `apply` takes the acquired rows (`Map<SsKey, StaticRow
+/// list>`), the catalog (for subject/relationship resolution and reference key
+/// sets), and the approved corrections, and returns the corrected rows plus
+/// count-bearing receipts — or a NAMED refusal. It builds no SQL. The Pipeline
+/// injects the corrected rows before the data composers / load plan see them
+/// (`emitted_or_loaded_rows = apply(receipts, acquired_source_rows)`), and threads
+/// the receipts onto the episode + row-fidelity proof.
+///
+/// Every correction is FAIL-CLOSED: an unresolved subject/source/parent/sentinel,
+/// a finding-count mismatch, an incomplete coverage, an extra reference match —
+/// each is a refusal that names itself, never a silent skip. A default config
+/// with no corrections leaves the rows byte-identical.
+
+/// A configured derivation with the inputs it needs to transform rows. The bare
+/// `DataCorrectionDerivation` (the classification axis on receipts) is projected
+/// from this by `toBare`.
+[<RequireQualifiedAccess>]
+type DataCorrectionDerivationSpec =
+    /// Copy the source attribute's cell into the subject cell (same row).
+    | SameRowAttribute of source: AttributeCoordinate
+    /// Copy a parent row's attribute into the subject cell, joined through the
+    /// named relationship on the subject's kind (the one cross-kind derivation).
+    | ParentAttribute of relationship: string * parentSource: AttributeCoordinate
+    /// Set the subject cell to a typed configured literal (sentinel user id,
+    /// migration instant, any constant).
+    | ConstantLiteral of value: string
+    /// Remove matching rows from the emitted/loaded row set.
+    | ExcludeRows
+
+[<RequireQualifiedAccess>]
+module DataCorrectionDerivationSpec =
+
+    let toBare (spec: DataCorrectionDerivationSpec) : DataCorrectionDerivation =
+        match spec with
+        | DataCorrectionDerivationSpec.SameRowAttribute _ -> DataCorrectionDerivation.SameRowAttribute
+        | DataCorrectionDerivationSpec.ParentAttribute _  -> DataCorrectionDerivation.ParentAttribute
+        | DataCorrectionDerivationSpec.ConstantLiteral _  -> DataCorrectionDerivation.ConstantLiteral
+        | DataCorrectionDerivationSpec.ExcludeRows        -> DataCorrectionDerivation.ExcludeRows
+
+    /// Whether the derivation needs another kind's rows — the pipelined-path
+    /// two-phase fallback trigger. Only `ParentAttribute` is cross-kind.
+    let isCrossKind (spec: DataCorrectionDerivationSpec) : bool =
+        DataCorrectionDerivation.isCrossKind (toBare spec)
+
+/// A configured extra reference probe: an entity + predicate that, if ANY row
+/// matches, proves an exclusion is UNSAFE (the operator-authored complement to
+/// the formal inbound-FK probe). Consumed by the `NoConfiguredReferenceMatches`
+/// guard.
+type ConfiguredReferenceProbe =
+    { Entity    : EntityCoordinate
+      Predicate : Predicate }
+
+/// One approved, publish-time inline data correction. `Subject` is the target
+/// attribute (reusing the operator-authorable `AttributeCoordinate`);
+/// `Predicate` selects the malformed rows; `Derivation` produces the corrected
+/// value or the exclusion; `Guards` are the fail-closed safety conditions.
+/// `Enabled = false` skips the correction entirely (no receipt).
+type ApprovedDataCorrection =
+    { Id                  : string
+      SourceRemediationId : string option
+      Enabled             : bool
+      Subject             : AttributeCoordinate
+      Predicate           : Predicate option
+      Derivation          : DataCorrectionDerivationSpec
+      Guards              : DataCorrectionGuard list
+      EvidenceColumns     : AttributeCoordinate list
+      /// The operator's expected match count — the `ExpectedFindingCount` guard
+      /// compares `RowsMatched` against it (evidence-drift protection).
+      ExpectedCount       : int64 option
+      /// The referenced target entity whose key set the `SentinelExists` /
+      /// `SourceReferencesExistingTarget` guards probe.
+      ReferencedEntity    : EntityCoordinate option
+      /// Extra reference probes for `NoConfiguredReferenceMatches`.
+      ConfiguredProbes    : ConfiguredReferenceProbe list
+      ApprovedBy          : string option
+      ApprovedAt          : string option }
+
+/// The engine's output: the corrected row map and the count-bearing receipts.
+type CorrectionOutcome =
+    { CorrectedRows : Map<SsKey, StaticRow list>
+      Receipts      : DataCorrectionReceipt list }
+
+[<RequireQualifiedAccess>]
+module ApprovedDataCorrections =
+
+    let private ciEq (a: string) (b: string) : bool =
+        System.String.Equals(a, b, System.StringComparison.OrdinalIgnoreCase)
+
+    let private err (code: string) (message: string) : Result<'a> =
+        Result.failureOf (ValidationError.create code message)
+
+    /// The rows of a kind: the correction map first (bootstrap-acquired rows),
+    /// else the catalog's static populations. Read-only lookup for guards; write
+    /// targets always land back in the output map.
+    let private rowsOfKind (catalog: Catalog) (rows: Map<SsKey, StaticRow list>) (kindKey: SsKey) : StaticRow list =
+        match Map.tryFind kindKey rows with
+        | Some rs -> rs
+        | None ->
+            match Catalog.tryFindKind kindKey catalog with
+            | Some k -> Kind.staticPopulations k
+            | None -> []
+
+    /// The single primary-key attribute's `Name` for a kind (the FK-target key).
+    let private pkNameOf (catalog: Catalog) (kindKey: SsKey) : Name option =
+        Catalog.tryFindKind kindKey catalog
+        |> Option.bind (fun k -> Kind.primaryKey k |> List.tryHead |> Option.map (fun a -> a.Name))
+
+    /// The set of PK cell values across a kind's rows — the target key set the
+    /// sentinel / reference guards probe.
+    let private keySetOf (catalog: Catalog) (rows: Map<SsKey, StaticRow list>) (kindKey: SsKey) : Set<string> =
+        match pkNameOf catalog kindKey with
+        | None -> Set.empty
+        | Some pk ->
+            rowsOfKind catalog rows kindKey
+            |> List.choose (fun r -> StaticRow.value pk r)
+            |> Set.ofList
+
+    /// Resolve an entity coordinate to its kind `SsKey` (case-insensitive; named
+    /// not-found / ambiguity refusals), mirroring `AttributeCoordinate.resolveFull`.
+    let private resolveEntity (catalog: Catalog) (coord: EntityCoordinate) : Result<SsKey> =
+        let matches =
+            Catalog.allModulesKinds catalog
+            |> List.filter (fun (m, k) ->
+                (coord.Module = "" || ciEq (Name.value m.Name) coord.Module) && ciEq (Name.value k.Name) coord.Entity)
+            |> List.map (fun (_, k) -> k.SsKey)
+            |> List.distinct
+        match matches with
+        | [ one ] -> Result.success one
+        | []      -> err "dataCorrection.entity.notFound" (String.concat "" [ "referenced entity '"; coord.Module; "/"; coord.Entity; "' is not in the model" ])
+        | _       -> err "dataCorrection.entity.ambiguous" (String.concat "" [ "referenced entity '"; coord.Module; "/"; coord.Entity; "' is ambiguous across the resolved scope" ])
+
+    /// A deterministic SHA-256 hex digest over a set of rows' subject cells
+    /// (sorted by row identity) — the receipt's before/after content anchor the
+    /// row-fidelity replay bounds against. SHA-256-in-Core is the house
+    /// precedent (`RowDigester.hashRowBytes`, `ActConsent`).
+    let private digestOf (subject: Name) (rows: StaticRow list) : string =
+        let canonical =
+            rows
+            |> List.map (fun r ->
+                let idText = SsKey.serialize r.Identifier
+                let cellText = match StaticRow.value subject r with Some v -> String.concat "" [ "S:"; v ] | None -> "N"
+                String.concat "" [ idText; cellText ])
+            |> List.sort
+            |> String.concat ""
+        let bytes = System.Text.Encoding.UTF8.GetBytes canonical
+        let hash = System.Security.Cryptography.SHA256.HashData(System.ReadOnlySpan<byte>(bytes))
+        (System.Convert.ToHexString hash).ToLowerInvariant()
+
+    let private identitySet (rows: StaticRow list) : Set<SsKey> =
+        rows |> List.map (fun r -> r.Identifier) |> Set.ofList
+
+    /// Apply one enabled correction, threading the row map. Returns the updated
+    /// map + the receipt, or a named fail-closed refusal.
+    let private applyOne
+        (catalog: Catalog)
+        (rows: Map<SsKey, StaticRow list>)
+        (c: ApprovedDataCorrection)
+        : Result<Map<SsKey, StaticRow list> * DataCorrectionReceipt> =
+        match AttributeCoordinate.resolveFull catalog c.Subject with
+        | Error _ ->
+            err "dataCorrection.subject.unresolved"
+                (String.concat "" [ "correction '"; c.Id; "': subject "; c.Subject.Module; "/"; c.Subject.Entity; "/"; c.Subject.Attribute; " is not in the model" ])
+        | Ok (kindKey, subjectName, _) ->
+            let kindRows = rowsOfKind catalog rows kindKey
+            let predicate = c.Predicate |> Option.defaultValue Predicate.All
+            let matched = kindRows |> List.filter (fun r -> Predicate.eval r predicate)
+            let hasGuard g = List.contains g c.Guards
+
+            // Per-derivation: compute the changeable subset (selector guards), the
+            // per-row transform, an optional whole-set assertion, and the bare
+            // derivation for the receipt.
+            let plan
+                : Result<StaticRow list * (StaticRow -> StaticRow) * (unit -> Result<unit>)> =
+                match c.Derivation with
+                | DataCorrectionDerivationSpec.SameRowAttribute source ->
+                    match AttributeCoordinate.resolveFull catalog source with
+                    | Error _ -> err "dataCorrection.source.unresolved" (String.concat "" [ "correction '"; c.Id; "': source attribute is not in the model" ])
+                    | Ok (srcKindKey, srcName, _) when srcKindKey <> kindKey ->
+                        err "dataCorrection.source.differentKind" (String.concat "" [ "correction '"; c.Id; "': same-row source attribute is on a different kind than the subject" ])
+                    | Ok (_, srcName, _) ->
+                        let refKeySet =
+                            if hasGuard DataCorrectionGuard.SourceReferencesExistingTarget then
+                                match c.ReferencedEntity with
+                                | Some ent -> resolveEntity catalog ent |> Result.map (keySetOf catalog rows)
+                                | None -> err "dataCorrection.referencedEntity.missing" (String.concat "" [ "correction '"; c.Id; "': sourceReferencesExistingTarget guard needs a referencedEntity" ])
+                            else Result.success Set.empty
+                        match refKeySet with
+                        | Error e -> Error e
+                        | Ok keySet ->
+                            let selectorOk (r: StaticRow) =
+                                (not (hasGuard DataCorrectionGuard.TargetIsNull) || Option.isNone (StaticRow.value subjectName r))
+                                && (not (hasGuard DataCorrectionGuard.SourceIsNotNull) || Option.isSome (StaticRow.value srcName r))
+                                && (not (hasGuard DataCorrectionGuard.SourceReferencesExistingTarget)
+                                    || (match StaticRow.value srcName r with Some v -> Set.contains v keySet | None -> false))
+                            let changeable = matched |> List.filter selectorOk
+                            let transform (r: StaticRow) = { r with Values = Map.add subjectName (StaticRow.value srcName r) r.Values }
+                            Result.success (changeable, transform, (fun () -> Result.success ()))
+
+                | DataCorrectionDerivationSpec.ParentAttribute (relationship, parentSource) ->
+                    match Catalog.tryFindKind kindKey catalog with
+                    | None -> err "dataCorrection.subject.kindMissing" (String.concat "" [ "correction '"; c.Id; "': subject kind missing from the catalog" ])
+                    | Some subjectKind ->
+                        match subjectKind.References |> List.tryFind (fun r -> ciEq (Name.value r.Name) relationship) with
+                        | None -> err "dataCorrection.relationship.unresolved" (String.concat "" [ "correction '"; c.Id; "': relationship '"; relationship; "' is not a reference on the subject kind" ])
+                        | Some reference ->
+                            let fkName =
+                                subjectKind.Attributes
+                                |> List.tryFind (fun a -> a.SsKey = reference.SourceAttribute)
+                                |> Option.map (fun a -> a.Name)
+                            match fkName with
+                            | None -> err "dataCorrection.relationship.fkMissing" (String.concat "" [ "correction '"; c.Id; "': relationship's source attribute is missing" ])
+                            | Some fk ->
+                                let parentKindKey = reference.TargetKind
+                                match AttributeCoordinate.resolveFull catalog parentSource with
+                                | Error _ -> err "dataCorrection.parentSource.unresolved" (String.concat "" [ "correction '"; c.Id; "': parent source attribute is not in the model" ])
+                                | Ok (pKindKey, _, _) when pKindKey <> parentKindKey ->
+                                    err "dataCorrection.parentSource.wrongKind" (String.concat "" [ "correction '"; c.Id; "': parent source attribute is not on the relationship's target kind" ])
+                                | Ok (_, pSrcName, _) ->
+                                    match pkNameOf catalog parentKindKey with
+                                    | None -> err "dataCorrection.parent.noPk" (String.concat "" [ "correction '"; c.Id; "': parent kind has no primary key to join on" ])
+                                    | Some parentPk ->
+                                        let parentMap =
+                                            rowsOfKind catalog rows parentKindKey
+                                            |> List.choose (fun r -> StaticRow.value parentPk r |> Option.map (fun k -> k, r))
+                                            |> Map.ofList
+                                        let parentOf (r: StaticRow) = StaticRow.value fk r |> Option.bind (fun k -> Map.tryFind k parentMap)
+                                        let selectorOk (r: StaticRow) =
+                                            (not (hasGuard DataCorrectionGuard.TargetIsNull) || Option.isNone (StaticRow.value subjectName r))
+                                            && (not (hasGuard DataCorrectionGuard.ParentExists) || Option.isSome (parentOf r))
+                                            && (not (hasGuard DataCorrectionGuard.ParentSourceIsNotNull)
+                                                || (match parentOf r with Some p -> Option.isSome (StaticRow.value pSrcName p) | None -> false))
+                                        let changeable = matched |> List.filter selectorOk
+                                        let transform (r: StaticRow) =
+                                            match parentOf r with
+                                            | Some p -> { r with Values = Map.add subjectName (StaticRow.value pSrcName p) r.Values }
+                                            | None -> r
+                                        Result.success (changeable, transform, (fun () -> Result.success ()))
+
+                | DataCorrectionDerivationSpec.ConstantLiteral value ->
+                    let sentinelAssertion () =
+                        if hasGuard DataCorrectionGuard.SentinelExists then
+                            match c.ReferencedEntity with
+                            | None -> err "dataCorrection.referencedEntity.missing" (String.concat "" [ "correction '"; c.Id; "': sentinelExists guard needs a referencedEntity" ])
+                            | Some ent ->
+                                match resolveEntity catalog ent with
+                                | Error e -> Error e
+                                | Ok k ->
+                                    if Set.contains value (keySetOf catalog rows k) then Result.success ()
+                                    else err "dataCorrection.sentinel.absent" (String.concat "" [ "correction '"; c.Id; "': sentinel value '"; value; "' does not exist in the referenced target key set" ])
+                        else Result.success ()
+                    let selectorOk (r: StaticRow) =
+                        (not (hasGuard DataCorrectionGuard.TargetIsNull) || Option.isNone (StaticRow.value subjectName r))
+                    let changeable = matched |> List.filter selectorOk
+                    let transform (r: StaticRow) = { r with Values = Map.add subjectName (Some value) r.Values }
+                    Result.success (changeable, transform, sentinelAssertion)
+
+                | DataCorrectionDerivationSpec.ExcludeRows ->
+                    let changeable = matched
+                    let excludedIds = identitySet changeable
+                    let excludedPkValues =
+                        match pkNameOf catalog kindKey with
+                        | Some pk -> changeable |> List.choose (fun r -> StaticRow.value pk r) |> Set.ofList
+                        | None -> Set.empty
+                    let inboundAssertion () =
+                        if hasGuard DataCorrectionGuard.NoFormalInboundReferences then
+                            let offending =
+                                Catalog.allModulesKinds catalog
+                                |> List.exists (fun (_, j) ->
+                                    j.References
+                                    |> List.filter (fun r -> r.TargetKind = kindKey)
+                                    |> List.exists (fun r ->
+                                        match j.Attributes |> List.tryFind (fun a -> a.SsKey = r.SourceAttribute) |> Option.map (fun a -> a.Name) with
+                                        | None -> false
+                                        | Some fk ->
+                                            let jRows = rowsOfKind catalog rows j.SsKey
+                                            let jRetained =
+                                                if j.SsKey = kindKey then jRows |> List.filter (fun r -> not (Set.contains r.Identifier excludedIds))
+                                                else jRows
+                                            jRetained |> List.exists (fun r ->
+                                                match StaticRow.value fk r with Some v -> Set.contains v excludedPkValues | None -> false)))
+                            if offending then err "dataCorrection.exclude.inboundReference" (String.concat "" [ "correction '"; c.Id; "': a retained row formally references a row about to be excluded" ])
+                            else Result.success ()
+                        else Result.success ()
+                    let probesAssertion () =
+                        if hasGuard DataCorrectionGuard.NoConfiguredReferenceMatches then
+                            let rec loop probes =
+                                match probes with
+                                | [] -> Result.success ()
+                                | (probe: ConfiguredReferenceProbe) :: rest ->
+                                    match resolveEntity catalog probe.Entity with
+                                    | Error e -> Error e
+                                    | Ok pk ->
+                                        let pRows = rowsOfKind catalog rows pk
+                                        if pRows |> List.exists (fun r -> Predicate.eval r probe.Predicate) then
+                                            err "dataCorrection.exclude.configuredReferenceMatch" (String.concat "" [ "correction '"; c.Id; "': a configured reference probe matched a retained row" ])
+                                        else loop rest
+                            loop c.ConfiguredProbes
+                        else Result.success ()
+                    let assertion () =
+                        match inboundAssertion () with
+                        | Error e -> Error e
+                        | Ok () -> probesAssertion ()
+                    Result.success (changeable, id, assertion)
+
+            match plan with
+            | Error e -> Error e
+            | Ok (changeable, transform, assertion) ->
+                let matchedCount = int64 (List.length matched)
+                let changeableCount = int64 (List.length changeable)
+                // Count / coverage guards (fail-closed).
+                let countCheck () =
+                    if hasGuard DataCorrectionGuard.ExpectedFindingCount then
+                        match c.ExpectedCount with
+                        | None -> err "dataCorrection.expectedCount.missing" (String.concat "" [ "correction '"; c.Id; "': expectedFindingCount guard needs an expectedCount" ])
+                        | Some expected when expected <> matchedCount ->
+                            err "dataCorrection.expectedCount.mismatch" (String.concat "" [ "correction '"; c.Id; "': expected "; string expected; " matched rows, found "; string matchedCount ])
+                        | Some _ -> Result.success ()
+                    else Result.success ()
+                let coverageCheck () =
+                    if hasGuard DataCorrectionGuard.ExpectedCoverage && changeableCount <> matchedCount then
+                        err "dataCorrection.coverage.incomplete" (String.concat "" [ "correction '"; c.Id; "': coverage incomplete — "; string changeableCount; " of "; string matchedCount; " matched rows carry the required evidence" ])
+                    else Result.success ()
+                match countCheck () with
+                | Error e -> Error e
+                | Ok () ->
+                    match coverageCheck () with
+                    | Error e -> Error e
+                    | Ok () ->
+                        match assertion () with
+                        | Error e -> Error e
+                        | Ok () ->
+                            let isExclude = (match c.Derivation with DataCorrectionDerivationSpec.ExcludeRows -> true | _ -> false)
+                            let changeableIds = identitySet changeable
+                            let newKindRows =
+                                if isExclude then kindRows |> List.filter (fun r -> not (Set.contains r.Identifier changeableIds))
+                                else kindRows |> List.map (fun r -> if Set.contains r.Identifier changeableIds then transform r else r)
+                            let beforeDigest = Some (digestOf subjectName changeable)
+                            let afterDigest =
+                                if isExclude then None
+                                else Some (digestOf subjectName (changeable |> List.map transform))
+                            let guardResults =
+                                c.Guards
+                                |> List.map (fun g ->
+                                    let observed =
+                                        match g with
+                                        | DataCorrectionGuard.ExpectedFindingCount -> Some matchedCount
+                                        | DataCorrectionGuard.ExpectedCoverage     -> Some changeableCount
+                                        | _ -> None
+                                    DataCorrectionGuardResult.passed g observed)
+                            let receipt =
+                                { CorrectionId        = c.Id
+                                  SourceRemediationId = c.SourceRemediationId
+                                  Subject             = c.Subject
+                                  Derivation          = DataCorrectionDerivationSpec.toBare c.Derivation
+                                  GuardResults        = guardResults
+                                  RowsMatched         = matchedCount
+                                  RowsChanged         = (if isExclude then 0L else changeableCount)
+                                  RowsExcluded        = (if isExclude then changeableCount else 0L)
+                                  BeforeDigest        = beforeDigest
+                                  AfterDigest         = afterDigest
+                                  ApprovedBy          = c.ApprovedBy
+                                  ApprovedAt          = c.ApprovedAt }
+                            Result.success (Map.add kindKey newKindRows rows, receipt)
+
+    /// Apply approved corrections to a row map, fail-closed. Disabled corrections
+    /// are skipped (no receipt). Returns the corrected rows + receipts, or the
+    /// first named refusal. A default (empty) correction list is the identity:
+    /// `apply catalog [] rows = { CorrectedRows = rows; Receipts = [] }`.
+    let apply
+        (catalog: Catalog)
+        (corrections: ApprovedDataCorrection list)
+        (rows: Map<SsKey, StaticRow list>)
+        : Result<CorrectionOutcome> =
+        let enabled = corrections |> List.filter (fun c -> c.Enabled)
+        let rec loop accRows accReceipts cs =
+            match cs with
+            | [] -> Result.success { CorrectedRows = accRows; Receipts = DataCorrectionReceipt.sorted (List.rev accReceipts) }
+            | c :: rest ->
+                match applyOne catalog accRows c with
+                | Error e -> Error e
+                | Ok (newRows, receipt) -> loop newRows (receipt :: accReceipts) rest
+        loop rows [] enabled
+
+    /// Whether any enabled correction is cross-kind (parent-derived) — the
+    /// pipelined publish path names a deliberate two-phase fallback when this
+    /// holds, because it never materializes a cross-kind row map.
+    let requiresTwoPhase (corrections: ApprovedDataCorrection list) : bool =
+        corrections |> List.exists (fun c -> c.Enabled && DataCorrectionDerivationSpec.isCrossKind c.Derivation)
+
+    /// The row-fidelity **reconciliation law** (the "receipt-bounded" half of
+    /// byte-identity-with-noted-exceptions): the receipts a proof REPLAYS over the
+    /// source must match the receipts the publish RECORDED, count-for-count. A
+    /// recorded receipt whose replay changes a different number of rows fails the
+    /// proof BY NAME — a receipt claiming 105 rows changed but replaying 104 is a
+    /// red proof, not a silent pass. Compared by `(CorrectionId, RowsChanged,
+    /// RowsExcluded)`; a receipt recorded-but-not-replayed (or vice versa) is also
+    /// a named failure. `reconcile [] [] = Ok` (the no-correction proof).
+    let reconcile (recorded: DataCorrectionReceipt list) (replayed: DataCorrectionReceipt list) : Result<unit> =
+        let toMap (rs: DataCorrectionReceipt list) = rs |> List.map (fun r -> r.CorrectionId, r) |> Map.ofList
+        let recMap = toMap recorded
+        let repMap = toMap replayed
+        let ids =
+            Set.union
+                (recorded |> List.map (fun r -> r.CorrectionId) |> Set.ofList)
+                (replayed |> List.map (fun r -> r.CorrectionId) |> Set.ofList)
+        let mismatch =
+            ids
+            |> Set.toList
+            |> List.sort
+            |> List.tryPick (fun id ->
+                match Map.tryFind id recMap, Map.tryFind id repMap with
+                | Some a, Some b when a.RowsChanged = b.RowsChanged && a.RowsExcluded = b.RowsExcluded -> None
+                | Some a, Some b ->
+                    Some (String.concat "" [ "correction '"; id; "': recorded (changed="; string a.RowsChanged; ", excluded="; string a.RowsExcluded; ") ≠ replayed (changed="; string b.RowsChanged; ", excluded="; string b.RowsExcluded; ")" ])
+                | Some _, None -> Some (String.concat "" [ "correction '"; id; "': recorded by the publish but not reproduced by the fidelity replay" ])
+                | None, Some _ -> Some (String.concat "" [ "correction '"; id; "': reproduced by the fidelity replay but never recorded by the publish" ])
+                | None, None -> None)
+        match mismatch with
+        | None -> Result.success ()
+        | Some detail -> err "dataCorrection.fidelity.receiptMismatch" detail
+
+    /// Pillar-9 registry metadata (A41) — the approved-correction transform is a
+    /// registered, first-class metadata surface, NOT an implementation detail
+    /// hidden inside the emitters. Domain.Data (it changes row values / row
+    /// membership); StageBinding.Pipeline (it fires between acquisition and the
+    /// data composers). The `OperatorIntent Insertion` site is the value/membership
+    /// change (the operator's approved corrections drive it); the two `DataIntent`
+    /// sites are the guard evaluation over acquired evidence and the correction
+    /// receipts / coverage diagnostics. Appended to `RegisteredAllTransforms.all`.
+    let registeredMetadata : RegisteredTransformMetadata =
+        { Name         = "approvedDataCorrections"
+          Domain       = Data
+          StageBinding = Pipeline
+          Sites =
+            [ TransformSite.operatorIntent "rowCorrection" Insertion
+                "Approved row-correction derivations (same-row / parent / constant / exclude) change the data VALUES and row MEMBERSHIP that emission and load receive — driven entirely by the operator-approved `emission.dataCorrections`. Empty ⇒ identity over rows (skeleton-purity preserved)."
+              TransformSite.dataIntent "guardEvaluation"
+                "Fail-closed guard evaluation over acquired row evidence (null / coverage / reference / finding-count probes). Pure over the row map + catalog; no operator opinion beyond which guards the correction declares."
+              TransformSite.dataIntent "correctionReceipts"
+                "Emit count-bearing correction receipts (rows matched / changed / excluded, guard results, before/after digest) threaded onto the episode + row-fidelity proof — the intervention ledger that bounds the byte-identity-with-noted-exceptions claim." ]
+          Status = Active }

--- a/sidecar/projection/src/Projection.Core/Catalog.fs
+++ b/sidecar/projection/src/Projection.Core/Catalog.fs
@@ -1670,6 +1670,13 @@ module Kind =
             System.Text.RegularExpressions.Regex.Matches(cfg.Expression, @"\[([^\]]+)\]")
             |> Seq.map (fun m -> m.Groups.[1].Value)
             |> Seq.filter (fun t -> not (Set.contains (t.ToUpperInvariant()) known))
+            // SQL Server's `sys.computed_columns.definition` BRACKETS the type
+            // name in a CAST/CONVERT target (`CONVERT([nvarchar](20), [Price])`),
+            // so a legitimate conversion would otherwise read as an unresolved
+            // COLUMN. Exclude bracketed tokens that name a SQL type keyword — the
+            // `known`-column check ran first, so a real column named like a type
+            // already resolved; only a non-column type token is dropped here.
+            |> Seq.filter (fun t -> Option.isNone (SqlStorageType.ofSqlType t None None None))
             |> Seq.distinct
             |> List.ofSeq
 

--- a/sidecar/projection/src/Projection.Core/DataCorrectionReceipt.fs
+++ b/sidecar/projection/src/Projection.Core/DataCorrectionReceipt.fs
@@ -1,0 +1,191 @@
+namespace Projection.Core
+
+/// The **durable value vocabulary** for approved inline data corrections — the
+/// part that must sit ahead of `Episode.fs` in the Core compile order so an
+/// `Episode` can carry a `DataCorrectionReceipt` provenance plane beside its
+/// `Tolerances` and `AppliedTransforms`. The config-authored `ApprovedDataCorrection`
+/// and the pure correction ENGINE live later (`ApprovedDataCorrections.fs`, after
+/// `SliceSpec.fs`), because they lean on `SliceSpec.Predicate` (a NULL-aware row
+/// predicate defined further down the chain).
+///
+/// This is the PUBLISH-side sibling of the SYNTHETIC-side `Correction`
+/// (`SyntheticCorrection.fs`, the σ override layer): both are "named, blessed
+/// divergences," but a synthetic correction reshapes generated data (`π ∘ σ`),
+/// whereas an approved data correction transforms ACQUIRED source rows in flight
+/// before emission/load — and, unlike a `Tolerance` (a passive, symmetric
+/// representation-equivalence the canary accepts), a data correction is an
+/// ACTIVE, asymmetric row change with provenance: who changed what, why, and how
+/// many rows. Receipts are that provenance; they are NEVER tolerances.
+
+/// The row derivation an approved correction applies — the "how the value or row
+/// membership is produced" axis. Closed; grows under evidence.
+[<RequireQualifiedAccess>]
+type DataCorrectionDerivation =
+    /// Populate the subject cell from another attribute on the SAME row.
+    | SameRowAttribute
+    /// Populate the subject cell from a PARENT row's attribute, joined through a
+    /// declared relationship — the ONE cross-kind derivation (it needs another
+    /// kind's rows, so it forces the two-phase publish schedule).
+    | ParentAttribute
+    /// Populate the subject cell with a typed configured literal (a sentinel
+    /// user / timestamp / any constant).
+    | ConstantLiteral
+    /// Remove matching rows from the emitted/loaded row set.
+    | ExcludeRows
+
+[<RequireQualifiedAccess>]
+module DataCorrectionDerivation =
+
+    let name (d: DataCorrectionDerivation) : string =
+        match d with
+        | DataCorrectionDerivation.SameRowAttribute -> "sameRowAttribute"
+        | DataCorrectionDerivation.ParentAttribute  -> "parentAttribute"
+        | DataCorrectionDerivation.ConstantLiteral  -> "constantLiteral"
+        | DataCorrectionDerivation.ExcludeRows      -> "excludeRows"
+
+    let parse (s: string) : Result<DataCorrectionDerivation> =
+        match s with
+        | "sameRowAttribute" -> Result.success DataCorrectionDerivation.SameRowAttribute
+        | "parentAttribute"  -> Result.success DataCorrectionDerivation.ParentAttribute
+        | "constantLiteral"  -> Result.success DataCorrectionDerivation.ConstantLiteral
+        | "excludeRows"      -> Result.success DataCorrectionDerivation.ExcludeRows
+        | other ->
+            Result.failureOf
+                (ValidationError.create "dataCorrection.derivation.unknown"
+                    (String.concat "" [ "unknown data-correction derivation '"; other; "'" ]))
+
+    /// Whether this derivation needs another kind's rows (a parent/lookup map).
+    /// The pipelined publish path drains and drops rows per-kind and never
+    /// materializes a cross-kind map, so a cross-kind correction names a
+    /// deliberate two-phase fallback rather than a silent miss. Only
+    /// `ParentAttribute` is cross-kind today.
+    let isCrossKind (d: DataCorrectionDerivation) : bool =
+        match d with
+        | DataCorrectionDerivation.ParentAttribute -> true
+        | DataCorrectionDerivation.SameRowAttribute
+        | DataCorrectionDerivation.ConstantLiteral
+        | DataCorrectionDerivation.ExcludeRows -> false
+
+/// A guard that must hold for an approved correction to apply. Every correction
+/// is FAIL-CLOSED: a failed guard refuses the correction by name; it never
+/// silently skips. The guards split into per-row predicates (evaluated against
+/// each matched row) and whole-set probes (evaluated once against the acquired
+/// evidence — counts, reference sets).
+[<RequireQualifiedAccess>]
+type DataCorrectionGuard =
+    /// The subject cell is NULL on the row (never overwrite a present value).
+    | TargetIsNull
+    /// The same-row source cell is non-NULL (there is a value to copy).
+    | SourceIsNotNull
+    /// The joined parent row exists.
+    | ParentExists
+    /// The joined parent's source cell is non-NULL.
+    | ParentSourceIsNotNull
+    /// The configured constant (sentinel) resolves to an existing row in the
+    /// referenced target table (e.g. the sentinel user exists).
+    | SentinelExists
+    /// The copied source value exists in the referenced target key set.
+    | SourceReferencesExistingTarget
+    /// No RETAINED row formally references (inbound FK) the rows about to be
+    /// excluded — a formal safety probe for `ExcludeRows`.
+    | NoFormalInboundReferences
+    /// No configured extra reference probe matches the rows about to be excluded
+    /// — the operator-authored complement to the formal probe.
+    | NoConfiguredReferenceMatches
+    /// The matched-row count equals the operator's expected finding count
+    /// (guards against evidence drift since the proposal was approved).
+    | ExpectedFindingCount
+    /// The correction's coverage over the affected population is complete (every
+    /// affected row carries the evidence the derivation needs).
+    | ExpectedCoverage
+
+[<RequireQualifiedAccess>]
+module DataCorrectionGuard =
+
+    let name (g: DataCorrectionGuard) : string =
+        match g with
+        | DataCorrectionGuard.TargetIsNull                   -> "targetIsNull"
+        | DataCorrectionGuard.SourceIsNotNull                -> "sourceIsNotNull"
+        | DataCorrectionGuard.ParentExists                   -> "parentExists"
+        | DataCorrectionGuard.ParentSourceIsNotNull          -> "parentSourceIsNotNull"
+        | DataCorrectionGuard.SentinelExists                 -> "sentinelExists"
+        | DataCorrectionGuard.SourceReferencesExistingTarget -> "sourceReferencesExistingTarget"
+        | DataCorrectionGuard.NoFormalInboundReferences      -> "noFormalInboundReferences"
+        | DataCorrectionGuard.NoConfiguredReferenceMatches   -> "noConfiguredReferenceMatches"
+        | DataCorrectionGuard.ExpectedFindingCount           -> "expectedFindingCount"
+        | DataCorrectionGuard.ExpectedCoverage               -> "expectedCoverage"
+
+    let parse (s: string) : Result<DataCorrectionGuard> =
+        match s with
+        | "targetIsNull"                   -> Result.success DataCorrectionGuard.TargetIsNull
+        | "sourceIsNotNull"                -> Result.success DataCorrectionGuard.SourceIsNotNull
+        | "parentExists"                   -> Result.success DataCorrectionGuard.ParentExists
+        | "parentSourceIsNotNull"          -> Result.success DataCorrectionGuard.ParentSourceIsNotNull
+        | "sentinelExists"                 -> Result.success DataCorrectionGuard.SentinelExists
+        | "sourceReferencesExistingTarget" -> Result.success DataCorrectionGuard.SourceReferencesExistingTarget
+        | "noFormalInboundReferences"      -> Result.success DataCorrectionGuard.NoFormalInboundReferences
+        | "noConfiguredReferenceMatches"   -> Result.success DataCorrectionGuard.NoConfiguredReferenceMatches
+        | "expectedFindingCount"           -> Result.success DataCorrectionGuard.ExpectedFindingCount
+        | "expectedCoverage"               -> Result.success DataCorrectionGuard.ExpectedCoverage
+        | other ->
+            Result.failureOf
+                (ValidationError.create "dataCorrection.guard.unknown"
+                    (String.concat "" [ "unknown data-correction guard '"; other; "'" ]))
+
+/// The recorded outcome of evaluating one guard while applying a correction. A
+/// receipt only exists on a SUCCESSFUL apply, so every result on a persisted
+/// receipt passed — but the observed count (`Observed`) and detail carry the
+/// evidence the guard stood on, so a reviewer can audit why the correction was
+/// accepted.
+type DataCorrectionGuardResult =
+    { Guard    : DataCorrectionGuard
+      Passed   : bool
+      Observed : int64 option
+      Detail   : string option }
+
+[<RequireQualifiedAccess>]
+module DataCorrectionGuardResult =
+
+    let create (guard: DataCorrectionGuard) (passed: bool) (observed: int64 option) (detail: string option) : DataCorrectionGuardResult =
+        { Guard = guard; Passed = passed; Observed = observed; Detail = detail }
+
+    let passed (guard: DataCorrectionGuard) (observed: int64 option) : DataCorrectionGuardResult =
+        create guard true observed None
+
+/// The durable, count-bearing provenance of ONE applied approved correction — a
+/// first-class intervention ledger entry. For same-row / parent-derived /
+/// constant derivations, `RowsChanged` counts the transformed rows; for an
+/// exclusion, `RowsExcluded` counts the removed rows. `BeforeDigest` /
+/// `AfterDigest` are deterministic content hashes over the affected subject
+/// cells, so a row-fidelity proof can bound the replay: a receipt claiming N
+/// changed rows that replays to a different N fails the proof BY NAME.
+///
+/// `Subject` reuses the operator-authorable `AttributeCoordinate`
+/// (`(module, entity, attribute)` by name) — the same logical address the
+/// synthetic-side blessed corrections use — rather than a new ref type.
+type DataCorrectionReceipt =
+    { CorrectionId        : string
+      SourceRemediationId : string option
+      Subject             : AttributeCoordinate
+      Derivation          : DataCorrectionDerivation
+      GuardResults        : DataCorrectionGuardResult list
+      RowsMatched         : int64
+      RowsChanged         : int64
+      RowsExcluded        : int64
+      BeforeDigest        : string option
+      AfterDigest         : string option
+      ApprovedBy          : string option
+      ApprovedAt          : string option }
+
+[<RequireQualifiedAccess>]
+module DataCorrectionReceipt =
+
+    /// A deterministic sort key: `(CorrectionId, module, entity, attribute)`.
+    /// The manifest / lifecycle artifact sorts by this so the persisted receipt
+    /// stream is byte-deterministic across runs.
+    let sortKey (r: DataCorrectionReceipt) : string * string * string * string =
+        (r.CorrectionId, r.Subject.Module, r.Subject.Entity, r.Subject.Attribute)
+
+    /// Order a receipt list deterministically by `sortKey`.
+    let sorted (receipts: DataCorrectionReceipt list) : DataCorrectionReceipt list =
+        receipts |> List.sortBy sortKey

--- a/sidecar/projection/src/Projection.Core/Episode.fs
+++ b/sidecar/projection/src/Projection.Core/Episode.fs
@@ -82,6 +82,14 @@ type Episode =
         /// a skeleton-only run; populated when the Pipeline threads the
         /// composed run's overlay enumeration onto the episode.
         AppliedTransforms : (SsKey * OverlayAxis option) list
+        /// The approved **data-correction receipts** applied to the row data
+        /// this run emitted/loaded (the addendum's first-class intervention
+        /// ledger). Empty for a run with no `emission.dataCorrections`; populated
+        /// when the Pipeline threads the correction engine's receipts onto the
+        /// episode — so a load record can explain exactly why target rows differ
+        /// from the raw source (`emitted_or_loaded_rows = apply(receipts,
+        /// acquired_source_rows)`), and no split-brain proof is possible.
+        DataCorrectionReceipts : DataCorrectionReceipt list
     }
 
 [<RequireQualifiedAccess>]
@@ -106,7 +114,8 @@ module Episode =
           RefactorLogRef = refactorLogRef
           Data = data
           Tolerances = Tolerance.strict
-          AppliedTransforms = [] }
+          AppliedTransforms = []
+          DataCorrectionReceipts = [] }
 
     /// A schema-only episode (no profiling, no data movement, no refactorlog,
     /// no accepted divergence, no applied overlay) — the genesis shape and the
@@ -125,6 +134,19 @@ module Episode =
         (episode: Episode)
         : Episode =
         { episode with Tolerances = tolerances; AppliedTransforms = appliedTransforms }
+
+    /// Thread the approved data-correction receipts onto an episode — the
+    /// count-bearing intervention ledger for the row data this run emitted or
+    /// loaded. Like the other provenance planes, Core only stamps the value; the
+    /// Pipeline computes it from the correction engine's output. Kept separate
+    /// from `withProvenance` so the receipts plane threads independently of the
+    /// tolerance/applied-transform planes (a publish-and-load leg records
+    /// receipts without touching tolerances).
+    let withDataCorrectionReceipts
+        (receipts: DataCorrectionReceipt list)
+        (episode: Episode)
+        : Episode =
+        { episode with DataCorrectionReceipts = DataCorrectionReceipt.sorted receipts }
 
     let schema (e: Episode) : Catalog = e.Schema
     let profile (e: Episode) : Profile = e.Profile

--- a/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
+++ b/sidecar/projection/src/Projection.Core/Projection.Core.fsproj
@@ -89,6 +89,14 @@
          enumeration (SsKey × OverlayAxis option) — the same outcome shape the
          SSDT ManifestEmitter records — at the change-manifest level. -->
     <Compile Include="Classification.fs" />
+    <!-- DataCorrectionReceipt.fs: the durable value vocabulary for approved
+         inline data corrections (derivation / guard / guard-result / receipt).
+         Compiled before Episode.fs so an Episode can carry a
+         DataCorrectionReceipts provenance plane beside Tolerances /
+         AppliedTransforms. Needs only AttributeCoordinate (SyntheticCorrection.fs)
+         + Catalog identity types; the config type + pure engine that lean on the
+         NULL-aware SliceSpec.Predicate live later in ApprovedDataCorrections.fs. -->
+    <Compile Include="DataCorrectionReceipt.fs" />
     <Compile Include="Episode.fs" />
     <Compile Include="ChangeManifest.fs" />
     <Compile Include="Migration.fs" />
@@ -157,6 +165,12 @@
          indifferent; consumed by Closure.fs (directive-aware walk) and the
          slice codec/verb. Depends only on Catalog.fs identity types. -->
     <Compile Include="SliceSpec.fs" />
+    <!-- ApprovedDataCorrections.fs: the config type + pure engine for approved
+         inline data corrections. Sits after SliceSpec.fs because a correction
+         gates rows on the NULL-aware Predicate and resolves AttributeCoordinates;
+         the durable receipt vocabulary it emits is defined earlier
+         (DataCorrectionReceipt.fs) so Episode can carry it. -->
+    <Compile Include="ApprovedDataCorrections.fs" />
     <!-- Closure.fs: the use-case-scoped referential-closure engine (data-
          portability front-end). Pure planner over the FK graph (Catalog.fs);
          materializes the `Map<SsKey, StaticRow list>` DataLoadPlan consumes,

--- a/sidecar/projection/src/Projection.Core/SliceSpec.fs
+++ b/sidecar/projection/src/Projection.Core/SliceSpec.fs
@@ -19,6 +19,15 @@ type Predicate =
     | Equals of column: Name * value: string
     /// `<column> IN (<values>)`.
     | In of column: Name * values: string list
+    /// `<column> IS NULL`. Tri-state: matches a genuine SQL NULL (or an
+    /// absent cell), NOT the empty string — the `value`/`valueOrEmpty` split
+    /// the write path keeps (`NULL ≠ ''`). Grown here (not a `Raw` escape)
+    /// because the second consumer — approved data corrections — gates every
+    /// derivation on a NULL test that MUST distinguish NULL from `''`.
+    | IsNull of column: Name
+    /// `<column> IS NOT NULL`. The tri-state complement of `IsNull`: matches
+    /// any present value, including the empty string.
+    | IsNotNull of column: Name
     /// Conjunction of sub-predicates (empty `And` ≡ `All`).
     | And of Predicate list
     /// A terminal raw-SQL escape hatch for predicates the typed arms cannot yet
@@ -39,6 +48,8 @@ module Predicate =
         | Predicate.All            -> true
         | Predicate.Equals (c, v)  -> StaticRow.valueOrEmpty c row = v
         | Predicate.In (c, vs)     -> List.contains (StaticRow.valueOrEmpty c row) vs
+        | Predicate.IsNull c       -> Option.isNone (StaticRow.value c row)
+        | Predicate.IsNotNull c    -> Option.isSome (StaticRow.value c row)
         | Predicate.And ps         -> List.forall (eval row) ps
         | Predicate.Raw _          -> true
 

--- a/sidecar/projection/src/Projection.Pipeline/Config.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Config.fs
@@ -362,6 +362,16 @@ module Config =
         /// the toggle is a SCHEDULE choice (equivalence pinned by test) and
         /// exists as the named diagnostic opt-out.
         PipelinedBootstrap    : bool
+        /// `emission.dataCorrections` — the APPROVED, publish-time inline data
+        /// corrections applied to acquired row data before the data composers /
+        /// load plan see it (`ApprovedDataCorrections.fs`). Empty (the default)
+        /// leaves the emitted/loaded rows byte-identical. A NON-empty list REQUIRES
+        /// the `data-correction` write-signoff (`Compose.buildPolicyFromConfig`
+        /// refuses `emission.dataCorrection.ungreenlit` otherwise) and threads
+        /// count-bearing receipts onto the episode + row-fidelity proof. Parsed
+        /// FAIL-CLOSED: an unknown derivation kind / guard / predicate op is a
+        /// named config error, never a silent drop.
+        DataCorrections       : ApprovedDataCorrection list
     }
 
     // NM-03 (2026-06-13) — `policy.selection` and `policy.userMatching` were
@@ -566,6 +576,9 @@ module Config =
         // P2 production wiring — acquisition-overlapped Bootstrap render +
         // evidence derivation on by default (identical bundle; schedule only).
         PipelinedBootstrap = true
+        // Approved inline data corrections default to none — a config with no
+        // corrections emits/loads byte-identical rows.
+        DataCorrections = []
     }
 
     let private defaultPolicy : PolicySection = {
@@ -1247,7 +1260,7 @@ module Config =
                     | None -> Result.failureOf (configError "emission.signoff.noMode" "each emission.signoff entry needs a 'mode'.")
                     | Some m ->
                         match WriteSignoff.parseMode m with
-                        | None -> Result.failureOf (configError "emission.signoff.modeUnknown" (sprintf "emission.signoff mode '%s' is not one of replace/fresh/drops/cdc/identity-insert/delete-scope." m))
+                        | None -> Result.failureOf (configError "emission.signoff.modeUnknown" (sprintf "emission.signoff mode '%s' is not one of replace/fresh/drops/cdc/identity-insert/delete-scope/data-correction." m))
                         | Some mode ->
                             Result.success
                                 { WriteSignoff.Mode = mode
@@ -1261,6 +1274,171 @@ module Config =
             else Result.success (parsed |> List.choose (function Ok a -> Some a | _ -> None))
         | Some _ ->
             Result.failureOf (configError "emission.signoff.shape" "emission.signoff must be an array of { mode, ... } objects.")
+
+    // --- emission.dataCorrections — approved inline data corrections ---
+    // FAIL-CLOSED: an unknown derivation kind / guard token / predicate op is a
+    // named config error, never a silent drop. Absent ⇒ `[]` (byte-identical
+    // default). Not part of `renderConfig`'s A44 surface, so parse-only.
+
+    let private dcStr (el: JsonElement) (name: string) : string option =
+        match el.TryGetProperty name with
+        | true, v when v.ValueKind = JsonValueKind.String -> Option.ofObj (v.GetString())
+        | _ -> None
+
+    let private dcCoordinate (el: JsonElement) (ctx: string) : Result<AttributeCoordinate> =
+        match dcStr el "module", dcStr el "entity", dcStr el "attribute" with
+        | Some m, Some e, Some a -> Result.success (AttributeCoordinate.create m e a)
+        | _ -> Result.failureOf (configError "emission.dataCorrections.coordinate" (sprintf "%s needs { module, entity, attribute }." ctx))
+
+    let private dcEntity (el: JsonElement) (ctx: string) : Result<EntityCoordinate> =
+        match dcStr el "module", dcStr el "entity" with
+        | Some m, Some e -> Result.success (EntityCoordinate.create m e)
+        | _ -> Result.failureOf (configError "emission.dataCorrections.entity" (sprintf "%s needs { module, entity }." ctx))
+
+    let private dcColumnName (el: JsonElement) : Result<Name> =
+        match dcStr el "column" with
+        | Some c -> Name.create c
+        | None -> Result.failureOf (configError "emission.dataCorrections.predicate.column" "a column predicate needs a 'column'.")
+
+    let rec private dcPredicate (el: JsonElement) : Result<Predicate> =
+        match dcStr el "op" with
+        | Some "all" -> Result.success Predicate.All
+        | Some "eq" ->
+            dcColumnName el |> Result.bind (fun c ->
+                match dcStr el "value" with
+                | Some v -> Result.success (Predicate.Equals (c, v))
+                | None -> Result.failureOf (configError "emission.dataCorrections.predicate.eq" "'eq' predicate needs a 'value'."))
+        | Some "in" ->
+            dcColumnName el |> Result.bind (fun c ->
+                match el.TryGetProperty "values" with
+                | true, a when a.ValueKind = JsonValueKind.Array ->
+                    Result.success (Predicate.In (c, [ for e in a.EnumerateArray() do if e.ValueKind = JsonValueKind.String then match Option.ofObj (e.GetString()) with Some s -> yield s | None -> () ]))
+                | _ -> Result.failureOf (configError "emission.dataCorrections.predicate.in" "'in' predicate needs a 'values' array."))
+        | Some "isNull" -> dcColumnName el |> Result.map Predicate.IsNull
+        | Some "isNotNull" -> dcColumnName el |> Result.map Predicate.IsNotNull
+        | Some "and" ->
+            match el.TryGetProperty "terms" with
+            | true, a when a.ValueKind = JsonValueKind.Array ->
+                [ for e in a.EnumerateArray() -> dcPredicate e ] |> Result.aggregate |> Result.map Predicate.And
+            | _ -> Result.failureOf (configError "emission.dataCorrections.predicate.and" "'and' predicate needs a 'terms' array.")
+        | Some "raw" ->
+            match dcStr el "sql" with
+            | Some s -> Result.success (Predicate.Raw s)
+            | None -> Result.failureOf (configError "emission.dataCorrections.predicate.raw" "'raw' predicate needs a 'sql' string.")
+        | Some other -> Result.failureOf (configError "emission.dataCorrections.predicate.op" (sprintf "unknown predicate op '%s'." other))
+        | None -> Result.failureOf (configError "emission.dataCorrections.predicate.op" "a predicate needs an 'op'.")
+
+    let private dcDerivation (el: JsonElement) : Result<DataCorrectionDerivationSpec> =
+        match dcStr el "kind" with
+        | Some "sameRowAttribute" ->
+            match el.TryGetProperty "source" with
+            | true, s when s.ValueKind = JsonValueKind.Object -> dcCoordinate s "derivation.source" |> Result.map DataCorrectionDerivationSpec.SameRowAttribute
+            | _ -> Result.failureOf (configError "emission.dataCorrections.derivation.source" "'sameRowAttribute' needs a 'source' coordinate.")
+        | Some "parentAttribute" ->
+            match dcStr el "relationship", el.TryGetProperty "parentSource" with
+            | Some rel, (true, ps) when ps.ValueKind = JsonValueKind.Object ->
+                dcCoordinate ps "derivation.parentSource" |> Result.map (fun c -> DataCorrectionDerivationSpec.ParentAttribute (rel, c))
+            | _ -> Result.failureOf (configError "emission.dataCorrections.derivation.parent" "'parentAttribute' needs a 'relationship' and a 'parentSource' coordinate.")
+        | Some "constantLiteral" ->
+            match dcStr el "value" with
+            | Some v -> Result.success (DataCorrectionDerivationSpec.ConstantLiteral v)
+            | None -> Result.failureOf (configError "emission.dataCorrections.derivation.constant" "'constantLiteral' needs a 'value'.")
+        | Some "excludeRows" -> Result.success DataCorrectionDerivationSpec.ExcludeRows
+        | Some other -> Result.failureOf (configError "emission.dataCorrections.derivation.kind" (sprintf "unknown derivation kind '%s'." other))
+        | None -> Result.failureOf (configError "emission.dataCorrections.derivation.kind" "a derivation needs a 'kind'.")
+
+    let private dcGuards (el: JsonElement) : Result<DataCorrectionGuard list> =
+        match el.TryGetProperty "guards" with
+        | true, a when a.ValueKind = JsonValueKind.Array ->
+            [ for e in a.EnumerateArray() do
+                if e.ValueKind = JsonValueKind.String then
+                    match Option.ofObj (e.GetString()) with Some s -> yield DataCorrectionGuard.parse s | None -> () ]
+            |> Result.aggregate
+        | _ -> Result.success []
+
+    let private dcEvidence (el: JsonElement) : Result<AttributeCoordinate list> =
+        match el.TryGetProperty "evidenceColumns" with
+        | true, a when a.ValueKind = JsonValueKind.Array ->
+            [ for e in a.EnumerateArray() do if e.ValueKind = JsonValueKind.Object then yield dcCoordinate e "evidenceColumns[]" ] |> Result.aggregate
+        | _ -> Result.success []
+
+    let private dcProbe (e: JsonElement) : Result<ConfiguredReferenceProbe> =
+        result {
+            let! ent =
+                match e.TryGetProperty "entity" with
+                | true, en when en.ValueKind = JsonValueKind.Object -> dcEntity en "configuredProbes[].entity"
+                | _ -> Result.failureOf (configError "emission.dataCorrections.probe.entity" "a configured probe needs an 'entity'.")
+            let! pred =
+                match e.TryGetProperty "predicate" with
+                | true, p when p.ValueKind = JsonValueKind.Object -> dcPredicate p
+                | _ -> Result.failureOf (configError "emission.dataCorrections.probe.predicate" "a configured probe needs a 'predicate'.")
+            return ({ Entity = ent; Predicate = pred } : ConfiguredReferenceProbe) }
+
+    let private dcProbes (el: JsonElement) : Result<ConfiguredReferenceProbe list> =
+        match el.TryGetProperty "configuredProbes" with
+        | true, a when a.ValueKind = JsonValueKind.Array ->
+            [ for e in a.EnumerateArray() do if e.ValueKind = JsonValueKind.Object then yield dcProbe e ] |> Result.aggregate
+        | _ -> Result.success []
+
+    let private dcOne (el: JsonElement) : Result<ApprovedDataCorrection> =
+        if el.ValueKind <> JsonValueKind.Object then
+            Result.failureOf (configError "emission.dataCorrections.shape" "each emission.dataCorrections entry must be an object.")
+        else
+            let boolOr (name: string) (d: bool) =
+                match el.TryGetProperty name with
+                | true, v when v.ValueKind = JsonValueKind.True -> true
+                | true, v when v.ValueKind = JsonValueKind.False -> false
+                | _ -> d
+            let int64Opt (name: string) =
+                match el.TryGetProperty name with
+                | true, v when v.ValueKind = JsonValueKind.Number -> (match v.TryGetInt64() with true, n -> Some n | _ -> None)
+                | _ -> None
+            result {
+                let! id =
+                    match dcStr el "id" with
+                    | Some i -> Result.success i
+                    | None -> Result.failureOf (configError "emission.dataCorrections.id" "each correction needs an 'id'.")
+                let! subject =
+                    match el.TryGetProperty "subject" with
+                    | true, s when s.ValueKind = JsonValueKind.Object -> dcCoordinate s "subject"
+                    | _ -> Result.failureOf (configError "emission.dataCorrections.subject" "each correction needs a 'subject' coordinate.")
+                let! predicate =
+                    match el.TryGetProperty "predicate" with
+                    | true, p when p.ValueKind = JsonValueKind.Object -> dcPredicate p |> Result.map Some
+                    | _ -> Result.success None
+                let! derivation =
+                    match el.TryGetProperty "derivation" with
+                    | true, d when d.ValueKind = JsonValueKind.Object -> dcDerivation d
+                    | _ -> Result.failureOf (configError "emission.dataCorrections.derivation" "each correction needs a 'derivation'.")
+                let! guards = dcGuards el
+                let! evidence = dcEvidence el
+                let! probes = dcProbes el
+                let! referencedEntity =
+                    match el.TryGetProperty "referencedEntity" with
+                    | true, r when r.ValueKind = JsonValueKind.Object -> dcEntity r "referencedEntity" |> Result.map Some
+                    | _ -> Result.success None
+                return
+                    { Id = id
+                      SourceRemediationId = dcStr el "sourceRemediationId"
+                      Enabled = boolOr "enabled" true
+                      Subject = subject
+                      Predicate = predicate
+                      Derivation = derivation
+                      Guards = guards
+                      EvidenceColumns = evidence
+                      ExpectedCount = int64Opt "expectedCount"
+                      ReferencedEntity = referencedEntity
+                      ConfiguredProbes = probes
+                      ApprovedBy = dcStr el "approvedBy"
+                      ApprovedAt = dcStr el "approvedAt" } }
+
+    let private parseDataCorrections (emission: JsonElement) : Result<ApprovedDataCorrection list> =
+        match tryGetProperty emission "dataCorrections" with
+        | None -> Result.success []
+        | Some arr when arr.ValueKind = JsonValueKind.Array ->
+            [ for e in arr.EnumerateArray() -> dcOne e ] |> Result.aggregate
+        | Some _ ->
+            Result.failureOf (configError "emission.dataCorrections.shape" "emission.dataCorrections must be an array of correction objects.")
 
     /// Wave-3 slice 3.4 (now WIRED) — parse `emission.tolerance`: an array of
     /// `ToleratedDivergence` name tokens → `Tolerance option`. Absent ⇒ `None`
@@ -1378,6 +1556,7 @@ module Config =
                                 (sprintf "emission.dataReadConcurrency must be >= 1; got %d." c))
                     | other -> other
                 let! pipelinedBootstrap = read "pipelinedBootstrap" defaultEmission.PipelinedBootstrap
+                let! dataCorrections = parseDataCorrections element
                 return {
                     Ssdt = ssdt
                     Dacpac = dacpac
@@ -1402,6 +1581,7 @@ module Config =
                     DataStaging = dataStaging
                     DataReadConcurrency = dataReadConcurrency
                     PipelinedBootstrap = pipelinedBootstrap
+                    DataCorrections = dataCorrections
                 }
             }
 

--- a/sidecar/projection/src/Projection.Pipeline/FidelityCompareRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/FidelityCompareRun.fs
@@ -373,11 +373,131 @@ module FidelityCompareRun =
     // One kind's comparison — the alignment package applied.
     // ------------------------------------------------------------------
 
+    // ------------------------------------------------------------------
+    // Approved-data-correction SOURCE replay (T17 / the intervention ledger's
+    // count-bearing half). A correction rewrote/excluded row VALUES at publish;
+    // the fidelity proof must replay those onto the SOURCE before comparing, or a
+    // corrected target reads as a diverged source. The replay REUSES the publish
+    // engine (`ApprovedDataCorrections.apply`) over buffered source rows, so the
+    // replayed change counts match the recorded receipts exactly — no per-quantum
+    // reimplementation that could diverge on whole-set guards.
+    // ------------------------------------------------------------------
+
+    let private ccEq (a: string) (b: string) = System.String.Equals(a, b, System.StringComparison.OrdinalIgnoreCase)
+
+    /// A pull stream over a materialized quantum list — the substitute source for
+    /// a kind whose rows the correction replay rewrote.
+    let private streamOfList (items: RowQuantum list) : AsyncStream<RowQuantum> =
+        let arr = List.toArray items
+        let mutable i = 0
+        fun () ->
+            task {
+                if i < arr.Length then
+                    let q = arr.[i]
+                    i <- i + 1
+                    return Some q
+                else return None
+            }
+
+    /// Drain a kind's SOURCE rows into logical-name-keyed `StaticRow`s (the grain
+    /// the correction engine consumes). Identity is synthesized per row position —
+    /// the engine keys exclusions on it and the proof re-derives it deterministically.
+    let private bufferKindRows (source: SqlConnection) (physicalKind: Kind) (basis: RowBasis) : Task<StaticRow list> =
+        task {
+            let pull = Ingestion.streamKind source physicalKind
+            let acc = System.Collections.Generic.List<StaticRow>()
+            let mutable go = true
+            let mutable idx = 0
+            while go do
+                match! pull () with
+                | Some q ->
+                    acc.Add { Identifier = StaticRow.readsideIdentity "fidelity" (Name.value physicalKind.Name) idx
+                              Values = RowQuantum.toValues basis q }
+                    idx <- idx + 1
+                | None -> go <- false
+            return List.ofSeq acc
+        }
+
+    /// The logical kinds one correction reads: its subject kind, its referenced
+    /// entity (reference/sentinel guards), and its parent kind (parentAttribute) —
+    /// buffered so the engine's guards see real key sets in the fidelity context.
+    let private neededKindKeys (model: Catalog) (c: ApprovedDataCorrection) : Set<SsKey> =
+        let subjectKey =
+            match AttributeCoordinate.resolveFull model c.Subject with
+            | Ok (k, _, _) -> Set.singleton k
+            | Error _ -> Set.empty
+        let referencedKey =
+            match c.ReferencedEntity with
+            | Some ent ->
+                Catalog.allModulesKinds model
+                |> List.tryPick (fun (m, k) ->
+                    if (ent.Module = "" || ccEq (Name.value m.Name) ent.Module) && ccEq (Name.value k.Name) ent.Entity
+                    then Some k.SsKey else None)
+                |> Option.map Set.singleton |> Option.defaultValue Set.empty
+            | None -> Set.empty
+        let parentKey =
+            match c.Derivation with
+            | DataCorrectionDerivationSpec.ParentAttribute (rel, _) ->
+                match AttributeCoordinate.resolveFull model c.Subject with
+                | Ok (k, _, _) ->
+                    match Catalog.tryFindKind k model with
+                    | Some kind ->
+                        kind.References
+                        |> List.tryFind (fun r -> ccEq (Name.value r.Name) rel)
+                        |> Option.map (fun r -> Set.singleton r.TargetKind)
+                        |> Option.defaultValue Set.empty
+                    | None -> Set.empty
+                | Error _ -> Set.empty
+            | _ -> Set.empty
+        Set.unionMany [ subjectKey; referencedKey; parentKey ]
+
+    let private correctedKindKeys (model: Catalog) (enabled: ApprovedDataCorrection list) : Set<SsKey> =
+        enabled
+        |> List.choose (fun c -> match AttributeCoordinate.resolveFull model c.Subject with Ok (k, _, _) -> Some k | Error _ -> None)
+        |> Set.ofList
+
+    /// Replay approved corrections onto the source: buffer each needed kind's
+    /// source rows, run the publish engine, and return the corrected rows FOR THE
+    /// SUBJECT KINDS (the ones whose source stream is substituted in the compare)
+    /// plus the count-bearing receipts. Empty corrections ⇒ identity. A named
+    /// engine refusal (e.g. a parent-derived correction whose parent evidence is
+    /// unavailable) fails the proof BY NAME rather than silently comparing raw.
+    let private replayCorrections
+        (source: SqlConnection)
+        (physical: Catalog)
+        (model: Catalog)
+        (renamesByKind: Map<SsKey, Map<Name, Name>>)
+        (corrections: ApprovedDataCorrection list)
+        : Task<Result<Map<SsKey, StaticRow list> * DataCorrectionReceipt list>> =
+        task {
+            let enabled = corrections |> List.filter (fun c -> c.Enabled)
+            if List.isEmpty enabled then return Result.success (Map.empty, [])
+            else
+                let needed = enabled |> List.map (neededKindKeys model) |> Set.unionMany
+                let acc = System.Collections.Generic.Dictionary<SsKey, StaticRow list>()
+                for logicalKey in Set.toList needed do
+                    match Catalog.tryFindKind logicalKey physical, Catalog.tryFindKind logicalKey model with
+                    | Some physKind, Some _ ->
+                        let renameMap = RenameProjection.forKind logicalKey renamesByKind
+                        let basis = RowBasis.rename renameMap (Kind.rowBasis physKind)
+                        let! rows = bufferKindRows source physKind basis
+                        acc.[logicalKey] <- rows
+                    | _ -> ()
+                let rowMap = acc |> Seq.map (fun kv -> kv.Key, kv.Value) |> Map.ofSeq
+                match ApprovedDataCorrections.apply model enabled rowMap with
+                | Error e -> return Error e
+                | Ok outcome ->
+                    let corrected = correctedKindKeys model enabled
+                    let correctedByKind = outcome.CorrectedRows |> Map.filter (fun k _ -> Set.contains k corrected)
+                    return Result.success (correctedByKind, outcome.Receipts)
+        }
+
     let private compareKind
         (source: SqlConnection)
         (target: SqlConnection)
         (renamesByKind: Map<SsKey, Map<Name, Name>>)
         (replayMaps: Map<string, Map<string, string>>)
+        (correctedByKind: Map<SsKey, StaticRow list>)
         (sampleCap: int)
         (physicalKind: Kind)
         (logicalKind: Kind)
@@ -426,7 +546,15 @@ module FidelityCompareRun =
                     | _ -> None)
             let transformSource (q: RowQuantum) : RowQuantum =
                 canonicalize (RowFidelity.replayQuantum keyRewrite fkRewrites q)
-            let sourceStream = mapStream transformSource (Ingestion.streamKind source physicalKind)
+            // Approved-correction replay: when this kind's rows were corrected,
+            // the source stream is the ENGINE-corrected rows (rebased onto the
+            // source basis), so `target == replay(corrections, source)`. Otherwise
+            // the live source streams as before.
+            let sourcePull =
+                match Map.tryFind logicalKind.SsKey correctedByKind with
+                | Some correctedRows -> streamOfList (correctedRows |> List.map (RowQuantum.ofStaticRow sourceBasis))
+                | None -> Ingestion.streamKind source physicalKind
+            let sourceStream = mapStream transformSource sourcePull
             let targetStream = mapStream canonicalize (Ingestion.streamKind target logicalKind)
             match RowFidelity.keyPlanOf logicalKind with
             | RowFidelity.KeyPlan.Int64Key pkName ->
@@ -585,6 +713,7 @@ module FidelityCompareRun =
         (target: SqlConnection)
         (renamesByKind: Map<SsKey, Map<Name, Name>>)
         (replayMaps: Map<string, Map<string, string>>)
+        (correctedByKind: Map<SsKey, StaticRow list>)
         (sampleCap: int)
         (pairs: (Kind * Kind) list)
         (acc: KindRowVerdict list)
@@ -593,8 +722,8 @@ module FidelityCompareRun =
             match pairs with
             | [] -> return List.rev acc
             | (physicalKind, logicalKind) :: rest ->
-                let! verdict = compareKind source target renamesByKind replayMaps sampleCap physicalKind logicalKind
-                return! compareKinds source target renamesByKind replayMaps sampleCap rest (verdict :: acc)
+                let! verdict = compareKind source target renamesByKind replayMaps correctedByKind sampleCap physicalKind logicalKind
+                return! compareKinds source target renamesByKind replayMaps correctedByKind sampleCap rest (verdict :: acc)
         }
 
     // ------------------------------------------------------------------
@@ -615,6 +744,8 @@ module FidelityCompareRun =
         (moduleFilter: string option)
         (sampleCap: int)
         (interventions: (string * Map<string, Map<string, string>>) option)
+        (corrections: ApprovedDataCorrection list)
+        (recordedReceipts: DataCorrectionReceipt list)
         : Task<Result<RowFidelityReport>> =
         task {
             try
@@ -650,16 +781,32 @@ module FidelityCompareRun =
                         |> List.choose (fun logicalKind ->
                             Catalog.tryFindKind logicalKind.SsKey physical
                             |> Option.map (fun physicalKind -> physicalKind, logicalKind))
-                    let! verdicts = compareKinds source target renamesByKind replayMaps sampleCap paired []
-                    return
-                        Result.success
-                            { BeforeLabel = beforeLabel
-                              AfterLabel = afterLabel
-                              ModelBasis = modelBasis
-                              Interventions = interventions |> Option.map fst
-                              TolerancesInForce = tolerancesInForce |> List.map ToleratedDivergence.name
-                              DataCorrectionReceipts = []
-                              Kinds = verdicts }
+                    // Replay approved corrections onto the source (engine-reuse) —
+                    // the subject kinds' streams become the corrected rows, so a
+                    // corrected target proves byte-identical against the replayed
+                    // source. A named engine refusal fails the proof by name.
+                    match! replayCorrections source physical model renamesByKind corrections with
+                    | Error es -> return Result.failure es
+                    | Ok (correctedByKind, replayedReceipts) ->
+                        // The count-bounded reconciliation: when recorded receipts
+                        // are supplied, the replay must reproduce them count-for-count
+                        // (a tampered / drifted count reds the proof by name).
+                        let reconciliation =
+                            if List.isEmpty recordedReceipts then Result.success ()
+                            else ApprovedDataCorrections.reconcile recordedReceipts replayedReceipts
+                        match reconciliation with
+                        | Error es -> return Result.failure es
+                        | Ok () ->
+                            let! verdicts = compareKinds source target renamesByKind replayMaps correctedByKind sampleCap paired []
+                            return
+                                Result.success
+                                    { BeforeLabel = beforeLabel
+                                      AfterLabel = afterLabel
+                                      ModelBasis = modelBasis
+                                      Interventions = interventions |> Option.map fst
+                                      TolerancesInForce = tolerancesInForce |> List.map ToleratedDivergence.name
+                                      DataCorrectionReceipts = DataCorrectionReceipt.sorted replayedReceipts
+                                      Kinds = verdicts }
             with ex ->
                 return Result.failureOf (ValidationError.create "fidelity.rows.readFailed" ex.Message)
         }
@@ -675,6 +822,8 @@ module FidelityCompareRun =
         (moduleFilter: string option)
         (sampleCap: int)
         (interventionsPath: string option)
+        (corrections: ApprovedDataCorrection list)
+        (recordedReceipts: DataCorrectionReceipt list)
         : Task<Result<RowFidelityReport>> =
         task {
             // The ledger loads BEFORE the connections open — a bad path is a
@@ -691,7 +840,7 @@ module FidelityCompareRun =
                     use target = new SqlConnection(afterConn)
                     do! source.OpenAsync()
                     do! target.OpenAsync()
-                    return! runWith source target beforeLabel afterLabel modelBasis model kindFilter moduleFilter sampleCap interventions
+                    return! runWith source target beforeLabel afterLabel modelBasis model kindFilter moduleFilter sampleCap interventions corrections recordedReceipts
                 with ex ->
                     return Result.failureOf (ValidationError.create "fidelity.rows.readFailed" ex.Message)
         }

--- a/sidecar/projection/src/Projection.Pipeline/FidelityCompareRun.fs
+++ b/sidecar/projection/src/Projection.Pipeline/FidelityCompareRun.fs
@@ -26,6 +26,14 @@ type RowFidelityReport =
         /// The canonical row form's named erasures, in force on every
         /// `--rows` proof (T17/B4b) — declared, never silent.
         TolerancesInForce : string list
+        /// The approved data-correction receipts replayed onto the source before
+        /// comparing (the intervention ledger's count-bearing half). Empty ⇒ the
+        /// proof claims byte-identity with no approved corrections; non-empty ⇒
+        /// every non-identical raw-source difference is accounted for by a named,
+        /// counted receipt. `TolerancesInForce` are representation erasures;
+        /// `DataCorrectionReceipts` are approved semantic row changes — distinct
+        /// planes (a correction is never a tolerance).
+        DataCorrectionReceipts : DataCorrectionReceipt list
         Kinds       : KindRowVerdict list
     }
 
@@ -43,6 +51,14 @@ module RowFidelityReport =
     /// The exact difference total across every kind.
     let differenceTotal (report: RowFidelityReport) : int64 =
         report.Kinds |> List.sumBy (fun k -> k.DifferenceTotal)
+
+    /// Attach the approved data-correction receipts the publish recorded — the
+    /// intervention ledger the proof's noted-exceptions cite (sorted for
+    /// determinism). The fidelity face threads the episode's receipts here so a
+    /// green proof NAMES its approved corrections rather than claiming raw
+    /// byte-identity.
+    let withDataCorrectionReceipts (receipts: DataCorrectionReceipt list) (report: RowFidelityReport) : RowFidelityReport =
+        { report with DataCorrectionReceipts = DataCorrectionReceipt.sorted receipts }
 
     /// The kinds that disagree, largest difference first.
     let disagreeing (report: RowFidelityReport) : KindRowVerdict list =
@@ -560,6 +576,7 @@ module FidelityCompareRun =
                   ModelBasis = "the portable proof manifest"
                   Interventions = None
                   TolerancesInForce = tolerancesInForce
+                  DataCorrectionReceipts = []
                   Kinds = List.ofSeq verdicts }
         }
 
@@ -641,6 +658,7 @@ module FidelityCompareRun =
                               ModelBasis = modelBasis
                               Interventions = interventions |> Option.map fst
                               TolerancesInForce = tolerancesInForce |> List.map ToleratedDivergence.name
+                              DataCorrectionReceipts = []
                               Kinds = verdicts }
             with ex ->
                 return Result.failureOf (ValidationError.create "fidelity.rows.readFailed" ex.Message)
@@ -709,6 +727,13 @@ module FidelityCompareRun =
           | Some ledger ->
               yield sprintf "  Interventions: %s — the journal's key remaps replay onto the source before comparing." ledger
           | None -> ()
+          match report.DataCorrectionReceipts with
+          | [] -> ()
+          | receipts ->
+              let changed = receipts |> List.sumBy (fun r -> r.RowsChanged)
+              let excluded = receipts |> List.sumBy (fun r -> r.RowsExcluded)
+              yield sprintf "  Interventions: approved data corrections replayed onto the source before comparing — %s correction(s), %s row(s) changed, %s excluded; every difference cites its receipt."
+                        (humane64 (int64 (List.length receipts))) (humane64 changed) (humane64 excluded)
           for verdict in report.Kinds do
               if KindRowVerdict.agrees verdict then
                   yield sprintf "  %s — %s row(s), byte-identical." verdict.KindName (humane64 verdict.Source.Count)
@@ -762,6 +787,20 @@ module FidelityCompareRun =
         let tolerances = JsonArray()
         for t in report.TolerancesInForce do tolerances.Add(JsonValue.Create t)
         root.["tolerancesInForce"] <- tolerances
+        // The approved data-correction receipts — the count-bearing ledger a green
+        // proof's noted-exceptions cite (distinct from the representation erasures
+        // in `tolerancesInForce`). Deterministic (sorted at attach time).
+        let receipts = JsonArray()
+        for r in report.DataCorrectionReceipts do
+            let o = JsonObject()
+            o.["correctionId"] <- JsonValue.Create r.CorrectionId
+            (match r.SourceRemediationId with Some s -> o.["sourceRemediationId"] <- JsonValue.Create s | None -> ())
+            o.["derivation"] <- JsonValue.Create(DataCorrectionDerivation.name r.Derivation)
+            o.["rowsMatched"] <- JsonValue.Create r.RowsMatched
+            o.["rowsChanged"] <- JsonValue.Create r.RowsChanged
+            o.["rowsExcluded"] <- JsonValue.Create r.RowsExcluded
+            receipts.Add o
+        root.["dataCorrectionReceipts"] <- receipts
         root.["agrees"] <- JsonValue.Create(RowFidelityReport.agrees report)
         root.["rowsCompared"] <- JsonValue.Create(RowFidelityReport.rowsCompared report)
         root.["differenceTotal"] <- JsonValue.Create(RowFidelityReport.differenceTotal report)

--- a/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
+++ b/sidecar/projection/src/Projection.Pipeline/LifecycleStore.fs
@@ -119,6 +119,47 @@ module LifecycleStore =
             jw.WriteEndObject()
         jw.WriteEndArray()
 
+    let private writeGuardResult (jw: Utf8JsonWriter) (gr: DataCorrectionGuardResult) : unit =
+        jw.WriteStartObject()
+        jw.WriteString("guard", DataCorrectionGuard.name gr.Guard)
+        jw.WriteBoolean("passed", gr.Passed)
+        match gr.Observed with Some n -> jw.WriteNumber("observed", n) | None -> jw.WriteNull("observed")
+        match gr.Detail with Some d -> jw.WriteString("detail", d) | None -> jw.WriteNull("detail")
+        jw.WriteEndObject()
+
+    /// The episode's **approved data-correction receipts** — the count-bearing
+    /// intervention ledger for the row data this run emitted/loaded. Sorted by
+    /// `DataCorrectionReceipt.sortKey` for byte-determinism (T1), the same
+    /// discipline `writeTolerances` follows. Empty ⇒ `[]`, so a run with no
+    /// `emission.dataCorrections` writes an empty array and stays byte-identical
+    /// to a pre-feature store save modulo the one new (empty) field.
+    let private writeDataCorrectionReceipts (jw: Utf8JsonWriter) (receipts: DataCorrectionReceipt list) : unit =
+        jw.WriteStartArray()
+        for r in DataCorrectionReceipt.sorted receipts do
+            jw.WriteStartObject()
+            jw.WriteString("correctionId", r.CorrectionId)
+            match r.SourceRemediationId with Some s -> jw.WriteString("sourceRemediationId", s) | None -> jw.WriteNull("sourceRemediationId")
+            jw.WritePropertyName "subject"
+            jw.WriteStartObject()
+            jw.WriteString("module", r.Subject.Module)
+            jw.WriteString("entity", r.Subject.Entity)
+            jw.WriteString("attribute", r.Subject.Attribute)
+            jw.WriteEndObject()
+            jw.WriteString("derivation", DataCorrectionDerivation.name r.Derivation)
+            jw.WritePropertyName "guardResults"
+            jw.WriteStartArray()
+            for gr in r.GuardResults do writeGuardResult jw gr
+            jw.WriteEndArray()
+            jw.WriteNumber("rowsMatched", r.RowsMatched)
+            jw.WriteNumber("rowsChanged", r.RowsChanged)
+            jw.WriteNumber("rowsExcluded", r.RowsExcluded)
+            match r.BeforeDigest with Some d -> jw.WriteString("beforeDigest", d) | None -> jw.WriteNull("beforeDigest")
+            match r.AfterDigest with Some d -> jw.WriteString("afterDigest", d) | None -> jw.WriteNull("afterDigest")
+            match r.ApprovedBy with Some s -> jw.WriteString("approvedBy", s) | None -> jw.WriteNull("approvedBy")
+            match r.ApprovedAt with Some s -> jw.WriteString("approvedAt", s) | None -> jw.WriteNull("approvedAt")
+            jw.WriteEndObject()
+        jw.WriteEndArray()
+
     let private writeEpisode (jw: Utf8JsonWriter) (e: Episode) : unit =
         jw.WriteStartObject()
         jw.WritePropertyName "coordinate"
@@ -144,6 +185,12 @@ module LifecycleStore =
         writeTolerances jw e.Tolerances
         jw.WritePropertyName "appliedTransforms"
         writeAppliedTransforms jw e.AppliedTransforms
+        // The approved data-correction receipts plane — persisted (and KEPT by
+        // `durableProjection`) so a stored episode equals its own durable
+        // projection, and a load record can explain why target rows differ from
+        // the raw source.
+        jw.WritePropertyName "dataCorrectionReceipts"
+        writeDataCorrectionReceipts jw e.DataCorrectionReceipts
         jw.WriteEndObject()
 
     let private serialize (lifecycle: EpisodicLifecycle) : byte[] =
@@ -214,6 +261,22 @@ module LifecycleStore =
                 | true, n -> Ok n
                 | _ -> Error (sprintf "field '%s' is not an int32" name)
             else Error (sprintf "field '%s': expected number, got %A" name v.ValueKind)
+
+    let private fieldInt64 (el: JsonElement) (name: string) : Result<int64, string> =
+        match prop el name with
+        | Error m -> Error m
+        | Ok v ->
+            if v.ValueKind = JsonValueKind.Number then
+                match v.TryGetInt64() with
+                | true, n -> Ok n
+                | _ -> Error (sprintf "field '%s' is not an int64" name)
+            else Error (sprintf "field '%s': expected number, got %A" name v.ValueKind)
+
+    let private optInt64 (el: JsonElement) (name: string) : int64 option =
+        match el.TryGetProperty name with
+        | true, v when v.ValueKind = JsonValueKind.Number ->
+            match v.TryGetInt64() with true, n -> Some n | _ -> None
+        | _ -> None
 
     let private readEnvironment (el: JsonElement) : Result<Environment, string> =
         fieldStr el "kind"
@@ -306,6 +369,86 @@ module LifecycleStore =
         | true, v -> Error (sprintf "field 'appliedTransforms': expected array, got %A" v.ValueKind)
         | _ -> Ok []
 
+    let private readGuardResult (el: JsonElement) : Result<DataCorrectionGuardResult, string> =
+        match fieldStr el "guard" with
+        | Error m -> Error m
+        | Ok token ->
+            match DataCorrectionGuard.parse token with
+            | Error errs -> Error (errorsToMessage errs)
+            | Ok guard ->
+                let passed =
+                    match el.TryGetProperty "passed" with
+                    | true, v when v.ValueKind = JsonValueKind.True || v.ValueKind = JsonValueKind.False -> v.GetBoolean()
+                    | _ -> true
+                Ok { Guard = guard; Passed = passed; Observed = optInt64 el "observed"; Detail = optStr el "detail" }
+
+    let private readReceipt (el: JsonElement) : Result<DataCorrectionReceipt, string> =
+        match fieldStr el "correctionId" with
+        | Error m -> Error m
+        | Ok correctionId ->
+            match prop el "subject" with
+            | Error m -> Error m
+            | Ok subjEl ->
+                match fieldStr subjEl "module", fieldStr subjEl "entity", fieldStr subjEl "attribute" with
+                | Ok m, Ok e, Ok a ->
+                    match fieldStr el "derivation" |> bindR (fun t -> match DataCorrectionDerivation.parse t with Ok d -> Ok d | Error errs -> Error (errorsToMessage errs)) with
+                    | Error msg -> Error msg
+                    | Ok derivation ->
+                        let guardResults =
+                            match el.TryGetProperty "guardResults" with
+                            | true, v when v.ValueKind = JsonValueKind.Array ->
+                                let rec loop acc rows =
+                                    match rows with
+                                    | [] -> Ok (List.rev acc)
+                                    | row :: rest ->
+                                        match readGuardResult row with
+                                        | Error m -> Error m
+                                        | Ok gr -> loop (gr :: acc) rest
+                                loop [] (v.EnumerateArray() |> Seq.toList)
+                            | _ -> Ok []
+                        match guardResults with
+                        | Error msg -> Error msg
+                        | Ok grs ->
+                            match fieldInt64 el "rowsMatched", fieldInt64 el "rowsChanged", fieldInt64 el "rowsExcluded" with
+                            | Ok matched, Ok changed, Ok excluded ->
+                                Ok { CorrectionId = correctionId
+                                     SourceRemediationId = optStr el "sourceRemediationId"
+                                     Subject = AttributeCoordinate.create m e a
+                                     Derivation = derivation
+                                     GuardResults = grs
+                                     RowsMatched = matched
+                                     RowsChanged = changed
+                                     RowsExcluded = excluded
+                                     BeforeDigest = optStr el "beforeDigest"
+                                     AfterDigest = optStr el "afterDigest"
+                                     ApprovedBy = optStr el "approvedBy"
+                                     ApprovedAt = optStr el "approvedAt" }
+                            | Error msg, _, _ -> Error msg
+                            | _, Error msg, _ -> Error msg
+                            | _, _, Error msg -> Error msg
+                | Error msg, _, _ -> Error msg
+                | _, Error msg, _ -> Error msg
+                | _, _, Error msg -> Error msg
+
+    /// The episode's approved data-correction receipts. A **missing**
+    /// `dataCorrectionReceipts` field reads as `[]` (forward-compatible with
+    /// pre-feature stores), exactly like the `tolerances`/`appliedTransforms`
+    /// planes. A malformed receipt (unknown derivation/guard token, bad counts)
+    /// is a hard error — the store is never silently partial.
+    let private readDataCorrectionReceipts (el: JsonElement) : Result<DataCorrectionReceipt list, string> =
+        match el.TryGetProperty "dataCorrectionReceipts" with
+        | true, v when v.ValueKind = JsonValueKind.Array ->
+            let rec loop acc rows =
+                match rows with
+                | [] -> Ok (List.rev acc)
+                | row :: rest ->
+                    match readReceipt row with
+                    | Error m -> Error m
+                    | Ok r -> loop (r :: acc) rest
+            loop [] (v.EnumerateArray() |> Seq.toList)
+        | true, v -> Error (sprintf "field 'dataCorrectionReceipts': expected array, got %A" v.ValueKind)
+        | _ -> Ok []
+
     let private readEpisode (el: JsonElement) : Result<Episode, string> =
         match prop el "coordinate" |> bindR readCoordinate with
         | Error m -> Error m
@@ -324,12 +467,14 @@ module LifecycleStore =
                         // provenance planes (NM-34) ARE persisted and KEPT by
                         // `durableProjection`, so they are re-threaded here via
                         // `withProvenance` — that is what makes stored = durable.
-                        match readTolerances el, readAppliedTransforms el with
-                        | Error m, _ -> Error m
-                        | _, Error m -> Error m
-                        | Ok tolerances, Ok appliedTransforms ->
+                        match readTolerances el, readAppliedTransforms el, readDataCorrectionReceipts el with
+                        | Error m, _, _ -> Error m
+                        | _, Error m, _ -> Error m
+                        | _, _, Error m -> Error m
+                        | Ok tolerances, Ok appliedTransforms, Ok receipts ->
                             Episode.create coordinate schema Profile.empty (optStr el "refactorLogRef") data
                             |> Episode.withProvenance tolerances appliedTransforms
+                            |> Episode.withDataCorrectionReceipts receipts
                             |> Ok
 
     /// Reconstruct the chain from a non-empty episode list, enforcing the

--- a/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSpec.fs
@@ -838,7 +838,11 @@ and CheckDataRowsArgs =
       /// B4b) — a transfer journal file, or the `--journal` directory that
       /// holds exactly one; `@runId` resolves through the run store's
       /// recorded `JournalRef` (wave B4a). `None` claims strict byte-identity.
-      Interventions : string option }
+      Interventions : string option
+      /// The approved data corrections (`emission.dataCorrections`) replayed onto
+      /// the SOURCE before comparing — a corrected target proves byte-identical
+      /// against the replayed source. Empty ⇒ raw byte-identity.
+      Corrections : ApprovedDataCorrection list }
 
 /// How `check fidelity <flow>` stands the target's shape up on the container
 /// stand-in before the load + proof (P1-S1): apply the emitted DDL batch (the
@@ -916,7 +920,11 @@ and CheckFidelityFlowArgs =
       /// SHIPS reproduces the source byte-identical. A `Lanes` load writes the
       /// source keys directly (the lanes bracket IDENTITY_INSERT) and needs no
       /// transfer journal, so the compare aligns by identity.
-      Load       : LoadMode }
+      Load       : LoadMode
+      /// The approved data corrections (`emission.dataCorrections`) replayed onto
+      /// the SOURCE before comparing — a corrected target proves byte-identical
+      /// against the replayed source. Empty ⇒ raw byte-identity.
+      Corrections : ApprovedDataCorrection list }
 
 /// The OFFLINE reconcile's operands (`check fidelity --against <manifest>
 /// --target <ref>`, P2-S3): the portable manifest path, and the target the

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -873,7 +873,7 @@ module ProjectionConfig =
                                        Date = field o "date" } : WriteSignoff.ActBlessing))
                     | None, Some modeStr ->
                         match WriteSignoff.parseMode modeStr with
-                        | None -> Result.failureOf (err "cli.config.signoffModeUnknown" (sprintf "flow '%s' signoff mode '%s' is not replace | fresh | drops | cdc | identity-insert | delete-scope." name modeStr))
+                        | None -> Result.failureOf (err "cli.config.signoffModeUnknown" (sprintf "flow '%s' signoff mode '%s' is not replace | fresh | drops | cdc | identity-insert | delete-scope | data-correction." name modeStr))
                         | Some mode ->
                             Result.success (Choice1Of2
                                 { WriteSignoff.Mode = mode

--- a/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
+++ b/sidecar/projection/src/Projection.Pipeline/MovementSurface.fs
@@ -2266,7 +2266,10 @@ module Command =
                                          Module      = valueOf "--module"
                                          SampleCap   = cap
                                          AsJson      = (valueOf "--format" = Some "json")
-                                         Interventions = ledger }))
+                                         Interventions = ledger
+                                         // The raw two-connection rows compare is
+                                         // not tied to a publish config's emission.
+                                         Corrections = [] }))
                      | (Error es, _) | (_, Error es) -> PlanAction.Refused (6, List.head es))
                 | _ -> PlanAction.Refused (2, err "cli.check.dataArgs" "projection check data --rows: requires --before <environment> --after <environment> --model <ref>.")
             | "data" :: _ ->
@@ -2609,7 +2612,10 @@ module Command =
                                           Stage      = stg
                                           Capture    = valueOf "--capture"
                                           IdentityPolicy = identityPolicy
-                                          Load       = ld })
+                                          Load       = ld
+                                          // The flow's approved corrections replay
+                                          // onto the source before comparing.
+                                          Corrections = cfg.Shaping.Emission.DataCorrections })
                                | Error es, _, _, _ -> PlanAction.Refused (6, List.head es)
                                | _, Error es, _, _ -> PlanAction.Refused (2, List.head es)
                                | _, _, Error es, _ -> PlanAction.Refused (2, List.head es)

--- a/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Pipeline.fs
@@ -1409,6 +1409,23 @@ module Compose =
                             (ValidationError.create "emission.deleteScope.ungreenlit"
                                 (sprintf "the emission's convergent-delete arm (`emission.deleteScope`) is not greenlit — %s Declare { \"mode\": \"delete-scope\" } in `emission.signoff` (with the impact acknowledged) before emitting." reason))
                 | None -> Result.success ()
+            // The approved-inline-data-corrections gate (the emission-plane
+            // counterpart of the delete-scope gate). A NON-empty
+            // `emission.dataCorrections` rewrites/excludes row VALUES before
+            // emission/load, so the emitted or loaded rows differ from the raw
+            // source — REFUSED until the emission plane greenlights
+            // `data-correction`. Presence-gated (the blast radius is the receipts,
+            // not a table set).
+            let! () =
+                if List.isEmpty cfg.Emission.DataCorrections then Result.success ()
+                else
+                    match WriteSignoff.verify "emission" cfg.Emission.Signoff WriteSignoff.WriteMode.DataCorrection [] with
+                    | WriteSignoff.Confirmed _ -> Result.success ()
+                    | WriteSignoff.Missing (reason, _)
+                    | WriteSignoff.ScopeMismatch (reason, _) ->
+                        Result.failureOf
+                            (ValidationError.create "emission.dataCorrection.ungreenlit"
+                                (sprintf "approved inline data corrections (`emission.dataCorrections`) rewrite or exclude row data before emission/load, but are not greenlit — %s Declare { \"mode\": \"data-correction\" } in `emission.signoff` (with the impact acknowledged) before publishing." reason))
             return {
                 Policy.empty with
                     Tightening = tightening
@@ -2218,6 +2235,13 @@ module Compose =
             | Config.ProfilerProvider.Live -> true
             | _ -> false)
         && connectionString <> ""
+        // Approved data corrections take the NAMED two-phase fallback: the
+        // pipelined path drains and drops rows per-kind and never materializes a
+        // cross-kind row map, so the correction engine (which needs the whole map
+        // in hand for parent joins / reference key sets) runs on the two-phase
+        // schedule. The emitted bundle is identical either way (the pipelined
+        // toggle is a schedule choice); the fallback is explicit, not silent.
+        && List.isEmpty cfg.Emission.DataCorrections
 
     /// Phase A of the pipelined arm: bind the run's shaping (the SAME
     /// superset `runWithConfigCore` binds, so a binding failure surfaces the
@@ -2473,7 +2497,38 @@ module Compose =
         /// renders the seed plan against ITS catalog + topology, so the
         /// deployed seed cannot drift from the published bundle.
         FinalState    : ComposeState
+        /// The approved data-correction receipts applied to this acquisition's
+        /// row data (empty when `emission.dataCorrections` is empty). The
+        /// load/store legs reuse the SAME corrected data + receipts, so the
+        /// recorded episode explains exactly why loaded rows differ from the raw
+        /// source — no split-brain proof.
+        Receipts      : DataCorrectionReceipt list
     }
+
+    /// Apply approved inline data corrections on the TWO-PHASE schedule (the
+    /// whole `Map<SsKey, StaticRow list>` in hand). Returns the corrected catalog
+    /// (static-lane populations re-grafted), the corrected bootstrap-lane map
+    /// (restricted to the ORIGINAL bootstrap keys so a corrected static kind is
+    /// not emitted by BOTH lanes), and the receipts. Empty corrections ⇒ identity
+    /// (byte-identical). FAIL-CLOSED: the engine's named refusal surfaces as the
+    /// extract stage's failure. Module-level (FS3511).
+    let private applyDataCorrectionsTwoPhase
+        (cfg: Config.Config)
+        (catalog: Catalog)
+        (rows: Map<SsKey, StaticRow list>)
+        : Result<Catalog * Map<SsKey, StaticRow list> * DataCorrectionReceipt list> =
+        if List.isEmpty cfg.Emission.DataCorrections then Result.success (catalog, rows, [])
+        else
+            ApprovedDataCorrections.apply catalog cfg.Emission.DataCorrections rows
+            |> Result.map (fun outcome ->
+                // Static-lane kinds are emitted from the catalog (StaticSeedsEmitter);
+                // re-graft their corrected rows there. The bootstrap lane keeps only
+                // the kinds it originally carried, so a corrected static kind that the
+                // engine added to the output map is not ALSO emitted by the bootstrap
+                // lane (T11 keyset agreement preserved).
+                let correctedCatalog = Hydration.graftStaticPopulations outcome.CorrectedRows catalog
+                let bootstrapMap = outcome.CorrectedRows |> Map.filter (fun k _ -> Map.containsKey k rows)
+                (correctedCatalog, bootstrapMap, outcome.Receipts))
 
     /// The publish, returning the `EstateAcquisition` beside the report —
     /// the combined verbs (`runWithConfigAndLoad` / `runWithConfigAndStore`)
@@ -2541,7 +2596,11 @@ module Compose =
                                               Hydrated = extracted.Hydrated
                                               BootstrapLane = lane
                                               Migration = extracted.Migration
-                                              FinalState = finalState })
+                                              FinalState = finalState
+                                              // The pipelined arm never runs with corrections
+                                              // (the gate forces the two-phase fallback), so its
+                                              // receipts are always empty.
+                                              Receipts = [] })
                                     emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
                                     return result
                                 })
@@ -2559,13 +2618,21 @@ module Compose =
                                     let! parsed = readAndHydrateConfigModel cfg
                                     match parsed with
                                     | Ok (readCatalog, catalog, bootRows, migration) ->
-                                        emitStageMarker LogSink.Extract "extract.completed" LogSink.End
-                                            (Map.ofList [ "moduleCount", box (List.length catalog.Modules) ])
-                                        return Ok (readCatalog, catalog, bootRows, migration)
+                                        // Approved inline data corrections applied in-flight
+                                        // (two-phase: the whole row map is in hand). Empty ⇒
+                                        // identity (byte-identical); a named refusal fails the
+                                        // extract stage.
+                                        match applyDataCorrectionsTwoPhase cfg catalog bootRows with
+                                        | Ok (catalog', bootRows', receipts) ->
+                                            emitStageMarker LogSink.Extract "extract.completed" LogSink.End
+                                                (Map.ofList [ "moduleCount", box (List.length catalog'.Modules) ])
+                                            return Ok (readCatalog, catalog', bootRows', migration, receipts)
+                                        | Error errors ->
+                                            return Error errors
                                     | Error errors ->
                                         return Error errors
                                 })
-                        let readCatalog, catalog, bootstrapRows, migration = extracted
+                        let readCatalog, catalog, bootstrapRows, migration, receipts = extracted
                         let! profile =
                             Staged.stage Stages.profile (fun () ->
                                 task {
@@ -2593,7 +2660,8 @@ module Compose =
                                               Hydrated = catalog
                                               BootstrapLane = lane
                                               Migration = migration
-                                              FinalState = finalState })
+                                              FinalState = finalState
+                                              Receipts = receipts })
                                     emitStageMarker LogSink.Emit "emit.completed" LogSink.End Map.empty
                                     return result
                                 })
@@ -2711,7 +2779,13 @@ module Compose =
             return
                 match parsed with
                 | Error es -> Result.failure es
-                | Ok (readCatalog, hydrated, bootRows, migration) ->
+                | Ok (readCatalog, hydrated0, bootRows0, migration) ->
+                    // Apply approved data corrections so the standalone seed plan
+                    // reflects the SAME corrected rows the publish path emits
+                    // (identity-gate parity). Empty ⇒ byte-identical.
+                    match applyDataCorrectionsTwoPhase cfg hydrated0 bootRows0 with
+                    | Error es -> Result.failure es
+                    | Ok (hydrated, bootRows, receipts) ->
                     match applyRenames cfg hydrated with
                     | Error es -> Result.failure es
                     | Ok renamed ->
@@ -2726,7 +2800,8 @@ module Compose =
                                   Hydrated = hydrated
                                   BootstrapLane = DataComposer.BootstrapLane.Rows bootRows
                                   Migration = migration
-                                  FinalState = composePrefixState pins policy groups renamed }
+                                  FinalState = composePrefixState pins policy groups renamed
+                                  Receipts = receipts }
         }
 
     /// PL-1 (S51) — the ONE durable read per store leg. `None` is genesis (no
@@ -2898,6 +2973,7 @@ module Compose =
         (data: DataObservation)
         (tolerances: Tolerance)
         (appliedTransforms: (SsKey * OverlayAxis option) list)
+        (receipts: DataCorrectionReceipt list)
         (emitted: Catalog)
         : Result<FullExportStoreLeg, FullExportStoreError> =
         let loaded = storePrior.Loaded
@@ -2920,6 +2996,7 @@ module Compose =
                             let episode =
                                 Episode.create coordinate emitted Profile.empty refactorLogRef data
                                 |> Episode.withProvenance tolerances appliedTransforms
+                                |> Episode.withDataCorrectionReceipts receipts
                             match recordEpisodeOnChain path timeline episode loaded with
                             | Error e -> Error e
                             | Ok chain ->
@@ -2976,7 +3053,7 @@ module Compose =
         | Error errors -> Result.failure errors
         | Ok emitted ->
             let physicalNamed = operatorRenamedKinds cfg acquired.ReadCatalog
-            match runStoreLegOnPrior storePath storePrior physicalNamed timeline environment at None DataObservation.empty (emittedToleranceResidual (defaultArg cfg.Emission.Tolerance Tolerance.permissive) emitted) appliedTransforms emitted with
+            match runStoreLegOnPrior storePath storePrior physicalNamed timeline environment at None DataObservation.empty (emittedToleranceResidual (defaultArg cfg.Emission.Tolerance Tolerance.permissive) emitted) appliedTransforms acquired.Receipts emitted with
             | Ok leg -> Result.success (Some leg)
             | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
 
@@ -3085,6 +3162,7 @@ module Compose =
         (emitted: Catalog)
         (cdcDelta: int)
         (pins: Set<SsKey>)
+        (receipts: DataCorrectionReceipt list)
         (storePath: string option)
         (timeline: Timeline)
         (environment: Environment)
@@ -3110,7 +3188,7 @@ module Compose =
             match loadStorePrior path with
             | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
             | Ok storePrior ->
-                match runStoreLegOnPrior path storePrior pins timeline environment at None data (emittedToleranceResidual Tolerance.permissive emitted) [] emitted with
+                match runStoreLegOnPrior path storePrior pins timeline environment at None data (emittedToleranceResidual Tolerance.permissive emitted) [] receipts emitted with
                 | Ok leg -> Result.success (Some leg, cdcDelta)
                 | Error storeErr -> Result.failureOf (mapStoreErr storeErr)
         | _ -> Result.success (None, cdcDelta)
@@ -3126,6 +3204,7 @@ module Compose =
         (emitted: Catalog)
         (sink: SqlConnection)
         (pins: Set<SsKey>)
+        (receipts: DataCorrectionReceipt list)
         (storePath: string option)
         (timeline: Timeline)
         (environment: Environment)
@@ -3142,7 +3221,7 @@ module Compose =
                 match! cdcCaptureTotal sink with
                 | Error es -> return Result.failure es
                 | Ok post ->
-                    return recordLoad emitted (post - baseline) pins storePath timeline environment at
+                    return recordLoad emitted (post - baseline) pins receipts storePath timeline environment at
         }
 
     /// The fused-string load shape — what an operator executing the
@@ -3171,7 +3250,7 @@ module Compose =
                 // An empty seed loads nothing.
                 if System.String.IsNullOrWhiteSpace seed then Task.FromResult ()
                 else executeBatch sink seed)
-            emitted sink Set.empty storePath timeline environment at
+            emitted sink Set.empty [] storePath timeline environment at
 
     /// Card P2 — the LEVELED production load: same CDC bracket, same
     /// episode recording, but the seed deploys as the leveled plan
@@ -3181,6 +3260,7 @@ module Compose =
     /// own pooled connection; `sink` stays the CDC measure's connection).
     let private loadLeveledSeedAndRecordWithPins
         (pins: Set<SsKey>)
+        (receipts: DataCorrectionReceipt list)
         (cdcCaptureTotal: SqlConnection -> Task<Result<int>>)
         (executeLeveled: DataComposer.LeveledDeploymentText -> Task<unit>)
         (emitted: Catalog)
@@ -3199,7 +3279,7 @@ module Compose =
                 // whitespace gate.
                 if DataComposer.LeveledDeploymentText.isEmpty plan then Task.FromResult ()
                 else executeLeveled plan)
-            emitted sink pins storePath timeline environment at
+            emitted sink pins receipts storePath timeline environment at
 
     let loadLeveledSeedAndRecord
         (cdcCaptureTotal: SqlConnection -> Task<Result<int>>)
@@ -3214,7 +3294,7 @@ module Compose =
         : Task<Result<FullExportStoreLeg option * int>> =
         // Config-less witness surface (pins parity with `loadSeedAndRecord`);
         // the production path threads real pins via `loadFromAcquisition`.
-        loadLeveledSeedAndRecordWithPins Set.empty cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
+        loadLeveledSeedAndRecordWithPins Set.empty [] cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
 
     /// AC-X1 (part B) — `runWithConfig` PLUS the live data-load leg the W1-B
     /// store leg deferred. After the bundle is published (unchanged), the
@@ -3247,7 +3327,7 @@ module Compose =
             // G3 — the production record leg carries this run's operator-renamed
             // kind set so its deployed-vocabulary entries agree with the bundle's.
             let physicalNamed = operatorRenamedKinds cfg acquired.ReadCatalog
-            loadLeveledSeedAndRecordWithPins physicalNamed cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
+            loadLeveledSeedAndRecordWithPins physicalNamed acquired.Receipts cdcCaptureTotal executeLeveled emitted plan sink storePath timeline environment at
 
     /// Card P2 re-threaded seam: the second argument is the LEVELED seed
     /// executor (`Deploy.executeLeveledSeed <connection string>` at the CLI

--- a/sidecar/projection/src/Projection.Pipeline/RegisteredAllTransforms.fs
+++ b/sidecar/projection/src/Projection.Pipeline/RegisteredAllTransforms.fs
@@ -98,7 +98,13 @@ module RegisteredAllTransforms =
             // F13 (audit 2026-06-17) — the static-row hydration adapter
             // (`fullExportHydration`) was already authored but never wired into
             // this totality view — registered-in-isolation; the wiring closes it.
-            Hydration.registeredMetadata ]
+            Hydration.registeredMetadata
+            // Approved inline data corrections — the publish-time row-correction
+            // transform (Domain.Data, StageBinding.Pipeline). Registered as a
+            // first-class metadata surface (not hidden inside the emitters), like
+            // the data-bundle emitters above; executed at the correction seam
+            // between acquisition and the data composers.
+            ApprovedDataCorrections.registeredMetadata ]
         // F2 + F3 (audit 2026-06-17) — the post-chain EMISSION SEAM's registered
         // rewrites, projected from the SAME `EmissionSeam.rewrites` the Pipeline
         // executes (`EmissionSeam.apply`). Splicing the seam's metadata here, and

--- a/sidecar/projection/src/Projection.Pipeline/WriteSignoff.fs
+++ b/sidecar/projection/src/Projection.Pipeline/WriteSignoff.fs
@@ -42,6 +42,10 @@ module WriteSignoff =
         | IdentityInsert
         /// A convergent `WHEN NOT MATCHED BY SOURCE … DELETE` arm (emission lane).
         | DeleteScope
+        /// Approved inline data corrections rewrite/exclude row VALUES in flight
+        /// before emission/load — the emitted or loaded rows differ from the raw
+        /// source by the approved receipts (`emission.dataCorrections`).
+        | DataCorrection
 
     /// One authored `signoff` entry — the mode approved, an optional table scope
     /// (empty = the flow's whole set for this mode), the operator's acknowledged
@@ -92,6 +96,7 @@ module WriteSignoff =
         | WriteMode.Cdc            -> "cdc"
         | WriteMode.IdentityInsert -> "identity-insert"
         | WriteMode.DeleteScope    -> "delete-scope"
+        | WriteMode.DataCorrection -> "data-correction"
 
     /// Parse a config label to a mode (case/whitespace-insensitive).
     let parseMode (s: string) : WriteMode option =
@@ -102,6 +107,7 @@ module WriteSignoff =
         | "cdc"             -> Some WriteMode.Cdc
         | "identity-insert" -> Some WriteMode.IdentityInsert
         | "delete-scope"    -> Some WriteMode.DeleteScope
+        | "data-correction" -> Some WriteMode.DataCorrection
         | _                 -> None
 
     /// The default IMPACT statement a mode carries — stative, evidence-grounded
@@ -122,6 +128,8 @@ module WriteSignoff =
             "Source surrogate keys are written directly under SET IDENTITY_INSERT — explicit primary keys that can collide with keys the target already minted."
         | WriteMode.DeleteScope ->
             "A convergent MERGE arm deletes every target row absent from the source within the scope predicate — the target converges to the source, losing the rows outside it."
+        | WriteMode.DataCorrection ->
+            "Approved inline data corrections rewrite required attributes and exclude malformed rows in flight — the emitted or loaded rows differ from the raw source by the approved receipts, each of which names its rows-changed count."
 
     /// The verdict of checking ONE destructive mode a run performs against the
     /// flow's approvals.

--- a/sidecar/projection/src/Projection.Targets.Json/SliceCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/SliceCodec.fs
@@ -36,6 +36,10 @@ module SliceCodec =
              jw.WriteStartArray("values")
              for v in vs do jw.WriteStringValue v
              jw.WriteEndArray()
+         | Predicate.IsNull c ->
+             jw.WriteString("op", "isNull"); jw.WriteString("column", Name.value c)
+         | Predicate.IsNotNull c ->
+             jw.WriteString("op", "isNotNull"); jw.WriteString("column", Name.value c)
          | Predicate.And ps ->
              jw.WriteString("op", "and")
              jw.WriteStartArray("terms")
@@ -108,6 +112,8 @@ module SliceCodec =
                     | true, vs when vs.ValueKind = JsonValueKind.Array ->
                         vs.EnumerateArray() |> Seq.map asString |> Result.collect |> Result.map (fun vals -> Predicate.In (c, vals))
                     | _ -> fail "slice.predicate.in.values" "'in' predicate missing a 'values' array")
+            | "isNull"    -> field el "column" readName |> Result.map Predicate.IsNull
+            | "isNotNull" -> field el "column" readName |> Result.map Predicate.IsNotNull
             | "and" ->
                 (match el.TryGetProperty "terms" with
                  | true, ts when ts.ValueKind = JsonValueKind.Array ->

--- a/sidecar/projection/tests/Projection.Tests.Integration/FidelityRowsDockerTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/FidelityRowsDockerTests.fs
@@ -81,7 +81,7 @@ module FidelityRowsDockerTests =
                             task {
                                 // -- identical data in the two renditions → byte-identity across the gap
                                 let! firstR =
-                                    FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None
+                                    FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None [] []
                                 let first = Result.value firstR
                                 Assert.True(RowFidelityReport.agrees first, "identical renditions read as differing")
                                 let verdict = first.Kinds |> List.exactlyOne
@@ -99,7 +99,7 @@ module FidelityRowsDockerTests =
                                         (ColumnRealization.columnNameText (logicalKind.Attributes |> List.find (fun a -> a.IsPrimaryKey)).Column)
                                 let! _ = flip.ExecuteNonQueryAsync()
                                 let! secondR =
-                                    FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None
+                                    FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None [] []
                                 let second = Result.value secondR
                                 Assert.False(RowFidelityReport.agrees second)
                                 let flipped = second.Kinds |> List.exactlyOne
@@ -141,7 +141,7 @@ module FidelityRowsDockerTests =
                                 do! Deploy.executeBatch tgt (seedFor logicalKind rows)
                                 // CAPTURE — the SOURCE's per-kind (logical-aligned) digests, to a portable file.
                                 let! reportR =
-                                    FidelityCompareRun.runWith src tgt "src" "tgt" "the authored model" model None None 20 None
+                                    FidelityCompareRun.runWith src tgt "src" "tgt" "the authored model" model None None 20 None [] []
                                 let report = Result.value reportR
                                 Assert.True(RowFidelityReport.agrees report, "capture precondition: the two renditions must agree")
                                 let manifest =
@@ -173,6 +173,78 @@ module FidelityRowsDockerTests =
                                     finally
                                         try System.IO.File.Delete manifestPath with _ -> ()
                                         try System.IO.File.Delete "fidelity.rows.json" with _ -> ()
+                            }))
+                Assert.Equal(0, result)
+            })
+
+    // -- Approved-data-correction SOURCE replay (the fidelity addendum) --------
+    // A same-row backfill: the source carries the malformed pre-correction state
+    // (Name NULL) and the target the corrected state (Name backfilled from Email,
+    // as publish would load it). Replaying the correction onto the source proves
+    // byte-identity; the raw source diverges; a tampered receipt count reds by name.
+
+    let private seedNullable (kind: Kind) (rows: (int * string * string option) list) : string =
+        let columnOf (a: Attribute) : string = ColumnRealization.columnNameText a.Column
+        let columnDdl (a: Attribute) : string =
+            let sqlType = match a.Type with | Integer -> "INT" | _ -> "NVARCHAR(100)"
+            let nullability = if a.IsPrimaryKey then "NOT NULL PRIMARY KEY" else "NULL"
+            sprintf "[%s] %s %s" (columnOf a) sqlType nullability
+        let table = sprintf "[%s].[%s]" (TableId.schemaText kind.Physical) (TableId.tableText kind.Physical)
+        let create = sprintf "CREATE TABLE %s (%s);" table (kind.Attributes |> List.map columnDdl |> String.concat ", ")
+        let columnList = kind.Attributes |> List.map (fun a -> sprintf "[%s]" (columnOf a)) |> String.concat ","
+        let cell (v: string option) = match v with Some s -> sprintf "N'%s'" s | None -> "NULL"
+        let values =
+            rows
+            |> List.map (fun (id, email, name) -> sprintf "(%d, N'%s', %s)" id email (cell name))
+            |> String.concat ", "
+        sprintf "%s INSERT INTO %s (%s) VALUES %s;" create table columnList values
+
+    let private backfillCorrection : ApprovedDataCorrection =
+        { Id = "backfill-name"
+          SourceRemediationId = Some "D1-name"
+          Enabled = true
+          Subject = AttributeCoordinate.create "Fid" "Thing" "Name"
+          Predicate = Some (Predicate.IsNull (mkName "Name"))
+          Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Fid" "Thing" "Email")
+          Guards = [ DataCorrectionGuard.TargetIsNull; DataCorrectionGuard.SourceIsNotNull ]
+          EvidenceColumns = []
+          ExpectedCount = None
+          ReferencedEntity = None
+          ConfiguredProbes = []
+          ApprovedBy = Some "operator"
+          ApprovedAt = Some "2026-07-23" }
+
+    [<Fact>]
+    let ``fidelity replay: a corrected target proves byte-identical when the correction replays onto the source; raw source reds; a tampered receipt count reds by name`` () =
+        let label = "FidRowsCorr"
+        if not (skipIfNoDocker label) then () else
+        TaskSync.run (fun () ->
+            task {
+                let physicalKind = CatalogRendition.physical model |> Catalog.allKinds |> List.head
+                let logicalKind = CatalogRendition.logical model |> Catalog.allKinds |> List.head
+                let srcSeed = seedNullable physicalKind [ 1, "a@x.example", None; 2, "b@x.example", None ]
+                let tgtSeed = seedNullable logicalKind [ 1, "a@x.example", Some "a@x.example"; 2, "b@x.example", Some "b@x.example" ]
+                let! result =
+                    Deploy.withBootstrappedDatabase "FidCorrSrc" srcSeed (fun source ->
+                        Deploy.withBootstrappedDatabase "FidCorrTgt" tgtSeed (fun target ->
+                            task {
+                                // Raw source (Name NULL) diverges from the corrected target.
+                                let! rawR = FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None [] []
+                                Assert.False(RowFidelityReport.agrees (Result.value rawR), "raw source should diverge from the corrected target")
+                                // The correction replays onto the source → byte-identical, and the ledger names the receipt.
+                                let! greenR = FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None [ backfillCorrection ] []
+                                let green = Result.value greenR
+                                Assert.True(RowFidelityReport.agrees green, "the replayed correction should make the proof byte-identical")
+                                let receipt = green.DataCorrectionReceipts |> List.exactlyOne
+                                Assert.Equal("backfill-name", receipt.CorrectionId)
+                                Assert.Equal(2L, receipt.RowsChanged)
+                                // A tampered recorded receipt count reds the proof BY NAME.
+                                let tampered = { receipt with RowsChanged = 999L }
+                                let! redR = FidelityCompareRun.runWith source target "src" "tgt" "the authored model" model None None 20 None [ backfillCorrection ] [ tampered ]
+                                match redR with
+                                | Ok _ -> Assert.True(false, "a tampered receipt count should fail the proof")
+                                | Error es -> Assert.Equal("dataCorrection.fidelity.receiptMismatch", (List.head es).Code)
+                                return 0
                             }))
                 Assert.Equal(0, result)
             })

--- a/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/ReverseLegCanaryTests.fs
@@ -555,7 +555,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                     do! Deploy.executeBatch src ReverseLegFixtures.physicalSeed
                     let run () =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
-                            { Flow = "b5-proof"; FromLabel = "b5-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer }
+                            { Flow = "b5-proof"; FromLabel = "b5-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer; Corrections = [] }
                     try
                         // GREEN — the machinery is faithful: every minted key
                         // and every FK cell translates through the journal;
@@ -609,7 +609,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                     do! Deploy.executeBatch src ReverseLegFixtures.physicalSeed
                     let run () =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
-                            { Flow = "p1s1-dacfx"; FromLabel = "p1s1-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Dacfx; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer }
+                            { Flow = "p1s1-dacfx"; FromLabel = "p1s1-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Dacfx; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer; Corrections = [] }
                     try
                         // GREEN — the DacFx-published stand-in carries the target
                         // shape; the journaled load lands every row byte-identical
@@ -656,7 +656,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                     let code =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
                             { Flow = "p2s2"; FromLabel = "p2s2-src"; SourceConn = srcConnStr; SampleCap = 20
-                              AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = Some manifestPath; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer }
+                              AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = Some manifestPath; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer; Corrections = [] }
                     try
                         // A green proof AND a manifest written beside it.
                         Assert.Equal(0, code)
@@ -702,7 +702,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
                             { Flow = "p1s3"; FromLabel = "p1s3-src"; SourceConn = srcConnStr; SampleCap = 20
                               AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None
-                              IdentityPolicy = IdentityPolicy.PreferPreservedKeys; Load = LoadMode.Transfer }
+                              IdentityPolicy = IdentityPolicy.PreferPreservedKeys; Load = LoadMode.Transfer; Corrections = [] }
                     try
                         // GREEN — the FullRights load preserves the source keys; the
                         // stand-in reproduces the estate byte-identically with no remap.
@@ -743,7 +743,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
                             { Flow = "p1s4"; FromLabel = "p1s4-src"; SourceConn = srcConnStr; SampleCap = 20
                               AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None
-                              IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Lanes }
+                              IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Lanes; Corrections = [] }
                     try
                         // GREEN — the emitted lanes, live-hydrated and applied to the
                         // stand-in, reproduce the source byte-identical. The proof runs
@@ -773,7 +773,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                     do! Deploy.executeBatch src ReverseLegFixtures.physicalSeed
                     let run () =
                         Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
-                            { Flow = flow; FromLabel = "b6-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer }
+                            { Flow = flow; FromLabel = "b6-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = false; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer; Corrections = [] }
                     try
                         // RUN 1 — a green proof runs the container AND caches its
                         // result (the source's fingerprints were probed live, the
@@ -795,7 +795,7 @@ type ReverseLegCanaryTests(fixture: EphemeralContainerFixture) =
                         // (the container runs again, recreating the journal).
                         let refreshed () =
                             Projection.Cli.Faces.Fidelity.runCheckFidelityFlow model
-                                { Flow = flow; FromLabel = "b6-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = true; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer }
+                                { Flow = flow; FromLabel = "b6-src"; SourceConn = srcConnStr; SampleCap = 20; AsJson = false; Refresh = true; Stage = StagingMode.Ddl; Capture = None; IdentityPolicy = IdentityPolicy.Structural; Load = LoadMode.Transfer; Corrections = [] }
                         Assert.Equal(0, refreshed ())
                         Assert.True(System.IO.Directory.Exists flowDir, "--refresh forces the container to run again")
                     finally

--- a/sidecar/projection/tests/Projection.Tests/ApprovedDataCorrectionsTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ApprovedDataCorrectionsTests.fs
@@ -1,0 +1,312 @@
+module Projection.Tests.ApprovedDataCorrectionsTests
+
+open Xunit
+open Projection.Core
+
+// The pure approved-data-correction engine (ApprovedDataCorrections.fs). The
+// laws exercised here:
+//   * default (no corrections) is the identity — byte-identical rows, no receipts;
+//   * each derivation (same-row / constant / parent / exclude) transforms the
+//     matched, guard-passing subset and emits ONE count-bearing receipt;
+//   * guards are fail-closed — a finding-count mismatch, an absent sentinel, or a
+//     retained inbound reference REFUSES the correction by name;
+//   * NULL is distinguished from '' (the IsNull predicate + TargetIsNull guard).
+
+let private nm (s: string) : Name = Name.create s |> Result.value
+let private key (parts: string list) : SsKey = SsKey.synthesizedComposite "DC" parts |> Result.value
+
+let private attribute (keyParts: string list) (name: string) (isPk: bool) (isMandatory: bool) : Attribute =
+    { Attribute.create (key keyParts) (nm name) PrimitiveType.Text with
+        Column = ColumnRealization.create name false |> Result.value
+        IsPrimaryKey = isPk
+        IsMandatory = isMandatory }
+
+let private mkKind (ssKey: SsKey) (name: string) (attrs: Attribute list) (refs: Reference list) : Kind =
+    { SsKey = ssKey
+      Name = nm name
+      Origin = Native
+      Modality = []
+      Physical = TableId.create "dbo" name |> Result.value
+      Attributes = attrs
+      References = refs
+      Indexes = []
+      Description = None
+      IsActive = true
+      Triggers = []
+      ColumnChecks = []
+      ExtendedProperties = [] }
+
+let private row (keyParts: string list) (cells: (string * string option) list) : StaticRow =
+    { Identifier = key keyParts
+      Values = cells |> List.map (fun (n, v) -> nm n, v) |> Map.ofList }
+
+let private customerKey = key [ "Customer" ]
+let private accountKey = key [ "Account" ]
+
+let private catalog : Catalog =
+    let customer =
+        mkKind customerKey "Customer"
+            [ attribute [ "Customer"; "Id" ] "Id" true true
+              attribute [ "Customer"; "Name" ] "Name" false false ]
+            []
+    let custRef =
+        Reference.create (key [ "Account"; "CustRef" ]) (nm "CustRef") (key [ "Account"; "CustomerId" ]) customerKey
+    let account =
+        mkKind accountKey "Account"
+            [ attribute [ "Account"; "Id" ] "Id" true true
+              attribute [ "Account"; "CustomerId" ] "CustomerId" false false
+              attribute [ "Account"; "LegacyCustomerId" ] "LegacyCustomerId" false false
+              attribute [ "Account"; "OwnerName" ] "OwnerName" false false ]
+            [ custRef ]
+    Catalog.create
+        [ { SsKey = key [ "Mod" ]; Name = nm "Sales"; Kinds = [ customer; account ]; IsActive = true; ExtendedProperties = [] } ]
+        []
+    |> Result.value
+
+let private customerRows =
+    [ row [ "Customer"; "R"; "C1" ] [ "Id", Some "C1"; "Name", Some "Acme" ]
+      row [ "Customer"; "R"; "C2" ] [ "Id", Some "C2"; "Name", Some "Beta" ] ]
+
+// a1: needs backfill (CustomerId null, legacy C1 exists)
+// a2: CustomerId already C1 (references C1) — skipped by a null predicate
+// a3: both null — the malformed exclusion candidate
+// a4: legacy C9 does NOT exist in the customer key set
+let private accountRows =
+    [ row [ "Account"; "R"; "a1" ] [ "Id", Some "a1"; "CustomerId", None;      "LegacyCustomerId", Some "C1"; "OwnerName", None ]
+      row [ "Account"; "R"; "a2" ] [ "Id", Some "a2"; "CustomerId", Some "C1"; "LegacyCustomerId", Some "C1"; "OwnerName", None ]
+      row [ "Account"; "R"; "a3" ] [ "Id", Some "a3"; "CustomerId", None;      "LegacyCustomerId", None;      "OwnerName", None ]
+      row [ "Account"; "R"; "a4" ] [ "Id", Some "a4"; "CustomerId", None;      "LegacyCustomerId", Some "C9"; "OwnerName", None ] ]
+
+let private rowsMap = Map.ofList [ customerKey, customerRows; accountKey, accountRows ]
+
+let private baseCorrection : ApprovedDataCorrection =
+    { Id = "c"
+      SourceRemediationId = None
+      Enabled = true
+      Subject = AttributeCoordinate.create "Sales" "Account" "CustomerId"
+      Predicate = None
+      Derivation = DataCorrectionDerivationSpec.ConstantLiteral ""
+      Guards = []
+      EvidenceColumns = []
+      ExpectedCount = None
+      ReferencedEntity = None
+      ConfiguredProbes = []
+      ApprovedBy = Some "operator"
+      ApprovedAt = Some "2026-07-23" }
+
+let private applyOk (corrections: ApprovedDataCorrection list) : CorrectionOutcome =
+    match ApprovedDataCorrections.apply catalog corrections rowsMap with
+    | Ok o -> o
+    | Error es -> failwithf "expected Ok; got %A" (es |> List.map (fun e -> e.Code))
+
+let private applyErr (corrections: ApprovedDataCorrection list) : string =
+    match ApprovedDataCorrections.apply catalog corrections rowsMap with
+    | Ok _ -> failwith "expected fail-closed refusal; got Ok"
+    | Error es -> (List.head es).Code
+
+let private cellOf (o: CorrectionOutcome) (kindKey: SsKey) (rowParts: string list) (col: string) : string option =
+    o.CorrectedRows.[kindKey] |> List.find (fun r -> r.Identifier = key rowParts) |> StaticRow.value (nm col)
+
+let private countOf (o: CorrectionOutcome) (kindKey: SsKey) : int =
+    o.CorrectedRows.[kindKey] |> List.length
+
+[<Fact>]
+let ``no corrections is the identity: rows unchanged, no receipts`` () =
+    let o = applyOk []
+    Assert.Equal<Map<SsKey, StaticRow list>>(rowsMap, o.CorrectedRows)
+    Assert.Empty o.Receipts
+
+[<Fact>]
+let ``disabled correction is skipped: no receipt, rows unchanged`` () =
+    let c = { baseCorrection with Enabled = false
+                                  Derivation = DataCorrectionDerivationSpec.ConstantLiteral "X"
+                                  Predicate = Some (Predicate.IsNull (nm "CustomerId")) }
+    let o = applyOk [ c ]
+    Assert.Equal<Map<SsKey, StaticRow list>>(rowsMap, o.CorrectedRows)
+    Assert.Empty o.Receipts
+
+[<Fact>]
+let ``same-row backfill copies source into null target, source-not-null narrows the set`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Sales" "Account" "LegacyCustomerId")
+            Guards = [ DataCorrectionGuard.SourceIsNotNull ] }
+    let o = applyOk [ c ]
+    // matched a1,a3,a4 (CustomerId null); changeable a1,a4 (legacy not null); a3 stays null
+    Assert.Equal(Some "C1", cellOf o accountKey [ "Account"; "R"; "a1" ] "CustomerId")
+    Assert.Equal(Some "C9", cellOf o accountKey [ "Account"; "R"; "a4" ] "CustomerId")
+    Assert.Equal(None, cellOf o accountKey [ "Account"; "R"; "a3" ] "CustomerId")
+    let r = List.exactlyOne o.Receipts
+    Assert.Equal(3L, r.RowsMatched)
+    Assert.Equal(2L, r.RowsChanged)
+    Assert.Equal(0L, r.RowsExcluded)
+    Assert.Equal(DataCorrectionDerivation.SameRowAttribute, r.Derivation)
+
+[<Fact>]
+let ``source-references-existing-target excludes rows whose copied value is absent from the key set`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Sales" "Account" "LegacyCustomerId")
+            Guards = [ DataCorrectionGuard.SourceIsNotNull; DataCorrectionGuard.SourceReferencesExistingTarget ]
+            ReferencedEntity = Some (EntityCoordinate.create "Sales" "Customer") }
+    let o = applyOk [ c ]
+    // C9 is absent from the customer key set → a4 is NOT changed
+    Assert.Equal(Some "C1", cellOf o accountKey [ "Account"; "R"; "a1" ] "CustomerId")
+    Assert.Equal(None, cellOf o accountKey [ "Account"; "R"; "a4" ] "CustomerId")
+    Assert.Equal(1L, (List.exactlyOne o.Receipts).RowsChanged)
+
+[<Fact>]
+let ``expected-finding-count mismatch refuses by name`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Sales" "Account" "LegacyCustomerId")
+            Guards = [ DataCorrectionGuard.ExpectedFindingCount ]
+            ExpectedCount = Some 5L }
+    Assert.Equal("dataCorrection.expectedCount.mismatch", applyErr [ c ])
+
+[<Fact>]
+let ``expected-finding-count match passes`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Sales" "Account" "LegacyCustomerId")
+            Guards = [ DataCorrectionGuard.ExpectedFindingCount ]
+            ExpectedCount = Some 3L }
+    let o = applyOk [ c ]
+    Assert.Equal(3L, (List.exactlyOne o.Receipts).RowsMatched)
+
+[<Fact>]
+let ``constant literal fills every null target`` () =
+    let c =
+        { baseCorrection with
+            Subject = AttributeCoordinate.create "Sales" "Account" "OwnerName"
+            Predicate = Some (Predicate.IsNull (nm "OwnerName"))
+            Derivation = DataCorrectionDerivationSpec.ConstantLiteral "MIGRATED"
+            Guards = [ DataCorrectionGuard.TargetIsNull ] }
+    let o = applyOk [ c ]
+    Assert.Equal(Some "MIGRATED", cellOf o accountKey [ "Account"; "R"; "a1" ] "OwnerName")
+    Assert.Equal(4L, (List.exactlyOne o.Receipts).RowsChanged)
+
+[<Fact>]
+let ``sentinel-exists passes when the constant is in the target key set, refuses when absent`` () =
+    let present =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.ConstantLiteral "C1"
+            Guards = [ DataCorrectionGuard.TargetIsNull; DataCorrectionGuard.SentinelExists ]
+            ReferencedEntity = Some (EntityCoordinate.create "Sales" "Customer") }
+    Assert.Equal(3L, (List.exactlyOne (applyOk [ present ]).Receipts).RowsChanged)
+    let absent = { present with Derivation = DataCorrectionDerivationSpec.ConstantLiteral "C9" }
+    Assert.Equal("dataCorrection.sentinel.absent", applyErr [ absent ])
+
+[<Fact>]
+let ``parent-derived recovery copies the parent attribute through the relationship`` () =
+    let c =
+        { baseCorrection with
+            Subject = AttributeCoordinate.create "Sales" "Account" "OwnerName"
+            Predicate = Some (Predicate.IsNull (nm "OwnerName"))
+            Derivation = DataCorrectionDerivationSpec.ParentAttribute ("CustRef", AttributeCoordinate.create "Sales" "Customer" "Name")
+            Guards = [ DataCorrectionGuard.ParentExists; DataCorrectionGuard.ParentSourceIsNotNull ] }
+    let o = applyOk [ c ]
+    // only a2 has a resolvable parent (CustomerId = C1 → Acme)
+    Assert.Equal(Some "Acme", cellOf o accountKey [ "Account"; "R"; "a2" ] "OwnerName")
+    Assert.Equal(None, cellOf o accountKey [ "Account"; "R"; "a1" ] "OwnerName")
+    Assert.Equal(1L, (List.exactlyOne o.Receipts).RowsChanged)
+
+[<Fact>]
+let ``exclude-rows removes the malformed rows and emits an exclusion receipt`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.And [ Predicate.IsNull (nm "CustomerId"); Predicate.IsNull (nm "LegacyCustomerId") ])
+            Derivation = DataCorrectionDerivationSpec.ExcludeRows
+            Guards = [ DataCorrectionGuard.NoFormalInboundReferences ] }
+    let o = applyOk [ c ]
+    Assert.Equal(3, countOf o accountKey) // a3 removed
+    let r = List.exactlyOne o.Receipts
+    Assert.Equal(1L, r.RowsExcluded)
+    Assert.Equal(0L, r.RowsChanged)
+
+[<Fact>]
+let ``exclude-rows refuses when a retained row formally references the excluded row`` () =
+    // a2 references C1; excluding Customer C1 with the formal inbound guard refuses
+    let excludeReferenced =
+        { baseCorrection with
+            Subject = AttributeCoordinate.create "Sales" "Customer" "Id"
+            Predicate = Some (Predicate.Equals (nm "Id", "C1"))
+            Derivation = DataCorrectionDerivationSpec.ExcludeRows
+            Guards = [ DataCorrectionGuard.NoFormalInboundReferences ] }
+    Assert.Equal("dataCorrection.exclude.inboundReference", applyErr [ excludeReferenced ])
+    // C2 is referenced by nobody → excluding it passes
+    let excludeUnreferenced = { excludeReferenced with Predicate = Some (Predicate.Equals (nm "Id", "C2")) }
+    Assert.Equal(1L, (List.exactlyOne (applyOk [ excludeUnreferenced ]).Receipts).RowsExcluded)
+
+[<Fact>]
+let ``unknown subject refuses by name`` () =
+    let c = { baseCorrection with Subject = AttributeCoordinate.create "Sales" "Account" "NoSuchColumn"
+                                  Derivation = DataCorrectionDerivationSpec.ConstantLiteral "X" }
+    Assert.Equal("dataCorrection.subject.unresolved", applyErr [ c ])
+
+[<Fact>]
+let ``requiresTwoPhase is true only when an enabled parent-derived correction is present`` () =
+    let parent = { baseCorrection with Derivation = DataCorrectionDerivationSpec.ParentAttribute ("CustRef", AttributeCoordinate.create "Sales" "Customer" "Name") }
+    let sameRow = { baseCorrection with Derivation = DataCorrectionDerivationSpec.SameRowAttribute (AttributeCoordinate.create "Sales" "Account" "LegacyCustomerId") }
+    Assert.True(ApprovedDataCorrections.requiresTwoPhase [ parent ])
+    Assert.False(ApprovedDataCorrections.requiresTwoPhase [ sameRow ])
+    Assert.False(ApprovedDataCorrections.requiresTwoPhase [ { parent with Enabled = false } ])
+
+// -- the row-fidelity reconciliation law (receipt-bounded replay) ------------
+
+let private mkReceipt (id: string) (changed: int64) (excluded: int64) : DataCorrectionReceipt =
+    { CorrectionId = id
+      SourceRemediationId = None
+      Subject = AttributeCoordinate.create "M" "E" "A"
+      Derivation = DataCorrectionDerivation.ConstantLiteral
+      GuardResults = []
+      RowsMatched = changed + excluded
+      RowsChanged = changed
+      RowsExcluded = excluded
+      BeforeDigest = None
+      AfterDigest = None
+      ApprovedBy = None
+      ApprovedAt = None }
+
+[<Fact>]
+let ``reconcile of no receipts is the no-correction proof (Ok)`` () =
+    match ApprovedDataCorrections.reconcile [] [] with
+    | Ok () -> ()
+    | Error es -> Assert.Fail(sprintf "expected Ok; got %A" es)
+
+[<Fact>]
+let ``reconcile passes when recorded and replayed counts agree (order-insensitive)`` () =
+    let recorded = [ mkReceipt "c1" 105L 0L; mkReceipt "c2" 0L 12L ]
+    let replayed = [ mkReceipt "c2" 0L 12L; mkReceipt "c1" 105L 0L ]
+    match ApprovedDataCorrections.reconcile recorded replayed with
+    | Ok () -> ()
+    | Error es -> Assert.Fail(sprintf "expected Ok; got %A" es)
+
+[<Fact>]
+let ``reconcile fails by name on a rows-changed count mismatch (105 vs 104)`` () =
+    match ApprovedDataCorrections.reconcile [ mkReceipt "c1" 105L 0L ] [ mkReceipt "c1" 104L 0L ] with
+    | Ok () -> Assert.Fail "expected mismatch"
+    | Error es -> Assert.Equal("dataCorrection.fidelity.receiptMismatch", (List.head es).Code)
+
+[<Fact>]
+let ``reconcile fails when a recorded receipt is not reproduced by the replay`` () =
+    match ApprovedDataCorrections.reconcile [ mkReceipt "c1" 5L 0L ] [] with
+    | Ok () -> Assert.Fail "expected mismatch"
+    | Error es -> Assert.Equal("dataCorrection.fidelity.receiptMismatch", (List.head es).Code)
+
+[<Fact>]
+let ``a value correction records before/after digests for the changed rows`` () =
+    let c =
+        { baseCorrection with
+            Predicate = Some (Predicate.IsNull (nm "CustomerId"))
+            Derivation = DataCorrectionDerivationSpec.ConstantLiteral "SENTINEL"
+            Guards = [ DataCorrectionGuard.TargetIsNull ] }
+    let r = List.exactlyOne (applyOk [ c ]).Receipts
+    Assert.True(Option.isSome r.BeforeDigest)
+    Assert.True(Option.isSome r.AfterDigest)
+    Assert.NotEqual<string option>(r.BeforeDigest, r.AfterDigest)

--- a/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ConfigTests.fs
@@ -678,3 +678,84 @@ let ``Config.parse: read-concurrency below 1 is a named refusal`` () =
     let jsonProfiler = """{ "model": { "path": "m.json" }, "profiler": { "maxConcurrency": -1 } }"""
     let errors2 = Config.parse jsonProfiler |> mustFail
     Assert.True(errors2 |> List.exists (fun e -> e.Code.Contains "profiler.maxConcurrency.invalid"))
+
+// -----------------------------------------------------------------------
+// emission.dataCorrections — approved inline data corrections (parse /
+// default / fail-closed). The signoff GATE is exercised in WriteSignoffTests
+// and the Pipeline layer; here we prove the config surface parses and refuses.
+// -----------------------------------------------------------------------
+
+let private withCorrections (arrJson: string) : string =
+    sprintf """{ "model": { "path": "m.json" }, "emission": { "dataCorrections": %s } }""" arrJson
+
+[<Fact>]
+let ``Config.parse: emission.dataCorrections absent is the empty default (byte-identical)`` () =
+    let cfg = Config.parse """{ "model": { "path": "m.json" } }""" |> mustOk
+    Assert.Empty cfg.Emission.DataCorrections
+
+[<Fact>]
+let ``Config.parse: a same-row correction parses its subject, predicate, derivation, and guards`` () =
+    let json =
+        withCorrections """[
+            { "id": "backfill-customerid",
+              "sourceRemediationId": "D1-legacy",
+              "subject": { "module": "Sales", "entity": "Account", "attribute": "CustomerId" },
+              "predicate": { "op": "isNull", "column": "CustomerId" },
+              "derivation": { "kind": "sameRowAttribute", "source": { "module": "Sales", "entity": "Account", "attribute": "LegacyCustomerId" } },
+              "guards": [ "targetIsNull", "sourceIsNotNull" ],
+              "expectedCount": 4120 } ]"""
+    let cfg = Config.parse json |> mustOk
+    let c = List.exactlyOne cfg.Emission.DataCorrections
+    Assert.Equal("backfill-customerid", c.Id)
+    Assert.Equal(Some "D1-legacy", c.SourceRemediationId)
+    Assert.True(c.Enabled) // default true
+    Assert.Equal("CustomerId", c.Subject.Attribute)
+    Assert.Equal(Some 4120L, c.ExpectedCount)
+    (match c.Predicate with
+     | Some (Predicate.IsNull n) -> Assert.Equal("CustomerId", Name.value n)
+     | other -> Assert.Fail(sprintf "expected IsNull predicate, got %A" other))
+    (match c.Derivation with
+     | DataCorrectionDerivationSpec.SameRowAttribute src -> Assert.Equal("LegacyCustomerId", src.Attribute)
+     | other -> Assert.Fail(sprintf "expected SameRowAttribute, got %A" other))
+    Assert.Equal<DataCorrectionGuard list>([ DataCorrectionGuard.TargetIsNull; DataCorrectionGuard.SourceIsNotNull ], c.Guards)
+
+[<Fact>]
+let ``Config.parse: a parent-derived and an exclude correction parse their derivations`` () =
+    let json =
+        withCorrections """[
+            { "id": "parent-actor", "subject": { "module": "M", "entity": "Child", "attribute": "AddedBy" },
+              "derivation": { "kind": "parentAttribute", "relationship": "ParentRef", "parentSource": { "module": "M", "entity": "Parent", "attribute": "CreatedBy" } } },
+            { "id": "drop-malformed", "enabled": false, "subject": { "module": "M", "entity": "Rule", "attribute": "Id" },
+              "derivation": { "kind": "excludeRows" } } ]"""
+    let cfg = Config.parse json |> mustOk
+    Assert.Equal(2, List.length cfg.Emission.DataCorrections)
+    let parent = cfg.Emission.DataCorrections |> List.find (fun c -> c.Id = "parent-actor")
+    (match parent.Derivation with
+     | DataCorrectionDerivationSpec.ParentAttribute (rel, ps) ->
+         Assert.Equal("ParentRef", rel)
+         Assert.Equal("CreatedBy", ps.Attribute)
+     | other -> Assert.Fail(sprintf "expected ParentAttribute, got %A" other))
+    let excl = cfg.Emission.DataCorrections |> List.find (fun c -> c.Id = "drop-malformed")
+    Assert.False excl.Enabled
+    (match excl.Derivation with
+     | DataCorrectionDerivationSpec.ExcludeRows -> ()
+     | other -> Assert.Fail(sprintf "expected ExcludeRows, got %A" other))
+
+[<Fact>]
+let ``Config.parse: an unknown derivation kind fails FAIL-CLOSED`` () =
+    let json = withCorrections """[ { "id": "c", "subject": { "module": "M", "entity": "E", "attribute": "A" }, "derivation": { "kind": "teleport" } } ]"""
+    Assert.True(Config.parse json |> mustFail |> hasCode "pipeline.config.emission.dataCorrections.derivation.kind")
+
+[<Fact>]
+let ``Config.parse: an unknown guard token fails FAIL-CLOSED`` () =
+    let json = withCorrections """[ { "id": "c", "subject": { "module": "M", "entity": "E", "attribute": "A" }, "derivation": { "kind": "excludeRows" }, "guards": [ "vibeCheck" ] } ]"""
+    Assert.True(Config.parse json |> mustFail |> hasCode "dataCorrection.guard.unknown")
+
+[<Fact>]
+let ``Config.parse: a correction missing its id fails FAIL-CLOSED`` () =
+    let json = withCorrections """[ { "subject": { "module": "M", "entity": "E", "attribute": "A" }, "derivation": { "kind": "excludeRows" } } ]"""
+    Assert.True(Config.parse json |> mustFail |> hasCode "pipeline.config.emission.dataCorrections.id")
+
+[<Fact>]
+let ``Config.parse: emission.dataCorrections as a non-array fails FAIL-CLOSED`` () =
+    Assert.True(Config.parse (withCorrections "\"nope\"") |> mustFail |> hasCode "pipeline.config.emission.dataCorrections.shape")

--- a/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/EmissionFoldersBindingTests.fs
@@ -98,7 +98,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Sqlproj = false; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true; DataCorrections = []
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/InsertionPolicyBindingTests.fs
@@ -33,7 +33,7 @@ let private mkConfig (insertion: string) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Sqlproj = false; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true; DataCorrections = []
         }
         Policy      = {
             Insertion       = insertion

--- a/sidecar/projection/tests/Projection.Tests/LifecycleStoreTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/LifecycleStoreTests.fs
@@ -261,3 +261,62 @@ let ``NM-34: an unknown tolerated-divergence token fails the load (fail-closed, 
         match LifecycleStore.load path with
         | FsResult.Error (LifecycleStoreError.ParseFailure _) -> ()
         | other -> Assert.Fail(sprintf "expected ParseFailure on an unknown divergence token, got %A" other))
+
+// -- approved data-correction receipts: the intervention-ledger plane ---------
+
+let private sampleReceipts : DataCorrectionReceipt list =
+    [ { CorrectionId = "backfill-customerid"; SourceRemediationId = Some "D1-legacy"
+        Subject = AttributeCoordinate.create "Sales" "Account" "CustomerId"
+        Derivation = DataCorrectionDerivation.SameRowAttribute
+        GuardResults =
+            [ DataCorrectionGuardResult.passed DataCorrectionGuard.TargetIsNull (Some 4120L)
+              DataCorrectionGuardResult.passed DataCorrectionGuard.SourceIsNotNull None ]
+        RowsMatched = 4120L; RowsChanged = 4118L; RowsExcluded = 0L
+        BeforeDigest = Some "abc123"; AfterDigest = Some "def456"
+        ApprovedBy = Some "operator"; ApprovedAt = Some "2026-07-23" }
+      { CorrectionId = "drop-malformed"; SourceRemediationId = None
+        Subject = AttributeCoordinate.create "Ops" "Rule" "Id"
+        Derivation = DataCorrectionDerivation.ExcludeRows
+        GuardResults = [ DataCorrectionGuardResult.passed DataCorrectionGuard.NoFormalInboundReferences None ]
+        RowsMatched = 12L; RowsChanged = 0L; RowsExcluded = 12L
+        BeforeDigest = Some "ghi789"; AfterDigest = None
+        ApprovedBy = None; ApprovedAt = None } ]
+
+let private receiptEpisode : Episode =
+    Episode.create (coord 1 "1.1.0" Environment.Qa 8) targetCatalog Profile.empty (Some "reflog#1") (DataObservation.create 120 (Some "lsn:0x10"))
+    |> Episode.withDataCorrectionReceipts sampleReceipts
+
+let private receiptChain : EpisodicLifecycle =
+    EpisodicLifecycle.genesis (tl "dev") e0
+    |> (fun lc -> EpisodicLifecycle.append receiptEpisode lc |> mustResultOk)
+
+[<Fact>]
+let ``data-correction receipts survive the store round-trip (counts, guards, digests)`` () =
+    withTempFile (fun path ->
+        LifecycleStore.save path receiptChain |> mustStoreOk
+        let loaded = LifecycleStore.load path |> mustStoreOk
+        let loadedE1 = EpisodicLifecycle.episodes loaded |> List.item 1
+        Assert.Equal<DataCorrectionReceipt list>(DataCorrectionReceipt.sorted sampleReceipts, loadedE1.DataCorrectionReceipts))
+
+[<Fact>]
+let ``a receipt-bearing loaded episode equals its own durableProjection (stored = durable)`` () =
+    withTempFile (fun path ->
+        LifecycleStore.save path receiptChain |> mustStoreOk
+        let loaded = LifecycleStore.load path |> mustStoreOk
+        let expected =
+            EpisodicLifecycle.genesis (tl "dev") (Episode.durableProjection e0)
+            |> (fun lc -> EpisodicLifecycle.append (Episode.durableProjection receiptEpisode) lc |> mustResultOk)
+        Assert.Equal<EpisodicLifecycle>(expected, loaded))
+
+[<Fact>]
+let ``a pre-feature store (no dataCorrectionReceipts field) loads as empty`` () =
+    withTempFile (fun path ->
+        LifecycleStore.save path chain |> mustStoreOk
+        let stripped =
+            (System.IO.File.ReadAllText path)
+                .Replace(",\n      \"dataCorrectionReceipts\": []", "")
+        Assert.DoesNotContain("dataCorrectionReceipts", stripped)
+        System.IO.File.WriteAllText(path, stripped)
+        let loaded = LifecycleStore.load path |> mustStoreOk
+        for e in EpisodicLifecycle.episodes loaded do
+            Assert.Empty e.DataCorrectionReceipts)

--- a/sidecar/projection/tests/Projection.Tests/MigrationDependenciesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/MigrationDependenciesBindingTests.fs
@@ -91,7 +91,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Sqlproj = false; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true; DataCorrections = []
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -340,6 +340,7 @@
     <Compile Include="CatalogCodecTests.fs" />
     <Compile Include="ProfileCodecTests.fs" />
     <Compile Include="CorrectionCodecTests.fs" />
+    <Compile Include="ApprovedDataCorrectionsTests.fs" />
     <Compile Include="DistributionsEmitterTests.fs" />
     <Compile Include="SiblingEmitterContractTests.fs" />
     <Compile Include="DiagnosticsEndToEndTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/SliceCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SliceCodecTests.fs
@@ -19,7 +19,9 @@ let private sample : SliceSpec =
     let roots =
         [ { Entity = EntityCoordinate.create "Sales" "Order"
             Predicate = Predicate.And [ Predicate.Equals (mkName "REGION", "West")
-                                        Predicate.In (mkName "STATUS", [ "open"; "shipped" ]) ] }
+                                        Predicate.In (mkName "STATUS", [ "open"; "shipped" ])
+                                        Predicate.IsNull (mkName "CLOSEDON")
+                                        Predicate.IsNotNull (mkName "CREATEDON") ] }
           { Entity = EntityCoordinate.ofEntity "Invoice"
             Predicate = Predicate.Raw "[YEAR] >= 2025" } ]
     let directives =

--- a/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SpecialCircumstancesBindingTests.fs
@@ -98,7 +98,7 @@ let private mkConfig (overrides: Config.OverridesSection) : Config.Config =
         Emission    = {
             Ssdt = true; Dacpac = true; Sqlproj = false; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true; DataCorrections = []
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/TransformGroupsBindingTests.fs
@@ -32,7 +32,7 @@ let private mkConfig (entries: Config.TransformGroupEntry list) : Config.Config 
         Emission    = {
             Ssdt = true; Dacpac = true; Sqlproj = false; Json = true; Distributions = true
             StaticSeeds = true; MigrationDependencies = true; Bootstrap = true; BootstrapAllData = false
-            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true
+            DecisionLog = true; Opportunities = true; Validations = true; IncludePlatformAutoIndexes = true; DeleteScope = None; Signoff = []; RenderConstraintsElegant = true; RenderDataElegant = true; EmitIdentityAnnotations = true; DataVerification = Projection.Core.DataVerification.Standard; Tolerance = None; DataStaging = Projection.Core.DataStagingPolicy.auto; DataReadConcurrency = 4; PipelinedBootstrap = true; DataCorrections = []
         }
         Policy      = {
             Insertion       = "SchemaOnly"

--- a/sidecar/projection/tests/Projection.Tests/WriteSignoffTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/WriteSignoffTests.fs
@@ -20,7 +20,8 @@ let private allModes : WriteSignoff.WriteMode list =
       WriteSignoff.WriteMode.Drops
       WriteSignoff.WriteMode.Cdc
       WriteSignoff.WriteMode.IdentityInsert
-      WriteSignoff.WriteMode.DeleteScope ]
+      WriteSignoff.WriteMode.DeleteScope
+      WriteSignoff.WriteMode.DataCorrection ]
 
 [<Fact>]
 let ``parseMode ∘ modeLabel = Some for every mode (the label bridge round-trips)`` () =
@@ -34,10 +35,10 @@ let ``parseMode is case/whitespace-insensitive and rejects an unknown label`` ()
     Assert.Equal(None, WriteSignoff.parseMode "wipe")
 
 [<Fact>]
-let ``the six canonical labels are the operator-writable vocabulary`` () =
+let ``the seven canonical labels are the operator-writable vocabulary`` () =
     let labels = allModes |> List.map WriteSignoff.modeLabel
     Assert.Equal<string list>(
-        [ "replace"; "fresh"; "drops"; "cdc"; "identity-insert"; "delete-scope" ],
+        [ "replace"; "fresh"; "drops"; "cdc"; "identity-insert"; "delete-scope"; "data-correction" ],
         labels)
 
 // -- the impact register: stative, evidence-grounded (THE_VOICE) -------------


### PR DESCRIPTION
## Summary

Adds **approved inline data corrections** to the V2 sidecar: a non-empty `emission.dataCorrections`
rewrites/excludes acquired row **values** before the data composers and load plan see them, so the
emitted bundle, live seed load, transfer load, profile evidence, and row-fidelity proof all see the
**same corrected data**. The source database is never mutated — the engine transforms the
`Map<SsKey, StaticRow list>` the publish already holds.

The posture: **estate proves and proposes · emission approves · publish applies.** The
`policy.tightening` propose→consume loop already exists end-to-end, so this PR builds the
approve+apply half (`publish` consumes a hand-authored `emission.dataCorrections`); estate
auto-proposal of the config blocks is deferred (see below).

## What's here

**Core**
- `DataCorrectionReceipt.fs` — the durable value vocabulary (derivation / guard / guard-result /
  receipt), compiled before `Episode.fs` so an episode carries a receipts provenance plane.
- `ApprovedDataCorrections.fs` — the pure engine (`apply`), four derivations
  (same-row / parent / constant / exclude), row-selector + fail-closed assertion guards,
  count-bearing receipts with SHA-256 before/after digests, the fidelity `reconcile` law, and
  registered pillar-9 metadata.
- Reuse over new types: subject/source refs reuse `AttributeCoordinate`; the row predicate reuses
  `SliceSpec.Predicate`, **extended with tri-state `IsNull`/`IsNotNull`** (preserving `NULL ≠ ''`)
  across `eval`, `SliceCodec`, and `ClosureOracle`.
- `Episode` gains `DataCorrectionReceipts` (default `[]`, preserved by `durableProjection`).

**Pipeline**
- `emission.dataCorrections` config surface (parse / default / fail-closed).
- `WriteSignoff.WriteMode.DataCorrection` + the `buildPolicyFromConfig` gate (non-empty ⇒ requires
  the `data-correction` signoff, mirroring `delete-scope`).
- Two-phase publish injection (corrected rows feed composer + profile + load); the pipelined path
  takes a **named two-phase fallback** when corrections are set (identical bundle, explicit).
- Receipts thread onto `EstateAcquisition` and the recorded `Episode`; `LifecycleStore` serializes
  `dataCorrectionReceipts` forward-compatibly.
- **Row-fidelity replay**: `FidelityCompareRun` replays corrections onto the source for corrected
  kinds (engine-reuse — buffer the subject kinds + declared dependencies, run the same engine,
  substitute corrected rows), so a corrected target proves byte-identical against the replayed
  source. The report carries the receipt ledger (JSON + text render). A tampered recorded receipt
  count reds the proof by name via `reconcile`.

**Drive-by fix** (uncovered by the fidelity subsystem): `Kind.unresolvedComputedIdentifiers`
counted SQL Server's bracketed CAST/CONVERT type name (`CONVERT([nvarchar](20), [Price])`) as an
unresolved column, falsely refusing a legitimate computed column at publish — it now excludes SQL
type keywords. This fixes the pre-existing `BtReferenceFkFlowTests` failure.

## Two design calls (flagged for review)

- **Placement in Core, not Pipeline** (as the design suggested): the engine is pure and `Episode`
  must reference the receipt, so the value types + engine live in Core; Pipeline keeps the wiring.
- **Cross-kind corrections are in scope**, running on the two-phase schedule (per the "named
  two-phase fallback" decision).

## Tests

- Pure (`Projection.Tests`, green — 4633 passed): engine derivations + all guards + fail-closed
  refusals, the `reconcile` law, config parse/default/fail-closed, `data-correction` signoff
  round-trip, lifecycle receipt round-trip + forward-compat, predicate codec, registry
  bidirectional (auto-covers the new metadata).
- Docker (`FidelityRowsDockerTests`, green): a corrected target proves byte-identical when the
  correction replays onto the source; the raw source reds; a tampered receipt count reds by name.

## Deferred (named follow-ups)

- Estate **auto-proposal** of `readiness.estate.remediations` / `emission.dataCorrections` blocks
  (the proposal loop for `policy.tightening` already exists as artifacts).
- A publish-and-load docker test proving `runWithConfigAndLoad` loads corrected rows end-to-end
  (the engine is validated on live SQL via the fidelity replay; the injection wiring is
  compile-checked and follows established seams).

A `DECISIONS.md` entry records the posture and the decisions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNqB6zHRNJTvxoV8PmweJ3)_