### PR TITLE
Twin: sql_variant + rowversion read-back support; exclude views before column type mapping

### DIFF
--- a/sidecar/projection/DECISIONS.md
+++ b/sidecar/projection/DECISIONS.md
@@ -30867,5 +30867,45 @@ reproduce here and the **standing witness on main is the regression test**:
 `TwinViewLoopTests` (Docker collection `Twin-Docker`, its own `twin-e2e-view`/21733 fixture,
 which authors its own multi-base-table view) asserts `up` returns `Ok` with the view present,
 base tables mint, the view stays published and queryable, and a re-seed stays deterministic.
+
+## 2026-08-30 — `sql_variant` + `rowversion` enter the storage vocabulary (on-prem read-back); views excluded before column type mapping
+
+The estate's on-prem databases carry DBA-authored `sql_variant` and `rowversion` columns —
+the evidence that fires the IR-growth trigger (no OutSystems attribute type produces either;
+they enter through read-back and `external_dbType` overrides only). Until now one such column
+made `ReadSide.read` refuse the whole catalog (`sqlTypeCorrespondence.unknown`), taking
+`twin up` / `twin check` / evidence import down with it.
+
+- **`SqlStorageType.SqlVariant` → `Text`.** The raw plane carries a variant cell as its
+  canonical invariant string: `ReadSide.formatRawValue`'s Text arm now canonicalizes the
+  boxed base-typed value through the same `RawValueCodec` forms the dedicated categories use
+  (a culture-sensitive `ToString()` there would have made the raw plane machine-dependent);
+  genuine string cells pass through unchanged. The stored base type does not survive a
+  transfer — named lossy (`EmissionLossyScalar`, the WP-17 posture), never silent.
+- **`SqlStorageType.RowVersion` → `Binary`, plus `SqlStorageType.isEngineStamped`.** The
+  engine writes the value on every INSERT/UPDATE and refuses an explicit one (Msg 273), so σ
+  generates no cell for it — the sink-only projection rule then omits the column and the
+  engine stamps at load; `S-stable` holds, content-addressed streams leave every sibling
+  untouched — and `twin check`'s re-mint digest projects it away (a restamp across two
+  identical mints is not a difference). Both catalog spellings parse: the catalog views
+  report the legacy `timestamp` for a rowversion column.
+- **ReadSide hydrates `SqlStorage` for exactly these two** — the semantic category erases
+  their load-bearing semantics (variant-ness; engine-stamped-ness). Every other type keeps
+  the documented `None`, emission byte-identical.
+- **Views are excluded BEFORE column type mapping.** The combined read's column batch was
+  the one view-leaky query (every sibling batch was already `sys.tables`-scoped); it now
+  joins `INFORMATION_SCHEMA.TABLES … TABLE_TYPE = 'BASE TABLE'`, so a view exposing a type
+  the mapping does not know cannot refuse the read-back. Extends the 2026-08-11 rule (a view
+  carries no data); the Twin's `sys.views` strip stays as the `[twin]`-schema owner and the
+  defensive twin.
+
+Witnesses: `SqlStorageTypeTests` (both spellings; `isEngineStamped`), `ReadSideRawFormTests`
+(canonical variant carriage), `SyntheticDataTests` (no generated cell; siblings `S-stable`),
+`CatalogCodecTests` / `SqlStorageEmissionTests` (codec + DDL round-trips), and the Docker
+witness `SqlVariantRowVersionReadbackTests` — four claims on a real SQL Server: both types
+read back typed and canonical (via the live `timestamp` spelling), a variant cell's boxed
+base values land in canonical raw form with NULL out-of-band, the engine stamps what σ
+omits, and a `hierarchyid`-bearing view neither refuses the read-back nor reconstructs as a
+kind. `TwinViewLoopTests` stays green (the view stays published; base tables mint).
 Charter note in `THE_TWIN.md` §6 data-flow. **Re-open trigger:** a need to mint *into* an
 updatable single-table view (none today; estate views are read models).

--- a/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
+++ b/sidecar/projection/src/Projection.Adapters.Sql/ReadSide.fs
@@ -577,8 +577,18 @@ module ReadSide =
                             // semantic `Type` drives the canary's
                             // PhysicalSchema comparison; `SqlStorage`
                             // stays `None` (semantic fallback) so this
-                            // path's emission is unchanged.
-                            SqlStorage = None
+                            // path's emission is unchanged — EXCEPT the
+                            // two storage types whose load-bearing
+                            // semantics the semantic category erases:
+                            // `sql_variant` (variant-ness; bare `Text`
+                            // would re-emit as NVARCHAR) and
+                            // `rowversion` (engine-stamped; σ and the
+                            // re-mint digest must exclude the column).
+                            // Everything else keeps None, byte-identical.
+                            SqlStorage =
+                                match SqlStorageType.ofSqlType row.DataType row.Length row.Precision row.Scale with
+                                | Some ((SqlStorageType.SqlVariant | SqlStorageType.RowVersion) as st) -> Some st
+                                | _ -> None
                             // WP8 / NM-72 — ReadSide reflects the deployed
                             // SQL Server schema, which carries no OutSystems
                             // authored attribute order (ORDINAL_POSITION is
@@ -680,9 +690,29 @@ module ReadSide =
                 | :? single as s -> s.ToString("G9", inv)
                 | _ -> System.Convert.ToDecimal(v).ToString(inv)
             | Text ->
-                match v.ToString() with
-                | null -> ""
-                | s -> s
+                // A `sql_variant` column (semantic Text) surfaces its
+                // UNDERLYING base-typed value boxed — int, decimal,
+                // DateTime, byte[], Guid, … — and `ToString()` on those
+                // is culture-sensitive. Canonicalize through the same
+                // RawValueCodec forms the dedicated categories use, so
+                // a variant cell's raw form is deterministic and
+                // machine-independent; genuine string cells (every
+                // non-variant text storage type) pass through unchanged.
+                match v with
+                | :? string as s -> s
+                | :? System.DateTimeOffset as dto -> RawValueCodec.formatDateTimeOffset dto
+                | :? System.DateTime as dt -> RawValueCodec.formatDateTime dt
+                | :? System.TimeSpan as ts -> RawValueCodec.formatTime ts
+                | :? bool as b -> RawValueCodec.formatBoolean b
+                | :? System.Guid as g -> RawValueCodec.formatGuid g
+                | :? (byte[]) as b -> System.Convert.ToHexString b
+                | :? double as d -> d.ToString("G17", inv)
+                | :? single as s -> s.ToString("G9", inv)
+                | :? decimal as m -> m.ToString(inv)
+                | _ ->
+                    match System.Convert.ToString(v, inv) with
+                    | null -> ""
+                    | s -> s
             | Binary ->
                 // Older SqlClient surfaces `varbinary`/`binary` as
                 // `SqlBytes` / `SqlBinary` rather than `byte[]`.
@@ -1445,16 +1475,26 @@ module ReadSide =
             cmd.CommandText <-
                 // Five batches separated by `;`. Order matters — the
                 // `NextResultAsync` walk below depends on it.
-                //   1. columns          (INFORMATION_SCHEMA.COLUMNS)
+                //   1. columns          (INFORMATION_SCHEMA.COLUMNS, BASE TABLEs only —
+                //                        every other batch below is already sys.tables-
+                //                        scoped; scoping this one keeps a VIEW's columns
+                //                        out of the type mapping, so a view exposing a
+                //                        type the mapping does not know cannot refuse
+                //                        the whole read-back. A view carries no data;
+                //                        consumers that care about views probe sys.views
+                //                        themselves, per the Twin's Readback.)
                 //   2. primary keys     (INFORMATION_SCHEMA.TABLE_CONSTRAINTS join)
                 //   3. identity cols    (sys.columns)
                 //   4. foreign keys     (sys.foreign_keys join)
                 //   5. logical-name xps (sys.extended_properties; slice D.1.b)
-                "SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE, \
-                        CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE \
-                 FROM INFORMATION_SCHEMA.COLUMNS \
-                 WHERE TABLE_SCHEMA NOT IN ('sys','INFORMATION_SCHEMA') \
-                 ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION; \
+                "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.DATA_TYPE, c.IS_NULLABLE, \
+                        c.CHARACTER_MAXIMUM_LENGTH, c.NUMERIC_PRECISION, c.NUMERIC_SCALE \
+                 FROM INFORMATION_SCHEMA.COLUMNS c \
+                 JOIN INFORMATION_SCHEMA.TABLES tt \
+                   ON tt.TABLE_SCHEMA = c.TABLE_SCHEMA AND tt.TABLE_NAME = c.TABLE_NAME \
+                 WHERE c.TABLE_SCHEMA NOT IN ('sys','INFORMATION_SCHEMA') \
+                   AND tt.TABLE_TYPE = 'BASE TABLE' \
+                 ORDER BY c.TABLE_SCHEMA, c.TABLE_NAME, c.ORDINAL_POSITION; \
                  SELECT kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME \
                  FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc \
                  JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu \

--- a/sidecar/projection/src/Projection.Core/SqlStorageType.fs
+++ b/sidecar/projection/src/Projection.Core/SqlStorageType.fs
@@ -66,6 +66,18 @@ type SqlStorageType =
     | Image
     | UniqueIdentifier
     | Xml
+    /// A variant cell carries a base-typed value; the raw plane carries
+    /// its canonical invariant string, so the stored base type is not
+    /// preserved through a transfer (named lossy — `Estate`'s
+    /// `EmissionLossyScalar`). Enters through DBA-authored on-prem
+    /// columns only; OutSystems produces none.
+    | SqlVariant
+    /// Engine-stamped 8-byte row stamp (`rowversion`; catalog views
+    /// report the legacy name `timestamp`). SQL Server writes it on
+    /// every INSERT/UPDATE and refuses an explicit value (Msg 273), so
+    /// it is read back but never minted, never bulk-loaded, and never
+    /// part of a re-mint content digest.
+    | RowVersion
 
 [<RequireQualifiedAccess>]
 module SqlStorageType =
@@ -104,8 +116,15 @@ module SqlStorageType =
         | SqlStorageType.Time _ -> Time
         | SqlStorageType.VarBinary _
         | SqlStorageType.Binary _
-        | SqlStorageType.Image -> Binary
+        | SqlStorageType.Image
+        // 8 opaque engine-stamped bytes — semantically binary; the
+        // engine-stamped write semantics live in `isEngineStamped`.
+        | SqlStorageType.RowVersion -> Binary
         | SqlStorageType.UniqueIdentifier -> Guid
+        // The raw plane carries a variant cell as its canonical
+        // invariant string (`ReadSide.formatRawValue`), so the
+        // semantic category is Text.
+        | SqlStorageType.SqlVariant -> Text
 
     /// The canonical concrete realization a bare `PrimitiveType`
     /// implies when no source evidence narrows it further. This is the
@@ -135,6 +154,17 @@ module SqlStorageType =
         | Time     -> SqlStorageType.Time None
         | Binary   -> SqlStorageType.VarBinary Max
         | Guid     -> SqlStorageType.UniqueIdentifier
+
+    /// The engine-stamped storage types: SQL Server writes the value on
+    /// every INSERT and UPDATE and refuses an explicit one (`rowversion`
+    /// — Msg 273). Consumers exclude such columns from generated cells
+    /// (σ — the shaping layer then omits the column and the engine
+    /// stamps it at load) and from re-mint content digests (the stamp
+    /// differs across two identical mints by construction).
+    let isEngineStamped (st: SqlStorageType) : bool =
+        match st with
+        | SqlStorageType.RowVersion -> true
+        | _ -> false
 
     /// Parse a SQL Server type expression into a concrete storage type.
     /// Two evidence shapes converge here:
@@ -225,4 +255,10 @@ module SqlStorageType =
             | "image"            -> Some SqlStorageType.Image
             | "uniqueidentifier" -> Some SqlStorageType.UniqueIdentifier
             | "xml"              -> Some SqlStorageType.Xml
+            | "sql_variant"      -> Some SqlStorageType.SqlVariant
+            // `rowversion` is the preferred name; the catalog views
+            // (INFORMATION_SCHEMA.DATA_TYPE, sys.types) still report
+            // the legacy `timestamp` — both spellings are one type.
+            | "rowversion"
+            | "timestamp"        -> Some SqlStorageType.RowVersion
             | _                  -> None

--- a/sidecar/projection/src/Projection.Core/SyntheticData.fs
+++ b/sidecar/projection/src/Projection.Core/SyntheticData.fs
@@ -617,6 +617,13 @@ module SyntheticData =
                 | None      -> Map.empty
             let cells =
                 kind.Attributes
+                // An engine-stamped column (`rowversion`) takes no
+                // generated cell: absent from the row's Values, the bulk
+                // projection omits the column (the sink-only rule) and
+                // the engine stamps the value at load. `S-stable` holds —
+                // every other column's stream is content-addressed to its
+                // own coordinate, untouched by this exclusion.
+                |> List.filter (fun attr -> not (attr.SqlStorage |> Option.exists SqlStorageType.isEngineStamped))
                 |> List.choose (fun attr ->
                     let attrHash = fnv1a (SsKey.serialize attr.SsKey)
                     let nullable = attr.Column.IsNullable

--- a/sidecar/projection/src/Projection.Pipeline/Estate.fs
+++ b/sidecar/projection/src/Projection.Pipeline/Estate.fs
@@ -1292,6 +1292,8 @@ module Estate =
                     | Some SqlStorageType.Real               -> Some ("real", "IEEE-754 single precision, carried as a decimal string")
                     | Some (SqlStorageType.DateTimeOffset _) -> Some ("datetimeoffset", "the time-zone offset")
                     | Some SqlStorageType.Xml                -> Some ("xml", "whitespace and attribute order, since the document is re-serialized")
+                    | Some SqlStorageType.SqlVariant         -> Some ("sql_variant", "the stored base type, since the value is carried as its canonical string")
+                    | Some SqlStorageType.RowVersion         -> Some ("rowversion", "the value itself — the engine restamps it at every write, so it is never carried")
                     | _                                      -> None
                 lossy
                 |> Option.map (fun (typeName, what) ->

--- a/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
+++ b/sidecar/projection/src/Projection.Targets.Json/CatalogCodec.fs
@@ -161,7 +161,9 @@ module CatalogCodec =
          | SqlStorageType.Binary n         -> jw.WriteStringValue "Binary"; jw.WriteNumber("length", n)
          | SqlStorageType.Image            -> jw.WriteStringValue "Image"
          | SqlStorageType.UniqueIdentifier -> jw.WriteStringValue "UniqueIdentifier"
-         | SqlStorageType.Xml              -> jw.WriteStringValue "Xml")
+         | SqlStorageType.Xml              -> jw.WriteStringValue "Xml"
+         | SqlStorageType.SqlVariant       -> jw.WriteStringValue "SqlVariant"
+         | SqlStorageType.RowVersion       -> jw.WriteStringValue "RowVersion")
         jw.WriteEndObject()
 
     let private wSqlLiteral (jw: Utf8JsonWriter) (lit: SqlLiteral) : unit =
@@ -580,6 +582,8 @@ module CatalogCodec =
             | "Image"            -> Ok SqlStorageType.Image
             | "UniqueIdentifier" -> Ok SqlStorageType.UniqueIdentifier
             | "Xml"              -> Ok SqlStorageType.Xml
+            | "SqlVariant"       -> Ok SqlStorageType.SqlVariant
+            | "RowVersion"       -> Ok SqlStorageType.RowVersion
             | o -> fail "codec.sqlStorage.unknown" (sprintf "unknown SqlStorageType kind '%s'" o)) el
 
     let private readSqlLiteral (el: JsonElement) : Result<SqlLiteral> =

--- a/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
+++ b/sidecar/projection/src/Projection.Targets.SSDT/ScriptDomBuild.fs
@@ -232,6 +232,8 @@ module ScriptDomBuild =
         | SqlStorageType.Binary _         -> SqlDataTypeOption.Binary
         | SqlStorageType.Image            -> SqlDataTypeOption.Image
         | SqlStorageType.UniqueIdentifier -> SqlDataTypeOption.UniqueIdentifier
+        | SqlStorageType.SqlVariant       -> SqlDataTypeOption.Sql_Variant
+        | SqlStorageType.RowVersion       -> SqlDataTypeOption.Rowversion
         | SqlStorageType.Xml              -> SqlDataTypeOption.None  // unreachable; Xml builds XmlDataTypeReference before this call
 
     /// Build a `DataTypeReference` from a concrete `SqlStorageType` —

--- a/sidecar/projection/src/Twin.Runtime/Check.fs
+++ b/sidecar/projection/src/Twin.Runtime/Check.fs
@@ -104,7 +104,24 @@ module Check =
             let mutable acc = Map.empty
             for kind in Catalog.allKinds catalog do
                 let table = Projection.Targets.SSDT.Render.tableQualified kind.Physical
-                let! d = scalar cnn (System.String.Concat("SELECT COALESCE(CHECKSUM_AGG(BINARY_CHECKSUM(*)), 0) FROM ", table, ";"))  // LINT-ALLOW: terminal SQL-text probe; the table identifier passes through the SSDT renderer's quoting
+                // An engine-stamped column (`rowversion`) restamps on every
+                // load, so its bytes differ across two identical mints —
+                // include it and the re-mint identity ruler lies. Project
+                // it away through a derived table; `BINARY_CHECKSUM(*)`
+                // keeps its ignore-noncomparable semantics for the rest.
+                let stamped, carried =
+                    kind.Attributes
+                    |> List.partition (fun a -> a.SqlStorage |> Option.exists SqlStorageType.isEngineStamped)
+                let source =
+                    match stamped, carried with
+                    | [], _ | _, [] -> table
+                    | _ ->
+                        let cols =
+                            carried
+                            |> List.map (fun a -> Projection.Targets.SSDT.Render.quote (ColumnRealization.columnNameText a.Column))
+                            |> String.concat ", "  // LINT-ALLOW: terminal SQL select-list comma joiner over renderer-quoted column names
+                        System.String.Concat("(SELECT ", cols, " FROM ", table, ") AS [q]")  // LINT-ALLOW: terminal SQL-text probe; identifiers pass through the SSDT renderer's quoting
+                let! d = scalar cnn (System.String.Concat("SELECT COALESCE(CHECKSUM_AGG(BINARY_CHECKSUM(*)), 0) FROM ", source, ";"))  // LINT-ALLOW: terminal SQL-text probe; the table identifier passes through the SSDT renderer's quoting
                 acc <- Map.add table d acc
             return acc
         }

--- a/sidecar/projection/src/Twin.Runtime/Readback.fs
+++ b/sidecar/projection/src/Twin.Runtime/Readback.fs
@@ -50,9 +50,11 @@ module Readback =
                 |> List.filter (fun m -> not (List.isEmpty m.Kinds)) }
 
     /// The normalized `schema.table` keys of every VIEW in the twin
-    /// database. Read from `sys.views` so a view can be told from a base
-    /// table (the read-back catalog does not distinguish them — both
-    /// arrive as `Kind`s). A view has no rows to wipe or mint.
+    /// database, read from `sys.views`. `ReadSide.read` scopes its column
+    /// ingestion to BASE TABLEs (a view's columns never reach the type
+    /// mapping, so an exotic view column cannot refuse the read-back);
+    /// this probe and the strip below stay as the defensive twin of that
+    /// rule. A view has no rows to wipe or mint.
     let private readViewKeys (twinCnn: SqlConnection) : Task<Set<string>> =
         task {
             use cmd = twinCnn.CreateCommand()

--- a/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
+++ b/sidecar/projection/tests/Projection.Tests.Integration/Projection.Tests.Integration.fsproj
@@ -70,6 +70,7 @@
     <Compile Include="IndexPhysicalMetadataDeployE2ETests.fs" />
     <Compile Include="SsdtDataBehaviorE2ETests.fs" />
     <Compile Include="ScalarCarriageRoundTripTests.fs" />
+    <Compile Include="SqlVariantRowVersionReadbackTests.fs" />
     <Compile Include="StagedMergeDeployE2ETests.fs" />
     <Compile Include="MergeScaleMeasurement.fs" />
     <Compile Include="ReadConcurrencyMeasurementTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests.Integration/SqlVariantRowVersionReadbackTests.fs
+++ b/sidecar/projection/tests/Projection.Tests.Integration/SqlVariantRowVersionReadbackTests.fs
@@ -1,0 +1,181 @@
+module Projection.Tests.SqlVariantRowVersionReadbackTests
+
+// ============================================================================
+// On-prem estates carry DBA-authored `sql_variant` and `rowversion` columns
+// (no OutSystems attribute type produces either). Three claims on a REAL
+// SQL Server:
+//
+//   1. Read-back reconstructs both — `sql_variant` → Text + SqlVariant
+//      storage; `rowversion` → Binary + RowVersion storage — with no
+//      `sqlTypeCorrespondence.unknown` refusal. The catalog views report the
+//      legacy name `timestamp` for the rowversion column, so this is also
+//      the both-spellings proof against a live INFORMATION_SCHEMA.
+//   2. A variant cell reads back CANONICAL: the boxed base-type value
+//      (int / nvarchar / datetime) lands in the same invariant raw form the
+//      dedicated categories use; NULL stays out-of-band.
+//   3. The engine stamps what σ omits: generated rows carry no cell for the
+//      engine-stamped column, the bulk projection omits the column, the load
+//      lands, and every landed row holds a non-null stamp.
+//   4. A VIEW is excluded BEFORE column type mapping: a view exposing a type
+//      the mapping does not know (hierarchyid) neither refuses the read-back
+//      nor reconstructs as a kind. (A view carries no data; the Twin probes
+//      sys.views itself.)
+// ============================================================================
+
+open System.Threading.Tasks
+open Microsoft.Data.SqlClient
+open Xunit
+open Projection.Core
+open Projection.Pipeline
+open Projection.Adapters.Sql
+open Projection.Tests.Fixtures   // mkTableId
+open Projection.Tests.IRBuilders // mkModule, mkCatalog
+
+[<RequireQualifiedAccess>]
+module private VariantFixture =
+
+    let mkKey (parts: string list) : SsKey =
+        SsKey.synthesizedComposite "OS_VAR" parts |> Result.value
+
+    let name (s: string) : Name = Name.create s |> Result.value
+
+    let attr
+        (key: SsKey) (logical: string) (physical: string)
+        (ptype: PrimitiveType) (isPk: bool) (nullable: bool)
+        (storage: SqlStorageType option) : Attribute =
+        { Attribute.create key (name logical) ptype with
+            Column = ColumnRealization.create physical nullable |> Result.value
+            IsPrimaryKey = isPk
+            IsMandatory = not nullable
+            SqlStorage = storage }
+
+    let kindKey = mkKey [ "Variant"; "Carriage" ]
+
+    let mintKind () : Kind =
+        Kind.create kindKey (name "VariantCarriage") (mkTableId "dbo" "VARIANT_CARRIAGE")
+            [ attr (mkKey [ "Variant"; "Id" ])      "Id"      "ID"      Integer true  false None
+              attr (mkKey [ "Variant"; "Payload" ]) "Payload" "PAYLOAD" Text    false true  (Some SqlStorageType.SqlVariant)
+              attr (mkKey [ "Variant"; "Stamp" ])   "Stamp"   "STAMP"   Binary  false false (Some SqlStorageType.RowVersion) ]
+
+    let skipIfNoDocker (label: string) : bool =
+        if Deploy.Docker.ensureRunning () then true
+        else printfn "SKIP %s: Docker daemon not reachable." label; false
+
+    let scalar (cnn: SqlConnection) (sql: string) : Task<string> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            let! v = cmd.ExecuteScalarAsync()
+            return string v
+        }
+
+    /// Read one column back through the SAME formatter the read-back row
+    /// loop uses; NULL is carried out-of-band, as the row loop carries it.
+    let readRaw (cnn: SqlConnection) (typ: PrimitiveType) (sql: string) : Task<string list> =
+        task {
+            use cmd = cnn.CreateCommand()
+            cmd.CommandText <- sql
+            use! reader = cmd.ExecuteReaderAsync()
+            let acc = ResizeArray<string>()
+            let mutable go = true
+            while go do
+                let! more = reader.ReadAsync()
+                if more then
+                    if reader.IsDBNull 0 then acc.Add "<null>"
+                    else acc.Add (ReadSide.formatRawValue typ (reader.GetValue 0))
+                else go <- false
+            return List.ofSeq acc
+        }
+
+[<Xunit.Collection("Docker-SqlServer")>]
+type SqlVariantRowVersionReadbackTests(fixture: EphemeralContainerFixture) =
+    interface IClassFixture<EphemeralContainerFixture>
+
+    [<Fact>]
+    member _.``sql_variant + rowversion read back typed and canonical; the engine stamps what σ omits`` () =
+        if not (VariantFixture.skipIfNoDocker "SqlVariantRowVersionReadback") then () else
+        TaskSync.run (fun () ->
+            fixture.WithEphemeralDatabase "VariantRowVersion" (fun cnn _connStr ->
+                task {
+                    do! Deploy.executeBatch cnn
+                            ("CREATE TABLE [dbo].[VARIANT_CARRIAGE] (\n"
+                             + "  [ID] INT NOT NULL CONSTRAINT [PK_VARIANT_CARRIAGE] PRIMARY KEY,\n"
+                             + "  [PAYLOAD] SQL_VARIANT NULL,\n"
+                             + "  [STAMP] ROWVERSION NOT NULL);")
+                    // One INSERT per row: a multi-row VALUES constructor folds
+                    // the column to ONE common type (datetime outranks
+                    // nvarchar) BEFORE the sql_variant conversion — separate
+                    // statements keep each cell's base type.
+                    do! Deploy.executeBatch cnn
+                            ("INSERT INTO [dbo].[VARIANT_CARRIAGE] ([ID], [PAYLOAD]) VALUES (1, CAST(42 AS INT));\n"
+                             + "INSERT INTO [dbo].[VARIANT_CARRIAGE] ([ID], [PAYLOAD]) VALUES (2, CAST(N'plain' AS NVARCHAR(50)));\n"
+                             + "INSERT INTO [dbo].[VARIANT_CARRIAGE] ([ID], [PAYLOAD]) VALUES (3, CAST('2026-07-16T12:30:00' AS DATETIME));\n"
+                             + "INSERT INTO [dbo].[VARIANT_CARRIAGE] ([ID], [PAYLOAD]) VALUES (4, NULL);")
+                    // A view exposing a type the mapping does not know — it
+                    // must be excluded BEFORE column type mapping (claim 4).
+                    do! Deploy.executeBatch cnn
+                            ("CREATE VIEW [dbo].[VARIANT_VIEW] AS\n"
+                             + "  SELECT [ID], CAST(NULL AS HIERARCHYID) AS [Exotic] FROM [dbo].[VARIANT_CARRIAGE];")
+
+                    // 1 — read-back reconstructs BOTH types, no refusal.
+                    let! read = ReadSide.read cnn
+                    let catalog =
+                        match read with
+                        | Ok c -> c
+                        | Error es -> failwithf "readback refused: %A" es
+                    let kind =
+                        Catalog.allKinds catalog
+                        |> List.find (fun k -> TableId.tableText k.Physical = "VARIANT_CARRIAGE")
+                    let attrOf (colName: string) : Attribute =
+                        kind.Attributes |> List.find (fun a -> ColumnRealization.columnNameText a.Column = colName)
+                    let payload = attrOf "PAYLOAD"
+                    Assert.Equal (Text, payload.Type)
+                    Assert.Equal (Some SqlStorageType.SqlVariant, payload.SqlStorage)
+                    let stamp = attrOf "STAMP"
+                    Assert.Equal (Binary, stamp.Type)
+                    Assert.Equal (Some SqlStorageType.RowVersion, stamp.SqlStorage)
+                    // 4 — the view (with its unmappable hierarchyid column)
+                    // neither refused the read-back (the Ok above) nor
+                    // reconstructed as a kind.
+                    Assert.False (
+                        Catalog.allKinds catalog
+                        |> List.exists (fun k -> TableId.tableText k.Physical = "VARIANT_VIEW"),
+                        "a VIEW must be excluded before column type mapping")
+
+                    // 2 — canonical variant carriage; NULL out-of-band.
+                    let! payloadRaws =
+                        VariantFixture.readRaw cnn Text
+                            "SELECT [PAYLOAD] FROM [dbo].[VARIANT_CARRIAGE] ORDER BY [ID];"
+                    Assert.Equal<string list>(
+                        [ "42"
+                          "plain"
+                          RawValueCodec.formatDateTime (System.DateTime(2026, 7, 16, 12, 30, 0))
+                          "<null>" ],
+                        payloadRaws)
+                    let! stampRaws =
+                        VariantFixture.readRaw cnn Binary
+                            "SELECT [STAMP] FROM [dbo].[VARIANT_CARRIAGE] ORDER BY [ID];"
+                    for s in stampRaws do
+                        Assert.Equal (16, s.Length)   // 8 engine-stamped bytes, hex carriage
+
+                    // 3 — σ omits the engine-stamped column; the load lands;
+                    // the engine stamps every row.
+                    do! Deploy.executeBatch cnn "DELETE FROM [dbo].[VARIANT_CARRIAGE];"
+                    let mintKind = VariantFixture.mintKind ()
+                    let mintCatalog =
+                        mkCatalog [ mkModule (VariantFixture.mkKey [ "Variant"; "M" ]) (VariantFixture.name "M") [ mintKind ] ]
+                    let cfg =
+                        { SyntheticConfig.defaultConfig with
+                            VolumeByKind = Map.ofList [ VariantFixture.kindKey, VolumeTarget.Absolute 5 ] }
+                    let rows = (SyntheticData.generate mintCatalog Profile.empty cfg 7UL).[VariantFixture.kindKey]
+                    Assert.Equal (5, List.length rows)
+                    for r in rows do
+                        Assert.True (
+                            StaticRow.value (VariantFixture.name "Stamp") r |> Option.isNone,
+                            "σ must not generate a cell for an engine-stamped column")
+                    do! Bulk.copyRows cnn mintKind.Physical (TransferCellShaping.toCellRows mintKind Set.empty rows)
+                    let! landed = VariantFixture.scalar cnn "SELECT COUNT(*) FROM [dbo].[VARIANT_CARRIAGE];"
+                    Assert.Equal ("5", landed)
+                    let! stamped = VariantFixture.scalar cnn "SELECT COUNT(*) FROM [dbo].[VARIANT_CARRIAGE] WHERE [STAMP] IS NOT NULL;"
+                    Assert.Equal ("5", stamped)
+                }))

--- a/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/CatalogCodecTests.fs
@@ -264,7 +264,8 @@ let private allStorageTypes : SqlStorageType list =
       SqlStorageType.DateTimeOffset (Some 3); SqlStorageType.DateTimeOffset None
       SqlStorageType.SmallDateTime; SqlStorageType.Date; SqlStorageType.Time (Some 2); SqlStorageType.Time None
       SqlStorageType.VarBinary (SqlLength.Bounded 16); SqlStorageType.VarBinary SqlLength.Max
-      SqlStorageType.Binary 8; SqlStorageType.Image; SqlStorageType.UniqueIdentifier; SqlStorageType.Xml ]
+      SqlStorageType.Binary 8; SqlStorageType.Image; SqlStorageType.UniqueIdentifier; SqlStorageType.Xml
+      SqlStorageType.SqlVariant; SqlStorageType.RowVersion ]
 
 [<Fact>]
 let ``every SqlStorageType (incl. SqlLength Bounded/Max) round-trips`` () =

--- a/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
+++ b/sidecar/projection/tests/Projection.Tests/Projection.Tests.fsproj
@@ -95,6 +95,7 @@
     <Compile Include="SqlStorageTypeTests.fs" />
     <Compile Include="SqlLiteralTests.fs" />
     <Compile Include="BulkTests.fs" />
+    <Compile Include="ReadSideRawFormTests.fs" />
     <Compile Include="SqlIdentifierTests.fs" />
     <Compile Include="OssysTypeMappingTests.fs" />
     <Compile Include="LineageTests.fs" />

--- a/sidecar/projection/tests/Projection.Tests/ReadSideRawFormTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/ReadSideRawFormTests.fs
@@ -1,0 +1,36 @@
+module Projection.Tests.ReadSideRawFormTests
+
+open Xunit
+open Projection.Core
+open Projection.Adapters.Sql
+
+// ---------------------------------------------------------------------------
+// `ReadSide.formatRawValue` on the Text lane — the `sql_variant` carriage
+// contract. A variant column (semantic Text) surfaces its UNDERLYING boxed
+// base-type value — int, decimal, DateTime, byte[], Guid, … — and a
+// culture-sensitive `ToString()` there would make the raw plane
+// machine-dependent. The formatter must canonicalize every base type through
+// the same invariant forms the dedicated categories use, and pass genuine
+// strings (every non-variant text storage type) through unchanged.
+// ---------------------------------------------------------------------------
+
+let private inv = System.Globalization.CultureInfo.InvariantCulture
+
+[<Fact>]
+let ``a variant cell's boxed base values land in canonical raw form`` () =
+    let f (v: obj | null) = ReadSide.formatRawValue Text v
+    // The identity pass-through every genuine text column takes.
+    Assert.Equal ("plain", f (box "plain"))
+    // The variant-surfaced base types, each in its canonical form.
+    Assert.Equal ("42", f (box 42))
+    Assert.Equal ("42", f (box 42L))
+    Assert.Equal ("3.14", f (box 3.14M))
+    Assert.Equal ((1.5).ToString("G17", inv), f (box 1.5))
+    Assert.Equal (RawValueCodec.formatBoolean true, f (box true))
+    let dt = System.DateTime(2026, 7, 16, 12, 30, 0)
+    Assert.Equal (RawValueCodec.formatDateTime dt, f (box dt))
+    let dto = System.DateTimeOffset(2026, 7, 16, 12, 30, 0, System.TimeSpan.FromHours -3.0)
+    Assert.Equal (RawValueCodec.formatDateTimeOffset dto, f (box dto))
+    let g = System.Guid.Parse "00000000-0000-0000-0000-000000000001"
+    Assert.Equal (RawValueCodec.formatGuid g, f (box g))
+    Assert.Equal ("CAFEBABE", f (box [| 0xCAuy; 0xFEuy; 0xBAuy; 0xBEuy |]))

--- a/sidecar/projection/tests/Projection.Tests/SqlStorageEmissionTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlStorageEmissionTests.fs
@@ -221,3 +221,17 @@ let ``Emission: external_dbType override renders the concrete type`` () =
 let ``Emission: xml renders XML (via XmlDataTypeReference)`` () =
     let body = emitBody (singleAttrJson "xml" "null" "null")
     Assert.Contains ("XML", body)
+
+[<Fact>]
+let ``Emission: external_dbType sql_variant renders SQL_VARIANT`` () =
+    // No OutSystems attribute type produces a variant; it enters through
+    // a DBA-authored override (or read-back). Text-category consistent.
+    let body = emitBody (singleAttrJson "rtText" "null" "\"SQL_VARIANT\"")
+    Assert.Contains ("SQL_VARIANT", body.ToUpperInvariant())
+
+[<Fact>]
+let ``Emission: external_dbType rowversion renders ROWVERSION`` () =
+    // Binary-category consistent; the engine-stamped semantics live in
+    // `SqlStorageType.isEngineStamped`, not in the DDL.
+    let body = emitBody (singleAttrJson "binarydata" "null" "\"ROWVERSION\"")
+    Assert.Contains ("ROWVERSION", body.ToUpperInvariant())

--- a/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SqlStorageTypeTests.fs
@@ -122,3 +122,33 @@ let ``ofSqlType returns None for empty and unknown types`` () =
 let ``ofSqlType parenthesized parameters win over facet arguments`` () =
     // External override "NVARCHAR(MAX)" beats a stray facet length.
     Assert.Equal (Some (SqlStorageType.NVarChar Max), SqlStorageType.ofSqlType "NVARCHAR(MAX)" (Some 50) None None)
+
+// ---------------------------------------------------------------------------
+// sql_variant / rowversion — the on-prem DBA-authored scalars (no OutSystems
+// attribute type produces either; they enter through read-back only).
+// ---------------------------------------------------------------------------
+
+[<Fact>]
+let ``sql_variant and rowversion project to Text and Binary`` () =
+    // A variant cell rides the raw plane as its canonical string; the
+    // engine-stamped row stamp is 8 opaque bytes.
+    Assert.Equal (Text, SqlStorageType.toPrimitiveType SqlStorageType.SqlVariant)
+    Assert.Equal (Binary, SqlStorageType.toPrimitiveType SqlStorageType.RowVersion)
+
+[<Fact>]
+let ``ofSqlType parses sql_variant and BOTH rowversion spellings`` () =
+    // The catalog views (INFORMATION_SCHEMA.DATA_TYPE, sys.types) report
+    // the legacy name `timestamp` for a rowversion column — a read-back
+    // that only knew the preferred spelling would still refuse.
+    Assert.Equal (Some SqlStorageType.SqlVariant, SqlStorageType.ofSqlType "sql_variant" None None None)
+    Assert.Equal (Some SqlStorageType.SqlVariant, SqlStorageType.ofSqlType "SQL_VARIANT" None None None)
+    Assert.Equal (Some SqlStorageType.RowVersion, SqlStorageType.ofSqlType "rowversion" None None None)
+    Assert.Equal (Some SqlStorageType.RowVersion, SqlStorageType.ofSqlType "timestamp" None None None)
+
+[<Fact>]
+let ``isEngineStamped names exactly the engine-written storage types`` () =
+    Assert.True (SqlStorageType.isEngineStamped SqlStorageType.RowVersion)
+    Assert.False (SqlStorageType.isEngineStamped SqlStorageType.SqlVariant)
+    Assert.False (SqlStorageType.isEngineStamped SqlStorageType.Xml)
+    Assert.False (SqlStorageType.isEngineStamped (SqlStorageType.VarBinary Max))
+    Assert.False (SqlStorageType.isEngineStamped SqlStorageType.UniqueIdentifier)

--- a/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
+++ b/sidecar/projection/tests/Projection.Tests/SyntheticDataTests.fs
@@ -723,3 +723,25 @@ let ``unique tokens fit the declared width and stay verbatim where the width all
     // The wide column keeps the verbatim full token — the fitting rule only
     // engages where the width would truncate.
     Assert.All(wides, fun v -> Assert.StartsWith("u:", v))
+
+[<Fact>]
+let ``an engine-stamped column (rowversion) takes no generated cell; sibling columns hold S-stable`` () =
+    // σ generates no cell for `rowversion` storage: absent from the row's
+    // Values, the bulk projection omits the column (the sink-only rule)
+    // and the ENGINE stamps the value at load. Content-addressed streams
+    // keep every sibling column byte-identical to the stamp-less kind.
+    let stampKey = attrKey ["C"; "Stamp"]
+    let stamped : Kind =
+        { customer with
+            Attributes =
+                customer.Attributes
+                @ [ { attr stampKey "Stamp" Binary false false with
+                        SqlStorage = Some SqlStorageType.RowVersion } ] }
+    let catalogStamped : Catalog =
+        Catalog.create [ mkModule (modKey "M") (name "M") [ stamped; order ] ] [] |> mkOk
+    let v1 = SyntheticData.generate catalog        profile cfg 7UL
+    let v2 = SyntheticData.generate catalogStamped profile cfg 7UL
+    Assert.NotEmpty v2.[custKey]
+    Assert.Empty (valuesOf v2 custKey "Stamp")
+    for attrName in [ "Id"; "Status"; "Email"; "Score"; "Notes" ] do
+        Assert.Equal<string list>(valuesOf v1 custKey attrName, valuesOf v2 custKey attrName)


### PR DESCRIPTION
The estate's on-prem databases carry DBA-authored `sql_variant` and `rowversion` columns. One such column made `ReadSide.read` refuse the entire catalog (`sqlTypeCorrespondence.unknown`), taking `twin up` / `twin check` / evidence import down with it. Recorded as **DECISIONS 2026-08-30**.

Rebased onto current `main` (post-#701): the engine-stamped filter re-verified against the array-backed synthetic draws, and the tail conflict with the width-fitting test resolved by keeping both.

## What changes

- **`SqlStorageType.SqlVariant` → `Text`**: the raw plane carries a variant cell as its canonical invariant string — `ReadSide.formatRawValue`'s Text arm canonicalizes the boxed base-typed value through `RawValueCodec` (a culture-sensitive `ToString()` there would have made the raw plane machine-dependent); genuine string cells pass through unchanged. The stored base type does not survive a transfer — named lossy (`EmissionLossyScalar`), never silent.
- **`SqlStorageType.RowVersion` → `Binary`, plus `SqlStorageType.isEngineStamped`**: the engine writes the value on every INSERT/UPDATE and refuses an explicit one (Msg 273), so σ generates no cell for it — the sink-only projection rule then omits the column and the engine stamps at load; `S-stable` holds — and `twin check`'s re-mint digest projects it away (a restamp across two identical mints is not a difference). **Both catalog spellings parse** — INFORMATION_SCHEMA reports the legacy `timestamp` for a rowversion column.
- **ReadSide hydrates `SqlStorage` for exactly these two types** (the semantic category erases their load-bearing semantics: variant-ness; engine-stamped-ness); every other type keeps the documented `None`, emission byte-identical.
- **Views are excluded BEFORE column type mapping**: the combined read's column batch — the one view-leaky query among `sys.tables`-scoped siblings — now joins `INFORMATION_SCHEMA.TABLES … TABLE_TYPE = 'BASE TABLE'`, so a view exposing an unmappable type (e.g. `hierarchyid`) cannot refuse the read-back. Extends the 2026-08-11 rule (a view carries no data); the Twin's `sys.views` strip stays as the `[twin]`-schema owner and defensive twin.
- ScriptDom emission (`Sql_Variant` / `Rowversion`), catalog codec tags, and the estate lossy-scalar findings extend accordingly.

## Verification (on this rebased head)

- Full pure pool **PASSED** (266s); focused suites for the touched files **110/110**.
- Docker witness `SqlVariantRowVersionReadbackTests` (new) + `ScalarCarriageRoundTripTests` **2/2** — four claims on a real SQL Server: both types read back typed and canonical (via the live `timestamp` spelling), variant cells land in canonical raw form with NULL out-of-band, the engine stamps what σ omits (5/5 rows), and a `hierarchyid`-bearing view neither refuses the read-back nor reconstructs as a kind.
- `TwinViewLoopTests` + `TwinMintLoopTests` **6/6** — the view law and T1 mint determinism hold with the engine-stamped exclusion in place, on top of main's array-backed draws.
- `src/` Release-builds clean; `lint-discipline` clean.

Worth knowing: a multi-row `VALUES` constructor folds a column to one common type *before* the variant conversion (datetime outranks nvarchar), so seeding mixed-base variant rows takes one INSERT per row — the Docker test documents this in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8fx2TFW7T79JDU5vjSeZe

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8fx2TFW7T79JDU5vjSeZe)_